### PR TITLE
Remember that we've pushed when the watch state is reconnected

### DIFF
--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/WatchState.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/WatchState.cs
@@ -50,7 +50,6 @@ namespace Google.Cloud.Firestore
         public void OnStreamInitialization(StreamInitializationCause cause)
         {
             _current = false;
-            _hasPushed = false;
             if (cause == StreamInitializationCause.StreamCompleted || cause == StreamInitializationCause.RpcError)
             {
                 _changeMap.Clear();


### PR DESCRIPTION
Fixes #2542.

All our tests for WatchState are via proto-based conformance tests.
There will be a new test for that case over time, but it's not present yet.
I didn't feel it worth creating a new test class to do this manually until that point. (I can do so if necessary.)
The existing tests all still pass, and I've validated manually that this fixes the problem (both for collection and document listen operations).