### PR TITLE
Use readlink -f instead of realpath in toolversions.sh

### DIFF
--- a/toolversions.sh
+++ b/toolversions.sh
@@ -3,7 +3,7 @@
 
 # TODO: Make all of this work under Linux too, if it's useful
 
-declare -r REPO_ROOT=$(realpath $(dirname ${BASH_SOURCE}))
+declare -r REPO_ROOT=$(readlink -f $(dirname ${BASH_SOURCE}))
 declare -r TOOL_PACKAGES=$REPO_ROOT/packages
 
 declare -r DOCFX_VERSION=2.39.1


### PR DESCRIPTION
We use realpath in a couple of other places, but those are expected
to be run on developer machines, which is okay. realpath appears not
to be available on our Travis environment.

Fixes #2572.