### PR TITLE
Make it easier to see timings for build actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ AllTests.txt
 
 # Benchmarks
 BenchmarkDotNet.Artifacts
+
+# Log files
+build_timing_log.txt

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -10,3 +10,4 @@ cd ..
 
 ./build.sh
 
+./processbuildtiminglog.sh

--- a/.kokoro/builddocs.sh
+++ b/.kokoro/builddocs.sh
@@ -14,3 +14,5 @@ cd ..
 # Build the docs.
 cd docs
 ./builddocs.sh
+cd ..
+./processbuildtiminglog.sh

--- a/.kokoro/cleantestdata.sh
+++ b/.kokoro/cleantestdata.sh
@@ -10,3 +10,4 @@ cd ..
 
 ./cleantestdata.sh
 
+./processbuildtiminglog.sh

--- a/.kokoro/release.sh
+++ b/.kokoro/release.sh
@@ -26,3 +26,7 @@ cd ../..
 # Push the changes to nuget.
 cd ./releasebuild/nuget
 for pkg in *.nupkg; do dotnet nuget push -s https://api.nuget.org/v3/index.json -k $NUGET_API_KEY $pkg; done
+
+# Process the build log in releasebuild
+cd ..
+./processbuildtiminglog.sh

--- a/.kokoro/runintegrationtests.sh
+++ b/.kokoro/runintegrationtests.sh
@@ -46,3 +46,5 @@ rm -rf coverage
 ./runintegrationtests.sh $script_flags --retry
 # Even if we set up here some upload report flags, if --upload is not present we won't upload the report.
 ./createcoveragereport.sh $report_flags --upload_reportname integrationtests
+
+./processbuildtiminglog.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,4 @@ addons:
 
 script:
   - ./build.sh --diff --regex $API_REGEX
+  - ./processbuildtiminglog.sh

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -17,3 +17,5 @@ else
   # build and run tests.
   ./build.sh --diff
 fi
+
+./processbuildtiminglog.sh

--- a/build.sh
+++ b/build.sh
@@ -93,7 +93,8 @@ then
 fi
 
 # First build the analyzers, for use in everything else.
-echo "$(date +%T) Building analyzers"
+log_build_action "(Start) build.sh"
+log_build_action "Building analyzers"
 
 dotnet publish -c Release -f netstandard1.3 tools/Google.Cloud.Tools.Analyzers
 
@@ -110,6 +111,7 @@ do
     continue
   fi
 
+  log_build_action "Building $apidir"
   dotnet build -c Release $apidir
 
   # On Linux, we don't have desktop .NET, so any projects which only
@@ -123,13 +125,14 @@ do
   done
 done
 
+log_build_action "(Start) Unit tests"
 if [[ "$runtests" = true ]]
 then
   # Could use xargs, but this is more flexible
   while read testproject
   do  
-    echo "$(date +%T) Testing $testproject"
     testdir=$(dirname $testproject)
+    log_build_action "Testing $testdir"
     if [[ "$runcoverage" = true && -f "$testdir/coverage.xml" ]]
     then
       echo "(Running with coverage)"
@@ -140,4 +143,5 @@ then
   done < AllTests.txt
 fi
 
-echo "$(date +%T) Build finished."
+log_build_action "(End) Unit tests"
+log_build_action "(End) build.sh"

--- a/cleantestdata.sh
+++ b/cleantestdata.sh
@@ -9,6 +9,8 @@ set -e
 
 cd $(dirname $0)
 
+source toolversions.sh
+
 apis=$(echo apis/Google.* | sed 's/apis\///g')
 
 echo "Using test project '$TEST_PROJECT'"
@@ -18,7 +20,7 @@ do
   cleantestdir=apis/$api/$api.CleanTestData
   if [[ -d "$cleantestdir" ]]
   then
-    echo "Cleaning test data for $api"
+    log_build_action "Cleaning test data for $api"
     dotnet build -c Release $cleantestdir
     dotnet run --project $cleantestdir -- $TEST_PROJECT
   fi

--- a/docs/builddocs.sh
+++ b/docs/builddocs.sh
@@ -6,7 +6,7 @@ source ../toolversions.sh
 install_docfx
 
 build_api_docs() {
-  echo "$(date +%T) Building docs for $1"
+  log_build_action "Building docs for $1"
   local api=$1
 
   # Special case "root" where we don't need to generate the sources
@@ -58,7 +58,7 @@ build_api_docs() {
 
 if [[ ! -d "dependencies" ]]
 then
-  echo "Fetching external dependencies repo"
+  log_build_action "Fetching external dependencies repo"
   git clone https://github.com/googleapis/google-cloud-dotnet dependencies --quiet -b dependencies --depth=1
 fi
 
@@ -78,7 +78,9 @@ then
   apis="`/usr/bin/find ../apis -mindepth 2 -maxdepth 2 -name docs -type d | cut -d/ -f3` root"
 fi
 
+log_build_action "(Start) Building docs"
 for api in $apis
 do 
   build_api_docs $api
 done
+log_build_action "(End) Building docs"

--- a/processbuildtiminglog.sh
+++ b/processbuildtiminglog.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+echo ----------------
+echo Build timing log
+echo ----------------
+dotnet run -p tools/Google.Cloud.Tools.ProcessBuildTimingLog -- build_timing_log.txt

--- a/runintegrationtests.sh
+++ b/runintegrationtests.sh
@@ -85,8 +85,10 @@ else
   declare -r testdirs=$(echo */*.IntegrationTests */*.Snippets */*.SmokeTests)
 fi
 
+log_build_action "(Start) Integration tests"
 for testdir in $testdirs
 do
+  log_build_action "Testing $testdir"
   if [[ "$testdir" =~ Metadata || "$testdir" =~ EntityFrameworkCore.Spanner ]]
   then
     echo "Skipping $testdir; test not supported yet."
@@ -106,6 +108,7 @@ do
     (cd $testdir; dotnet test -c Release --no-build || echo "$testdir" >> $FAILURE_TEMP_FILE)
   fi
 done
+log_build_action "(End) Integration tests"
 
 mv -f $FAILURE_TEMP_FILE $FAILURE_FILE
 

--- a/tools/Google.Cloud.Tools.ProcessBuildTimingLog/Google.Cloud.Tools.ProcessBuildTimingLog.csproj
+++ b/tools/Google.Cloud.Tools.ProcessBuildTimingLog/Google.Cloud.Tools.ProcessBuildTimingLog.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <Description>Console app to process a build timing log</Description>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NodaTime" Version="2.4.0" />
+  </ItemGroup>
+
+</Project>

--- a/tools/Google.Cloud.Tools.ProcessBuildTimingLog/LogEntry.cs
+++ b/tools/Google.Cloud.Tools.ProcessBuildTimingLog/LogEntry.cs
@@ -39,6 +39,13 @@ namespace Google.Cloud.Tools.ProcessBuildTimingLog
             {
                 throw new ArgumentException("Invalid log line: {line}");
             }
+            // Horrible hack: on Travis, we end up with +0000 instead of +00:00. It's simpler
+            // to fix when processing than in the shell scripts.
+            if (bits[0].EndsWith("+0000"))
+            {
+                bits[0] = bits[0].Insert(bits[0].Length - 2, ":");
+            }
+
             var instant = OffsetDateTimePattern.ExtendedIso.Parse(bits[0]).Value.ToInstant();
             return new LogEntry(bits[1], instant);
         }

--- a/tools/Google.Cloud.Tools.ProcessBuildTimingLog/LogEntry.cs
+++ b/tools/Google.Cloud.Tools.ProcessBuildTimingLog/LogEntry.cs
@@ -1,0 +1,46 @@
+﻿// Copyright 2018 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using NodaTime;
+using NodaTime.Text;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Google.Cloud.Tools.ProcessBuildTimingLog
+{
+    /// <summary>
+    /// The separated parts of a raw log line.
+    /// </summary>
+    public class LogEntry
+    {
+        private static readonly char[] s_separators = { ' ' };
+        public string Action { get; }
+        public Instant Timestamp { get; }
+
+        private LogEntry(string action, Instant timestamp) =>
+            (Action, Timestamp) = (action, timestamp);
+
+        public static LogEntry FromLogLine(string line)
+        {
+            string[] bits = line.Split(s_separators, 2);
+            if (bits.Length != 2)
+            {
+                throw new ArgumentException("Invalid log line: {line}");
+            }
+            var instant = OffsetDateTimePattern.ExtendedIso.Parse(bits[0]).Value.ToInstant();
+            return new LogEntry(bits[1], instant);
+        }
+    }
+}

--- a/tools/Google.Cloud.Tools.ProcessBuildTimingLog/Program.cs
+++ b/tools/Google.Cloud.Tools.ProcessBuildTimingLog/Program.cs
@@ -1,0 +1,108 @@
+﻿// Copyright 2018 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using NodaTime;
+using NodaTime.Text;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Google.Cloud.Tools.ProcessBuildTimingLog
+{
+    /// <summary>
+    /// Processes a build timing log created by the log_build_action function in toolversions.sh.
+    /// This makes it easy to see how long each part of the build takes.
+    /// </summary>
+    class Program
+    {
+        private static readonly DurationPattern s_durationPattern = DurationPattern.CreateWithInvariantCulture("-HH:mm:ss");
+        // The text to use instead of a duration for entries with no duration
+        private const string NoDurationText = "--------";
+
+        private const string StartPrefix = "(Start) ";
+        private const string EndPrefix = "(End) ";
+
+        private static int Main(string[] args)
+        {
+            if (args.Length != 1)
+            {
+                Console.WriteLine("Required single argument: log file path");
+                return 1;
+            }
+            string[] lines = File.ReadAllLines(args[0]);
+
+            var logEntries = lines.Where(line => line.Length > 0).Select(LogEntry.FromLogLine).ToList();
+
+            for (int i = 0; i < logEntries.Count; i++)
+            {
+                ProcessEntry(logEntries, i);
+            }
+
+            return 0;
+        }
+
+        private static void ProcessEntry(List<LogEntry> entries, int index)
+        {
+            LogEntry entry = entries[index];
+
+            // Ignore any "end" actions. Assume they've already been handled (or are useless if they're orphans)
+            if (entry.Action.StartsWith(EndPrefix))
+            {
+                return;
+            }
+
+            // If we have a "start" action, find the next matching "start" or "end", and handle appropriately
+            if (entry.Action.StartsWith(StartPrefix))
+            {
+                string unprefixedAction = entry.Action.Substring(StartPrefix.Length);
+                string expectedEndAction = EndPrefix + unprefixedAction;
+
+                // Note: in theory we should probably do this by index rather than timing, but it's very unlikely
+                // to cause issues.
+                var nextStart = entries.Skip(index + 1).FirstOrDefault(e => e.Action.StartsWith(entry.Action));
+                var nextEnd = entries.Skip(index + 1).FirstOrDefault(e => e.Action.StartsWith(expectedEndAction));
+                if (nextEnd == null)
+                {
+                    PrintEntry(entry.Timestamp, null, $"No matching end: {unprefixedAction}");
+                    return;
+                }
+                if (nextStart != null && nextStart.Timestamp < nextEnd.Timestamp)
+                {
+                    PrintEntry(entry.Timestamp, null, $"Matching start before end: {unprefixedAction}");
+                    return;
+                }
+                // We report the action in parentheses as a simple indication that it's a compound action.
+                PrintEntry(entry.Timestamp, nextEnd.Timestamp, $"({unprefixedAction})");
+                return;
+            }
+            // Simple case: just one line for this action. Use the next entry if we have one.
+            if (index == entries.Count)
+            {
+                PrintEntry(entry.Timestamp, null, $"Final line of file: {entry.Action}");
+            }
+            else
+            {
+                PrintEntry(entry.Timestamp, entries[index + 1].Timestamp, entry.Action);
+            }
+        
+            void PrintEntry(Instant start, Instant? end, string action)
+            {
+                string formattedDuration = end != null
+                    ? s_durationPattern.Format(end.Value - start)
+                    : NoDurationText;
+                Console.WriteLine($"{InstantPattern.General.Format(start)} {formattedDuration} {action}");
+            }
+        }
+    }
+}

--- a/tools/Google.Cloud.Tools.sln
+++ b/tools/Google.Cloud.Tools.sln
@@ -42,6 +42,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Tools.Generate
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.AnalyzersTesting", "Google.Cloud.AnalyzersTesting\Google.Cloud.AnalyzersTesting.csproj", "{5608BDB2-A160-49C0-A545-C08787534B18}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Tools.ProcessBuildTimingLog", "Google.Cloud.Tools.ProcessBuildTimingLog\Google.Cloud.Tools.ProcessBuildTimingLog.csproj", "{E47C244F-96BC-4753-BFE1-7A54A3C3AA3E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -292,6 +294,18 @@ Global
 		{5608BDB2-A160-49C0-A545-C08787534B18}.Release|x64.Build.0 = Release|Any CPU
 		{5608BDB2-A160-49C0-A545-C08787534B18}.Release|x86.ActiveCfg = Release|Any CPU
 		{5608BDB2-A160-49C0-A545-C08787534B18}.Release|x86.Build.0 = Release|Any CPU
+		{E47C244F-96BC-4753-BFE1-7A54A3C3AA3E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E47C244F-96BC-4753-BFE1-7A54A3C3AA3E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E47C244F-96BC-4753-BFE1-7A54A3C3AA3E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E47C244F-96BC-4753-BFE1-7A54A3C3AA3E}.Debug|x64.Build.0 = Debug|Any CPU
+		{E47C244F-96BC-4753-BFE1-7A54A3C3AA3E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E47C244F-96BC-4753-BFE1-7A54A3C3AA3E}.Debug|x86.Build.0 = Debug|Any CPU
+		{E47C244F-96BC-4753-BFE1-7A54A3C3AA3E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E47C244F-96BC-4753-BFE1-7A54A3C3AA3E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E47C244F-96BC-4753-BFE1-7A54A3C3AA3E}.Release|x64.ActiveCfg = Release|Any CPU
+		{E47C244F-96BC-4753-BFE1-7A54A3C3AA3E}.Release|x64.Build.0 = Release|Any CPU
+		{E47C244F-96BC-4753-BFE1-7A54A3C3AA3E}.Release|x86.ActiveCfg = Release|Any CPU
+		{E47C244F-96BC-4753-BFE1-7A54A3C3AA3E}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/toolversions.sh
+++ b/toolversions.sh
@@ -82,3 +82,9 @@ install_docfx() {
      )
   fi  
 }
+
+# Logs to both stdout and a build timing log, allowing
+# post-processing to see how long each part of the build takes.
+log_build_action() {
+  echo "$(date -u -Iseconds) $1" | tee -a $REPO_ROOT/build_timing_log.txt
+}


### PR DESCRIPTION
I'd suggest letting the Travis and AppVeyor builds go green before reviewing, because then you should be able to see the result at the end of the log.