### PR TITLE
Remove 'Simple' from comment in pubsub test

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Tests/SubscriberClientTest.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Tests/SubscriberClientTest.cs
@@ -615,7 +615,7 @@ namespace Google.Cloud.PubSub.V1.Tests
                 fake.Scheduler.Run(() =>
                 {
                     fake.Subscriber.StartAsync((msg, ct) => throw new Exception());
-                    // Only allowed to start a SimpleSubscriber once.
+                    // Only allowed to start a Subscriber once.
                     Assert.Throws<InvalidOperationException>((Action)(() => fake.Subscriber.StartAsync((msg, ct) => throw new Exception())));
                 });
             }


### PR DESCRIPTION
Missed this during the rename from SimpleSubscriber