### PR TITLE
Forcing choco install to confirm all prompts.

### DIFF
--- a/createcoveragereport.sh
+++ b/createcoveragereport.sh
@@ -64,7 +64,8 @@ $REPORTGENERATOR \
 
 if [[ "$upload_report" = true ]]
 then
-  choco install codecov
+  # -y option to confirm all prompts.
+  choco install codecov -y
 
   # Assume we've created the coverage file by this point. If we haven't, there should already have been an error.
   # Pass whatever parameters we recieved.


### PR DESCRIPTION
It might have been working in AppVeyor because apart from setting the `-y` option when executing `choco install`, there's a [global feature setting](https://github.com/chocolatey/choco/issues/178#issuecomment-83757651) that has the same effect for all `choco install` executions and that is probably set in AppVeyor.