### PR TITLE
Fixup `SubscriberClient.StopAsync` when Token is Already Cancelled

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberClient.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberClient.cs
@@ -452,6 +452,10 @@ namespace Google.Cloud.PubSub.V1
             }
             _globalSoftStopCts.Cancel();
             var registration = hardStopToken.Register(() => _globalHardStopCts.Cancel());
+            if (hardStopToken.IsCancellationRequested)
+            {
+                _globalHardStopCts.Cancel();
+            }
             // Do not register this Task to be awaited on at shutdown.
             // It completes *after* _mainTcs, and all registered tasks must complete before _mainTcs
             _taskHelper.Run(async () =>


### PR DESCRIPTION
If the token passed in as the 'hard stop' token is already cancelled
then the registration will never fire and the client will peform a
soft stop instead. This can take quite some time.

The fix is to check _after_ we have registered on the token if the
token has been cancelled, and if so cancel the hard stop token source
too.