### PR TITLE
Use a recent timestamp for Asset API smoke test

### DIFF
--- a/apis/Google.Cloud.Asset.V1Beta1/Google.Cloud.Asset.V1Beta1.SmokeTests/AssetServiceSmokeTest.cs
+++ b/apis/Google.Cloud.Asset.V1Beta1/Google.Cloud.Asset.V1Beta1.SmokeTests/AssetServiceSmokeTest.cs
@@ -50,7 +50,7 @@ namespace Google.Cloud.Asset.V1Beta1.SmokeTests
             {
                 ParentAsProjectName = new ProjectName(projectId),
                 ContentType = ContentType.Resource,
-                ReadTimeWindow = new TimeWindow { StartTime = DateTime.UtcNow.AddDays(-30).ToTimestamp() },
+                ReadTimeWindow = new TimeWindow { StartTime = DateTime.UtcNow.AddDays(-1).ToTimestamp() },
             };
 
             // Call API method


### PR DESCRIPTION
The API has a restriction (to be documented soon) that the read time
must be on/after 2018-10-2. With this change, that will always be
the case.