### PR TITLE
Add Asset and Redis V1 APIs to root docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The following libraries are available at a [GA](#versioning) quality level:
 
 The following libraries are available at a [beta](#versioning) quality level:
 
+* [Google Cloud Asset Inventory](https://cloud.google.com/resource-manager/docs/cai/) - [API docs](http://googleapis.github.io/google-cloud-dotnet/docs/Google.Cloud.Asset.V1Beta1/) (beta)
 * [Google BigQuery Data Transfer](https://cloud.google.com/bigquery/transfer/) - [API docs](http://googleapis.github.io/google-cloud-dotnet/docs/Google.Cloud.BigQuery.DataTransfer.V1/) (beta)
 * [Google Cloud Bigtable](https://cloud.google.com/bigtable/) - [API docs](http://googleapis.github.io/google-cloud-dotnet/docs/Google.Cloud.Bigtable.V2/) (beta)
   * Also the Bigtable admin API - [API docs](http://googleapis.github.io/google-cloud-dotnet/docs/Google.Cloud.Bigtable.Admin.V2/) (beta)
@@ -55,7 +56,8 @@ The following libraries are available at a [beta](#versioning) quality level:
 * [Google Cloud Key Management Service](https://cloud.google.com/kms/) - [API docs](http://googleapis.github.io/google-cloud-dotnet/docs/Google.Cloud.Kms.V1/) (beta)
 * [Google OS Login](https://cloud.google.com/compute/docs/instances/managing-instance-access) - [API docs](http://googleapis.github.io/google-cloud-dotnet/docs/Google.Cloud.OsLogin.V1/) (beta)
 * [Google Cloud Pub/Sub](https://cloud.google.com/pubsub/) - [API docs](http://googleapis.github.io/google-cloud-dotnet/docs/Google.Cloud.PubSub.V1/) (beta)
-* [Google Cloud Memorystore for Redis](https://cloud.google.com/memorystore/) - [API docs](http://googleapis.github.io/google-cloud-dotnet/docs/Google.Cloud.Redis.V1Beta1/) (beta)
+* [Google Cloud Memorystore for Redis](https://cloud.google.com/memorystore/) - [API docs](http://googleapis.github.io/google-cloud-dotnet/docs/Google.Cloud.Redis.V1/) (beta)
+  * The [V1Beta1 API package](http://googleapis.github.io/google-cloud-dotnet/docs/Google.Cloud.Redis.V1Beta1/) is also available (beta)
 * [Google Cloud Tasks](https://cloud.google.com/cloud-tasks/) (available for V2Beta2 and V2Beta3 API versions)
   * [V2Beta2 API docs](http://googleapis.github.io/google-cloud-dotnet/docs/Google.Cloud.Tasks.V2Beta2/) (beta)
   * [V2Beta3 API docs](http://googleapis.github.io/google-cloud-dotnet/docs/Google.Cloud.Tasks.V2Beta3/) (beta)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The following libraries are available at a [GA](#versioning) quality level:
 
 The following libraries are available at a [beta](#versioning) quality level:
 
-* [Google Cloud Asset Inventory](https://cloud.google.com/resource-manager/docs/cai/) - [API docs](http://googleapis.github.io/google-cloud-dotnet/docs/Google.Cloud.Asset.V1Beta1/) (beta)
+* [Google Cloud Asset Inventory](https://cloud.google.com/resource-manager/docs/cai/overview) - [API docs](http://googleapis.github.io/google-cloud-dotnet/docs/Google.Cloud.Asset.V1Beta1/) (beta)
 * [Google BigQuery Data Transfer](https://cloud.google.com/bigquery/transfer/) - [API docs](http://googleapis.github.io/google-cloud-dotnet/docs/Google.Cloud.BigQuery.DataTransfer.V1/) (beta)
 * [Google Cloud Bigtable](https://cloud.google.com/bigtable/) - [API docs](http://googleapis.github.io/google-cloud-dotnet/docs/Google.Cloud.Bigtable.V2/) (beta)
   * Also the Bigtable admin API - [API docs](http://googleapis.github.io/google-cloud-dotnet/docs/Google.Cloud.Bigtable.Admin.V2/) (beta)

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -24,7 +24,7 @@
   {
     "id": "Google.Cloud.Asset.V1Beta1",
     "productName": "Google Cloud Asset Inventory",
-    "productUrl": "https://cloud.google.com/resource-manager/docs/cai/",
+    "productUrl": "https://cloud.google.com/resource-manager/docs/cai/overview",
     "version": "1.0.0-beta01",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Asset Inventory API.",

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -41,6 +41,7 @@ GA:
 
 Beta:
 
+- [Google.Cloud.Asset.V1Beta1](Google.Cloud.Asset.V1Beta1/index.html)
 - [Google.Cloud.BigQuery.DataTransfer.V1](Google.Cloud.BigQuery.DataTransfer.V1/index.html)
 - [Google.Cloud.Bigtable.V2](Google.Cloud.Bigtable.V2/index.html)
 - [Google.Cloud.Bigtable.Admin.V2](Google.Cloud.Bigtable.Admin.V2/index.html)
@@ -60,6 +61,7 @@ Beta:
 - [Google.Cloud.Kms.V1](Google.Cloud.Kms.V1/index.html)
 - [Google.Cloud.OsLogin.V1](Google.Cloud.OsLogin.V1/index.html)
 - [Google.Cloud.PubSub.V1](Google.Cloud.PubSub.V1/index.html)
+- [Google.Cloud.Redis.V1](Google.Cloud.Redis.V1/index.html)
 - [Google.Cloud.Redis.V1Beta1](Google.Cloud.Redis.V1Beta1/index.html)
 - [Google.Cloud.Tasks.V2Beta2](Google.Cloud.Tasks.V2Beta2/index.html)
 - [Google.Cloud.Tasks.V2Beta3](Google.Cloud.Tasks.V2Beta3/index.html)


### PR DESCRIPTION
The Asset API page isn't available yet, so I'll wait before merging.