### PR TITLE
Increasing the read timeout for error entries to tackle flakiness in Diagnostics Error Reporting integration tests.

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/ErrorReporting/ErrorReportingTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/ErrorReporting/ErrorReportingTest.cs
@@ -37,16 +37,12 @@ namespace Google.Cloud.Diagnostics.AspNet.IntegrationTests
         private readonly TestServer _server;
         private readonly HttpClient _client;
 
-        private readonly DateTime _startTime;
-
         public ErrorReportingTest()
         {
             _testId = IdGenerator.FromDateTime();
 
             _server = TestServer.Create<ErrorReportingTestApplication>();
             _client = _server.HttpClient;
-
-            _startTime = DateTime.UtcNow;
         }
 
         [Fact]
@@ -56,7 +52,7 @@ namespace Google.Cloud.Diagnostics.AspNet.IntegrationTests
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-            var errorEvents = s_polling.GetEvents(_startTime, _testId, 0);
+            var errorEvents = s_polling.GetEvents(_testId, 0);
             Assert.Empty(errorEvents);
         }
 
@@ -68,7 +64,7 @@ namespace Google.Cloud.Diagnostics.AspNet.IntegrationTests
 
             Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
 
-            var errorEvent = s_polling.GetEvents(_startTime, _testId, 1).Single();
+            var errorEvent = s_polling.GetEvents(_testId, 1).Single();
 
             ErrorEventEntryVerifiers.VerifyFullErrorEventLogged(errorEvent, _testId, nameof(ErrorReportingController.ThrowsException));
 
@@ -94,7 +90,7 @@ namespace Google.Cloud.Diagnostics.AspNet.IntegrationTests
             response = await requestTask4;
             Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
 
-            var errorEvents = s_polling.GetEvents(_startTime, _testId, 4);
+            var errorEvents = s_polling.GetEvents(_testId, 4);
             Assert.Equal(4, errorEvents.Count());
 
             var exceptionEvents = errorEvents
@@ -118,7 +114,7 @@ namespace Google.Cloud.Diagnostics.AspNet.IntegrationTests
 
             Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
 
-            var errorEvent = s_polling.GetEvents(_startTime, _testId, 1).Single();
+            var errorEvent = s_polling.GetEvents(_testId, 1).Single();
 
             ErrorEventEntryVerifiers.VerifyFullErrorEventLogged(errorEvent, _testId, "SendAsync");
         }
@@ -130,7 +126,7 @@ namespace Google.Cloud.Diagnostics.AspNet.IntegrationTests
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-            var errorEvent = s_polling.GetEvents(_startTime, _testId, 1).Single();
+            var errorEvent = s_polling.GetEvents(_testId, 1).Single();
             ErrorEventEntryVerifiers.VerifyErrorEventLogged(errorEvent, _testId, nameof(ErrorReportingController.ThrowCatchWithGoogleLogger));
         }
 
@@ -141,7 +137,7 @@ namespace Google.Cloud.Diagnostics.AspNet.IntegrationTests
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-            var errorEvent = s_polling.GetEvents(_startTime, _testId, 1).Single();
+            var errorEvent = s_polling.GetEvents(_testId, 1).Single();
             ErrorEventEntryVerifiers.VerifyFullErrorEventLogged(errorEvent, _testId, nameof(ErrorReportingController.ThrowCatchWithGoogleWebApiLogger));
         }
 

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Snippets/ErrorReportingSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Snippets/ErrorReportingSnippets.cs
@@ -42,16 +42,12 @@ namespace Google.Cloud.Diagnostics.AspNet.Snippets
         private readonly TestServer _server;
         private readonly HttpClient _client;
 
-        private readonly DateTime _startTime;
-
         public ErrorReportingSnippetsTests()
         {
             _testId = IdGenerator.FromDateTime();
 
             _server = TestServer.Create<ErrorReportingTestApplication>();
             _client = _server.HttpClient;
-
-            _startTime = DateTime.UtcNow;
         }
 
         /// <summary>
@@ -66,7 +62,7 @@ namespace Google.Cloud.Diagnostics.AspNet.Snippets
 
             Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
 
-            var errorEvent = s_polling.GetEvents(_startTime, _testId, 1).Single();
+            var errorEvent = s_polling.GetEvents(_testId, 1).Single();
 
             ErrorEventEntryVerifiers.VerifyFullErrorEventLogged(
                 errorEvent, _testId, nameof(ErrorReportingController.ThrowsException));
@@ -80,7 +76,7 @@ namespace Google.Cloud.Diagnostics.AspNet.Snippets
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-            var errorEvent = s_polling.GetEvents(_startTime, _testId, 1).Single();
+            var errorEvent = s_polling.GetEvents(_testId, 1).Single();
             ErrorEventEntryVerifiers.VerifyFullErrorEventLogged(
                 errorEvent, _testId, "DoSomething");
         }

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/DiagnosticsWebHostTests.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/DiagnosticsWebHostTests.cs
@@ -93,7 +93,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
             {
                 await TestTrace(testId, startTime, client);
                 await TestLogging(testId, startTime, client);
-                await TestErrorReporting(testId, startTime, client);
+                await TestErrorReporting(testId, client);
             }
         }
 
@@ -131,11 +131,11 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
             Assert.False(response.Headers.Contains(TraceHeaderContext.TraceHeader));
         }
 
-        private static async Task TestErrorReporting(string testId, DateTime startTime, HttpClient client)
+        private static async Task TestErrorReporting(string testId, HttpClient client)
         {
             var polling = new ErrorEventEntryPolling();
             await Assert.ThrowsAsync<Exception>(() => client.GetAsync($"/ErrorReporting/{nameof(ErrorReportingController.ThrowsException)}/{testId}"));
-            var errorEvent = polling.GetEvents(startTime, testId, 1).Single();
+            var errorEvent = polling.GetEvents(testId, 1).Single();
             ErrorEventEntryVerifiers.VerifyFullErrorEventLogged(errorEvent, testId, nameof(ErrorReportingController.ThrowsException));
         }
     }

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/DiagnosticsSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/DiagnosticsSnippets.cs
@@ -71,7 +71,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
         {
             await Assert.ThrowsAsync<Exception>(() => _client.GetAsync($"/ErrorLoggingSamples/{nameof(ErrorLoggingSamplesController.ThrowsException)}/{_testId}"));
 
-            var errorEvent = s_errorPolling.GetEvents(_startTime, _testId, 1).Single();
+            var errorEvent = s_errorPolling.GetEvents(_testId, 1).Single();
 
             ErrorEventEntryVerifiers.VerifyFullErrorEventLogged(errorEvent, _testId, nameof(ErrorLoggingSamplesController.ThrowsException));
         }

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/ErrorReportingSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/ErrorReportingSnippets.cs
@@ -38,8 +38,6 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
         private readonly TestServer _server;
         private readonly HttpClient _client;
 
-        private readonly DateTime _startTime;
-
         public ErrorReportingSnippetsTests()
         {
             _testId = IdGenerator.FromDateTime();
@@ -47,8 +45,6 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
             var builder = new WebHostBuilder().UseStartup<ErrorReportingTestApplication>();
             _server = new TestServer(builder);
             _client = _server.CreateClient();
-
-            _startTime = DateTime.UtcNow;
         }
 
         /// <summary>
@@ -62,7 +58,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
             await Assert.ThrowsAsync<Exception>(()
                 => _client.GetAsync($"/ErrorLoggingSamples/{nameof(ErrorLoggingSamplesController.ThrowsException)}/{_testId}"));
 
-            var errorEvent = s_polling.GetEvents(_startTime, _testId, 1).Single();
+            var errorEvent = s_polling.GetEvents(_testId, 1).Single();
 
             ErrorEventEntryVerifiers.VerifyFullErrorEventLogged(errorEvent, _testId, nameof(ErrorLoggingSamplesController.ThrowsException));
         }
@@ -80,7 +76,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-            var errorEvent = s_polling.GetEvents(_startTime, _testId, 1).Single();
+            var errorEvent = s_polling.GetEvents(_testId, 1).Single();
 
             // Verifying with function name ThrowsExceptions because that is the function
             // that actually throws the Exception so will be the one included as

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/ErrorReporting/ErrorEventEntryPolling.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/ErrorReporting/ErrorEventEntryPolling.cs
@@ -37,18 +37,17 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
         private readonly ProjectName _projectName = new ProjectName(TestEnvironment.GetTestProjectId());
 
         // Give the error reporting events a little extra time to be processed.
-        internal ErrorEventEntryPolling() : base(TimeSpan.FromSeconds(120), TimeSpan.FromSeconds(30)) { }
+        internal ErrorEventEntryPolling() : base(TimeSpan.FromSeconds(180), TimeSpan.FromSeconds(30)) { }
 
         /// <summary>
         /// Gets error events that contain the passed in testId in the message.  Will poll
         /// and wait for the entries to appear.
         /// </summary>
-        /// <param name="startTime">The earliest error event time that will be looked at.</param>
         /// <param name="testId">The test id to filter error events on.</param>
         /// <param name="minEntries">The minimum number of error events that should be waited for.
         ///     If minEntries is zero this method will wait the full timeout before checking for the
         ///     entries.</param>
-        public IEnumerable<ErrorEvent> GetEvents(DateTime startTime, string testId, int minEntries)
+        public IEnumerable<ErrorEvent> GetEvents(string testId, int minEntries)
         {
             return GetEntries(minEntries, () =>
             {


### PR DESCRIPTION
Also removing a parameter from the ErrorEntryPolling helper that was not being used and was misleading by being there.