### PR TITLE
Fix the other version of Cloud Tasks in terms of a doc link...

### DIFF
--- a/apis/apis.json
+++ b/apis/apis.json
@@ -726,7 +726,7 @@
   {
     "id": "Google.Cloud.Tasks.V2Beta3",
     "productName": "Google Cloud Tasks",
-    "productUrl": "https://cloud.google.com/cloud-tasks/",
+    "productUrl": "https://cloud.google.com/tasks/",
     "version": "1.0.0-beta01",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Tasks API (v2beta3), which manages the execution of large numbers of distributed requests.",


### PR DESCRIPTION
(Will self-merge, as it's the same as #2581 but for another version.)