### PR TITLE
Adding context info on tests that might be failing because of read timeouts to confirm if that's the case.

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/ErrorReporting/ErrorReportingTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/ErrorReporting/ErrorReportingTest.cs
@@ -64,8 +64,7 @@ namespace Google.Cloud.Diagnostics.AspNet.IntegrationTests
 
             Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
 
-            var errorEvent = s_polling.GetEvents(_testId, 1).Single();
-
+            var errorEvent = ErrorEventEntryVerifiers.VerifySingle(s_polling, _testId);
             ErrorEventEntryVerifiers.VerifyFullErrorEventLogged(errorEvent, _testId, nameof(ErrorReportingController.ThrowsException));
 
             var content = await contentTask;
@@ -90,8 +89,7 @@ namespace Google.Cloud.Diagnostics.AspNet.IntegrationTests
             response = await requestTask4;
             Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
 
-            var errorEvents = s_polling.GetEvents(_testId, 4);
-            Assert.Equal(4, errorEvents.Count());
+            var errorEvents = ErrorEventEntryVerifiers.VerifyMany(s_polling, _testId, 4);
 
             var exceptionEvents = errorEvents
                 .Where(e => e.Message.Contains(nameof(ErrorReportingController.ThrowsException)));
@@ -114,8 +112,7 @@ namespace Google.Cloud.Diagnostics.AspNet.IntegrationTests
 
             Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
 
-            var errorEvent = s_polling.GetEvents(_testId, 1).Single();
-
+            var errorEvent = ErrorEventEntryVerifiers.VerifySingle(s_polling, _testId);
             ErrorEventEntryVerifiers.VerifyFullErrorEventLogged(errorEvent, _testId, "SendAsync");
         }
 
@@ -126,7 +123,7 @@ namespace Google.Cloud.Diagnostics.AspNet.IntegrationTests
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-            var errorEvent = s_polling.GetEvents(_testId, 1).Single();
+            var errorEvent = ErrorEventEntryVerifiers.VerifySingle(s_polling, _testId);
             ErrorEventEntryVerifiers.VerifyErrorEventLogged(errorEvent, _testId, nameof(ErrorReportingController.ThrowCatchWithGoogleLogger));
         }
 
@@ -137,7 +134,7 @@ namespace Google.Cloud.Diagnostics.AspNet.IntegrationTests
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-            var errorEvent = s_polling.GetEvents(_testId, 1).Single();
+            var errorEvent = ErrorEventEntryVerifiers.VerifySingle(s_polling, _testId);
             ErrorEventEntryVerifiers.VerifyFullErrorEventLogged(errorEvent, _testId, nameof(ErrorReportingController.ThrowCatchWithGoogleWebApiLogger));
         }
 

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Snippets/ErrorReportingSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Snippets/ErrorReportingSnippets.cs
@@ -62,8 +62,7 @@ namespace Google.Cloud.Diagnostics.AspNet.Snippets
 
             Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
 
-            var errorEvent = s_polling.GetEvents(_testId, 1).Single();
-
+            var errorEvent = ErrorEventEntryVerifiers.VerifySingle(s_polling, _testId);
             ErrorEventEntryVerifiers.VerifyFullErrorEventLogged(
                 errorEvent, _testId, nameof(ErrorReportingController.ThrowsException));
         }
@@ -76,7 +75,7 @@ namespace Google.Cloud.Diagnostics.AspNet.Snippets
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-            var errorEvent = s_polling.GetEvents(_testId, 1).Single();
+            var errorEvent = ErrorEventEntryVerifiers.VerifySingle(s_polling, _testId);
             ErrorEventEntryVerifiers.VerifyFullErrorEventLogged(
                 errorEvent, _testId, "DoSomething");
         }

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/DiagnosticsWebHostTests.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/DiagnosticsWebHostTests.cs
@@ -135,7 +135,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         {
             var polling = new ErrorEventEntryPolling();
             await Assert.ThrowsAsync<Exception>(() => client.GetAsync($"/ErrorReporting/{nameof(ErrorReportingController.ThrowsException)}/{testId}"));
-            var errorEvent = polling.GetEvents(testId, 1).Single();
+            var errorEvent = ErrorEventEntryVerifiers.VerifySingle(polling, testId);
             ErrorEventEntryVerifiers.VerifyFullErrorEventLogged(errorEvent, testId, nameof(ErrorReportingController.ThrowsException));
         }
     }

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/ErrorReporting/ErrorReportingTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/ErrorReporting/ErrorReportingTest.cs
@@ -64,7 +64,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-            var errorEvent = s_polling.GetEvents(_testId, 1).Single();
+            var errorEvent = ErrorEventEntryVerifiers.VerifySingle(s_polling, _testId);
             ErrorEventEntryVerifiers.VerifyFullErrorEventLogged(errorEvent, _testId, nameof(ErrorReportingController.ThrowCatchLog));
         }
 
@@ -74,7 +74,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
             await Assert.ThrowsAsync<Exception>(() =>
                 _client.GetAsync($"/ErrorReporting/{nameof(ErrorReportingController.ThrowsException)}/{_testId}"));
 
-            var errorEvent = s_polling.GetEvents(_testId, 1).Single();
+            var errorEvent = ErrorEventEntryVerifiers.VerifySingle(s_polling, _testId);
             ErrorEventEntryVerifiers.VerifyFullErrorEventLogged(errorEvent, _testId, nameof(ErrorReportingController.ThrowsException));
         }
 
@@ -90,8 +90,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
             await Assert.ThrowsAsync<Exception>(() =>
                 _client.GetAsync($"/ErrorReporting/{nameof(ErrorReportingController.ThrowsException)}/{_testId}"));
 
-            var errorEvents = s_polling.GetEvents(_testId, 4);
-            Assert.Equal(4, errorEvents.Count());
+            var errorEvents = ErrorEventEntryVerifiers.VerifyMany(s_polling, _testId, 4);
 
             var exceptionEvents = errorEvents.Where(e => e.Message.Contains(nameof(ErrorReportingController.ThrowsException)));
             Assert.Equal(3, exceptionEvents.Count());

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/DiagnosticsSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/DiagnosticsSnippets.cs
@@ -20,7 +20,6 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
 using System;
 using System.Linq;
-using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit;
@@ -71,8 +70,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
         {
             await Assert.ThrowsAsync<Exception>(() => _client.GetAsync($"/ErrorLoggingSamples/{nameof(ErrorLoggingSamplesController.ThrowsException)}/{_testId}"));
 
-            var errorEvent = s_errorPolling.GetEvents(_testId, 1).Single();
-
+            var errorEvent = ErrorEventEntryVerifiers.VerifySingle(s_errorPolling, _testId);
             ErrorEventEntryVerifiers.VerifyFullErrorEventLogged(errorEvent, _testId, nameof(ErrorLoggingSamplesController.ThrowsException));
         }
 

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/ErrorReportingSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/ErrorReportingSnippets.cs
@@ -58,8 +58,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
             await Assert.ThrowsAsync<Exception>(()
                 => _client.GetAsync($"/ErrorLoggingSamples/{nameof(ErrorLoggingSamplesController.ThrowsException)}/{_testId}"));
 
-            var errorEvent = s_polling.GetEvents(_testId, 1).Single();
-
+            var errorEvent = ErrorEventEntryVerifiers.VerifySingle(s_polling, _testId);
             ErrorEventEntryVerifiers.VerifyFullErrorEventLogged(errorEvent, _testId, nameof(ErrorLoggingSamplesController.ThrowsException));
         }
 
@@ -76,7 +75,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-            var errorEvent = s_polling.GetEvents(_testId, 1).Single();
+            var errorEvent = ErrorEventEntryVerifiers.VerifySingle(s_polling, _testId);
 
             // Verifying with function name ThrowsExceptions because that is the function
             // that actually throws the Exception so will be the one included as

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/ErrorReporting/ErrorEventEntryPolling.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/ErrorReporting/ErrorEventEntryPolling.cs
@@ -37,7 +37,7 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
         private readonly ProjectName _projectName = new ProjectName(TestEnvironment.GetTestProjectId());
 
         // Give the error reporting events a little extra time to be processed.
-        internal ErrorEventEntryPolling() : base(TimeSpan.FromSeconds(180), TimeSpan.FromSeconds(30)) { }
+        internal ErrorEventEntryPolling() : base(TimeSpan.FromSeconds(600), TimeSpan.FromSeconds(30)) { }
 
         /// <summary>
         /// Gets error events that contain the passed in testId in the message.  Will poll

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/ErrorReporting/ErrorEventEntryVerifiers.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/ErrorReporting/ErrorEventEntryVerifiers.cs
@@ -14,13 +14,38 @@
 
 using Google.Cloud.ClientTesting;
 using Google.Cloud.ErrorReporting.V1Beta1;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using Xunit;
 
 namespace Google.Cloud.Diagnostics.Common.IntegrationTests
 {
-    public static class ErrorEventEntryVerifiers
+    internal static class ErrorEventEntryVerifiers
     {
+        /// <summary>
+        /// Checks that there's only one event present.
+        /// Includes a message with context info to help track the possible issue.
+        /// </summary>
+        public static ErrorEvent VerifySingle(ErrorEventEntryPolling polling, string contextInfo)
+        {
+            var events = polling.GetEvents(contextInfo, 1);
+            var errorEvent = events.SingleOrDefault();
+            Assert.True(errorEvent != null, $"No entries found for context {contextInfo}");
+            return errorEvent;
+        }
+
+        /// <summary>
+        /// Checks that there are <paramref name="expected"/> events present.
+        /// Includes a message with context info to help track the possible issue.
+        /// </summary>
+        public static IEnumerable<ErrorEvent> VerifyMany(ErrorEventEntryPolling polling, string contextInfo, int expected)
+        {
+            var events = polling.GetEvents(contextInfo, expected).ToList();
+            Assert.True(expected == events.Count, $"Should have found {expected} entries for contest {contextInfo} but found {events.Count}");
+            return events;
+        }
+
         /// <summary>
         /// Checks that an <see cref="ErrorEvent"/> contains valid data,
         /// including HTTP Context data.


### PR DESCRIPTION
This will help confirm if and when the entries that we are not reading in a timely fashion are actually written on Stackdriver Error Reporting.