### PR TITLE
Changes to get the EF provider to build

### DIFF
--- a/apis/Google.Cloud.EntityFrameworkCore.Spanner/Google.Cloud.EntityFrameworkCore.Spanner.sln
+++ b/apis/Google.Cloud.EntityFrameworkCore.Spanner/Google.Cloud.EntityFrameworkCore.Spanner.sln
@@ -18,6 +18,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.ClientTesting"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.EntityFrameworkCore.Spanner.Snippets", "Google.Cloud.EntityFrameworkCore.Spanner.Snippets\Google.Cloud.EntityFrameworkCore.Spanner.Snippets.csproj", "{4C32D6C2-A08C-492D-A3D3-5FC01AF5EAFD}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Spanner.Common.V1", "..\Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1.csproj", "{2C711C88-C6B7-4468-A47E-1F6C90888085}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -124,6 +126,18 @@ Global
 		{4C32D6C2-A08C-492D-A3D3-5FC01AF5EAFD}.Release|x64.Build.0 = Release|Any CPU
 		{4C32D6C2-A08C-492D-A3D3-5FC01AF5EAFD}.Release|x86.ActiveCfg = Release|Any CPU
 		{4C32D6C2-A08C-492D-A3D3-5FC01AF5EAFD}.Release|x86.Build.0 = Release|Any CPU
+		{2C711C88-C6B7-4468-A47E-1F6C90888085}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2C711C88-C6B7-4468-A47E-1F6C90888085}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2C711C88-C6B7-4468-A47E-1F6C90888085}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2C711C88-C6B7-4468-A47E-1F6C90888085}.Debug|x64.Build.0 = Debug|Any CPU
+		{2C711C88-C6B7-4468-A47E-1F6C90888085}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2C711C88-C6B7-4468-A47E-1F6C90888085}.Debug|x86.Build.0 = Debug|Any CPU
+		{2C711C88-C6B7-4468-A47E-1F6C90888085}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2C711C88-C6B7-4468-A47E-1F6C90888085}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2C711C88-C6B7-4468-A47E-1F6C90888085}.Release|x64.ActiveCfg = Release|Any CPU
+		{2C711C88-C6B7-4468-A47E-1F6C90888085}.Release|x64.Build.0 = Release|Any CPU
+		{2C711C88-C6B7-4468-A47E-1F6C90888085}.Release|x86.ActiveCfg = Release|Any CPU
+		{2C711C88-C6B7-4468-A47E-1F6C90888085}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/apis/Google.Cloud.EntityFrameworkCore.Spanner/Google.Cloud.EntityFrameworkCore.Spanner/Diagnostics/SpannerLogBridge.cs
+++ b/apis/Google.Cloud.EntityFrameworkCore.Spanner/Google.Cloud.EntityFrameworkCore.Spanner/Diagnostics/SpannerLogBridge.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
     /// <summary>
     /// This is internal functionality and not intended for public use.
     /// </summary>
-    public class SpannerLogBridge<TLoggerCategory> : DefaultLogger
+    public class SpannerLogBridge<TLoggerCategory> : Logger
         where TLoggerCategory : LoggerCategory<TLoggerCategory>, new()
     {
         //Note: This class is used to forward logging messages from within the ADO.NET layer
@@ -76,7 +76,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <summary>
         /// This is internal functionality and not intended for public use.
         /// </summary>
-        public override void Warn(Func<string> messageFunc)
+        public override void Warn(Func<string> messageFunc, Exception exception = null)
         {
             _efLogger.Logger.Log(Microsoft.Extensions.Logging.LogLevel.Warning,
                 SpannerEventId.SpannerDiagnosticLog, messageFunc, null, (x, e) => x());
@@ -89,6 +89,24 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             _efLogger.Logger.Log(Microsoft.Extensions.Logging.LogLevel.Information,
                 SpannerEventId.SpannerDiagnosticLog, message, null, (x, e) => x);
+        }
+
+        /// <inheritdoc />
+        public override void Debug(string message) => Debug(() => message);
+
+        /// <inheritdoc />
+        public override void Info(string message) => Info(() => message);
+
+        /// <inheritdoc />
+        public override void Warn(string message, Exception exception = null) => Warn(() => message, exception);
+
+        /// <inheritdoc />
+        public override void Error(string message, Exception exception = null) => Error(() => message, exception);
+
+        /// <inheritdoc />
+        protected override void WriteLine(LogLevel level, string message)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Internal/Logging/Logger.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Internal/Logging/Logger.cs
@@ -21,6 +21,9 @@ using System.Threading.Tasks;
 
 namespace Google.Cloud.Spanner.V1.Internal.Logging
 {
+    // TODO: Clearer separation between default implementation and interface.
+    // (Use the EF provider and default logger to drive the design.)
+
     /// <summary>
     /// This is an internal class and is not intended to be used by external code.
     /// </summary>


### PR DESCRIPTION
- Add the Common project to the solution (otherwise VS gets confused)
- Override methods in Logger
- Add TODO in Logger to separate the implementation from the API more cleanly