### PR TITLE
Regenerate Spanner APIs

### DIFF
--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/SpannerDatabaseAdminGrpc.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/SpannerDatabaseAdminGrpc.cs
@@ -3,7 +3,7 @@
 //     source: google/spanner/admin/database/v1/spanner_database_admin.proto
 // </auto-generated>
 // Original file comments:
-// Copyright 2018 Google Inc.
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/SpannerInstanceAdminGrpc.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/SpannerInstanceAdminGrpc.cs
@@ -3,7 +3,7 @@
 //     source: google/spanner/admin/instance/v1/spanner_instance_admin.proto
 // </auto-generated>
 // Original file comments:
-// Copyright 2018 Google Inc.
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/ResultSet.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/ResultSet.cs
@@ -39,21 +39,22 @@ namespace Google.Cloud.Spanner.V1 {
             "KAwSMAoFc3RhdHMYBSABKAsyIS5nb29nbGUuc3Bhbm5lci52MS5SZXN1bHRT",
             "ZXRTdGF0cyJ5ChFSZXN1bHRTZXRNZXRhZGF0YRIvCghyb3dfdHlwZRgBIAEo",
             "CzIdLmdvb2dsZS5zcGFubmVyLnYxLlN0cnVjdFR5cGUSMwoLdHJhbnNhY3Rp",
-            "b24YAiABKAsyHi5nb29nbGUuc3Bhbm5lci52MS5UcmFuc2FjdGlvbiJwCg5S",
-            "ZXN1bHRTZXRTdGF0cxIwCgpxdWVyeV9wbGFuGAEgASgLMhwuZ29vZ2xlLnNw",
-            "YW5uZXIudjEuUXVlcnlQbGFuEiwKC3F1ZXJ5X3N0YXRzGAIgASgLMhcuZ29v",
-            "Z2xlLnByb3RvYnVmLlN0cnVjdEKaAQoVY29tLmdvb2dsZS5zcGFubmVyLnYx",
-            "Qg5SZXN1bHRTZXRQcm90b1ABWjhnb29nbGUuZ29sYW5nLm9yZy9nZW5wcm90",
-            "by9nb29nbGVhcGlzL3NwYW5uZXIvdjE7c3Bhbm5lcvgBAaoCF0dvb2dsZS5D",
-            "bG91ZC5TcGFubmVyLlYxygIXR29vZ2xlXENsb3VkXFNwYW5uZXJcVjFiBnBy",
-            "b3RvMw=="));
+            "b24YAiABKAsyHi5nb29nbGUuc3Bhbm5lci52MS5UcmFuc2FjdGlvbiK5AQoO",
+            "UmVzdWx0U2V0U3RhdHMSMAoKcXVlcnlfcGxhbhgBIAEoCzIcLmdvb2dsZS5z",
+            "cGFubmVyLnYxLlF1ZXJ5UGxhbhIsCgtxdWVyeV9zdGF0cxgCIAEoCzIXLmdv",
+            "b2dsZS5wcm90b2J1Zi5TdHJ1Y3QSGQoPcm93X2NvdW50X2V4YWN0GAMgASgD",
+            "SAASHwoVcm93X2NvdW50X2xvd2VyX2JvdW5kGAQgASgDSABCCwoJcm93X2Nv",
+            "dW50QpoBChVjb20uZ29vZ2xlLnNwYW5uZXIudjFCDlJlc3VsdFNldFByb3Rv",
+            "UAFaOGdvb2dsZS5nb2xhbmcub3JnL2dlbnByb3RvL2dvb2dsZWFwaXMvc3Bh",
+            "bm5lci92MTtzcGFubmVy+AEBqgIXR29vZ2xlLkNsb3VkLlNwYW5uZXIuVjHK",
+            "AhdHb29nbGVcQ2xvdWRcU3Bhbm5lclxWMWIGcHJvdG8z"));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Google.Api.AnnotationsReflection.Descriptor, global::Google.Protobuf.WellKnownTypes.StructReflection.Descriptor, global::Google.Cloud.Spanner.V1.QueryPlanReflection.Descriptor, global::Google.Cloud.Spanner.V1.TransactionReflection.Descriptor, global::Google.Cloud.Spanner.V1.TypeReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.Spanner.V1.ResultSet), global::Google.Cloud.Spanner.V1.ResultSet.Parser, new[]{ "Metadata", "Rows", "Stats" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.Spanner.V1.PartialResultSet), global::Google.Cloud.Spanner.V1.PartialResultSet.Parser, new[]{ "Metadata", "Values", "ChunkedValue", "ResumeToken", "Stats" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.Spanner.V1.ResultSetMetadata), global::Google.Cloud.Spanner.V1.ResultSetMetadata.Parser, new[]{ "RowType", "Transaction" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.Spanner.V1.ResultSetStats), global::Google.Cloud.Spanner.V1.ResultSetStats.Parser, new[]{ "QueryPlan", "QueryStats" }, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.Spanner.V1.ResultSetStats), global::Google.Cloud.Spanner.V1.ResultSetStats.Parser, new[]{ "QueryPlan", "QueryStats", "RowCountExact", "RowCountLowerBound" }, new[]{ "RowCount" }, null, null)
           }));
     }
     #endregion
@@ -136,8 +137,13 @@ namespace Google.Cloud.Spanner.V1 {
     public const int StatsFieldNumber = 3;
     private global::Google.Cloud.Spanner.V1.ResultSetStats stats_;
     /// <summary>
-    /// Query plan and execution statistics for the query that produced this
-    /// result set. These can be requested by setting
+    /// Query plan and execution statistics for the SQL statement that
+    /// produced this result set. These can be requested by setting
+    /// [ExecuteSqlRequest.query_mode][google.spanner.v1.ExecuteSqlRequest.query_mode].
+    /// DML statements always produce stats containing the number of rows
+    /// modified, unless executed using the
+    /// [ExecuteSqlRequest.QueryMode.PLAN][google.spanner.v1.ExecuteSqlRequest.QueryMode.PLAN] [ExecuteSqlRequest.query_mode][google.spanner.v1.ExecuteSqlRequest.query_mode].
+    /// Other fields may or may not be populated, based on the
     /// [ExecuteSqlRequest.query_mode][google.spanner.v1.ExecuteSqlRequest.query_mode].
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -450,10 +456,12 @@ namespace Google.Cloud.Spanner.V1 {
     public const int StatsFieldNumber = 5;
     private global::Google.Cloud.Spanner.V1.ResultSetStats stats_;
     /// <summary>
-    /// Query plan and execution statistics for the query that produced this
+    /// Query plan and execution statistics for the statement that produced this
     /// streaming result set. These can be requested by setting
     /// [ExecuteSqlRequest.query_mode][google.spanner.v1.ExecuteSqlRequest.query_mode] and are sent
     /// only once with the last response in the stream.
+    /// This field will also be present in the last response for DML
+    /// statements.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public global::Google.Cloud.Spanner.V1.ResultSetStats Stats {
@@ -832,6 +840,15 @@ namespace Google.Cloud.Spanner.V1 {
     public ResultSetStats(ResultSetStats other) : this() {
       queryPlan_ = other.queryPlan_ != null ? other.queryPlan_.Clone() : null;
       queryStats_ = other.queryStats_ != null ? other.queryStats_.Clone() : null;
+      switch (other.RowCountCase) {
+        case RowCountOneofCase.RowCountExact:
+          RowCountExact = other.RowCountExact;
+          break;
+        case RowCountOneofCase.RowCountLowerBound:
+          RowCountLowerBound = other.RowCountLowerBound;
+          break;
+      }
+
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -876,6 +893,54 @@ namespace Google.Cloud.Spanner.V1 {
       }
     }
 
+    /// <summary>Field number for the "row_count_exact" field.</summary>
+    public const int RowCountExactFieldNumber = 3;
+    /// <summary>
+    /// Standard DML returns an exact count of rows that were modified.
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public long RowCountExact {
+      get { return rowCountCase_ == RowCountOneofCase.RowCountExact ? (long) rowCount_ : 0L; }
+      set {
+        rowCount_ = value;
+        rowCountCase_ = RowCountOneofCase.RowCountExact;
+      }
+    }
+
+    /// <summary>Field number for the "row_count_lower_bound" field.</summary>
+    public const int RowCountLowerBoundFieldNumber = 4;
+    /// <summary>
+    /// Partitioned DML does not offer exactly-once semantics, so it
+    /// returns a lower bound of the rows modified.
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public long RowCountLowerBound {
+      get { return rowCountCase_ == RowCountOneofCase.RowCountLowerBound ? (long) rowCount_ : 0L; }
+      set {
+        rowCount_ = value;
+        rowCountCase_ = RowCountOneofCase.RowCountLowerBound;
+      }
+    }
+
+    private object rowCount_;
+    /// <summary>Enum of possible cases for the "row_count" oneof.</summary>
+    public enum RowCountOneofCase {
+      None = 0,
+      RowCountExact = 3,
+      RowCountLowerBound = 4,
+    }
+    private RowCountOneofCase rowCountCase_ = RowCountOneofCase.None;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public RowCountOneofCase RowCountCase {
+      get { return rowCountCase_; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void ClearRowCount() {
+      rowCountCase_ = RowCountOneofCase.None;
+      rowCount_ = null;
+    }
+
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as ResultSetStats);
@@ -891,6 +956,9 @@ namespace Google.Cloud.Spanner.V1 {
       }
       if (!object.Equals(QueryPlan, other.QueryPlan)) return false;
       if (!object.Equals(QueryStats, other.QueryStats)) return false;
+      if (RowCountExact != other.RowCountExact) return false;
+      if (RowCountLowerBound != other.RowCountLowerBound) return false;
+      if (RowCountCase != other.RowCountCase) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
@@ -899,6 +967,9 @@ namespace Google.Cloud.Spanner.V1 {
       int hash = 1;
       if (queryPlan_ != null) hash ^= QueryPlan.GetHashCode();
       if (queryStats_ != null) hash ^= QueryStats.GetHashCode();
+      if (rowCountCase_ == RowCountOneofCase.RowCountExact) hash ^= RowCountExact.GetHashCode();
+      if (rowCountCase_ == RowCountOneofCase.RowCountLowerBound) hash ^= RowCountLowerBound.GetHashCode();
+      hash ^= (int) rowCountCase_;
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -920,6 +991,14 @@ namespace Google.Cloud.Spanner.V1 {
         output.WriteRawTag(18);
         output.WriteMessage(QueryStats);
       }
+      if (rowCountCase_ == RowCountOneofCase.RowCountExact) {
+        output.WriteRawTag(24);
+        output.WriteInt64(RowCountExact);
+      }
+      if (rowCountCase_ == RowCountOneofCase.RowCountLowerBound) {
+        output.WriteRawTag(32);
+        output.WriteInt64(RowCountLowerBound);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -933,6 +1012,12 @@ namespace Google.Cloud.Spanner.V1 {
       }
       if (queryStats_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(QueryStats);
+      }
+      if (rowCountCase_ == RowCountOneofCase.RowCountExact) {
+        size += 1 + pb::CodedOutputStream.ComputeInt64Size(RowCountExact);
+      }
+      if (rowCountCase_ == RowCountOneofCase.RowCountLowerBound) {
+        size += 1 + pb::CodedOutputStream.ComputeInt64Size(RowCountLowerBound);
       }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
@@ -957,6 +1042,15 @@ namespace Google.Cloud.Spanner.V1 {
         }
         QueryStats.MergeFrom(other.QueryStats);
       }
+      switch (other.RowCountCase) {
+        case RowCountOneofCase.RowCountExact:
+          RowCountExact = other.RowCountExact;
+          break;
+        case RowCountOneofCase.RowCountLowerBound:
+          RowCountLowerBound = other.RowCountLowerBound;
+          break;
+      }
+
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
 
@@ -980,6 +1074,14 @@ namespace Google.Cloud.Spanner.V1 {
               queryStats_ = new global::Google.Protobuf.WellKnownTypes.Struct();
             }
             input.ReadMessage(queryStats_);
+            break;
+          }
+          case 24: {
+            RowCountExact = input.ReadInt64();
+            break;
+          }
+          case 32: {
+            RowCountLowerBound = input.ReadInt64();
             break;
           }
         }

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Spanner.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Spanner.cs
@@ -44,7 +44,7 @@ namespace Google.Cloud.Spanner.V1 {
             "EgoKcGFnZV90b2tlbhgDIAEoCRIOCgZmaWx0ZXIYBCABKAkiXQoUTGlzdFNl",
             "c3Npb25zUmVzcG9uc2USLAoIc2Vzc2lvbnMYASADKAsyGi5nb29nbGUuc3Bh",
             "bm5lci52MS5TZXNzaW9uEhcKD25leHRfcGFnZV90b2tlbhgCIAEoCSIkChRE",
-            "ZWxldGVTZXNzaW9uUmVxdWVzdBIMCgRuYW1lGAEgASgJItEDChFFeGVjdXRl",
+            "ZWxldGVTZXNzaW9uUmVxdWVzdBIMCgRuYW1lGAEgASgJIuADChFFeGVjdXRl",
             "U3FsUmVxdWVzdBIPCgdzZXNzaW9uGAEgASgJEjsKC3RyYW5zYWN0aW9uGAIg",
             "ASgLMiYuZ29vZ2xlLnNwYW5uZXIudjEuVHJhbnNhY3Rpb25TZWxlY3RvchIL",
             "CgNzcWwYAyABKAkSJwoGcGFyYW1zGAQgASgLMhcuZ29vZ2xlLnByb3RvYnVm",
@@ -52,96 +52,96 @@ namespace Google.Cloud.Spanner.V1 {
             "LnYxLkV4ZWN1dGVTcWxSZXF1ZXN0LlBhcmFtVHlwZXNFbnRyeRIUCgxyZXN1",
             "bWVfdG9rZW4YBiABKAwSQgoKcXVlcnlfbW9kZRgHIAEoDjIuLmdvb2dsZS5z",
             "cGFubmVyLnYxLkV4ZWN1dGVTcWxSZXF1ZXN0LlF1ZXJ5TW9kZRIXCg9wYXJ0",
-            "aXRpb25fdG9rZW4YCCABKAwaSgoPUGFyYW1UeXBlc0VudHJ5EgsKA2tleRgB",
-            "IAEoCRImCgV2YWx1ZRgCIAEoCzIXLmdvb2dsZS5zcGFubmVyLnYxLlR5cGU6",
-            "AjgBIi4KCVF1ZXJ5TW9kZRIKCgZOT1JNQUwQABIICgRQTEFOEAESCwoHUFJP",
-            "RklMRRACIkgKEFBhcnRpdGlvbk9wdGlvbnMSHAoUcGFydGl0aW9uX3NpemVf",
-            "Ynl0ZXMYASABKAMSFgoObWF4X3BhcnRpdGlvbnMYAiABKAMi9gIKFVBhcnRp",
-            "dGlvblF1ZXJ5UmVxdWVzdBIPCgdzZXNzaW9uGAEgASgJEjsKC3RyYW5zYWN0",
-            "aW9uGAIgASgLMiYuZ29vZ2xlLnNwYW5uZXIudjEuVHJhbnNhY3Rpb25TZWxl",
-            "Y3RvchILCgNzcWwYAyABKAkSJwoGcGFyYW1zGAQgASgLMhcuZ29vZ2xlLnBy",
-            "b3RvYnVmLlN0cnVjdBJNCgtwYXJhbV90eXBlcxgFIAMoCzI4Lmdvb2dsZS5z",
-            "cGFubmVyLnYxLlBhcnRpdGlvblF1ZXJ5UmVxdWVzdC5QYXJhbVR5cGVzRW50",
-            "cnkSPgoRcGFydGl0aW9uX29wdGlvbnMYBiABKAsyIy5nb29nbGUuc3Bhbm5l",
-            "ci52MS5QYXJ0aXRpb25PcHRpb25zGkoKD1BhcmFtVHlwZXNFbnRyeRILCgNr",
-            "ZXkYASABKAkSJgoFdmFsdWUYAiABKAsyFy5nb29nbGUuc3Bhbm5lci52MS5U",
-            "eXBlOgI4ASL/AQoUUGFydGl0aW9uUmVhZFJlcXVlc3QSDwoHc2Vzc2lvbhgB",
-            "IAEoCRI7Cgt0cmFuc2FjdGlvbhgCIAEoCzImLmdvb2dsZS5zcGFubmVyLnYx",
-            "LlRyYW5zYWN0aW9uU2VsZWN0b3ISDQoFdGFibGUYAyABKAkSDQoFaW5kZXgY",
-            "BCABKAkSDwoHY29sdW1ucxgFIAMoCRIqCgdrZXlfc2V0GAYgASgLMhkuZ29v",
-            "Z2xlLnNwYW5uZXIudjEuS2V5U2V0Ej4KEXBhcnRpdGlvbl9vcHRpb25zGAkg",
-            "ASgLMiMuZ29vZ2xlLnNwYW5uZXIudjEuUGFydGl0aW9uT3B0aW9ucyIkCglQ",
-            "YXJ0aXRpb24SFwoPcGFydGl0aW9uX3Rva2VuGAEgASgMInoKEVBhcnRpdGlv",
-            "blJlc3BvbnNlEjAKCnBhcnRpdGlvbnMYASADKAsyHC5nb29nbGUuc3Bhbm5l",
-            "ci52MS5QYXJ0aXRpb24SMwoLdHJhbnNhY3Rpb24YAiABKAsyHi5nb29nbGUu",
-            "c3Bhbm5lci52MS5UcmFuc2FjdGlvbiL0AQoLUmVhZFJlcXVlc3QSDwoHc2Vz",
-            "c2lvbhgBIAEoCRI7Cgt0cmFuc2FjdGlvbhgCIAEoCzImLmdvb2dsZS5zcGFu",
-            "bmVyLnYxLlRyYW5zYWN0aW9uU2VsZWN0b3ISDQoFdGFibGUYAyABKAkSDQoF",
-            "aW5kZXgYBCABKAkSDwoHY29sdW1ucxgFIAMoCRIqCgdrZXlfc2V0GAYgASgL",
-            "MhkuZ29vZ2xlLnNwYW5uZXIudjEuS2V5U2V0Eg0KBWxpbWl0GAggASgDEhQK",
-            "DHJlc3VtZV90b2tlbhgJIAEoDBIXCg9wYXJ0aXRpb25fdG9rZW4YCiABKAwi",
-            "YgoXQmVnaW5UcmFuc2FjdGlvblJlcXVlc3QSDwoHc2Vzc2lvbhgBIAEoCRI2",
-            "CgdvcHRpb25zGAIgASgLMiUuZ29vZ2xlLnNwYW5uZXIudjEuVHJhbnNhY3Rp",
-            "b25PcHRpb25zIsIBCg1Db21taXRSZXF1ZXN0Eg8KB3Nlc3Npb24YASABKAkS",
-            "GAoOdHJhbnNhY3Rpb25faWQYAiABKAxIABJHChZzaW5nbGVfdXNlX3RyYW5z",
-            "YWN0aW9uGAMgASgLMiUuZ29vZ2xlLnNwYW5uZXIudjEuVHJhbnNhY3Rpb25P",
-            "cHRpb25zSAASLgoJbXV0YXRpb25zGAQgAygLMhsuZ29vZ2xlLnNwYW5uZXIu",
-            "djEuTXV0YXRpb25CDQoLdHJhbnNhY3Rpb24iRgoOQ29tbWl0UmVzcG9uc2US",
-            "NAoQY29tbWl0X3RpbWVzdGFtcBgBIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5U",
-            "aW1lc3RhbXAiOgoPUm9sbGJhY2tSZXF1ZXN0Eg8KB3Nlc3Npb24YASABKAkS",
-            "FgoOdHJhbnNhY3Rpb25faWQYAiABKAwygxEKB1NwYW5uZXISmwEKDUNyZWF0",
-            "ZVNlc3Npb24SJy5nb29nbGUuc3Bhbm5lci52MS5DcmVhdGVTZXNzaW9uUmVx",
-            "dWVzdBoaLmdvb2dsZS5zcGFubmVyLnYxLlNlc3Npb24iRYLT5JMCPyI6L3Yx",
-            "L3tkYXRhYmFzZT1wcm9qZWN0cy8qL2luc3RhbmNlcy8qL2RhdGFiYXNlcy8q",
-            "fS9zZXNzaW9uczoBKhKQAQoKR2V0U2Vzc2lvbhIkLmdvb2dsZS5zcGFubmVy",
-            "LnYxLkdldFNlc3Npb25SZXF1ZXN0GhouZ29vZ2xlLnNwYW5uZXIudjEuU2Vz",
-            "c2lvbiJAgtPkkwI6EjgvdjEve25hbWU9cHJvamVjdHMvKi9pbnN0YW5jZXMv",
-            "Ki9kYXRhYmFzZXMvKi9zZXNzaW9ucy8qfRKjAQoMTGlzdFNlc3Npb25zEiYu",
-            "Z29vZ2xlLnNwYW5uZXIudjEuTGlzdFNlc3Npb25zUmVxdWVzdBonLmdvb2ds",
-            "ZS5zcGFubmVyLnYxLkxpc3RTZXNzaW9uc1Jlc3BvbnNlIkKC0+STAjwSOi92",
-            "MS97ZGF0YWJhc2U9cHJvamVjdHMvKi9pbnN0YW5jZXMvKi9kYXRhYmFzZXMv",
-            "Kn0vc2Vzc2lvbnMSkgEKDURlbGV0ZVNlc3Npb24SJy5nb29nbGUuc3Bhbm5l",
-            "ci52MS5EZWxldGVTZXNzaW9uUmVxdWVzdBoWLmdvb2dsZS5wcm90b2J1Zi5F",
-            "bXB0eSJAgtPkkwI6KjgvdjEve25hbWU9cHJvamVjdHMvKi9pbnN0YW5jZXMv",
-            "Ki9kYXRhYmFzZXMvKi9zZXNzaW9ucy8qfRKjAQoKRXhlY3V0ZVNxbBIkLmdv",
-            "b2dsZS5zcGFubmVyLnYxLkV4ZWN1dGVTcWxSZXF1ZXN0GhwuZ29vZ2xlLnNw",
-            "YW5uZXIudjEuUmVzdWx0U2V0IlGC0+STAksiRi92MS97c2Vzc2lvbj1wcm9q",
-            "ZWN0cy8qL2luc3RhbmNlcy8qL2RhdGFiYXNlcy8qL3Nlc3Npb25zLyp9OmV4",
-            "ZWN1dGVTcWw6ASoSvgEKE0V4ZWN1dGVTdHJlYW1pbmdTcWwSJC5nb29nbGUu",
-            "c3Bhbm5lci52MS5FeGVjdXRlU3FsUmVxdWVzdBojLmdvb2dsZS5zcGFubmVy",
-            "LnYxLlBhcnRpYWxSZXN1bHRTZXQiWoLT5JMCVCJPL3YxL3tzZXNzaW9uPXBy",
+            "aXRpb25fdG9rZW4YCCABKAwSDQoFc2Vxbm8YCSABKAMaSgoPUGFyYW1UeXBl",
+            "c0VudHJ5EgsKA2tleRgBIAEoCRImCgV2YWx1ZRgCIAEoCzIXLmdvb2dsZS5z",
+            "cGFubmVyLnYxLlR5cGU6AjgBIi4KCVF1ZXJ5TW9kZRIKCgZOT1JNQUwQABII",
+            "CgRQTEFOEAESCwoHUFJPRklMRRACIkgKEFBhcnRpdGlvbk9wdGlvbnMSHAoU",
+            "cGFydGl0aW9uX3NpemVfYnl0ZXMYASABKAMSFgoObWF4X3BhcnRpdGlvbnMY",
+            "AiABKAMi9gIKFVBhcnRpdGlvblF1ZXJ5UmVxdWVzdBIPCgdzZXNzaW9uGAEg",
+            "ASgJEjsKC3RyYW5zYWN0aW9uGAIgASgLMiYuZ29vZ2xlLnNwYW5uZXIudjEu",
+            "VHJhbnNhY3Rpb25TZWxlY3RvchILCgNzcWwYAyABKAkSJwoGcGFyYW1zGAQg",
+            "ASgLMhcuZ29vZ2xlLnByb3RvYnVmLlN0cnVjdBJNCgtwYXJhbV90eXBlcxgF",
+            "IAMoCzI4Lmdvb2dsZS5zcGFubmVyLnYxLlBhcnRpdGlvblF1ZXJ5UmVxdWVz",
+            "dC5QYXJhbVR5cGVzRW50cnkSPgoRcGFydGl0aW9uX29wdGlvbnMYBiABKAsy",
+            "Iy5nb29nbGUuc3Bhbm5lci52MS5QYXJ0aXRpb25PcHRpb25zGkoKD1BhcmFt",
+            "VHlwZXNFbnRyeRILCgNrZXkYASABKAkSJgoFdmFsdWUYAiABKAsyFy5nb29n",
+            "bGUuc3Bhbm5lci52MS5UeXBlOgI4ASL/AQoUUGFydGl0aW9uUmVhZFJlcXVl",
+            "c3QSDwoHc2Vzc2lvbhgBIAEoCRI7Cgt0cmFuc2FjdGlvbhgCIAEoCzImLmdv",
+            "b2dsZS5zcGFubmVyLnYxLlRyYW5zYWN0aW9uU2VsZWN0b3ISDQoFdGFibGUY",
+            "AyABKAkSDQoFaW5kZXgYBCABKAkSDwoHY29sdW1ucxgFIAMoCRIqCgdrZXlf",
+            "c2V0GAYgASgLMhkuZ29vZ2xlLnNwYW5uZXIudjEuS2V5U2V0Ej4KEXBhcnRp",
+            "dGlvbl9vcHRpb25zGAkgASgLMiMuZ29vZ2xlLnNwYW5uZXIudjEuUGFydGl0",
+            "aW9uT3B0aW9ucyIkCglQYXJ0aXRpb24SFwoPcGFydGl0aW9uX3Rva2VuGAEg",
+            "ASgMInoKEVBhcnRpdGlvblJlc3BvbnNlEjAKCnBhcnRpdGlvbnMYASADKAsy",
+            "HC5nb29nbGUuc3Bhbm5lci52MS5QYXJ0aXRpb24SMwoLdHJhbnNhY3Rpb24Y",
+            "AiABKAsyHi5nb29nbGUuc3Bhbm5lci52MS5UcmFuc2FjdGlvbiL0AQoLUmVh",
+            "ZFJlcXVlc3QSDwoHc2Vzc2lvbhgBIAEoCRI7Cgt0cmFuc2FjdGlvbhgCIAEo",
+            "CzImLmdvb2dsZS5zcGFubmVyLnYxLlRyYW5zYWN0aW9uU2VsZWN0b3ISDQoF",
+            "dGFibGUYAyABKAkSDQoFaW5kZXgYBCABKAkSDwoHY29sdW1ucxgFIAMoCRIq",
+            "CgdrZXlfc2V0GAYgASgLMhkuZ29vZ2xlLnNwYW5uZXIudjEuS2V5U2V0Eg0K",
+            "BWxpbWl0GAggASgDEhQKDHJlc3VtZV90b2tlbhgJIAEoDBIXCg9wYXJ0aXRp",
+            "b25fdG9rZW4YCiABKAwiYgoXQmVnaW5UcmFuc2FjdGlvblJlcXVlc3QSDwoH",
+            "c2Vzc2lvbhgBIAEoCRI2CgdvcHRpb25zGAIgASgLMiUuZ29vZ2xlLnNwYW5u",
+            "ZXIudjEuVHJhbnNhY3Rpb25PcHRpb25zIsIBCg1Db21taXRSZXF1ZXN0Eg8K",
+            "B3Nlc3Npb24YASABKAkSGAoOdHJhbnNhY3Rpb25faWQYAiABKAxIABJHChZz",
+            "aW5nbGVfdXNlX3RyYW5zYWN0aW9uGAMgASgLMiUuZ29vZ2xlLnNwYW5uZXIu",
+            "djEuVHJhbnNhY3Rpb25PcHRpb25zSAASLgoJbXV0YXRpb25zGAQgAygLMhsu",
+            "Z29vZ2xlLnNwYW5uZXIudjEuTXV0YXRpb25CDQoLdHJhbnNhY3Rpb24iRgoO",
+            "Q29tbWl0UmVzcG9uc2USNAoQY29tbWl0X3RpbWVzdGFtcBgBIAEoCzIaLmdv",
+            "b2dsZS5wcm90b2J1Zi5UaW1lc3RhbXAiOgoPUm9sbGJhY2tSZXF1ZXN0Eg8K",
+            "B3Nlc3Npb24YASABKAkSFgoOdHJhbnNhY3Rpb25faWQYAiABKAwygxEKB1Nw",
+            "YW5uZXISmwEKDUNyZWF0ZVNlc3Npb24SJy5nb29nbGUuc3Bhbm5lci52MS5D",
+            "cmVhdGVTZXNzaW9uUmVxdWVzdBoaLmdvb2dsZS5zcGFubmVyLnYxLlNlc3Np",
+            "b24iRYLT5JMCPyI6L3YxL3tkYXRhYmFzZT1wcm9qZWN0cy8qL2luc3RhbmNl",
+            "cy8qL2RhdGFiYXNlcy8qfS9zZXNzaW9uczoBKhKQAQoKR2V0U2Vzc2lvbhIk",
+            "Lmdvb2dsZS5zcGFubmVyLnYxLkdldFNlc3Npb25SZXF1ZXN0GhouZ29vZ2xl",
+            "LnNwYW5uZXIudjEuU2Vzc2lvbiJAgtPkkwI6EjgvdjEve25hbWU9cHJvamVj",
+            "dHMvKi9pbnN0YW5jZXMvKi9kYXRhYmFzZXMvKi9zZXNzaW9ucy8qfRKjAQoM",
+            "TGlzdFNlc3Npb25zEiYuZ29vZ2xlLnNwYW5uZXIudjEuTGlzdFNlc3Npb25z",
+            "UmVxdWVzdBonLmdvb2dsZS5zcGFubmVyLnYxLkxpc3RTZXNzaW9uc1Jlc3Bv",
+            "bnNlIkKC0+STAjwSOi92MS97ZGF0YWJhc2U9cHJvamVjdHMvKi9pbnN0YW5j",
+            "ZXMvKi9kYXRhYmFzZXMvKn0vc2Vzc2lvbnMSkgEKDURlbGV0ZVNlc3Npb24S",
+            "Jy5nb29nbGUuc3Bhbm5lci52MS5EZWxldGVTZXNzaW9uUmVxdWVzdBoWLmdv",
+            "b2dsZS5wcm90b2J1Zi5FbXB0eSJAgtPkkwI6KjgvdjEve25hbWU9cHJvamVj",
+            "dHMvKi9pbnN0YW5jZXMvKi9kYXRhYmFzZXMvKi9zZXNzaW9ucy8qfRKjAQoK",
+            "RXhlY3V0ZVNxbBIkLmdvb2dsZS5zcGFubmVyLnYxLkV4ZWN1dGVTcWxSZXF1",
+            "ZXN0GhwuZ29vZ2xlLnNwYW5uZXIudjEuUmVzdWx0U2V0IlGC0+STAksiRi92",
+            "MS97c2Vzc2lvbj1wcm9qZWN0cy8qL2luc3RhbmNlcy8qL2RhdGFiYXNlcy8q",
+            "L3Nlc3Npb25zLyp9OmV4ZWN1dGVTcWw6ASoSvgEKE0V4ZWN1dGVTdHJlYW1p",
+            "bmdTcWwSJC5nb29nbGUuc3Bhbm5lci52MS5FeGVjdXRlU3FsUmVxdWVzdBoj",
+            "Lmdvb2dsZS5zcGFubmVyLnYxLlBhcnRpYWxSZXN1bHRTZXQiWoLT5JMCVCJP",
+            "L3YxL3tzZXNzaW9uPXByb2plY3RzLyovaW5zdGFuY2VzLyovZGF0YWJhc2Vz",
+            "Lyovc2Vzc2lvbnMvKn06ZXhlY3V0ZVN0cmVhbWluZ1NxbDoBKjABEpEBCgRS",
+            "ZWFkEh4uZ29vZ2xlLnNwYW5uZXIudjEuUmVhZFJlcXVlc3QaHC5nb29nbGUu",
+            "c3Bhbm5lci52MS5SZXN1bHRTZXQiS4LT5JMCRSJAL3YxL3tzZXNzaW9uPXBy",
             "b2plY3RzLyovaW5zdGFuY2VzLyovZGF0YWJhc2VzLyovc2Vzc2lvbnMvKn06",
-            "ZXhlY3V0ZVN0cmVhbWluZ1NxbDoBKjABEpEBCgRSZWFkEh4uZ29vZ2xlLnNw",
-            "YW5uZXIudjEuUmVhZFJlcXVlc3QaHC5nb29nbGUuc3Bhbm5lci52MS5SZXN1",
-            "bHRTZXQiS4LT5JMCRSJAL3YxL3tzZXNzaW9uPXByb2plY3RzLyovaW5zdGFu",
-            "Y2VzLyovZGF0YWJhc2VzLyovc2Vzc2lvbnMvKn06cmVhZDoBKhKsAQoNU3Ry",
-            "ZWFtaW5nUmVhZBIeLmdvb2dsZS5zcGFubmVyLnYxLlJlYWRSZXF1ZXN0GiMu",
-            "Z29vZ2xlLnNwYW5uZXIudjEuUGFydGlhbFJlc3VsdFNldCJUgtPkkwJOIkkv",
-            "djEve3Nlc3Npb249cHJvamVjdHMvKi9pbnN0YW5jZXMvKi9kYXRhYmFzZXMv",
-            "Ki9zZXNzaW9ucy8qfTpzdHJlYW1pbmdSZWFkOgEqMAEStwEKEEJlZ2luVHJh",
-            "bnNhY3Rpb24SKi5nb29nbGUuc3Bhbm5lci52MS5CZWdpblRyYW5zYWN0aW9u",
-            "UmVxdWVzdBoeLmdvb2dsZS5zcGFubmVyLnYxLlRyYW5zYWN0aW9uIleC0+ST",
-            "AlEiTC92MS97c2Vzc2lvbj1wcm9qZWN0cy8qL2luc3RhbmNlcy8qL2RhdGFi",
-            "YXNlcy8qL3Nlc3Npb25zLyp9OmJlZ2luVHJhbnNhY3Rpb246ASoSnAEKBkNv",
-            "bW1pdBIgLmdvb2dsZS5zcGFubmVyLnYxLkNvbW1pdFJlcXVlc3QaIS5nb29n",
-            "bGUuc3Bhbm5lci52MS5Db21taXRSZXNwb25zZSJNgtPkkwJHIkIvdjEve3Nl",
-            "c3Npb249cHJvamVjdHMvKi9pbnN0YW5jZXMvKi9kYXRhYmFzZXMvKi9zZXNz",
-            "aW9ucy8qfTpjb21taXQ6ASoSlwEKCFJvbGxiYWNrEiIuZ29vZ2xlLnNwYW5u",
-            "ZXIudjEuUm9sbGJhY2tSZXF1ZXN0GhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5",
-            "Ik+C0+STAkkiRC92MS97c2Vzc2lvbj1wcm9qZWN0cy8qL2luc3RhbmNlcy8q",
-            "L2RhdGFiYXNlcy8qL3Nlc3Npb25zLyp9OnJvbGxiYWNrOgEqErcBCg5QYXJ0",
-            "aXRpb25RdWVyeRIoLmdvb2dsZS5zcGFubmVyLnYxLlBhcnRpdGlvblF1ZXJ5",
-            "UmVxdWVzdBokLmdvb2dsZS5zcGFubmVyLnYxLlBhcnRpdGlvblJlc3BvbnNl",
-            "IlWC0+STAk8iSi92MS97c2Vzc2lvbj1wcm9qZWN0cy8qL2luc3RhbmNlcy8q",
-            "L2RhdGFiYXNlcy8qL3Nlc3Npb25zLyp9OnBhcnRpdGlvblF1ZXJ5OgEqErQB",
-            "Cg1QYXJ0aXRpb25SZWFkEicuZ29vZ2xlLnNwYW5uZXIudjEuUGFydGl0aW9u",
-            "UmVhZFJlcXVlc3QaJC5nb29nbGUuc3Bhbm5lci52MS5QYXJ0aXRpb25SZXNw",
-            "b25zZSJUgtPkkwJOIkkvdjEve3Nlc3Npb249cHJvamVjdHMvKi9pbnN0YW5j",
-            "ZXMvKi9kYXRhYmFzZXMvKi9zZXNzaW9ucy8qfTpwYXJ0aXRpb25SZWFkOgEq",
-            "QpUBChVjb20uZ29vZ2xlLnNwYW5uZXIudjFCDFNwYW5uZXJQcm90b1ABWjhn",
-            "b29nbGUuZ29sYW5nLm9yZy9nZW5wcm90by9nb29nbGVhcGlzL3NwYW5uZXIv",
-            "djE7c3Bhbm5lcqoCF0dvb2dsZS5DbG91ZC5TcGFubmVyLlYxygIXR29vZ2xl",
-            "XENsb3VkXFNwYW5uZXJcVjFiBnByb3RvMw=="));
+            "cmVhZDoBKhKsAQoNU3RyZWFtaW5nUmVhZBIeLmdvb2dsZS5zcGFubmVyLnYx",
+            "LlJlYWRSZXF1ZXN0GiMuZ29vZ2xlLnNwYW5uZXIudjEuUGFydGlhbFJlc3Vs",
+            "dFNldCJUgtPkkwJOIkkvdjEve3Nlc3Npb249cHJvamVjdHMvKi9pbnN0YW5j",
+            "ZXMvKi9kYXRhYmFzZXMvKi9zZXNzaW9ucy8qfTpzdHJlYW1pbmdSZWFkOgEq",
+            "MAEStwEKEEJlZ2luVHJhbnNhY3Rpb24SKi5nb29nbGUuc3Bhbm5lci52MS5C",
+            "ZWdpblRyYW5zYWN0aW9uUmVxdWVzdBoeLmdvb2dsZS5zcGFubmVyLnYxLlRy",
+            "YW5zYWN0aW9uIleC0+STAlEiTC92MS97c2Vzc2lvbj1wcm9qZWN0cy8qL2lu",
+            "c3RhbmNlcy8qL2RhdGFiYXNlcy8qL3Nlc3Npb25zLyp9OmJlZ2luVHJhbnNh",
+            "Y3Rpb246ASoSnAEKBkNvbW1pdBIgLmdvb2dsZS5zcGFubmVyLnYxLkNvbW1p",
+            "dFJlcXVlc3QaIS5nb29nbGUuc3Bhbm5lci52MS5Db21taXRSZXNwb25zZSJN",
+            "gtPkkwJHIkIvdjEve3Nlc3Npb249cHJvamVjdHMvKi9pbnN0YW5jZXMvKi9k",
+            "YXRhYmFzZXMvKi9zZXNzaW9ucy8qfTpjb21taXQ6ASoSlwEKCFJvbGxiYWNr",
+            "EiIuZ29vZ2xlLnNwYW5uZXIudjEuUm9sbGJhY2tSZXF1ZXN0GhYuZ29vZ2xl",
+            "LnByb3RvYnVmLkVtcHR5Ik+C0+STAkkiRC92MS97c2Vzc2lvbj1wcm9qZWN0",
+            "cy8qL2luc3RhbmNlcy8qL2RhdGFiYXNlcy8qL3Nlc3Npb25zLyp9OnJvbGxi",
+            "YWNrOgEqErcBCg5QYXJ0aXRpb25RdWVyeRIoLmdvb2dsZS5zcGFubmVyLnYx",
+            "LlBhcnRpdGlvblF1ZXJ5UmVxdWVzdBokLmdvb2dsZS5zcGFubmVyLnYxLlBh",
+            "cnRpdGlvblJlc3BvbnNlIlWC0+STAk8iSi92MS97c2Vzc2lvbj1wcm9qZWN0",
+            "cy8qL2luc3RhbmNlcy8qL2RhdGFiYXNlcy8qL3Nlc3Npb25zLyp9OnBhcnRp",
+            "dGlvblF1ZXJ5OgEqErQBCg1QYXJ0aXRpb25SZWFkEicuZ29vZ2xlLnNwYW5u",
+            "ZXIudjEuUGFydGl0aW9uUmVhZFJlcXVlc3QaJC5nb29nbGUuc3Bhbm5lci52",
+            "MS5QYXJ0aXRpb25SZXNwb25zZSJUgtPkkwJOIkkvdjEve3Nlc3Npb249cHJv",
+            "amVjdHMvKi9pbnN0YW5jZXMvKi9kYXRhYmFzZXMvKi9zZXNzaW9ucy8qfTpw",
+            "YXJ0aXRpb25SZWFkOgEqQpUBChVjb20uZ29vZ2xlLnNwYW5uZXIudjFCDFNw",
+            "YW5uZXJQcm90b1ABWjhnb29nbGUuZ29sYW5nLm9yZy9nZW5wcm90by9nb29n",
+            "bGVhcGlzL3NwYW5uZXIvdjE7c3Bhbm5lcqoCF0dvb2dsZS5DbG91ZC5TcGFu",
+            "bmVyLlYxygIXR29vZ2xlXENsb3VkXFNwYW5uZXJcVjFiBnByb3RvMw=="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Google.Api.AnnotationsReflection.Descriptor, global::Google.Protobuf.WellKnownTypes.EmptyReflection.Descriptor, global::Google.Protobuf.WellKnownTypes.StructReflection.Descriptor, global::Google.Protobuf.WellKnownTypes.TimestampReflection.Descriptor, global::Google.Cloud.Spanner.V1.KeysReflection.Descriptor, global::Google.Cloud.Spanner.V1.MutationReflection.Descriptor, global::Google.Cloud.Spanner.V1.ResultSetReflection.Descriptor, global::Google.Cloud.Spanner.V1.TransactionReflection.Descriptor, global::Google.Cloud.Spanner.V1.TypeReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
@@ -151,7 +151,7 @@ namespace Google.Cloud.Spanner.V1 {
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.Spanner.V1.ListSessionsRequest), global::Google.Cloud.Spanner.V1.ListSessionsRequest.Parser, new[]{ "Database", "PageSize", "PageToken", "Filter" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.Spanner.V1.ListSessionsResponse), global::Google.Cloud.Spanner.V1.ListSessionsResponse.Parser, new[]{ "Sessions", "NextPageToken" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.Spanner.V1.DeleteSessionRequest), global::Google.Cloud.Spanner.V1.DeleteSessionRequest.Parser, new[]{ "Name" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.Spanner.V1.ExecuteSqlRequest), global::Google.Cloud.Spanner.V1.ExecuteSqlRequest.Parser, new[]{ "Session", "Transaction", "Sql", "Params", "ParamTypes", "ResumeToken", "QueryMode", "PartitionToken" }, null, new[]{ typeof(global::Google.Cloud.Spanner.V1.ExecuteSqlRequest.Types.QueryMode) }, new pbr::GeneratedClrTypeInfo[] { null, }),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.Spanner.V1.ExecuteSqlRequest), global::Google.Cloud.Spanner.V1.ExecuteSqlRequest.Parser, new[]{ "Session", "Transaction", "Sql", "Params", "ParamTypes", "ResumeToken", "QueryMode", "PartitionToken", "Seqno" }, null, new[]{ typeof(global::Google.Cloud.Spanner.V1.ExecuteSqlRequest.Types.QueryMode) }, new pbr::GeneratedClrTypeInfo[] { null, }),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.Spanner.V1.PartitionOptions), global::Google.Cloud.Spanner.V1.PartitionOptions.Parser, new[]{ "PartitionSizeBytes", "MaxPartitions" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.Spanner.V1.PartitionQueryRequest), global::Google.Cloud.Spanner.V1.PartitionQueryRequest.Parser, new[]{ "Session", "Transaction", "Sql", "Params", "ParamTypes", "PartitionOptions" }, null, null, new pbr::GeneratedClrTypeInfo[] { null, }),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.Spanner.V1.PartitionReadRequest), global::Google.Cloud.Spanner.V1.PartitionReadRequest.Parser, new[]{ "Session", "Transaction", "Table", "Index", "Columns", "KeySet", "PartitionOptions" }, null, null, null),
@@ -1289,6 +1289,7 @@ namespace Google.Cloud.Spanner.V1 {
       resumeToken_ = other.resumeToken_;
       queryMode_ = other.queryMode_;
       partitionToken_ = other.partitionToken_;
+      seqno_ = other.seqno_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -1317,6 +1318,17 @@ namespace Google.Cloud.Spanner.V1 {
     /// <summary>
     /// The transaction to use. If none is provided, the default is a
     /// temporary read-only transaction with strong concurrency.
+    ///
+    /// The transaction to use.
+    ///
+    /// For queries, if none is provided, the default is a temporary read-only
+    /// transaction with strong concurrency.
+    ///
+    /// Standard DML statements require a ReadWrite transaction. Single-use
+    /// transactions are not supported (to avoid replay).  The caller must
+    /// either supply an existing transaction ID or begin a new transaction.
+    ///
+    /// Partitioned DML requires an existing PartitionedDml transaction ID.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public global::Google.Cloud.Spanner.V1.TransactionSelector Transaction {
@@ -1330,7 +1342,7 @@ namespace Google.Cloud.Spanner.V1 {
     public const int SqlFieldNumber = 3;
     private string sql_ = "";
     /// <summary>
-    /// Required. The SQL query string.
+    /// Required. The SQL string.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public string Sql {
@@ -1344,7 +1356,7 @@ namespace Google.Cloud.Spanner.V1 {
     public const int ParamsFieldNumber = 4;
     private global::Google.Protobuf.WellKnownTypes.Struct params_;
     /// <summary>
-    /// The SQL query string can contain parameter placeholders. A parameter
+    /// The SQL string can contain parameter placeholders. A parameter
     /// placeholder consists of `'@'` followed by the parameter
     /// name. Parameter names consist of any combination of letters,
     /// numbers, and underscores.
@@ -1353,7 +1365,7 @@ namespace Google.Cloud.Spanner.V1 {
     /// parameter name can be used more than once, for example:
     ///   `"WHERE id > @msg_id AND id &lt; @msg_id + 100"`
     ///
-    /// It is an error to execute an SQL query with unbound parameters.
+    /// It is an error to execute an SQL statement with unbound parameters.
     ///
     /// Parameter values are specified using `params`, which is a JSON
     /// object whose keys are parameter names, and whose values are the
@@ -1378,7 +1390,7 @@ namespace Google.Cloud.Spanner.V1 {
     /// of type `STRING` both appear in [params][google.spanner.v1.ExecuteSqlRequest.params] as JSON strings.
     ///
     /// In these cases, `param_types` can be used to specify the exact
-    /// SQL type for some or all of the SQL query parameters. See the
+    /// SQL type for some or all of the SQL statement parameters. See the
     /// definition of [Type][google.spanner.v1.Type] for more information
     /// about SQL types.
     /// </summary>
@@ -1391,10 +1403,10 @@ namespace Google.Cloud.Spanner.V1 {
     public const int ResumeTokenFieldNumber = 6;
     private pb::ByteString resumeToken_ = pb::ByteString.Empty;
     /// <summary>
-    /// If this request is resuming a previously interrupted SQL query
+    /// If this request is resuming a previously interrupted SQL statement
     /// execution, `resume_token` should be copied from the last
     /// [PartialResultSet][google.spanner.v1.PartialResultSet] yielded before the interruption. Doing this
-    /// enables the new SQL query execution to resume where the last one left
+    /// enables the new SQL statement execution to resume where the last one left
     /// off. The rest of the request parameters must exactly match the
     /// request that yielded this token.
     /// </summary>
@@ -1439,6 +1451,29 @@ namespace Google.Cloud.Spanner.V1 {
       }
     }
 
+    /// <summary>Field number for the "seqno" field.</summary>
+    public const int SeqnoFieldNumber = 9;
+    private long seqno_;
+    /// <summary>
+    /// A per-transaction sequence number used to identify this request. This
+    /// makes each request idempotent such that if the request is received multiple
+    /// times, at most one will succeed.
+    ///
+    /// The sequence number must be monotonically increasing within the
+    /// transaction. If a request arrives for the first time with an out-of-order
+    /// sequence number, the transaction may be aborted. Replays of previously
+    /// handled requests will yield the same response as the first execution.
+    ///
+    /// Required for DML statements. Ignored for queries.
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public long Seqno {
+      get { return seqno_; }
+      set {
+        seqno_ = value;
+      }
+    }
+
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as ExecuteSqlRequest);
@@ -1460,6 +1495,7 @@ namespace Google.Cloud.Spanner.V1 {
       if (ResumeToken != other.ResumeToken) return false;
       if (QueryMode != other.QueryMode) return false;
       if (PartitionToken != other.PartitionToken) return false;
+      if (Seqno != other.Seqno) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
@@ -1474,6 +1510,7 @@ namespace Google.Cloud.Spanner.V1 {
       if (ResumeToken.Length != 0) hash ^= ResumeToken.GetHashCode();
       if (QueryMode != 0) hash ^= QueryMode.GetHashCode();
       if (PartitionToken.Length != 0) hash ^= PartitionToken.GetHashCode();
+      if (Seqno != 0L) hash ^= Seqno.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -1516,6 +1553,10 @@ namespace Google.Cloud.Spanner.V1 {
         output.WriteRawTag(66);
         output.WriteBytes(PartitionToken);
       }
+      if (Seqno != 0L) {
+        output.WriteRawTag(72);
+        output.WriteInt64(Seqno);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -1545,6 +1586,9 @@ namespace Google.Cloud.Spanner.V1 {
       }
       if (PartitionToken.Length != 0) {
         size += 1 + pb::CodedOutputStream.ComputeBytesSize(PartitionToken);
+      }
+      if (Seqno != 0L) {
+        size += 1 + pb::CodedOutputStream.ComputeInt64Size(Seqno);
       }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
@@ -1584,6 +1628,9 @@ namespace Google.Cloud.Spanner.V1 {
       }
       if (other.PartitionToken.Length != 0) {
         PartitionToken = other.PartitionToken;
+      }
+      if (other.Seqno != 0L) {
+        Seqno = other.Seqno;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
@@ -1634,6 +1681,10 @@ namespace Google.Cloud.Spanner.V1 {
             PartitionToken = input.ReadBytes();
             break;
           }
+          case 72: {
+            Seqno = input.ReadInt64();
+            break;
+          }
         }
       }
     }
@@ -1643,22 +1694,21 @@ namespace Google.Cloud.Spanner.V1 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static partial class Types {
       /// <summary>
-      /// Mode in which the query must be processed.
+      /// Mode in which the statement must be processed.
       /// </summary>
       public enum QueryMode {
         /// <summary>
-        /// The default mode where only the query result, without any information
-        /// about the query plan is returned.
+        /// The default mode. Only the statement results are returned.
         /// </summary>
         [pbr::OriginalName("NORMAL")] Normal = 0,
         /// <summary>
-        /// This mode returns only the query plan, without any result rows or
+        /// This mode returns only the query plan, without any results or
         /// execution statistics information.
         /// </summary>
         [pbr::OriginalName("PLAN")] Plan = 1,
         /// <summary>
         /// This mode returns both the query plan and the execution statistics along
-        /// with the result rows.
+        /// with the results.
         /// </summary>
         [pbr::OriginalName("PROFILE")] Profile = 2,
       }
@@ -1928,6 +1978,10 @@ namespace Google.Cloud.Spanner.V1 {
     /// union operator conceptually divides one or more tables into multiple
     /// splits, remotely evaluates a subquery independently on each split, and
     /// then unions all results.
+    ///
+    /// This must not contain DML commands, such as INSERT, UPDATE, or
+    /// DELETE. Use [ExecuteStreamingSql][google.spanner.v1.Spanner.ExecuteStreamingSql] with a
+    /// PartitionedDml transaction for large, partition-friendly DML operations.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public string Sql {

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SpannerClient.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SpannerClient.cs
@@ -1262,12 +1262,12 @@ namespace Google.Cloud.Spanner.V1
         }
 
         /// <summary>
-        /// Executes an SQL query, returning all rows in a single reply. This
+        /// Executes an SQL statement, returning all results in a single reply. This
         /// method cannot be used to return a result set larger than 10 MiB;
         /// if the query yields more data than that, the query fails with
         /// a `FAILED_PRECONDITION` error.
         ///
-        /// Queries inside read-write transactions might return `ABORTED`. If
+        /// Operations inside read-write transactions might return `ABORTED`. If
         /// this occurs, the application should restart the transaction from
         /// the beginning. See [Transaction][google.spanner.v1.Transaction] for more details.
         ///
@@ -1291,12 +1291,12 @@ namespace Google.Cloud.Spanner.V1
         }
 
         /// <summary>
-        /// Executes an SQL query, returning all rows in a single reply. This
+        /// Executes an SQL statement, returning all results in a single reply. This
         /// method cannot be used to return a result set larger than 10 MiB;
         /// if the query yields more data than that, the query fails with
         /// a `FAILED_PRECONDITION` error.
         ///
-        /// Queries inside read-write transactions might return `ABORTED`. If
+        /// Operations inside read-write transactions might return `ABORTED`. If
         /// this occurs, the application should restart the transaction from
         /// the beginning. See [Transaction][google.spanner.v1.Transaction] for more details.
         ///
@@ -1319,12 +1319,12 @@ namespace Google.Cloud.Spanner.V1
                 gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        /// Executes an SQL query, returning all rows in a single reply. This
+        /// Executes an SQL statement, returning all results in a single reply. This
         /// method cannot be used to return a result set larger than 10 MiB;
         /// if the query yields more data than that, the query fails with
         /// a `FAILED_PRECONDITION` error.
         ///
-        /// Queries inside read-write transactions might return `ABORTED`. If
+        /// Operations inside read-write transactions might return `ABORTED`. If
         /// this occurs, the application should restart the transaction from
         /// the beginning. See [Transaction][google.spanner.v1.Transaction] for more details.
         ///
@@ -2157,8 +2157,11 @@ namespace Google.Cloud.Spanner.V1
         /// of the query result to read.  The same session and read-only transaction
         /// must be used by the PartitionQueryRequest used to create the
         /// partition tokens and the ExecuteSqlRequests that use the partition tokens.
+        ///
         /// Partition tokens become invalid when the session used to create them
-        /// is deleted or begins a new transaction.
+        /// is deleted, is idle for too long, begins a new transaction, or becomes too
+        /// old.  When any of these happen, it is not possible to resume the query, and
+        /// the whole operation must be restarted from the beginning.
         /// </summary>
         /// <param name="request">
         /// The request object containing all of the parameters for the API call.
@@ -2183,8 +2186,11 @@ namespace Google.Cloud.Spanner.V1
         /// of the query result to read.  The same session and read-only transaction
         /// must be used by the PartitionQueryRequest used to create the
         /// partition tokens and the ExecuteSqlRequests that use the partition tokens.
+        ///
         /// Partition tokens become invalid when the session used to create them
-        /// is deleted or begins a new transaction.
+        /// is deleted, is idle for too long, begins a new transaction, or becomes too
+        /// old.  When any of these happen, it is not possible to resume the query, and
+        /// the whole operation must be restarted from the beginning.
         /// </summary>
         /// <param name="request">
         /// The request object containing all of the parameters for the API call.
@@ -2208,8 +2214,11 @@ namespace Google.Cloud.Spanner.V1
         /// of the query result to read.  The same session and read-only transaction
         /// must be used by the PartitionQueryRequest used to create the
         /// partition tokens and the ExecuteSqlRequests that use the partition tokens.
+        ///
         /// Partition tokens become invalid when the session used to create them
-        /// is deleted or begins a new transaction.
+        /// is deleted, is idle for too long, begins a new transaction, or becomes too
+        /// old.  When any of these happen, it is not possible to resume the query, and
+        /// the whole operation must be restarted from the beginning.
         /// </summary>
         /// <param name="request">
         /// The request object containing all of the parameters for the API call.
@@ -2233,9 +2242,14 @@ namespace Google.Cloud.Spanner.V1
         /// by [StreamingRead][google.spanner.v1.Spanner.StreamingRead] to specify a subset of the read
         /// result to read.  The same session and read-only transaction must be used by
         /// the PartitionReadRequest used to create the partition tokens and the
-        /// ReadRequests that use the partition tokens.
+        /// ReadRequests that use the partition tokens.  There are no ordering
+        /// guarantees on rows returned among the returned partition tokens, or even
+        /// within each individual StreamingRead call issued with a partition_token.
+        ///
         /// Partition tokens become invalid when the session used to create them
-        /// is deleted or begins a new transaction.
+        /// is deleted, is idle for too long, begins a new transaction, or becomes too
+        /// old.  When any of these happen, it is not possible to resume the read, and
+        /// the whole operation must be restarted from the beginning.
         /// </summary>
         /// <param name="request">
         /// The request object containing all of the parameters for the API call.
@@ -2259,9 +2273,14 @@ namespace Google.Cloud.Spanner.V1
         /// by [StreamingRead][google.spanner.v1.Spanner.StreamingRead] to specify a subset of the read
         /// result to read.  The same session and read-only transaction must be used by
         /// the PartitionReadRequest used to create the partition tokens and the
-        /// ReadRequests that use the partition tokens.
+        /// ReadRequests that use the partition tokens.  There are no ordering
+        /// guarantees on rows returned among the returned partition tokens, or even
+        /// within each individual StreamingRead call issued with a partition_token.
+        ///
         /// Partition tokens become invalid when the session used to create them
-        /// is deleted or begins a new transaction.
+        /// is deleted, is idle for too long, begins a new transaction, or becomes too
+        /// old.  When any of these happen, it is not possible to resume the read, and
+        /// the whole operation must be restarted from the beginning.
         /// </summary>
         /// <param name="request">
         /// The request object containing all of the parameters for the API call.
@@ -2284,9 +2303,14 @@ namespace Google.Cloud.Spanner.V1
         /// by [StreamingRead][google.spanner.v1.Spanner.StreamingRead] to specify a subset of the read
         /// result to read.  The same session and read-only transaction must be used by
         /// the PartitionReadRequest used to create the partition tokens and the
-        /// ReadRequests that use the partition tokens.
+        /// ReadRequests that use the partition tokens.  There are no ordering
+        /// guarantees on rows returned among the returned partition tokens, or even
+        /// within each individual StreamingRead call issued with a partition_token.
+        ///
         /// Partition tokens become invalid when the session used to create them
-        /// is deleted or begins a new transaction.
+        /// is deleted, is idle for too long, begins a new transaction, or becomes too
+        /// old.  When any of these happen, it is not possible to resume the read, and
+        /// the whole operation must be restarted from the beginning.
         /// </summary>
         /// <param name="request">
         /// The request object containing all of the parameters for the API call.
@@ -2636,12 +2660,12 @@ namespace Google.Cloud.Spanner.V1
         }
 
         /// <summary>
-        /// Executes an SQL query, returning all rows in a single reply. This
+        /// Executes an SQL statement, returning all results in a single reply. This
         /// method cannot be used to return a result set larger than 10 MiB;
         /// if the query yields more data than that, the query fails with
         /// a `FAILED_PRECONDITION` error.
         ///
-        /// Queries inside read-write transactions might return `ABORTED`. If
+        /// Operations inside read-write transactions might return `ABORTED`. If
         /// this occurs, the application should restart the transaction from
         /// the beginning. See [Transaction][google.spanner.v1.Transaction] for more details.
         ///
@@ -2666,12 +2690,12 @@ namespace Google.Cloud.Spanner.V1
         }
 
         /// <summary>
-        /// Executes an SQL query, returning all rows in a single reply. This
+        /// Executes an SQL statement, returning all results in a single reply. This
         /// method cannot be used to return a result set larger than 10 MiB;
         /// if the query yields more data than that, the query fails with
         /// a `FAILED_PRECONDITION` error.
         ///
-        /// Queries inside read-write transactions might return `ABORTED`. If
+        /// Operations inside read-write transactions might return `ABORTED`. If
         /// this occurs, the application should restart the transaction from
         /// the beginning. See [Transaction][google.spanner.v1.Transaction] for more details.
         ///
@@ -3001,8 +3025,11 @@ namespace Google.Cloud.Spanner.V1
         /// of the query result to read.  The same session and read-only transaction
         /// must be used by the PartitionQueryRequest used to create the
         /// partition tokens and the ExecuteSqlRequests that use the partition tokens.
+        ///
         /// Partition tokens become invalid when the session used to create them
-        /// is deleted or begins a new transaction.
+        /// is deleted, is idle for too long, begins a new transaction, or becomes too
+        /// old.  When any of these happen, it is not possible to resume the query, and
+        /// the whole operation must be restarted from the beginning.
         /// </summary>
         /// <param name="request">
         /// The request object containing all of the parameters for the API call.
@@ -3028,8 +3055,11 @@ namespace Google.Cloud.Spanner.V1
         /// of the query result to read.  The same session and read-only transaction
         /// must be used by the PartitionQueryRequest used to create the
         /// partition tokens and the ExecuteSqlRequests that use the partition tokens.
+        ///
         /// Partition tokens become invalid when the session used to create them
-        /// is deleted or begins a new transaction.
+        /// is deleted, is idle for too long, begins a new transaction, or becomes too
+        /// old.  When any of these happen, it is not possible to resume the query, and
+        /// the whole operation must be restarted from the beginning.
         /// </summary>
         /// <param name="request">
         /// The request object containing all of the parameters for the API call.
@@ -3054,9 +3084,14 @@ namespace Google.Cloud.Spanner.V1
         /// by [StreamingRead][google.spanner.v1.Spanner.StreamingRead] to specify a subset of the read
         /// result to read.  The same session and read-only transaction must be used by
         /// the PartitionReadRequest used to create the partition tokens and the
-        /// ReadRequests that use the partition tokens.
+        /// ReadRequests that use the partition tokens.  There are no ordering
+        /// guarantees on rows returned among the returned partition tokens, or even
+        /// within each individual StreamingRead call issued with a partition_token.
+        ///
         /// Partition tokens become invalid when the session used to create them
-        /// is deleted or begins a new transaction.
+        /// is deleted, is idle for too long, begins a new transaction, or becomes too
+        /// old.  When any of these happen, it is not possible to resume the read, and
+        /// the whole operation must be restarted from the beginning.
         /// </summary>
         /// <param name="request">
         /// The request object containing all of the parameters for the API call.
@@ -3081,9 +3116,14 @@ namespace Google.Cloud.Spanner.V1
         /// by [StreamingRead][google.spanner.v1.Spanner.StreamingRead] to specify a subset of the read
         /// result to read.  The same session and read-only transaction must be used by
         /// the PartitionReadRequest used to create the partition tokens and the
-        /// ReadRequests that use the partition tokens.
+        /// ReadRequests that use the partition tokens.  There are no ordering
+        /// guarantees on rows returned among the returned partition tokens, or even
+        /// within each individual StreamingRead call issued with a partition_token.
+        ///
         /// Partition tokens become invalid when the session used to create them
-        /// is deleted or begins a new transaction.
+        /// is deleted, is idle for too long, begins a new transaction, or becomes too
+        /// old.  When any of these happen, it is not possible to resume the read, and
+        /// the whole operation must be restarted from the beginning.
         /// </summary>
         /// <param name="request">
         /// The request object containing all of the parameters for the API call.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SpannerGrpc.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SpannerGrpc.cs
@@ -3,7 +3,7 @@
 //     source: google/spanner/v1/spanner.proto
 // </auto-generated>
 // Original file comments:
-// Copyright 2018 Google Inc.
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -218,12 +218,12 @@ namespace Google.Cloud.Spanner.V1 {
       }
 
       /// <summary>
-      /// Executes an SQL query, returning all rows in a single reply. This
+      /// Executes an SQL statement, returning all results in a single reply. This
       /// method cannot be used to return a result set larger than 10 MiB;
       /// if the query yields more data than that, the query fails with
       /// a `FAILED_PRECONDITION` error.
       ///
-      /// Queries inside read-write transactions might return `ABORTED`. If
+      /// Operations inside read-write transactions might return `ABORTED`. If
       /// this occurs, the application should restart the transaction from
       /// the beginning. See [Transaction][google.spanner.v1.Transaction] for more details.
       ///
@@ -350,8 +350,11 @@ namespace Google.Cloud.Spanner.V1 {
       /// of the query result to read.  The same session and read-only transaction
       /// must be used by the PartitionQueryRequest used to create the
       /// partition tokens and the ExecuteSqlRequests that use the partition tokens.
+      ///
       /// Partition tokens become invalid when the session used to create them
-      /// is deleted or begins a new transaction.
+      /// is deleted, is idle for too long, begins a new transaction, or becomes too
+      /// old.  When any of these happen, it is not possible to resume the query, and
+      /// the whole operation must be restarted from the beginning.
       /// </summary>
       /// <param name="request">The request received from the client.</param>
       /// <param name="context">The context of the server-side call handler being invoked.</param>
@@ -367,9 +370,14 @@ namespace Google.Cloud.Spanner.V1 {
       /// by [StreamingRead][google.spanner.v1.Spanner.StreamingRead] to specify a subset of the read
       /// result to read.  The same session and read-only transaction must be used by
       /// the PartitionReadRequest used to create the partition tokens and the
-      /// ReadRequests that use the partition tokens.
+      /// ReadRequests that use the partition tokens.  There are no ordering
+      /// guarantees on rows returned among the returned partition tokens, or even
+      /// within each individual StreamingRead call issued with a partition_token.
+      ///
       /// Partition tokens become invalid when the session used to create them
-      /// is deleted or begins a new transaction.
+      /// is deleted, is idle for too long, begins a new transaction, or becomes too
+      /// old.  When any of these happen, it is not possible to resume the read, and
+      /// the whole operation must be restarted from the beginning.
       /// </summary>
       /// <param name="request">The request received from the client.</param>
       /// <param name="context">The context of the server-side call handler being invoked.</param>
@@ -661,12 +669,12 @@ namespace Google.Cloud.Spanner.V1 {
         return CallInvoker.AsyncUnaryCall(__Method_DeleteSession, null, options, request);
       }
       /// <summary>
-      /// Executes an SQL query, returning all rows in a single reply. This
+      /// Executes an SQL statement, returning all results in a single reply. This
       /// method cannot be used to return a result set larger than 10 MiB;
       /// if the query yields more data than that, the query fails with
       /// a `FAILED_PRECONDITION` error.
       ///
-      /// Queries inside read-write transactions might return `ABORTED`. If
+      /// Operations inside read-write transactions might return `ABORTED`. If
       /// this occurs, the application should restart the transaction from
       /// the beginning. See [Transaction][google.spanner.v1.Transaction] for more details.
       ///
@@ -683,12 +691,12 @@ namespace Google.Cloud.Spanner.V1 {
         return ExecuteSql(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
       /// <summary>
-      /// Executes an SQL query, returning all rows in a single reply. This
+      /// Executes an SQL statement, returning all results in a single reply. This
       /// method cannot be used to return a result set larger than 10 MiB;
       /// if the query yields more data than that, the query fails with
       /// a `FAILED_PRECONDITION` error.
       ///
-      /// Queries inside read-write transactions might return `ABORTED`. If
+      /// Operations inside read-write transactions might return `ABORTED`. If
       /// this occurs, the application should restart the transaction from
       /// the beginning. See [Transaction][google.spanner.v1.Transaction] for more details.
       ///
@@ -703,12 +711,12 @@ namespace Google.Cloud.Spanner.V1 {
         return CallInvoker.BlockingUnaryCall(__Method_ExecuteSql, null, options, request);
       }
       /// <summary>
-      /// Executes an SQL query, returning all rows in a single reply. This
+      /// Executes an SQL statement, returning all results in a single reply. This
       /// method cannot be used to return a result set larger than 10 MiB;
       /// if the query yields more data than that, the query fails with
       /// a `FAILED_PRECONDITION` error.
       ///
-      /// Queries inside read-write transactions might return `ABORTED`. If
+      /// Operations inside read-write transactions might return `ABORTED`. If
       /// this occurs, the application should restart the transaction from
       /// the beginning. See [Transaction][google.spanner.v1.Transaction] for more details.
       ///
@@ -725,12 +733,12 @@ namespace Google.Cloud.Spanner.V1 {
         return ExecuteSqlAsync(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
       /// <summary>
-      /// Executes an SQL query, returning all rows in a single reply. This
+      /// Executes an SQL statement, returning all results in a single reply. This
       /// method cannot be used to return a result set larger than 10 MiB;
       /// if the query yields more data than that, the query fails with
       /// a `FAILED_PRECONDITION` error.
       ///
-      /// Queries inside read-write transactions might return `ABORTED`. If
+      /// Operations inside read-write transactions might return `ABORTED`. If
       /// this occurs, the application should restart the transaction from
       /// the beginning. See [Transaction][google.spanner.v1.Transaction] for more details.
       ///
@@ -1103,8 +1111,11 @@ namespace Google.Cloud.Spanner.V1 {
       /// of the query result to read.  The same session and read-only transaction
       /// must be used by the PartitionQueryRequest used to create the
       /// partition tokens and the ExecuteSqlRequests that use the partition tokens.
+      ///
       /// Partition tokens become invalid when the session used to create them
-      /// is deleted or begins a new transaction.
+      /// is deleted, is idle for too long, begins a new transaction, or becomes too
+      /// old.  When any of these happen, it is not possible to resume the query, and
+      /// the whole operation must be restarted from the beginning.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
@@ -1122,8 +1133,11 @@ namespace Google.Cloud.Spanner.V1 {
       /// of the query result to read.  The same session and read-only transaction
       /// must be used by the PartitionQueryRequest used to create the
       /// partition tokens and the ExecuteSqlRequests that use the partition tokens.
+      ///
       /// Partition tokens become invalid when the session used to create them
-      /// is deleted or begins a new transaction.
+      /// is deleted, is idle for too long, begins a new transaction, or becomes too
+      /// old.  When any of these happen, it is not possible to resume the query, and
+      /// the whole operation must be restarted from the beginning.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="options">The options for the call.</param>
@@ -1139,8 +1153,11 @@ namespace Google.Cloud.Spanner.V1 {
       /// of the query result to read.  The same session and read-only transaction
       /// must be used by the PartitionQueryRequest used to create the
       /// partition tokens and the ExecuteSqlRequests that use the partition tokens.
+      ///
       /// Partition tokens become invalid when the session used to create them
-      /// is deleted or begins a new transaction.
+      /// is deleted, is idle for too long, begins a new transaction, or becomes too
+      /// old.  When any of these happen, it is not possible to resume the query, and
+      /// the whole operation must be restarted from the beginning.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
@@ -1158,8 +1175,11 @@ namespace Google.Cloud.Spanner.V1 {
       /// of the query result to read.  The same session and read-only transaction
       /// must be used by the PartitionQueryRequest used to create the
       /// partition tokens and the ExecuteSqlRequests that use the partition tokens.
+      ///
       /// Partition tokens become invalid when the session used to create them
-      /// is deleted or begins a new transaction.
+      /// is deleted, is idle for too long, begins a new transaction, or becomes too
+      /// old.  When any of these happen, it is not possible to resume the query, and
+      /// the whole operation must be restarted from the beginning.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="options">The options for the call.</param>
@@ -1174,9 +1194,14 @@ namespace Google.Cloud.Spanner.V1 {
       /// by [StreamingRead][google.spanner.v1.Spanner.StreamingRead] to specify a subset of the read
       /// result to read.  The same session and read-only transaction must be used by
       /// the PartitionReadRequest used to create the partition tokens and the
-      /// ReadRequests that use the partition tokens.
+      /// ReadRequests that use the partition tokens.  There are no ordering
+      /// guarantees on rows returned among the returned partition tokens, or even
+      /// within each individual StreamingRead call issued with a partition_token.
+      ///
       /// Partition tokens become invalid when the session used to create them
-      /// is deleted or begins a new transaction.
+      /// is deleted, is idle for too long, begins a new transaction, or becomes too
+      /// old.  When any of these happen, it is not possible to resume the read, and
+      /// the whole operation must be restarted from the beginning.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
@@ -1193,9 +1218,14 @@ namespace Google.Cloud.Spanner.V1 {
       /// by [StreamingRead][google.spanner.v1.Spanner.StreamingRead] to specify a subset of the read
       /// result to read.  The same session and read-only transaction must be used by
       /// the PartitionReadRequest used to create the partition tokens and the
-      /// ReadRequests that use the partition tokens.
+      /// ReadRequests that use the partition tokens.  There are no ordering
+      /// guarantees on rows returned among the returned partition tokens, or even
+      /// within each individual StreamingRead call issued with a partition_token.
+      ///
       /// Partition tokens become invalid when the session used to create them
-      /// is deleted or begins a new transaction.
+      /// is deleted, is idle for too long, begins a new transaction, or becomes too
+      /// old.  When any of these happen, it is not possible to resume the read, and
+      /// the whole operation must be restarted from the beginning.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="options">The options for the call.</param>
@@ -1210,9 +1240,14 @@ namespace Google.Cloud.Spanner.V1 {
       /// by [StreamingRead][google.spanner.v1.Spanner.StreamingRead] to specify a subset of the read
       /// result to read.  The same session and read-only transaction must be used by
       /// the PartitionReadRequest used to create the partition tokens and the
-      /// ReadRequests that use the partition tokens.
+      /// ReadRequests that use the partition tokens.  There are no ordering
+      /// guarantees on rows returned among the returned partition tokens, or even
+      /// within each individual StreamingRead call issued with a partition_token.
+      ///
       /// Partition tokens become invalid when the session used to create them
-      /// is deleted or begins a new transaction.
+      /// is deleted, is idle for too long, begins a new transaction, or becomes too
+      /// old.  When any of these happen, it is not possible to resume the read, and
+      /// the whole operation must be restarted from the beginning.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
@@ -1229,9 +1264,14 @@ namespace Google.Cloud.Spanner.V1 {
       /// by [StreamingRead][google.spanner.v1.Spanner.StreamingRead] to specify a subset of the read
       /// result to read.  The same session and read-only transaction must be used by
       /// the PartitionReadRequest used to create the partition tokens and the
-      /// ReadRequests that use the partition tokens.
+      /// ReadRequests that use the partition tokens.  There are no ordering
+      /// guarantees on rows returned among the returned partition tokens, or even
+      /// within each individual StreamingRead call issued with a partition_token.
+      ///
       /// Partition tokens become invalid when the session used to create them
-      /// is deleted or begins a new transaction.
+      /// is deleted, is idle for too long, begins a new transaction, or becomes too
+      /// old.  When any of these happen, it is not possible to resume the read, and
+      /// the whole operation must be restarted from the beginning.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="options">The options for the call.</param>

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Transaction.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Transaction.cs
@@ -27,31 +27,34 @@ namespace Google.Cloud.Spanner.V1 {
             "CiNnb29nbGUvc3Bhbm5lci92MS90cmFuc2FjdGlvbi5wcm90bxIRZ29vZ2xl",
             "LnNwYW5uZXIudjEaHGdvb2dsZS9hcGkvYW5ub3RhdGlvbnMucHJvdG8aHmdv",
             "b2dsZS9wcm90b2J1Zi9kdXJhdGlvbi5wcm90bxofZ29vZ2xlL3Byb3RvYnVm",
-            "L3RpbWVzdGFtcC5wcm90byLgAwoSVHJhbnNhY3Rpb25PcHRpb25zEkUKCnJl",
+            "L3RpbWVzdGFtcC5wcm90byLDBAoSVHJhbnNhY3Rpb25PcHRpb25zEkUKCnJl",
             "YWRfd3JpdGUYASABKAsyLy5nb29nbGUuc3Bhbm5lci52MS5UcmFuc2FjdGlv",
-            "bk9wdGlvbnMuUmVhZFdyaXRlSAASQwoJcmVhZF9vbmx5GAIgASgLMi4uZ29v",
-            "Z2xlLnNwYW5uZXIudjEuVHJhbnNhY3Rpb25PcHRpb25zLlJlYWRPbmx5SAAa",
-            "CwoJUmVhZFdyaXRlGqgCCghSZWFkT25seRIQCgZzdHJvbmcYASABKAhIABI4",
-            "ChJtaW5fcmVhZF90aW1lc3RhbXAYAiABKAsyGi5nb29nbGUucHJvdG9idWYu",
-            "VGltZXN0YW1wSAASMgoNbWF4X3N0YWxlbmVzcxgDIAEoCzIZLmdvb2dsZS5w",
-            "cm90b2J1Zi5EdXJhdGlvbkgAEjQKDnJlYWRfdGltZXN0YW1wGAQgASgLMhou",
-            "Z29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcEgAEjQKD2V4YWN0X3N0YWxlbmVz",
-            "cxgFIAEoCzIZLmdvb2dsZS5wcm90b2J1Zi5EdXJhdGlvbkgAEh0KFXJldHVy",
-            "bl9yZWFkX3RpbWVzdGFtcBgGIAEoCEIRCg90aW1lc3RhbXBfYm91bmRCBgoE",
-            "bW9kZSJNCgtUcmFuc2FjdGlvbhIKCgJpZBgBIAEoDBIyCg5yZWFkX3RpbWVz",
-            "dGFtcBgCIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXAipAEKE1Ry",
-            "YW5zYWN0aW9uU2VsZWN0b3ISOwoKc2luZ2xlX3VzZRgBIAEoCzIlLmdvb2ds",
-            "ZS5zcGFubmVyLnYxLlRyYW5zYWN0aW9uT3B0aW9uc0gAEgwKAmlkGAIgASgM",
-            "SAASNgoFYmVnaW4YAyABKAsyJS5nb29nbGUuc3Bhbm5lci52MS5UcmFuc2Fj",
-            "dGlvbk9wdGlvbnNIAEIKCghzZWxlY3RvckKZAQoVY29tLmdvb2dsZS5zcGFu",
-            "bmVyLnYxQhBUcmFuc2FjdGlvblByb3RvUAFaOGdvb2dsZS5nb2xhbmcub3Jn",
-            "L2dlbnByb3RvL2dvb2dsZWFwaXMvc3Bhbm5lci92MTtzcGFubmVyqgIXR29v",
-            "Z2xlLkNsb3VkLlNwYW5uZXIuVjHKAhdHb29nbGVcQ2xvdWRcU3Bhbm5lclxW",
-            "MWIGcHJvdG8z"));
+            "bk9wdGlvbnMuUmVhZFdyaXRlSAASTwoPcGFydGl0aW9uZWRfZG1sGAMgASgL",
+            "MjQuZ29vZ2xlLnNwYW5uZXIudjEuVHJhbnNhY3Rpb25PcHRpb25zLlBhcnRp",
+            "dGlvbmVkRG1sSAASQwoJcmVhZF9vbmx5GAIgASgLMi4uZ29vZ2xlLnNwYW5u",
+            "ZXIudjEuVHJhbnNhY3Rpb25PcHRpb25zLlJlYWRPbmx5SAAaCwoJUmVhZFdy",
+            "aXRlGhAKDlBhcnRpdGlvbmVkRG1sGqgCCghSZWFkT25seRIQCgZzdHJvbmcY",
+            "ASABKAhIABI4ChJtaW5fcmVhZF90aW1lc3RhbXAYAiABKAsyGi5nb29nbGUu",
+            "cHJvdG9idWYuVGltZXN0YW1wSAASMgoNbWF4X3N0YWxlbmVzcxgDIAEoCzIZ",
+            "Lmdvb2dsZS5wcm90b2J1Zi5EdXJhdGlvbkgAEjQKDnJlYWRfdGltZXN0YW1w",
+            "GAQgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcEgAEjQKD2V4YWN0",
+            "X3N0YWxlbmVzcxgFIAEoCzIZLmdvb2dsZS5wcm90b2J1Zi5EdXJhdGlvbkgA",
+            "Eh0KFXJldHVybl9yZWFkX3RpbWVzdGFtcBgGIAEoCEIRCg90aW1lc3RhbXBf",
+            "Ym91bmRCBgoEbW9kZSJNCgtUcmFuc2FjdGlvbhIKCgJpZBgBIAEoDBIyCg5y",
+            "ZWFkX3RpbWVzdGFtcBgCIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3Rh",
+            "bXAipAEKE1RyYW5zYWN0aW9uU2VsZWN0b3ISOwoKc2luZ2xlX3VzZRgBIAEo",
+            "CzIlLmdvb2dsZS5zcGFubmVyLnYxLlRyYW5zYWN0aW9uT3B0aW9uc0gAEgwK",
+            "AmlkGAIgASgMSAASNgoFYmVnaW4YAyABKAsyJS5nb29nbGUuc3Bhbm5lci52",
+            "MS5UcmFuc2FjdGlvbk9wdGlvbnNIAEIKCghzZWxlY3RvckKZAQoVY29tLmdv",
+            "b2dsZS5zcGFubmVyLnYxQhBUcmFuc2FjdGlvblByb3RvUAFaOGdvb2dsZS5n",
+            "b2xhbmcub3JnL2dlbnByb3RvL2dvb2dsZWFwaXMvc3Bhbm5lci92MTtzcGFu",
+            "bmVyqgIXR29vZ2xlLkNsb3VkLlNwYW5uZXIuVjHKAhdHb29nbGVcQ2xvdWRc",
+            "U3Bhbm5lclxWMWIGcHJvdG8z"));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Google.Api.AnnotationsReflection.Descriptor, global::Google.Protobuf.WellKnownTypes.DurationReflection.Descriptor, global::Google.Protobuf.WellKnownTypes.TimestampReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
-            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.Spanner.V1.TransactionOptions), global::Google.Cloud.Spanner.V1.TransactionOptions.Parser, new[]{ "ReadWrite", "ReadOnly" }, new[]{ "Mode" }, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.Spanner.V1.TransactionOptions.Types.ReadWrite), global::Google.Cloud.Spanner.V1.TransactionOptions.Types.ReadWrite.Parser, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.Spanner.V1.TransactionOptions), global::Google.Cloud.Spanner.V1.TransactionOptions.Parser, new[]{ "ReadWrite", "PartitionedDml", "ReadOnly" }, new[]{ "Mode" }, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.Spanner.V1.TransactionOptions.Types.ReadWrite), global::Google.Cloud.Spanner.V1.TransactionOptions.Types.ReadWrite.Parser, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.Spanner.V1.TransactionOptions.Types.PartitionedDml), global::Google.Cloud.Spanner.V1.TransactionOptions.Types.PartitionedDml.Parser, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.Spanner.V1.TransactionOptions.Types.ReadOnly), global::Google.Cloud.Spanner.V1.TransactionOptions.Types.ReadOnly.Parser, new[]{ "Strong", "MinReadTimestamp", "MaxStaleness", "ReadTimestamp", "ExactStaleness", "ReturnReadTimestamp" }, new[]{ "TimestampBound" }, null, null)}),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.Spanner.V1.Transaction), global::Google.Cloud.Spanner.V1.Transaction.Parser, new[]{ "Id", "ReadTimestamp" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.Spanner.V1.TransactionSelector), global::Google.Cloud.Spanner.V1.TransactionSelector.Parser, new[]{ "SingleUse", "Id", "Begin" }, new[]{ "Selector" }, null, null)
@@ -71,7 +74,7 @@ namespace Google.Cloud.Spanner.V1 {
   ///
   /// # Transaction Modes
   ///
-  /// Cloud Spanner supports two transaction modes:
+  /// Cloud Spanner supports three transaction modes:
   ///
   ///   1. Locking read-write. This type of transaction is the only way
   ///      to write data into Cloud Spanner. These transactions rely on
@@ -84,6 +87,13 @@ namespace Google.Cloud.Spanner.V1 {
   ///      writes. Snapshot read-only transactions can be configured to
   ///      read at timestamps in the past. Snapshot read-only
   ///      transactions do not need to be committed.
+  ///
+  ///   3. Partitioned DML. This type of transaction is used to execute
+  ///      a single Partitioned DML statement. Partitioned DML partitions
+  ///      the key space and runs the DML statement over each partition
+  ///      in parallel using separate, internal transactions that commit
+  ///      independently. Partitioned DML transactions do not need to be
+  ///      committed.
   ///
   /// For transactions that only read, snapshot read-only transactions
   /// provide simpler semantics and are almost always faster. In
@@ -111,11 +121,8 @@ namespace Google.Cloud.Spanner.V1 {
   /// inactivity at the client may cause Cloud Spanner to release a
   /// transaction's locks and abort it.
   ///
-  /// Reads performed within a transaction acquire locks on the data
-  /// being read. Writes can only be done at commit time, after all reads
-  /// have been completed.
   /// Conceptually, a read-write transaction consists of zero or more
-  /// reads or SQL queries followed by
+  /// reads or SQL statements followed by
   /// [Commit][google.spanner.v1.Spanner.Commit]. At any time before
   /// [Commit][google.spanner.v1.Spanner.Commit], the client can send a
   /// [Rollback][google.spanner.v1.Spanner.Rollback] request to abort the
@@ -278,6 +285,62 @@ namespace Google.Cloud.Spanner.V1 {
   /// restriction also applies to in-progress reads and/or SQL queries whose
   /// timestamp become too old while executing. Reads and SQL queries with
   /// too-old read timestamps fail with the error `FAILED_PRECONDITION`.
+  ///
+  /// ## Partitioned DML Transactions
+  ///
+  /// Partitioned DML transactions are used to execute DML statements with a
+  /// different execution strategy that provides different, and often better,
+  /// scalability properties for large, table-wide operations than DML in a
+  /// ReadWrite transaction. Smaller scoped statements, such as an OLTP workload,
+  /// should prefer using ReadWrite transactions.
+  ///
+  /// Partitioned DML partitions the keyspace and runs the DML statement on each
+  /// partition in separate, internal transactions. These transactions commit
+  /// automatically when complete, and run independently from one another.
+  ///
+  /// To reduce lock contention, this execution strategy only acquires read locks
+  /// on rows that match the WHERE clause of the statement. Additionally, the
+  /// smaller per-partition transactions hold locks for less time.
+  ///
+  /// That said, Partitioned DML is not a drop-in replacement for standard DML used
+  /// in ReadWrite transactions.
+  ///
+  ///  - The DML statement must be fully-partitionable. Specifically, the statement
+  ///    must be expressible as the union of many statements which each access only
+  ///    a single row of the table.
+  ///
+  ///  - The statement is not applied atomically to all rows of the table. Rather,
+  ///    the statement is applied atomically to partitions of the table, in
+  ///    independent transactions. Secondary index rows are updated atomically
+  ///    with the base table rows.
+  ///
+  ///  - Partitioned DML does not guarantee exactly-once execution semantics
+  ///    against a partition. The statement will be applied at least once to each
+  ///    partition. It is strongly recommended that the DML statement should be
+  ///    idempotent to avoid unexpected results. For instance, it is potentially
+  ///    dangerous to run a statement such as
+  ///    `UPDATE table SET column = column + 1` as it could be run multiple times
+  ///    against some rows.
+  ///
+  ///  - The partitions are committed automatically - there is no support for
+  ///    Commit or Rollback. If the call returns an error, or if the client issuing
+  ///    the ExecuteSql call dies, it is possible that some rows had the statement
+  ///    executed on them successfully. It is also possible that statement was
+  ///    never executed against other rows.
+  ///
+  ///  - Partitioned DML transactions may only contain the execution of a single
+  ///    DML statement via ExecuteSql or ExecuteStreamingSql.
+  ///
+  ///  - If any error is encountered during the execution of the partitioned DML
+  ///    operation (for instance, a UNIQUE INDEX violation, division by zero, or a
+  ///    value that cannot be stored due to schema constraints), then the
+  ///    operation is stopped at that point and an error is returned. It is
+  ///    possible that at this point, some partitions have been committed (or even
+  ///    committed multiple times), and other partitions have not been run at all.
+  ///
+  /// Given the above, Partitioned DML is good fit for large, database-wide,
+  /// operations that are idempotent, such as deleting old rows from a very large
+  /// table.
   /// </summary>
   public sealed partial class TransactionOptions : pb::IMessage<TransactionOptions> {
     private static readonly pb::MessageParser<TransactionOptions> _parser = new pb::MessageParser<TransactionOptions>(() => new TransactionOptions());
@@ -307,6 +370,9 @@ namespace Google.Cloud.Spanner.V1 {
       switch (other.ModeCase) {
         case ModeOneofCase.ReadWrite:
           ReadWrite = other.ReadWrite.Clone();
+          break;
+        case ModeOneofCase.PartitionedDml:
+          PartitionedDml = other.PartitionedDml.Clone();
           break;
         case ModeOneofCase.ReadOnly:
           ReadOnly = other.ReadOnly.Clone();
@@ -339,6 +405,24 @@ namespace Google.Cloud.Spanner.V1 {
       }
     }
 
+    /// <summary>Field number for the "partitioned_dml" field.</summary>
+    public const int PartitionedDmlFieldNumber = 3;
+    /// <summary>
+    /// Partitioned DML transaction.
+    ///
+    /// Authorization to begin a Partitioned DML transaction requires
+    /// `spanner.databases.beginPartitionedDmlTransaction` permission
+    /// on the `session` resource.
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public global::Google.Cloud.Spanner.V1.TransactionOptions.Types.PartitionedDml PartitionedDml {
+      get { return modeCase_ == ModeOneofCase.PartitionedDml ? (global::Google.Cloud.Spanner.V1.TransactionOptions.Types.PartitionedDml) mode_ : null; }
+      set {
+        mode_ = value;
+        modeCase_ = value == null ? ModeOneofCase.None : ModeOneofCase.PartitionedDml;
+      }
+    }
+
     /// <summary>Field number for the "read_only" field.</summary>
     public const int ReadOnlyFieldNumber = 2;
     /// <summary>
@@ -362,6 +446,7 @@ namespace Google.Cloud.Spanner.V1 {
     public enum ModeOneofCase {
       None = 0,
       ReadWrite = 1,
+      PartitionedDml = 3,
       ReadOnly = 2,
     }
     private ModeOneofCase modeCase_ = ModeOneofCase.None;
@@ -390,6 +475,7 @@ namespace Google.Cloud.Spanner.V1 {
         return true;
       }
       if (!object.Equals(ReadWrite, other.ReadWrite)) return false;
+      if (!object.Equals(PartitionedDml, other.PartitionedDml)) return false;
       if (!object.Equals(ReadOnly, other.ReadOnly)) return false;
       if (ModeCase != other.ModeCase) return false;
       return Equals(_unknownFields, other._unknownFields);
@@ -399,6 +485,7 @@ namespace Google.Cloud.Spanner.V1 {
     public override int GetHashCode() {
       int hash = 1;
       if (modeCase_ == ModeOneofCase.ReadWrite) hash ^= ReadWrite.GetHashCode();
+      if (modeCase_ == ModeOneofCase.PartitionedDml) hash ^= PartitionedDml.GetHashCode();
       if (modeCase_ == ModeOneofCase.ReadOnly) hash ^= ReadOnly.GetHashCode();
       hash ^= (int) modeCase_;
       if (_unknownFields != null) {
@@ -422,6 +509,10 @@ namespace Google.Cloud.Spanner.V1 {
         output.WriteRawTag(18);
         output.WriteMessage(ReadOnly);
       }
+      if (modeCase_ == ModeOneofCase.PartitionedDml) {
+        output.WriteRawTag(26);
+        output.WriteMessage(PartitionedDml);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -432,6 +523,9 @@ namespace Google.Cloud.Spanner.V1 {
       int size = 0;
       if (modeCase_ == ModeOneofCase.ReadWrite) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(ReadWrite);
+      }
+      if (modeCase_ == ModeOneofCase.PartitionedDml) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(PartitionedDml);
       }
       if (modeCase_ == ModeOneofCase.ReadOnly) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(ReadOnly);
@@ -453,6 +547,12 @@ namespace Google.Cloud.Spanner.V1 {
             ReadWrite = new global::Google.Cloud.Spanner.V1.TransactionOptions.Types.ReadWrite();
           }
           ReadWrite.MergeFrom(other.ReadWrite);
+          break;
+        case ModeOneofCase.PartitionedDml:
+          if (PartitionedDml == null) {
+            PartitionedDml = new global::Google.Cloud.Spanner.V1.TransactionOptions.Types.PartitionedDml();
+          }
+          PartitionedDml.MergeFrom(other.PartitionedDml);
           break;
         case ModeOneofCase.ReadOnly:
           if (ReadOnly == null) {
@@ -489,6 +589,15 @@ namespace Google.Cloud.Spanner.V1 {
             }
             input.ReadMessage(subBuilder);
             ReadOnly = subBuilder;
+            break;
+          }
+          case 26: {
+            global::Google.Cloud.Spanner.V1.TransactionOptions.Types.PartitionedDml subBuilder = new global::Google.Cloud.Spanner.V1.TransactionOptions.Types.PartitionedDml();
+            if (modeCase_ == ModeOneofCase.PartitionedDml) {
+              subBuilder.MergeFrom(PartitionedDml);
+            }
+            input.ReadMessage(subBuilder);
+            PartitionedDml = subBuilder;
             break;
           }
         }
@@ -605,6 +714,110 @@ namespace Google.Cloud.Spanner.V1 {
       }
 
       /// <summary>
+      /// Message type to initiate a Partitioned DML transaction.
+      /// </summary>
+      public sealed partial class PartitionedDml : pb::IMessage<PartitionedDml> {
+        private static readonly pb::MessageParser<PartitionedDml> _parser = new pb::MessageParser<PartitionedDml>(() => new PartitionedDml());
+        private pb::UnknownFieldSet _unknownFields;
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        public static pb::MessageParser<PartitionedDml> Parser { get { return _parser; } }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        public static pbr::MessageDescriptor Descriptor {
+          get { return global::Google.Cloud.Spanner.V1.TransactionOptions.Descriptor.NestedTypes[1]; }
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        pbr::MessageDescriptor pb::IMessage.Descriptor {
+          get { return Descriptor; }
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        public PartitionedDml() {
+          OnConstruction();
+        }
+
+        partial void OnConstruction();
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        public PartitionedDml(PartitionedDml other) : this() {
+          _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        public PartitionedDml Clone() {
+          return new PartitionedDml(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        public override bool Equals(object other) {
+          return Equals(other as PartitionedDml);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        public bool Equals(PartitionedDml other) {
+          if (ReferenceEquals(other, null)) {
+            return false;
+          }
+          if (ReferenceEquals(other, this)) {
+            return true;
+          }
+          return Equals(_unknownFields, other._unknownFields);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        public override int GetHashCode() {
+          int hash = 1;
+          if (_unknownFields != null) {
+            hash ^= _unknownFields.GetHashCode();
+          }
+          return hash;
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        public override string ToString() {
+          return pb::JsonFormatter.ToDiagnosticString(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        public void WriteTo(pb::CodedOutputStream output) {
+          if (_unknownFields != null) {
+            _unknownFields.WriteTo(output);
+          }
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        public int CalculateSize() {
+          int size = 0;
+          if (_unknownFields != null) {
+            size += _unknownFields.CalculateSize();
+          }
+          return size;
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        public void MergeFrom(PartitionedDml other) {
+          if (other == null) {
+            return;
+          }
+          _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        public void MergeFrom(pb::CodedInputStream input) {
+          uint tag;
+          while ((tag = input.ReadTag()) != 0) {
+            switch(tag) {
+              default:
+                _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+                break;
+            }
+          }
+        }
+
+      }
+
+      /// <summary>
       /// Message type to initiate a read-only transaction.
       /// </summary>
       public sealed partial class ReadOnly : pb::IMessage<ReadOnly> {
@@ -615,7 +828,7 @@ namespace Google.Cloud.Spanner.V1 {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pbr::MessageDescriptor Descriptor {
-          get { return global::Google.Cloud.Spanner.V1.TransactionOptions.Descriptor.NestedTypes[1]; }
+          get { return global::Google.Cloud.Spanner.V1.TransactionOptions.Descriptor.NestedTypes[2]; }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]


### PR DESCRIPTION
This change mostly introduces DML, which will then be used by manual code in a separate PR.

(This is purely autogenerated.)