### PR TITLE
On Travis and AppVeyor, start with a present-but-empty timing log

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,6 @@ addons:
     - dotnet-sharedframework-microsoft.netcore.app-1.0.5
 
 script:
+  - > build_timing_log.txt
   - ./build.sh --diff --regex $API_REGEX
   - ./processbuildtiminglog.sh

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -6,6 +6,8 @@ dotnet --info
 echo "Regenerating projects: if this fails, run generateprojects.sh and commit changes"
 bash generateprojects.sh && git diff --exit-code
 
+> build_timing_log.txt
+
 if [[ -z "$APPVEYOR_PULL_REQUEST_NUMBER" ]]
 then
   # Not in a pull request.


### PR DESCRIPTION
(Kokoro builds don't use --diff so will always have a log.)