### PR TITLE
Regenerate all APIs with GAPIC HEAD

### DIFF
--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/ResourceNames.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/ResourceNames.cs
@@ -21,6 +21,210 @@ using linq = System.Linq;
 namespace Google.Cloud.BigQuery.DataTransfer.V1
 {
     /// <summary>
+    /// Resource name which will contain one of a choice of resource names.
+    /// </summary>
+    /// <remarks>
+    /// This resource name will contain one of the following:
+    /// <list type="bullet">
+    /// <item><description>ProjectDataSourceName: A resource of type 'project_data_source'.</description></item>
+    /// <item><description>LocationDataSourceName: A resource of type 'location_data_source'.</description></item>
+    /// </list>
+    /// </remarks>
+    public sealed partial class DataSourceNameOneof : gax::IResourceName, sys::IEquatable<DataSourceNameOneof>
+    {
+        /// <summary>
+        /// The possible contents of <see cref="DataSourceNameOneof"/>.
+        /// </summary>
+        public enum OneofType
+        {
+            /// <summary>
+            /// A resource of an unknown type.
+            /// </summary>
+            Unknown = 0,
+
+            /// <summary>
+            /// A resource of type 'project_data_source'.
+            /// </summary>
+            ProjectDataSourceName = 1,
+
+            /// <summary>
+            /// A resource of type 'location_data_source'.
+            /// </summary>
+            LocationDataSourceName = 2,
+        }
+
+        /// <summary>
+        /// Parses a resource name in string form into a new <see cref="DataSourceNameOneof"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully the resource name must be one of the following:
+        /// <list type="bullet">
+        /// <item><description>ProjectDataSourceName: A resource of type 'project_data_source'.</description></item>
+        /// <item><description>LocationDataSourceName: A resource of type 'location_data_source'.</description></item>
+        /// </list>
+        /// Or an <see cref="gax::UnknownResourceName"/> if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnknown">If true, will successfully parse an unknown resource name
+        /// into an <see cref="gax::UnknownResourceName"/>; otherwise will throw an
+        /// <see cref="sys::ArgumentException"/> if an unknown resource name is given.</param>
+        /// <returns>The parsed <see cref="DataSourceNameOneof"/> if successful.</returns>
+        public static DataSourceNameOneof Parse(string name, bool allowUnknown)
+        {
+            DataSourceNameOneof result;
+            if (TryParse(name, allowUnknown, out result))
+            {
+                return result;
+            }
+            throw new sys::ArgumentException("Invalid name", nameof(name));
+        }
+
+        /// <summary>
+        /// Tries to parse a resource name in string form into a new <see cref="DataSourceNameOneof"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully the resource name must be one of the following:
+        /// <list type="bullet">
+        /// <item><description>ProjectDataSourceName: A resource of type 'project_data_source'.</description></item>
+        /// <item><description>LocationDataSourceName: A resource of type 'location_data_source'.</description></item>
+        /// </list>
+        /// Or an <see cref="gax::UnknownResourceName"/> if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnknown">If true, will successfully parse an unknown resource name
+        /// into an <see cref="gax::UnknownResourceName"/>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="DataSourceNameOneof"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string name, bool allowUnknown, out DataSourceNameOneof result)
+        {
+            gax::GaxPreconditions.CheckNotNull(name, nameof(name));
+            ProjectDataSourceName projectDataSourceName;
+            if (ProjectDataSourceName.TryParse(name, out projectDataSourceName))
+            {
+                result = new DataSourceNameOneof(OneofType.ProjectDataSourceName, projectDataSourceName);
+                return true;
+            }
+            LocationDataSourceName locationDataSourceName;
+            if (LocationDataSourceName.TryParse(name, out locationDataSourceName))
+            {
+                result = new DataSourceNameOneof(OneofType.LocationDataSourceName, locationDataSourceName);
+                return true;
+            }
+            if (allowUnknown)
+            {
+                gax::UnknownResourceName unknownResourceName;
+                if (gax::UnknownResourceName.TryParse(name, out unknownResourceName))
+                {
+                    result = new DataSourceNameOneof(OneofType.Unknown, unknownResourceName);
+                    return true;
+                }
+            }
+            result = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Construct a new instance of <see cref="DataSourceNameOneof"/> from the provided <see cref="ProjectDataSourceName"/>
+        /// </summary>
+        /// <param name="projectDataSourceName">The <see cref="ProjectDataSourceName"/> to be contained within
+        /// the returned <see cref="DataSourceNameOneof"/>. Must not be <c>null</c>.</param>
+        /// <returns>A new <see cref="DataSourceNameOneof"/>, containing <paramref name="projectDataSourceName"/>.</returns>
+        public static DataSourceNameOneof From(ProjectDataSourceName projectDataSourceName) => new DataSourceNameOneof(OneofType.ProjectDataSourceName, projectDataSourceName);
+
+        /// <summary>
+        /// Construct a new instance of <see cref="DataSourceNameOneof"/> from the provided <see cref="LocationDataSourceName"/>
+        /// </summary>
+        /// <param name="locationDataSourceName">The <see cref="LocationDataSourceName"/> to be contained within
+        /// the returned <see cref="DataSourceNameOneof"/>. Must not be <c>null</c>.</param>
+        /// <returns>A new <see cref="DataSourceNameOneof"/>, containing <paramref name="locationDataSourceName"/>.</returns>
+        public static DataSourceNameOneof From(LocationDataSourceName locationDataSourceName) => new DataSourceNameOneof(OneofType.LocationDataSourceName, locationDataSourceName);
+
+        private static bool IsValid(OneofType type, gax::IResourceName name)
+        {
+            switch (type)
+            {
+                case OneofType.Unknown: return true; // Anything goes with Unknown.
+                case OneofType.ProjectDataSourceName: return name is ProjectDataSourceName;
+                case OneofType.LocationDataSourceName: return name is LocationDataSourceName;
+                default: return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="DataSourceNameOneof"/> resource name class
+        /// from a suitable <see cref="gax::IResourceName"/> instance.
+        /// </summary>
+        public DataSourceNameOneof(OneofType type, gax::IResourceName name)
+        {
+            Type = gax::GaxPreconditions.CheckEnumValue<OneofType>(type, nameof(type));
+            Name = gax::GaxPreconditions.CheckNotNull(name, nameof(name));
+            if (!IsValid(type, name))
+            {
+                throw new sys::ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
+            }
+        }
+
+        /// <summary>
+        /// The <see cref="OneofType"/> of the Name contained in this instance.
+        /// </summary>
+        public OneofType Type { get; }
+
+        /// <summary>
+        /// The <see cref="gax::IResourceName"/> contained in this instance.
+        /// </summary>
+        public gax::IResourceName Name { get; }
+
+        private T CheckAndReturn<T>(OneofType type)
+        {
+            if (Type != type)
+            {
+                throw new sys::InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
+            }
+            return (T)Name;
+        }
+
+        /// <summary>
+        /// Get the contained <see cref="gax::IResourceName"/> as <see cref="ProjectDataSourceName"/>.
+        /// </summary>
+        /// <remarks>
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
+        /// contain an instance of <see cref="ProjectDataSourceName"/>.
+        /// </remarks>
+        public ProjectDataSourceName ProjectDataSourceName => CheckAndReturn<ProjectDataSourceName>(OneofType.ProjectDataSourceName);
+
+        /// <summary>
+        /// Get the contained <see cref="gax::IResourceName"/> as <see cref="LocationDataSourceName"/>.
+        /// </summary>
+        /// <remarks>
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
+        /// contain an instance of <see cref="LocationDataSourceName"/>.
+        /// </remarks>
+        public LocationDataSourceName LocationDataSourceName => CheckAndReturn<LocationDataSourceName>(OneofType.LocationDataSourceName);
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Oneof;
+
+        /// <inheritdoc />
+        public override string ToString() => Name.ToString();
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as DataSourceNameOneof);
+
+        /// <inheritdoc />
+        public bool Equals(DataSourceNameOneof other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(DataSourceNameOneof a, DataSourceNameOneof b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(DataSourceNameOneof a, DataSourceNameOneof b) => !(a == b);
+    }
+
+    /// <summary>
     /// Resource name for the 'location' resource.
     /// </summary>
     public sealed partial class LocationName : gax::IResourceName, sys::IEquatable<LocationName>
@@ -110,98 +314,6 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
 
         /// <inheritdoc />
         public static bool operator !=(LocationName a, LocationName b) => !(a == b);
-    }
-
-    /// <summary>
-    /// Resource name for the 'project_data_source' resource.
-    /// </summary>
-    public sealed partial class ProjectDataSourceName : gax::IResourceName, sys::IEquatable<ProjectDataSourceName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/dataSources/{data_source}");
-
-        /// <summary>
-        /// Parses the given project_data_source resource name in string form into a new
-        /// <see cref="ProjectDataSourceName"/> instance.
-        /// </summary>
-        /// <param name="projectDataSourceName">The project_data_source resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="ProjectDataSourceName"/> if successful.</returns>
-        public static ProjectDataSourceName Parse(string projectDataSourceName)
-        {
-            gax::GaxPreconditions.CheckNotNull(projectDataSourceName, nameof(projectDataSourceName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(projectDataSourceName);
-            return new ProjectDataSourceName(resourceName[0], resourceName[1]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given project_data_source resource name in string form into a new
-        /// <see cref="ProjectDataSourceName"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectDataSourceName"/> is null,
-        /// as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="projectDataSourceName">The project_data_source resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="ProjectDataSourceName"/>,
-        /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string projectDataSourceName, out ProjectDataSourceName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(projectDataSourceName, nameof(projectDataSourceName));
-            gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(projectDataSourceName, out resourceName))
-            {
-                result = new ProjectDataSourceName(resourceName[0], resourceName[1]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="ProjectDataSourceName"/> resource name class
-        /// from its component parts.
-        /// </summary>
-        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
-        /// <param name="dataSourceId">The dataSource ID. Must not be <c>null</c>.</param>
-        public ProjectDataSourceName(string projectId, string dataSourceId)
-        {
-            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
-            DataSourceId = gax::GaxPreconditions.CheckNotNull(dataSourceId, nameof(dataSourceId));
-        }
-
-        /// <summary>
-        /// The project ID. Never <c>null</c>.
-        /// </summary>
-        public string ProjectId { get; }
-
-        /// <summary>
-        /// The dataSource ID. Never <c>null</c>.
-        /// </summary>
-        public string DataSourceId { get; }
-
-        /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc />
-        public override string ToString() => s_template.Expand(ProjectId, DataSourceId);
-
-        /// <inheritdoc />
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as ProjectDataSourceName);
-
-        /// <inheritdoc />
-        public bool Equals(ProjectDataSourceName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc />
-        public static bool operator ==(ProjectDataSourceName a, ProjectDataSourceName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc />
-        public static bool operator !=(ProjectDataSourceName a, ProjectDataSourceName b) => !(a == b);
     }
 
     /// <summary>
@@ -301,296 +413,6 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
 
         /// <inheritdoc />
         public static bool operator !=(LocationDataSourceName a, LocationDataSourceName b) => !(a == b);
-    }
-
-    /// <summary>
-    /// Resource name for the 'project_transfer_config' resource.
-    /// </summary>
-    public sealed partial class ProjectTransferConfigName : gax::IResourceName, sys::IEquatable<ProjectTransferConfigName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/transferConfigs/{transfer_config}");
-
-        /// <summary>
-        /// Parses the given project_transfer_config resource name in string form into a new
-        /// <see cref="ProjectTransferConfigName"/> instance.
-        /// </summary>
-        /// <param name="projectTransferConfigName">The project_transfer_config resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="ProjectTransferConfigName"/> if successful.</returns>
-        public static ProjectTransferConfigName Parse(string projectTransferConfigName)
-        {
-            gax::GaxPreconditions.CheckNotNull(projectTransferConfigName, nameof(projectTransferConfigName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(projectTransferConfigName);
-            return new ProjectTransferConfigName(resourceName[0], resourceName[1]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given project_transfer_config resource name in string form into a new
-        /// <see cref="ProjectTransferConfigName"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectTransferConfigName"/> is null,
-        /// as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="projectTransferConfigName">The project_transfer_config resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="ProjectTransferConfigName"/>,
-        /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string projectTransferConfigName, out ProjectTransferConfigName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(projectTransferConfigName, nameof(projectTransferConfigName));
-            gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(projectTransferConfigName, out resourceName))
-            {
-                result = new ProjectTransferConfigName(resourceName[0], resourceName[1]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="ProjectTransferConfigName"/> resource name class
-        /// from its component parts.
-        /// </summary>
-        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
-        /// <param name="transferConfigId">The transferConfig ID. Must not be <c>null</c>.</param>
-        public ProjectTransferConfigName(string projectId, string transferConfigId)
-        {
-            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
-            TransferConfigId = gax::GaxPreconditions.CheckNotNull(transferConfigId, nameof(transferConfigId));
-        }
-
-        /// <summary>
-        /// The project ID. Never <c>null</c>.
-        /// </summary>
-        public string ProjectId { get; }
-
-        /// <summary>
-        /// The transferConfig ID. Never <c>null</c>.
-        /// </summary>
-        public string TransferConfigId { get; }
-
-        /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc />
-        public override string ToString() => s_template.Expand(ProjectId, TransferConfigId);
-
-        /// <inheritdoc />
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as ProjectTransferConfigName);
-
-        /// <inheritdoc />
-        public bool Equals(ProjectTransferConfigName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc />
-        public static bool operator ==(ProjectTransferConfigName a, ProjectTransferConfigName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc />
-        public static bool operator !=(ProjectTransferConfigName a, ProjectTransferConfigName b) => !(a == b);
-    }
-
-    /// <summary>
-    /// Resource name for the 'location_transfer_config' resource.
-    /// </summary>
-    public sealed partial class LocationTransferConfigName : gax::IResourceName, sys::IEquatable<LocationTransferConfigName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/locations/{location}/transferConfigs/{transfer_config}");
-
-        /// <summary>
-        /// Parses the given location_transfer_config resource name in string form into a new
-        /// <see cref="LocationTransferConfigName"/> instance.
-        /// </summary>
-        /// <param name="locationTransferConfigName">The location_transfer_config resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="LocationTransferConfigName"/> if successful.</returns>
-        public static LocationTransferConfigName Parse(string locationTransferConfigName)
-        {
-            gax::GaxPreconditions.CheckNotNull(locationTransferConfigName, nameof(locationTransferConfigName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(locationTransferConfigName);
-            return new LocationTransferConfigName(resourceName[0], resourceName[1], resourceName[2]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given location_transfer_config resource name in string form into a new
-        /// <see cref="LocationTransferConfigName"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="locationTransferConfigName"/> is null,
-        /// as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="locationTransferConfigName">The location_transfer_config resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="LocationTransferConfigName"/>,
-        /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string locationTransferConfigName, out LocationTransferConfigName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(locationTransferConfigName, nameof(locationTransferConfigName));
-            gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(locationTransferConfigName, out resourceName))
-            {
-                result = new LocationTransferConfigName(resourceName[0], resourceName[1], resourceName[2]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="LocationTransferConfigName"/> resource name class
-        /// from its component parts.
-        /// </summary>
-        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
-        /// <param name="locationId">The location ID. Must not be <c>null</c>.</param>
-        /// <param name="transferConfigId">The transferConfig ID. Must not be <c>null</c>.</param>
-        public LocationTransferConfigName(string projectId, string locationId, string transferConfigId)
-        {
-            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
-            LocationId = gax::GaxPreconditions.CheckNotNull(locationId, nameof(locationId));
-            TransferConfigId = gax::GaxPreconditions.CheckNotNull(transferConfigId, nameof(transferConfigId));
-        }
-
-        /// <summary>
-        /// The project ID. Never <c>null</c>.
-        /// </summary>
-        public string ProjectId { get; }
-
-        /// <summary>
-        /// The location ID. Never <c>null</c>.
-        /// </summary>
-        public string LocationId { get; }
-
-        /// <summary>
-        /// The transferConfig ID. Never <c>null</c>.
-        /// </summary>
-        public string TransferConfigId { get; }
-
-        /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc />
-        public override string ToString() => s_template.Expand(ProjectId, LocationId, TransferConfigId);
-
-        /// <inheritdoc />
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as LocationTransferConfigName);
-
-        /// <inheritdoc />
-        public bool Equals(LocationTransferConfigName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc />
-        public static bool operator ==(LocationTransferConfigName a, LocationTransferConfigName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc />
-        public static bool operator !=(LocationTransferConfigName a, LocationTransferConfigName b) => !(a == b);
-    }
-
-    /// <summary>
-    /// Resource name for the 'project_run' resource.
-    /// </summary>
-    public sealed partial class ProjectRunName : gax::IResourceName, sys::IEquatable<ProjectRunName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/transferConfigs/{transfer_config}/runs/{run}");
-
-        /// <summary>
-        /// Parses the given project_run resource name in string form into a new
-        /// <see cref="ProjectRunName"/> instance.
-        /// </summary>
-        /// <param name="projectRunName">The project_run resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="ProjectRunName"/> if successful.</returns>
-        public static ProjectRunName Parse(string projectRunName)
-        {
-            gax::GaxPreconditions.CheckNotNull(projectRunName, nameof(projectRunName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(projectRunName);
-            return new ProjectRunName(resourceName[0], resourceName[1], resourceName[2]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given project_run resource name in string form into a new
-        /// <see cref="ProjectRunName"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectRunName"/> is null,
-        /// as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="projectRunName">The project_run resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="ProjectRunName"/>,
-        /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string projectRunName, out ProjectRunName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(projectRunName, nameof(projectRunName));
-            gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(projectRunName, out resourceName))
-            {
-                result = new ProjectRunName(resourceName[0], resourceName[1], resourceName[2]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="ProjectRunName"/> resource name class
-        /// from its component parts.
-        /// </summary>
-        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
-        /// <param name="transferConfigId">The transferConfig ID. Must not be <c>null</c>.</param>
-        /// <param name="runId">The run ID. Must not be <c>null</c>.</param>
-        public ProjectRunName(string projectId, string transferConfigId, string runId)
-        {
-            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
-            TransferConfigId = gax::GaxPreconditions.CheckNotNull(transferConfigId, nameof(transferConfigId));
-            RunId = gax::GaxPreconditions.CheckNotNull(runId, nameof(runId));
-        }
-
-        /// <summary>
-        /// The project ID. Never <c>null</c>.
-        /// </summary>
-        public string ProjectId { get; }
-
-        /// <summary>
-        /// The transferConfig ID. Never <c>null</c>.
-        /// </summary>
-        public string TransferConfigId { get; }
-
-        /// <summary>
-        /// The run ID. Never <c>null</c>.
-        /// </summary>
-        public string RunId { get; }
-
-        /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc />
-        public override string ToString() => s_template.Expand(ProjectId, TransferConfigId, RunId);
-
-        /// <inheritdoc />
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as ProjectRunName);
-
-        /// <inheritdoc />
-        public bool Equals(ProjectRunName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc />
-        public static bool operator ==(ProjectRunName a, ProjectRunName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc />
-        public static bool operator !=(ProjectRunName a, ProjectRunName b) => !(a == b);
     }
 
     /// <summary>
@@ -697,6 +519,105 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
 
         /// <inheritdoc />
         public static bool operator !=(LocationRunName a, LocationRunName b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name for the 'location_transfer_config' resource.
+    /// </summary>
+    public sealed partial class LocationTransferConfigName : gax::IResourceName, sys::IEquatable<LocationTransferConfigName>
+    {
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/locations/{location}/transferConfigs/{transfer_config}");
+
+        /// <summary>
+        /// Parses the given location_transfer_config resource name in string form into a new
+        /// <see cref="LocationTransferConfigName"/> instance.
+        /// </summary>
+        /// <param name="locationTransferConfigName">The location_transfer_config resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="LocationTransferConfigName"/> if successful.</returns>
+        public static LocationTransferConfigName Parse(string locationTransferConfigName)
+        {
+            gax::GaxPreconditions.CheckNotNull(locationTransferConfigName, nameof(locationTransferConfigName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(locationTransferConfigName);
+            return new LocationTransferConfigName(resourceName[0], resourceName[1], resourceName[2]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given location_transfer_config resource name in string form into a new
+        /// <see cref="LocationTransferConfigName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="locationTransferConfigName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="locationTransferConfigName">The location_transfer_config resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="LocationTransferConfigName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string locationTransferConfigName, out LocationTransferConfigName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(locationTransferConfigName, nameof(locationTransferConfigName));
+            gax::TemplatedResourceName resourceName;
+            if (s_template.TryParseName(locationTransferConfigName, out resourceName))
+            {
+                result = new LocationTransferConfigName(resourceName[0], resourceName[1], resourceName[2]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="LocationTransferConfigName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
+        /// <param name="locationId">The location ID. Must not be <c>null</c>.</param>
+        /// <param name="transferConfigId">The transferConfig ID. Must not be <c>null</c>.</param>
+        public LocationTransferConfigName(string projectId, string locationId, string transferConfigId)
+        {
+            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
+            LocationId = gax::GaxPreconditions.CheckNotNull(locationId, nameof(locationId));
+            TransferConfigId = gax::GaxPreconditions.CheckNotNull(transferConfigId, nameof(transferConfigId));
+        }
+
+        /// <summary>
+        /// The project ID. Never <c>null</c>.
+        /// </summary>
+        public string ProjectId { get; }
+
+        /// <summary>
+        /// The location ID. Never <c>null</c>.
+        /// </summary>
+        public string LocationId { get; }
+
+        /// <summary>
+        /// The transferConfig ID. Never <c>null</c>.
+        /// </summary>
+        public string TransferConfigId { get; }
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(ProjectId, LocationId, TransferConfigId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as LocationTransferConfigName);
+
+        /// <inheritdoc />
+        public bool Equals(LocationTransferConfigName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(LocationTransferConfigName a, LocationTransferConfigName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(LocationTransferConfigName a, LocationTransferConfigName b) => !(a == b);
     }
 
     /// <summary>
@@ -904,411 +825,286 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
     }
 
     /// <summary>
-    /// Resource name which will contain one of a choice of resource names.
+    /// Resource name for the 'project_data_source' resource.
     /// </summary>
-    /// <remarks>
-    /// This resource name will contain one of the following:
-    /// <list type="bullet">
-    /// <item><description>ProjectDataSourceName: A resource of type 'project_data_source'.</description></item>
-    /// <item><description>LocationDataSourceName: A resource of type 'location_data_source'.</description></item>
-    /// </list>
-    /// </remarks>
-    public sealed partial class DataSourceNameOneof : gax::IResourceName, sys::IEquatable<DataSourceNameOneof>
+    public sealed partial class ProjectDataSourceName : gax::IResourceName, sys::IEquatable<ProjectDataSourceName>
     {
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/dataSources/{data_source}");
+
         /// <summary>
-        /// The possible contents of <see cref="DataSourceNameOneof"/>.
+        /// Parses the given project_data_source resource name in string form into a new
+        /// <see cref="ProjectDataSourceName"/> instance.
         /// </summary>
-        public enum OneofType
+        /// <param name="projectDataSourceName">The project_data_source resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="ProjectDataSourceName"/> if successful.</returns>
+        public static ProjectDataSourceName Parse(string projectDataSourceName)
         {
-            /// <summary>
-            /// A resource of an unknown type.
-            /// </summary>
-            Unknown = 0,
-
-            /// <summary>
-            /// A resource of type 'project_data_source'.
-            /// </summary>
-            ProjectDataSourceName = 1,
-
-            /// <summary>
-            /// A resource of type 'location_data_source'.
-            /// </summary>
-            LocationDataSourceName = 2,
+            gax::GaxPreconditions.CheckNotNull(projectDataSourceName, nameof(projectDataSourceName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(projectDataSourceName);
+            return new ProjectDataSourceName(resourceName[0], resourceName[1]);
         }
 
         /// <summary>
-        /// Parses a resource name in string form into a new <see cref="DataSourceNameOneof"/> instance.
+        /// Tries to parse the given project_data_source resource name in string form into a new
+        /// <see cref="ProjectDataSourceName"/> instance.
         /// </summary>
         /// <remarks>
-        /// To parse successfully the resource name must be one of the following:
-        /// <list type="bullet">
-        /// <item><description>ProjectDataSourceName: A resource of type 'project_data_source'.</description></item>
-        /// <item><description>LocationDataSourceName: A resource of type 'location_data_source'.</description></item>
-        /// </list>
-        /// Or an <see cref="gax::UnknownResourceName"/> if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectDataSourceName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
-        /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="allowUnknown">If true, will successfully parse an unknown resource name
-        /// into an <see cref="gax::UnknownResourceName"/>; otherwise will throw an
-        /// <see cref="sys::ArgumentException"/> if an unknown resource name is given.</param>
-        /// <returns>The parsed <see cref="DataSourceNameOneof"/> if successful.</returns>
-        public static DataSourceNameOneof Parse(string name, bool allowUnknown)
-        {
-            DataSourceNameOneof result;
-            if (TryParse(name, allowUnknown, out result))
-            {
-                return result;
-            }
-            throw new sys::ArgumentException("Invalid name", nameof(name));
-        }
-
-        /// <summary>
-        /// Tries to parse a resource name in string form into a new <see cref="DataSourceNameOneof"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// To parse successfully the resource name must be one of the following:
-        /// <list type="bullet">
-        /// <item><description>ProjectDataSourceName: A resource of type 'project_data_source'.</description></item>
-        /// <item><description>LocationDataSourceName: A resource of type 'location_data_source'.</description></item>
-        /// </list>
-        /// Or an <see cref="gax::UnknownResourceName"/> if <paramref name="allowUnknown"/> is <c>true</c>.
-        /// </remarks>
-        /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="allowUnknown">If true, will successfully parse an unknown resource name
-        /// into an <see cref="gax::UnknownResourceName"/>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="DataSourceNameOneof"/>,
+        /// <param name="projectDataSourceName">The project_data_source resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="ProjectDataSourceName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string name, bool allowUnknown, out DataSourceNameOneof result)
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string projectDataSourceName, out ProjectDataSourceName result)
         {
-            gax::GaxPreconditions.CheckNotNull(name, nameof(name));
-            ProjectDataSourceName projectDataSourceName;
-            if (ProjectDataSourceName.TryParse(name, out projectDataSourceName))
+            gax::GaxPreconditions.CheckNotNull(projectDataSourceName, nameof(projectDataSourceName));
+            gax::TemplatedResourceName resourceName;
+            if (s_template.TryParseName(projectDataSourceName, out resourceName))
             {
-                result = new DataSourceNameOneof(OneofType.ProjectDataSourceName, projectDataSourceName);
+                result = new ProjectDataSourceName(resourceName[0], resourceName[1]);
                 return true;
             }
-            LocationDataSourceName locationDataSourceName;
-            if (LocationDataSourceName.TryParse(name, out locationDataSourceName))
+            else
             {
-                result = new DataSourceNameOneof(OneofType.LocationDataSourceName, locationDataSourceName);
-                return true;
+                result = null;
+                return false;
             }
-            if (allowUnknown)
-            {
-                gax::UnknownResourceName unknownResourceName;
-                if (gax::UnknownResourceName.TryParse(name, out unknownResourceName))
-                {
-                    result = new DataSourceNameOneof(OneofType.Unknown, unknownResourceName);
-                    return true;
-                }
-            }
-            result = null;
-            return false;
         }
 
         /// <summary>
-        /// Construct a new instance of <see cref="DataSourceNameOneof"/> from the provided <see cref="ProjectDataSourceName"/>
+        /// Constructs a new instance of the <see cref="ProjectDataSourceName"/> resource name class
+        /// from its component parts.
         /// </summary>
-        /// <param name="projectDataSourceName">The <see cref="ProjectDataSourceName"/> to be contained within
-        /// the returned <see cref="DataSourceNameOneof"/>. Must not be <c>null</c>.</param>
-        /// <returns>A new <see cref="DataSourceNameOneof"/>, containing <paramref name="projectDataSourceName"/>.</returns>
-        public static DataSourceNameOneof From(ProjectDataSourceName projectDataSourceName) => new DataSourceNameOneof(OneofType.ProjectDataSourceName, projectDataSourceName);
-
-        /// <summary>
-        /// Construct a new instance of <see cref="DataSourceNameOneof"/> from the provided <see cref="LocationDataSourceName"/>
-        /// </summary>
-        /// <param name="locationDataSourceName">The <see cref="LocationDataSourceName"/> to be contained within
-        /// the returned <see cref="DataSourceNameOneof"/>. Must not be <c>null</c>.</param>
-        /// <returns>A new <see cref="DataSourceNameOneof"/>, containing <paramref name="locationDataSourceName"/>.</returns>
-        public static DataSourceNameOneof From(LocationDataSourceName locationDataSourceName) => new DataSourceNameOneof(OneofType.LocationDataSourceName, locationDataSourceName);
-
-        private static bool IsValid(OneofType type, gax::IResourceName name)
+        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
+        /// <param name="dataSourceId">The dataSource ID. Must not be <c>null</c>.</param>
+        public ProjectDataSourceName(string projectId, string dataSourceId)
         {
-            switch (type)
-            {
-                case OneofType.Unknown: return true; // Anything goes with Unknown.
-                case OneofType.ProjectDataSourceName: return name is ProjectDataSourceName;
-                case OneofType.LocationDataSourceName: return name is LocationDataSourceName;
-                default: return false;
-            }
+            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
+            DataSourceId = gax::GaxPreconditions.CheckNotNull(dataSourceId, nameof(dataSourceId));
         }
 
         /// <summary>
-        /// Constructs a new instance of the <see cref="DataSourceNameOneof"/> resource name class
-        /// from a suitable <see cref="gax::IResourceName"/> instance.
+        /// The project ID. Never <c>null</c>.
         /// </summary>
-        public DataSourceNameOneof(OneofType type, gax::IResourceName name)
-        {
-            Type = gax::GaxPreconditions.CheckEnumValue<OneofType>(type, nameof(type));
-            Name = gax::GaxPreconditions.CheckNotNull(name, nameof(name));
-            if (!IsValid(type, name))
-            {
-                throw new sys::ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
-            }
-        }
+        public string ProjectId { get; }
 
         /// <summary>
-        /// The <see cref="OneofType"/> of the Name contained in this instance.
+        /// The dataSource ID. Never <c>null</c>.
         /// </summary>
-        public OneofType Type { get; }
-
-        /// <summary>
-        /// The <see cref="gax::IResourceName"/> contained in this instance.
-        /// </summary>
-        public gax::IResourceName Name { get; }
-
-        private T CheckAndReturn<T>(OneofType type)
-        {
-            if (Type != type)
-            {
-                throw new sys::InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
-            }
-            return (T)Name;
-        }
-
-        /// <summary>
-        /// Get the contained <see cref="gax::IResourceName"/> as <see cref="ProjectDataSourceName"/>.
-        /// </summary>
-        /// <remarks>
-        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
-        /// contain an instance of <see cref="ProjectDataSourceName"/>.
-        /// </remarks>
-        public ProjectDataSourceName ProjectDataSourceName => CheckAndReturn<ProjectDataSourceName>(OneofType.ProjectDataSourceName);
-
-        /// <summary>
-        /// Get the contained <see cref="gax::IResourceName"/> as <see cref="LocationDataSourceName"/>.
-        /// </summary>
-        /// <remarks>
-        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
-        /// contain an instance of <see cref="LocationDataSourceName"/>.
-        /// </remarks>
-        public LocationDataSourceName LocationDataSourceName => CheckAndReturn<LocationDataSourceName>(OneofType.LocationDataSourceName);
+        public string DataSourceId { get; }
 
         /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Oneof;
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
 
         /// <inheritdoc />
-        public override string ToString() => Name.ToString();
+        public override string ToString() => s_template.Expand(ProjectId, DataSourceId);
 
         /// <inheritdoc />
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as DataSourceNameOneof);
+        public override bool Equals(object obj) => Equals(obj as ProjectDataSourceName);
 
         /// <inheritdoc />
-        public bool Equals(DataSourceNameOneof other) => ToString() == other?.ToString();
+        public bool Equals(ProjectDataSourceName other) => ToString() == other?.ToString();
 
         /// <inheritdoc />
-        public static bool operator ==(DataSourceNameOneof a, DataSourceNameOneof b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+        public static bool operator ==(ProjectDataSourceName a, ProjectDataSourceName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
 
         /// <inheritdoc />
-        public static bool operator !=(DataSourceNameOneof a, DataSourceNameOneof b) => !(a == b);
+        public static bool operator !=(ProjectDataSourceName a, ProjectDataSourceName b) => !(a == b);
     }
 
     /// <summary>
-    /// Resource name which will contain one of a choice of resource names.
+    /// Resource name for the 'project_run' resource.
     /// </summary>
-    /// <remarks>
-    /// This resource name will contain one of the following:
-    /// <list type="bullet">
-    /// <item><description>ProjectTransferConfigName: A resource of type 'project_transfer_config'.</description></item>
-    /// <item><description>LocationTransferConfigName: A resource of type 'location_transfer_config'.</description></item>
-    /// </list>
-    /// </remarks>
-    public sealed partial class TransferConfigNameOneof : gax::IResourceName, sys::IEquatable<TransferConfigNameOneof>
+    public sealed partial class ProjectRunName : gax::IResourceName, sys::IEquatable<ProjectRunName>
     {
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/transferConfigs/{transfer_config}/runs/{run}");
+
         /// <summary>
-        /// The possible contents of <see cref="TransferConfigNameOneof"/>.
+        /// Parses the given project_run resource name in string form into a new
+        /// <see cref="ProjectRunName"/> instance.
         /// </summary>
-        public enum OneofType
+        /// <param name="projectRunName">The project_run resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="ProjectRunName"/> if successful.</returns>
+        public static ProjectRunName Parse(string projectRunName)
         {
-            /// <summary>
-            /// A resource of an unknown type.
-            /// </summary>
-            Unknown = 0,
-
-            /// <summary>
-            /// A resource of type 'project_transfer_config'.
-            /// </summary>
-            ProjectTransferConfigName = 1,
-
-            /// <summary>
-            /// A resource of type 'location_transfer_config'.
-            /// </summary>
-            LocationTransferConfigName = 2,
+            gax::GaxPreconditions.CheckNotNull(projectRunName, nameof(projectRunName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(projectRunName);
+            return new ProjectRunName(resourceName[0], resourceName[1], resourceName[2]);
         }
 
         /// <summary>
-        /// Parses a resource name in string form into a new <see cref="TransferConfigNameOneof"/> instance.
+        /// Tries to parse the given project_run resource name in string form into a new
+        /// <see cref="ProjectRunName"/> instance.
         /// </summary>
         /// <remarks>
-        /// To parse successfully the resource name must be one of the following:
-        /// <list type="bullet">
-        /// <item><description>ProjectTransferConfigName: A resource of type 'project_transfer_config'.</description></item>
-        /// <item><description>LocationTransferConfigName: A resource of type 'location_transfer_config'.</description></item>
-        /// </list>
-        /// Or an <see cref="gax::UnknownResourceName"/> if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectRunName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
-        /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="allowUnknown">If true, will successfully parse an unknown resource name
-        /// into an <see cref="gax::UnknownResourceName"/>; otherwise will throw an
-        /// <see cref="sys::ArgumentException"/> if an unknown resource name is given.</param>
-        /// <returns>The parsed <see cref="TransferConfigNameOneof"/> if successful.</returns>
-        public static TransferConfigNameOneof Parse(string name, bool allowUnknown)
-        {
-            TransferConfigNameOneof result;
-            if (TryParse(name, allowUnknown, out result))
-            {
-                return result;
-            }
-            throw new sys::ArgumentException("Invalid name", nameof(name));
-        }
-
-        /// <summary>
-        /// Tries to parse a resource name in string form into a new <see cref="TransferConfigNameOneof"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// To parse successfully the resource name must be one of the following:
-        /// <list type="bullet">
-        /// <item><description>ProjectTransferConfigName: A resource of type 'project_transfer_config'.</description></item>
-        /// <item><description>LocationTransferConfigName: A resource of type 'location_transfer_config'.</description></item>
-        /// </list>
-        /// Or an <see cref="gax::UnknownResourceName"/> if <paramref name="allowUnknown"/> is <c>true</c>.
-        /// </remarks>
-        /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="allowUnknown">If true, will successfully parse an unknown resource name
-        /// into an <see cref="gax::UnknownResourceName"/>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="TransferConfigNameOneof"/>,
+        /// <param name="projectRunName">The project_run resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="ProjectRunName"/>,
         /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string name, bool allowUnknown, out TransferConfigNameOneof result)
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string projectRunName, out ProjectRunName result)
         {
-            gax::GaxPreconditions.CheckNotNull(name, nameof(name));
-            ProjectTransferConfigName projectTransferConfigName;
-            if (ProjectTransferConfigName.TryParse(name, out projectTransferConfigName))
+            gax::GaxPreconditions.CheckNotNull(projectRunName, nameof(projectRunName));
+            gax::TemplatedResourceName resourceName;
+            if (s_template.TryParseName(projectRunName, out resourceName))
             {
-                result = new TransferConfigNameOneof(OneofType.ProjectTransferConfigName, projectTransferConfigName);
+                result = new ProjectRunName(resourceName[0], resourceName[1], resourceName[2]);
                 return true;
             }
-            LocationTransferConfigName locationTransferConfigName;
-            if (LocationTransferConfigName.TryParse(name, out locationTransferConfigName))
+            else
             {
-                result = new TransferConfigNameOneof(OneofType.LocationTransferConfigName, locationTransferConfigName);
-                return true;
+                result = null;
+                return false;
             }
-            if (allowUnknown)
-            {
-                gax::UnknownResourceName unknownResourceName;
-                if (gax::UnknownResourceName.TryParse(name, out unknownResourceName))
-                {
-                    result = new TransferConfigNameOneof(OneofType.Unknown, unknownResourceName);
-                    return true;
-                }
-            }
-            result = null;
-            return false;
         }
 
         /// <summary>
-        /// Construct a new instance of <see cref="TransferConfigNameOneof"/> from the provided <see cref="ProjectTransferConfigName"/>
+        /// Constructs a new instance of the <see cref="ProjectRunName"/> resource name class
+        /// from its component parts.
         /// </summary>
-        /// <param name="projectTransferConfigName">The <see cref="ProjectTransferConfigName"/> to be contained within
-        /// the returned <see cref="TransferConfigNameOneof"/>. Must not be <c>null</c>.</param>
-        /// <returns>A new <see cref="TransferConfigNameOneof"/>, containing <paramref name="projectTransferConfigName"/>.</returns>
-        public static TransferConfigNameOneof From(ProjectTransferConfigName projectTransferConfigName) => new TransferConfigNameOneof(OneofType.ProjectTransferConfigName, projectTransferConfigName);
-
-        /// <summary>
-        /// Construct a new instance of <see cref="TransferConfigNameOneof"/> from the provided <see cref="LocationTransferConfigName"/>
-        /// </summary>
-        /// <param name="locationTransferConfigName">The <see cref="LocationTransferConfigName"/> to be contained within
-        /// the returned <see cref="TransferConfigNameOneof"/>. Must not be <c>null</c>.</param>
-        /// <returns>A new <see cref="TransferConfigNameOneof"/>, containing <paramref name="locationTransferConfigName"/>.</returns>
-        public static TransferConfigNameOneof From(LocationTransferConfigName locationTransferConfigName) => new TransferConfigNameOneof(OneofType.LocationTransferConfigName, locationTransferConfigName);
-
-        private static bool IsValid(OneofType type, gax::IResourceName name)
+        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
+        /// <param name="transferConfigId">The transferConfig ID. Must not be <c>null</c>.</param>
+        /// <param name="runId">The run ID. Must not be <c>null</c>.</param>
+        public ProjectRunName(string projectId, string transferConfigId, string runId)
         {
-            switch (type)
-            {
-                case OneofType.Unknown: return true; // Anything goes with Unknown.
-                case OneofType.ProjectTransferConfigName: return name is ProjectTransferConfigName;
-                case OneofType.LocationTransferConfigName: return name is LocationTransferConfigName;
-                default: return false;
-            }
+            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
+            TransferConfigId = gax::GaxPreconditions.CheckNotNull(transferConfigId, nameof(transferConfigId));
+            RunId = gax::GaxPreconditions.CheckNotNull(runId, nameof(runId));
         }
 
         /// <summary>
-        /// Constructs a new instance of the <see cref="TransferConfigNameOneof"/> resource name class
-        /// from a suitable <see cref="gax::IResourceName"/> instance.
+        /// The project ID. Never <c>null</c>.
         /// </summary>
-        public TransferConfigNameOneof(OneofType type, gax::IResourceName name)
-        {
-            Type = gax::GaxPreconditions.CheckEnumValue<OneofType>(type, nameof(type));
-            Name = gax::GaxPreconditions.CheckNotNull(name, nameof(name));
-            if (!IsValid(type, name))
-            {
-                throw new sys::ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
-            }
-        }
+        public string ProjectId { get; }
 
         /// <summary>
-        /// The <see cref="OneofType"/> of the Name contained in this instance.
+        /// The transferConfig ID. Never <c>null</c>.
         /// </summary>
-        public OneofType Type { get; }
+        public string TransferConfigId { get; }
 
         /// <summary>
-        /// The <see cref="gax::IResourceName"/> contained in this instance.
+        /// The run ID. Never <c>null</c>.
         /// </summary>
-        public gax::IResourceName Name { get; }
-
-        private T CheckAndReturn<T>(OneofType type)
-        {
-            if (Type != type)
-            {
-                throw new sys::InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
-            }
-            return (T)Name;
-        }
-
-        /// <summary>
-        /// Get the contained <see cref="gax::IResourceName"/> as <see cref="ProjectTransferConfigName"/>.
-        /// </summary>
-        /// <remarks>
-        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
-        /// contain an instance of <see cref="ProjectTransferConfigName"/>.
-        /// </remarks>
-        public ProjectTransferConfigName ProjectTransferConfigName => CheckAndReturn<ProjectTransferConfigName>(OneofType.ProjectTransferConfigName);
-
-        /// <summary>
-        /// Get the contained <see cref="gax::IResourceName"/> as <see cref="LocationTransferConfigName"/>.
-        /// </summary>
-        /// <remarks>
-        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
-        /// contain an instance of <see cref="LocationTransferConfigName"/>.
-        /// </remarks>
-        public LocationTransferConfigName LocationTransferConfigName => CheckAndReturn<LocationTransferConfigName>(OneofType.LocationTransferConfigName);
+        public string RunId { get; }
 
         /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Oneof;
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
 
         /// <inheritdoc />
-        public override string ToString() => Name.ToString();
+        public override string ToString() => s_template.Expand(ProjectId, TransferConfigId, RunId);
 
         /// <inheritdoc />
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as TransferConfigNameOneof);
+        public override bool Equals(object obj) => Equals(obj as ProjectRunName);
 
         /// <inheritdoc />
-        public bool Equals(TransferConfigNameOneof other) => ToString() == other?.ToString();
+        public bool Equals(ProjectRunName other) => ToString() == other?.ToString();
 
         /// <inheritdoc />
-        public static bool operator ==(TransferConfigNameOneof a, TransferConfigNameOneof b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+        public static bool operator ==(ProjectRunName a, ProjectRunName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
 
         /// <inheritdoc />
-        public static bool operator !=(TransferConfigNameOneof a, TransferConfigNameOneof b) => !(a == b);
+        public static bool operator !=(ProjectRunName a, ProjectRunName b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name for the 'project_transfer_config' resource.
+    /// </summary>
+    public sealed partial class ProjectTransferConfigName : gax::IResourceName, sys::IEquatable<ProjectTransferConfigName>
+    {
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/transferConfigs/{transfer_config}");
+
+        /// <summary>
+        /// Parses the given project_transfer_config resource name in string form into a new
+        /// <see cref="ProjectTransferConfigName"/> instance.
+        /// </summary>
+        /// <param name="projectTransferConfigName">The project_transfer_config resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="ProjectTransferConfigName"/> if successful.</returns>
+        public static ProjectTransferConfigName Parse(string projectTransferConfigName)
+        {
+            gax::GaxPreconditions.CheckNotNull(projectTransferConfigName, nameof(projectTransferConfigName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(projectTransferConfigName);
+            return new ProjectTransferConfigName(resourceName[0], resourceName[1]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given project_transfer_config resource name in string form into a new
+        /// <see cref="ProjectTransferConfigName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectTransferConfigName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="projectTransferConfigName">The project_transfer_config resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="ProjectTransferConfigName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string projectTransferConfigName, out ProjectTransferConfigName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(projectTransferConfigName, nameof(projectTransferConfigName));
+            gax::TemplatedResourceName resourceName;
+            if (s_template.TryParseName(projectTransferConfigName, out resourceName))
+            {
+                result = new ProjectTransferConfigName(resourceName[0], resourceName[1]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="ProjectTransferConfigName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
+        /// <param name="transferConfigId">The transferConfig ID. Must not be <c>null</c>.</param>
+        public ProjectTransferConfigName(string projectId, string transferConfigId)
+        {
+            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
+            TransferConfigId = gax::GaxPreconditions.CheckNotNull(transferConfigId, nameof(transferConfigId));
+        }
+
+        /// <summary>
+        /// The project ID. Never <c>null</c>.
+        /// </summary>
+        public string ProjectId { get; }
+
+        /// <summary>
+        /// The transferConfig ID. Never <c>null</c>.
+        /// </summary>
+        public string TransferConfigId { get; }
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(ProjectId, TransferConfigId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as ProjectTransferConfigName);
+
+        /// <inheritdoc />
+        public bool Equals(ProjectTransferConfigName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(ProjectTransferConfigName a, ProjectTransferConfigName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(ProjectTransferConfigName a, ProjectTransferConfigName b) => !(a == b);
     }
 
     /// <summary>
@@ -1513,6 +1309,210 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
 
         /// <inheritdoc />
         public static bool operator !=(RunNameOneof a, RunNameOneof b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name which will contain one of a choice of resource names.
+    /// </summary>
+    /// <remarks>
+    /// This resource name will contain one of the following:
+    /// <list type="bullet">
+    /// <item><description>ProjectTransferConfigName: A resource of type 'project_transfer_config'.</description></item>
+    /// <item><description>LocationTransferConfigName: A resource of type 'location_transfer_config'.</description></item>
+    /// </list>
+    /// </remarks>
+    public sealed partial class TransferConfigNameOneof : gax::IResourceName, sys::IEquatable<TransferConfigNameOneof>
+    {
+        /// <summary>
+        /// The possible contents of <see cref="TransferConfigNameOneof"/>.
+        /// </summary>
+        public enum OneofType
+        {
+            /// <summary>
+            /// A resource of an unknown type.
+            /// </summary>
+            Unknown = 0,
+
+            /// <summary>
+            /// A resource of type 'project_transfer_config'.
+            /// </summary>
+            ProjectTransferConfigName = 1,
+
+            /// <summary>
+            /// A resource of type 'location_transfer_config'.
+            /// </summary>
+            LocationTransferConfigName = 2,
+        }
+
+        /// <summary>
+        /// Parses a resource name in string form into a new <see cref="TransferConfigNameOneof"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully the resource name must be one of the following:
+        /// <list type="bullet">
+        /// <item><description>ProjectTransferConfigName: A resource of type 'project_transfer_config'.</description></item>
+        /// <item><description>LocationTransferConfigName: A resource of type 'location_transfer_config'.</description></item>
+        /// </list>
+        /// Or an <see cref="gax::UnknownResourceName"/> if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnknown">If true, will successfully parse an unknown resource name
+        /// into an <see cref="gax::UnknownResourceName"/>; otherwise will throw an
+        /// <see cref="sys::ArgumentException"/> if an unknown resource name is given.</param>
+        /// <returns>The parsed <see cref="TransferConfigNameOneof"/> if successful.</returns>
+        public static TransferConfigNameOneof Parse(string name, bool allowUnknown)
+        {
+            TransferConfigNameOneof result;
+            if (TryParse(name, allowUnknown, out result))
+            {
+                return result;
+            }
+            throw new sys::ArgumentException("Invalid name", nameof(name));
+        }
+
+        /// <summary>
+        /// Tries to parse a resource name in string form into a new <see cref="TransferConfigNameOneof"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully the resource name must be one of the following:
+        /// <list type="bullet">
+        /// <item><description>ProjectTransferConfigName: A resource of type 'project_transfer_config'.</description></item>
+        /// <item><description>LocationTransferConfigName: A resource of type 'location_transfer_config'.</description></item>
+        /// </list>
+        /// Or an <see cref="gax::UnknownResourceName"/> if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnknown">If true, will successfully parse an unknown resource name
+        /// into an <see cref="gax::UnknownResourceName"/>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="TransferConfigNameOneof"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string name, bool allowUnknown, out TransferConfigNameOneof result)
+        {
+            gax::GaxPreconditions.CheckNotNull(name, nameof(name));
+            ProjectTransferConfigName projectTransferConfigName;
+            if (ProjectTransferConfigName.TryParse(name, out projectTransferConfigName))
+            {
+                result = new TransferConfigNameOneof(OneofType.ProjectTransferConfigName, projectTransferConfigName);
+                return true;
+            }
+            LocationTransferConfigName locationTransferConfigName;
+            if (LocationTransferConfigName.TryParse(name, out locationTransferConfigName))
+            {
+                result = new TransferConfigNameOneof(OneofType.LocationTransferConfigName, locationTransferConfigName);
+                return true;
+            }
+            if (allowUnknown)
+            {
+                gax::UnknownResourceName unknownResourceName;
+                if (gax::UnknownResourceName.TryParse(name, out unknownResourceName))
+                {
+                    result = new TransferConfigNameOneof(OneofType.Unknown, unknownResourceName);
+                    return true;
+                }
+            }
+            result = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Construct a new instance of <see cref="TransferConfigNameOneof"/> from the provided <see cref="ProjectTransferConfigName"/>
+        /// </summary>
+        /// <param name="projectTransferConfigName">The <see cref="ProjectTransferConfigName"/> to be contained within
+        /// the returned <see cref="TransferConfigNameOneof"/>. Must not be <c>null</c>.</param>
+        /// <returns>A new <see cref="TransferConfigNameOneof"/>, containing <paramref name="projectTransferConfigName"/>.</returns>
+        public static TransferConfigNameOneof From(ProjectTransferConfigName projectTransferConfigName) => new TransferConfigNameOneof(OneofType.ProjectTransferConfigName, projectTransferConfigName);
+
+        /// <summary>
+        /// Construct a new instance of <see cref="TransferConfigNameOneof"/> from the provided <see cref="LocationTransferConfigName"/>
+        /// </summary>
+        /// <param name="locationTransferConfigName">The <see cref="LocationTransferConfigName"/> to be contained within
+        /// the returned <see cref="TransferConfigNameOneof"/>. Must not be <c>null</c>.</param>
+        /// <returns>A new <see cref="TransferConfigNameOneof"/>, containing <paramref name="locationTransferConfigName"/>.</returns>
+        public static TransferConfigNameOneof From(LocationTransferConfigName locationTransferConfigName) => new TransferConfigNameOneof(OneofType.LocationTransferConfigName, locationTransferConfigName);
+
+        private static bool IsValid(OneofType type, gax::IResourceName name)
+        {
+            switch (type)
+            {
+                case OneofType.Unknown: return true; // Anything goes with Unknown.
+                case OneofType.ProjectTransferConfigName: return name is ProjectTransferConfigName;
+                case OneofType.LocationTransferConfigName: return name is LocationTransferConfigName;
+                default: return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="TransferConfigNameOneof"/> resource name class
+        /// from a suitable <see cref="gax::IResourceName"/> instance.
+        /// </summary>
+        public TransferConfigNameOneof(OneofType type, gax::IResourceName name)
+        {
+            Type = gax::GaxPreconditions.CheckEnumValue<OneofType>(type, nameof(type));
+            Name = gax::GaxPreconditions.CheckNotNull(name, nameof(name));
+            if (!IsValid(type, name))
+            {
+                throw new sys::ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
+            }
+        }
+
+        /// <summary>
+        /// The <see cref="OneofType"/> of the Name contained in this instance.
+        /// </summary>
+        public OneofType Type { get; }
+
+        /// <summary>
+        /// The <see cref="gax::IResourceName"/> contained in this instance.
+        /// </summary>
+        public gax::IResourceName Name { get; }
+
+        private T CheckAndReturn<T>(OneofType type)
+        {
+            if (Type != type)
+            {
+                throw new sys::InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
+            }
+            return (T)Name;
+        }
+
+        /// <summary>
+        /// Get the contained <see cref="gax::IResourceName"/> as <see cref="ProjectTransferConfigName"/>.
+        /// </summary>
+        /// <remarks>
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
+        /// contain an instance of <see cref="ProjectTransferConfigName"/>.
+        /// </remarks>
+        public ProjectTransferConfigName ProjectTransferConfigName => CheckAndReturn<ProjectTransferConfigName>(OneofType.ProjectTransferConfigName);
+
+        /// <summary>
+        /// Get the contained <see cref="gax::IResourceName"/> as <see cref="LocationTransferConfigName"/>.
+        /// </summary>
+        /// <remarks>
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
+        /// contain an instance of <see cref="LocationTransferConfigName"/>.
+        /// </remarks>
+        public LocationTransferConfigName LocationTransferConfigName => CheckAndReturn<LocationTransferConfigName>(OneofType.LocationTransferConfigName);
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Oneof;
+
+        /// <inheritdoc />
+        public override string ToString() => Name.ToString();
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as TransferConfigNameOneof);
+
+        /// <inheritdoc />
+        public bool Equals(TransferConfigNameOneof other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(TransferConfigNameOneof a, TransferConfigNameOneof b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(TransferConfigNameOneof a, TransferConfigNameOneof b) => !(a == b);
     }
 
 

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/ResourceNames.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/ResourceNames.cs
@@ -23,98 +23,6 @@ using linq = System.Linq;
 namespace Google.Cloud.Bigtable.Admin.V2
 {
     /// <summary>
-    /// Resource name for the 'instance' resource.
-    /// </summary>
-    public sealed partial class InstanceName : gax::IResourceName, sys::IEquatable<InstanceName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/instances/{instance}");
-
-        /// <summary>
-        /// Parses the given instance resource name in string form into a new
-        /// <see cref="InstanceName"/> instance.
-        /// </summary>
-        /// <param name="instanceName">The instance resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="InstanceName"/> if successful.</returns>
-        public static InstanceName Parse(string instanceName)
-        {
-            gax::GaxPreconditions.CheckNotNull(instanceName, nameof(instanceName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(instanceName);
-            return new InstanceName(resourceName[0], resourceName[1]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given instance resource name in string form into a new
-        /// <see cref="InstanceName"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="instanceName"/> is null,
-        /// as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="instanceName">The instance resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="InstanceName"/>,
-        /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string instanceName, out InstanceName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(instanceName, nameof(instanceName));
-            gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(instanceName, out resourceName))
-            {
-                result = new InstanceName(resourceName[0], resourceName[1]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="InstanceName"/> resource name class
-        /// from its component parts.
-        /// </summary>
-        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
-        /// <param name="instanceId">The instance ID. Must not be <c>null</c>.</param>
-        public InstanceName(string projectId, string instanceId)
-        {
-            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
-            InstanceId = gax::GaxPreconditions.CheckNotNull(instanceId, nameof(instanceId));
-        }
-
-        /// <summary>
-        /// The project ID. Never <c>null</c>.
-        /// </summary>
-        public string ProjectId { get; }
-
-        /// <summary>
-        /// The instance ID. Never <c>null</c>.
-        /// </summary>
-        public string InstanceId { get; }
-
-        /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc />
-        public override string ToString() => s_template.Expand(ProjectId, InstanceId);
-
-        /// <inheritdoc />
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as InstanceName);
-
-        /// <inheritdoc />
-        public bool Equals(InstanceName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc />
-        public static bool operator ==(InstanceName a, InstanceName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc />
-        public static bool operator !=(InstanceName a, InstanceName b) => !(a == b);
-    }
-
-    /// <summary>
     /// Resource name for the 'app_profile' resource.
     /// </summary>
     public sealed partial class AppProfileName : gax::IResourceName, sys::IEquatable<AppProfileName>
@@ -310,6 +218,98 @@ namespace Google.Cloud.Bigtable.Admin.V2
 
         /// <inheritdoc />
         public static bool operator !=(ClusterName a, ClusterName b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name for the 'instance' resource.
+    /// </summary>
+    public sealed partial class InstanceName : gax::IResourceName, sys::IEquatable<InstanceName>
+    {
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/instances/{instance}");
+
+        /// <summary>
+        /// Parses the given instance resource name in string form into a new
+        /// <see cref="InstanceName"/> instance.
+        /// </summary>
+        /// <param name="instanceName">The instance resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="InstanceName"/> if successful.</returns>
+        public static InstanceName Parse(string instanceName)
+        {
+            gax::GaxPreconditions.CheckNotNull(instanceName, nameof(instanceName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(instanceName);
+            return new InstanceName(resourceName[0], resourceName[1]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given instance resource name in string form into a new
+        /// <see cref="InstanceName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="instanceName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="instanceName">The instance resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="InstanceName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string instanceName, out InstanceName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(instanceName, nameof(instanceName));
+            gax::TemplatedResourceName resourceName;
+            if (s_template.TryParseName(instanceName, out resourceName))
+            {
+                result = new InstanceName(resourceName[0], resourceName[1]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="InstanceName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
+        /// <param name="instanceId">The instance ID. Must not be <c>null</c>.</param>
+        public InstanceName(string projectId, string instanceId)
+        {
+            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
+            InstanceId = gax::GaxPreconditions.CheckNotNull(instanceId, nameof(instanceId));
+        }
+
+        /// <summary>
+        /// The project ID. Never <c>null</c>.
+        /// </summary>
+        public string ProjectId { get; }
+
+        /// <summary>
+        /// The instance ID. Never <c>null</c>.
+        /// </summary>
+        public string InstanceId { get; }
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(ProjectId, InstanceId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as InstanceName);
+
+        /// <inheritdoc />
+        public bool Equals(InstanceName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(InstanceName a, InstanceName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(InstanceName a, InstanceName b) => !(a == b);
     }
 
     /// <summary>

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ResourceNames.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ResourceNames.cs
@@ -22,44 +22,44 @@ using linq = System.Linq;
 namespace Google.Cloud.Dialogflow.V2
 {
     /// <summary>
-    /// Resource name for the 'session' resource.
+    /// Resource name for the 'agent' resource.
     /// </summary>
-    public sealed partial class SessionName : gax::IResourceName, sys::IEquatable<SessionName>
+    public sealed partial class AgentName : gax::IResourceName, sys::IEquatable<AgentName>
     {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/agent/sessions/{session}");
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/agents/{agent}");
 
         /// <summary>
-        /// Parses the given session resource name in string form into a new
-        /// <see cref="SessionName"/> instance.
+        /// Parses the given agent resource name in string form into a new
+        /// <see cref="AgentName"/> instance.
         /// </summary>
-        /// <param name="sessionName">The session resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="SessionName"/> if successful.</returns>
-        public static SessionName Parse(string sessionName)
+        /// <param name="agentName">The agent resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="AgentName"/> if successful.</returns>
+        public static AgentName Parse(string agentName)
         {
-            gax::GaxPreconditions.CheckNotNull(sessionName, nameof(sessionName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(sessionName);
-            return new SessionName(resourceName[0], resourceName[1]);
+            gax::GaxPreconditions.CheckNotNull(agentName, nameof(agentName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(agentName);
+            return new AgentName(resourceName[0], resourceName[1]);
         }
 
         /// <summary>
-        /// Tries to parse the given session resource name in string form into a new
-        /// <see cref="SessionName"/> instance.
+        /// Tries to parse the given agent resource name in string form into a new
+        /// <see cref="AgentName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="sessionName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="agentName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
-        /// <param name="sessionName">The session resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="SessionName"/>,
+        /// <param name="agentName">The agent resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="AgentName"/>,
         /// or <c>null</c> if parsing fails.</param>
         /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string sessionName, out SessionName result)
+        public static bool TryParse(string agentName, out AgentName result)
         {
-            gax::GaxPreconditions.CheckNotNull(sessionName, nameof(sessionName));
+            gax::GaxPreconditions.CheckNotNull(agentName, nameof(agentName));
             gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(sessionName, out resourceName))
+            if (s_template.TryParseName(agentName, out resourceName))
             {
-                result = new SessionName(resourceName[0], resourceName[1]);
+                result = new AgentName(resourceName[0], resourceName[1]);
                 return true;
             }
             else
@@ -70,15 +70,15 @@ namespace Google.Cloud.Dialogflow.V2
         }
 
         /// <summary>
-        /// Constructs a new instance of the <see cref="SessionName"/> resource name class
+        /// Constructs a new instance of the <see cref="AgentName"/> resource name class
         /// from its component parts.
         /// </summary>
         /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
-        /// <param name="sessionId">The session ID. Must not be <c>null</c>.</param>
-        public SessionName(string projectId, string sessionId)
+        /// <param name="agentId">The agent ID. Must not be <c>null</c>.</param>
+        public AgentName(string projectId, string agentId)
         {
             ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
-            SessionId = gax::GaxPreconditions.CheckNotNull(sessionId, nameof(sessionId));
+            AgentId = gax::GaxPreconditions.CheckNotNull(agentId, nameof(agentId));
         }
 
         /// <summary>
@@ -87,30 +87,30 @@ namespace Google.Cloud.Dialogflow.V2
         public string ProjectId { get; }
 
         /// <summary>
-        /// The session ID. Never <c>null</c>.
+        /// The agent ID. Never <c>null</c>.
         /// </summary>
-        public string SessionId { get; }
+        public string AgentId { get; }
 
         /// <inheritdoc />
         public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
 
         /// <inheritdoc />
-        public override string ToString() => s_template.Expand(ProjectId, SessionId);
+        public override string ToString() => s_template.Expand(ProjectId, AgentId);
 
         /// <inheritdoc />
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as SessionName);
+        public override bool Equals(object obj) => Equals(obj as AgentName);
 
         /// <inheritdoc />
-        public bool Equals(SessionName other) => ToString() == other?.ToString();
+        public bool Equals(AgentName other) => ToString() == other?.ToString();
 
         /// <inheritdoc />
-        public static bool operator ==(SessionName a, SessionName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+        public static bool operator ==(AgentName a, AgentName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
 
         /// <inheritdoc />
-        public static bool operator !=(SessionName a, SessionName b) => !(a == b);
+        public static bool operator !=(AgentName a, AgentName b) => !(a == b);
     }
 
     /// <summary>
@@ -210,91 +210,6 @@ namespace Google.Cloud.Dialogflow.V2
 
         /// <inheritdoc />
         public static bool operator !=(ContextName a, ContextName b) => !(a == b);
-    }
-
-    /// <summary>
-    /// Resource name for the 'project_agent' resource.
-    /// </summary>
-    public sealed partial class ProjectAgentName : gax::IResourceName, sys::IEquatable<ProjectAgentName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/agent");
-
-        /// <summary>
-        /// Parses the given project_agent resource name in string form into a new
-        /// <see cref="ProjectAgentName"/> instance.
-        /// </summary>
-        /// <param name="projectAgentName">The project_agent resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="ProjectAgentName"/> if successful.</returns>
-        public static ProjectAgentName Parse(string projectAgentName)
-        {
-            gax::GaxPreconditions.CheckNotNull(projectAgentName, nameof(projectAgentName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(projectAgentName);
-            return new ProjectAgentName(resourceName[0]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given project_agent resource name in string form into a new
-        /// <see cref="ProjectAgentName"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectAgentName"/> is null,
-        /// as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="projectAgentName">The project_agent resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="ProjectAgentName"/>,
-        /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string projectAgentName, out ProjectAgentName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(projectAgentName, nameof(projectAgentName));
-            gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(projectAgentName, out resourceName))
-            {
-                result = new ProjectAgentName(resourceName[0]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="ProjectAgentName"/> resource name class
-        /// from its component parts.
-        /// </summary>
-        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
-        public ProjectAgentName(string projectId)
-        {
-            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
-        }
-
-        /// <summary>
-        /// The project ID. Never <c>null</c>.
-        /// </summary>
-        public string ProjectId { get; }
-
-        /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc />
-        public override string ToString() => s_template.Expand(ProjectId);
-
-        /// <inheritdoc />
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as ProjectAgentName);
-
-        /// <inheritdoc />
-        public bool Equals(ProjectAgentName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc />
-        public static bool operator ==(ProjectAgentName a, ProjectAgentName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc />
-        public static bool operator !=(ProjectAgentName a, ProjectAgentName b) => !(a == b);
     }
 
     /// <summary>
@@ -482,44 +397,44 @@ namespace Google.Cloud.Dialogflow.V2
     }
 
     /// <summary>
-    /// Resource name for the 'agent' resource.
+    /// Resource name for the 'project_agent' resource.
     /// </summary>
-    public sealed partial class AgentName : gax::IResourceName, sys::IEquatable<AgentName>
+    public sealed partial class ProjectAgentName : gax::IResourceName, sys::IEquatable<ProjectAgentName>
     {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/agents/{agent}");
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/agent");
 
         /// <summary>
-        /// Parses the given agent resource name in string form into a new
-        /// <see cref="AgentName"/> instance.
+        /// Parses the given project_agent resource name in string form into a new
+        /// <see cref="ProjectAgentName"/> instance.
         /// </summary>
-        /// <param name="agentName">The agent resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="AgentName"/> if successful.</returns>
-        public static AgentName Parse(string agentName)
+        /// <param name="projectAgentName">The project_agent resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="ProjectAgentName"/> if successful.</returns>
+        public static ProjectAgentName Parse(string projectAgentName)
         {
-            gax::GaxPreconditions.CheckNotNull(agentName, nameof(agentName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(agentName);
-            return new AgentName(resourceName[0], resourceName[1]);
+            gax::GaxPreconditions.CheckNotNull(projectAgentName, nameof(projectAgentName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(projectAgentName);
+            return new ProjectAgentName(resourceName[0]);
         }
 
         /// <summary>
-        /// Tries to parse the given agent resource name in string form into a new
-        /// <see cref="AgentName"/> instance.
+        /// Tries to parse the given project_agent resource name in string form into a new
+        /// <see cref="ProjectAgentName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="agentName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectAgentName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
-        /// <param name="agentName">The agent resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="AgentName"/>,
+        /// <param name="projectAgentName">The project_agent resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="ProjectAgentName"/>,
         /// or <c>null</c> if parsing fails.</param>
         /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string agentName, out AgentName result)
+        public static bool TryParse(string projectAgentName, out ProjectAgentName result)
         {
-            gax::GaxPreconditions.CheckNotNull(agentName, nameof(agentName));
+            gax::GaxPreconditions.CheckNotNull(projectAgentName, nameof(projectAgentName));
             gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(agentName, out resourceName))
+            if (s_template.TryParseName(projectAgentName, out resourceName))
             {
-                result = new AgentName(resourceName[0], resourceName[1]);
+                result = new ProjectAgentName(resourceName[0]);
                 return true;
             }
             else
@@ -530,15 +445,100 @@ namespace Google.Cloud.Dialogflow.V2
         }
 
         /// <summary>
-        /// Constructs a new instance of the <see cref="AgentName"/> resource name class
+        /// Constructs a new instance of the <see cref="ProjectAgentName"/> resource name class
         /// from its component parts.
         /// </summary>
         /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
-        /// <param name="agentId">The agent ID. Must not be <c>null</c>.</param>
-        public AgentName(string projectId, string agentId)
+        public ProjectAgentName(string projectId)
         {
             ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
-            AgentId = gax::GaxPreconditions.CheckNotNull(agentId, nameof(agentId));
+        }
+
+        /// <summary>
+        /// The project ID. Never <c>null</c>.
+        /// </summary>
+        public string ProjectId { get; }
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(ProjectId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as ProjectAgentName);
+
+        /// <inheritdoc />
+        public bool Equals(ProjectAgentName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(ProjectAgentName a, ProjectAgentName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(ProjectAgentName a, ProjectAgentName b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name for the 'session' resource.
+    /// </summary>
+    public sealed partial class SessionName : gax::IResourceName, sys::IEquatable<SessionName>
+    {
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/agent/sessions/{session}");
+
+        /// <summary>
+        /// Parses the given session resource name in string form into a new
+        /// <see cref="SessionName"/> instance.
+        /// </summary>
+        /// <param name="sessionName">The session resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="SessionName"/> if successful.</returns>
+        public static SessionName Parse(string sessionName)
+        {
+            gax::GaxPreconditions.CheckNotNull(sessionName, nameof(sessionName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(sessionName);
+            return new SessionName(resourceName[0], resourceName[1]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given session resource name in string form into a new
+        /// <see cref="SessionName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="sessionName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="sessionName">The session resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="SessionName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string sessionName, out SessionName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(sessionName, nameof(sessionName));
+            gax::TemplatedResourceName resourceName;
+            if (s_template.TryParseName(sessionName, out resourceName))
+            {
+                result = new SessionName(resourceName[0], resourceName[1]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="SessionName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
+        /// <param name="sessionId">The session ID. Must not be <c>null</c>.</param>
+        public SessionName(string projectId, string sessionId)
+        {
+            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
+            SessionId = gax::GaxPreconditions.CheckNotNull(sessionId, nameof(sessionId));
         }
 
         /// <summary>
@@ -547,30 +547,30 @@ namespace Google.Cloud.Dialogflow.V2
         public string ProjectId { get; }
 
         /// <summary>
-        /// The agent ID. Never <c>null</c>.
+        /// The session ID. Never <c>null</c>.
         /// </summary>
-        public string AgentId { get; }
+        public string SessionId { get; }
 
         /// <inheritdoc />
         public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
 
         /// <inheritdoc />
-        public override string ToString() => s_template.Expand(ProjectId, AgentId);
+        public override string ToString() => s_template.Expand(ProjectId, SessionId);
 
         /// <inheritdoc />
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as AgentName);
+        public override bool Equals(object obj) => Equals(obj as SessionName);
 
         /// <inheritdoc />
-        public bool Equals(AgentName other) => ToString() == other?.ToString();
+        public bool Equals(SessionName other) => ToString() == other?.ToString();
 
         /// <inheritdoc />
-        public static bool operator ==(AgentName a, AgentName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+        public static bool operator ==(SessionName a, SessionName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
 
         /// <inheritdoc />
-        public static bool operator !=(AgentName a, AgentName b) => !(a == b);
+        public static bool operator !=(SessionName a, SessionName b) => !(a == b);
     }
 
     /// <summary>

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/ResourceNames.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/ResourceNames.cs
@@ -22,742 +22,6 @@ using linq = System.Linq;
 namespace Google.Cloud.Dlp.V2
 {
     /// <summary>
-    /// Resource name for the 'organization_deidentify_template' resource.
-    /// </summary>
-    public sealed partial class OrganizationDeidentifyTemplateName : gax::IResourceName, sys::IEquatable<OrganizationDeidentifyTemplateName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("organizations/{organization}/deidentifyTemplates/{deidentify_template}");
-
-        /// <summary>
-        /// Parses the given organization_deidentify_template resource name in string form into a new
-        /// <see cref="OrganizationDeidentifyTemplateName"/> instance.
-        /// </summary>
-        /// <param name="organizationDeidentifyTemplateName">The organization_deidentify_template resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="OrganizationDeidentifyTemplateName"/> if successful.</returns>
-        public static OrganizationDeidentifyTemplateName Parse(string organizationDeidentifyTemplateName)
-        {
-            gax::GaxPreconditions.CheckNotNull(organizationDeidentifyTemplateName, nameof(organizationDeidentifyTemplateName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(organizationDeidentifyTemplateName);
-            return new OrganizationDeidentifyTemplateName(resourceName[0], resourceName[1]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given organization_deidentify_template resource name in string form into a new
-        /// <see cref="OrganizationDeidentifyTemplateName"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="organizationDeidentifyTemplateName"/> is null,
-        /// as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="organizationDeidentifyTemplateName">The organization_deidentify_template resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="OrganizationDeidentifyTemplateName"/>,
-        /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string organizationDeidentifyTemplateName, out OrganizationDeidentifyTemplateName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(organizationDeidentifyTemplateName, nameof(organizationDeidentifyTemplateName));
-            gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(organizationDeidentifyTemplateName, out resourceName))
-            {
-                result = new OrganizationDeidentifyTemplateName(resourceName[0], resourceName[1]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="OrganizationDeidentifyTemplateName"/> resource name class
-        /// from its component parts.
-        /// </summary>
-        /// <param name="organizationId">The organization ID. Must not be <c>null</c>.</param>
-        /// <param name="deidentifyTemplateId">The deidentifyTemplate ID. Must not be <c>null</c>.</param>
-        public OrganizationDeidentifyTemplateName(string organizationId, string deidentifyTemplateId)
-        {
-            OrganizationId = gax::GaxPreconditions.CheckNotNull(organizationId, nameof(organizationId));
-            DeidentifyTemplateId = gax::GaxPreconditions.CheckNotNull(deidentifyTemplateId, nameof(deidentifyTemplateId));
-        }
-
-        /// <summary>
-        /// The organization ID. Never <c>null</c>.
-        /// </summary>
-        public string OrganizationId { get; }
-
-        /// <summary>
-        /// The deidentifyTemplate ID. Never <c>null</c>.
-        /// </summary>
-        public string DeidentifyTemplateId { get; }
-
-        /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc />
-        public override string ToString() => s_template.Expand(OrganizationId, DeidentifyTemplateId);
-
-        /// <inheritdoc />
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as OrganizationDeidentifyTemplateName);
-
-        /// <inheritdoc />
-        public bool Equals(OrganizationDeidentifyTemplateName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc />
-        public static bool operator ==(OrganizationDeidentifyTemplateName a, OrganizationDeidentifyTemplateName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc />
-        public static bool operator !=(OrganizationDeidentifyTemplateName a, OrganizationDeidentifyTemplateName b) => !(a == b);
-    }
-
-    /// <summary>
-    /// Resource name for the 'project_deidentify_template' resource.
-    /// </summary>
-    public sealed partial class ProjectDeidentifyTemplateName : gax::IResourceName, sys::IEquatable<ProjectDeidentifyTemplateName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/deidentifyTemplates/{deidentify_template}");
-
-        /// <summary>
-        /// Parses the given project_deidentify_template resource name in string form into a new
-        /// <see cref="ProjectDeidentifyTemplateName"/> instance.
-        /// </summary>
-        /// <param name="projectDeidentifyTemplateName">The project_deidentify_template resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="ProjectDeidentifyTemplateName"/> if successful.</returns>
-        public static ProjectDeidentifyTemplateName Parse(string projectDeidentifyTemplateName)
-        {
-            gax::GaxPreconditions.CheckNotNull(projectDeidentifyTemplateName, nameof(projectDeidentifyTemplateName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(projectDeidentifyTemplateName);
-            return new ProjectDeidentifyTemplateName(resourceName[0], resourceName[1]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given project_deidentify_template resource name in string form into a new
-        /// <see cref="ProjectDeidentifyTemplateName"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectDeidentifyTemplateName"/> is null,
-        /// as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="projectDeidentifyTemplateName">The project_deidentify_template resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="ProjectDeidentifyTemplateName"/>,
-        /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string projectDeidentifyTemplateName, out ProjectDeidentifyTemplateName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(projectDeidentifyTemplateName, nameof(projectDeidentifyTemplateName));
-            gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(projectDeidentifyTemplateName, out resourceName))
-            {
-                result = new ProjectDeidentifyTemplateName(resourceName[0], resourceName[1]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="ProjectDeidentifyTemplateName"/> resource name class
-        /// from its component parts.
-        /// </summary>
-        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
-        /// <param name="deidentifyTemplateId">The deidentifyTemplate ID. Must not be <c>null</c>.</param>
-        public ProjectDeidentifyTemplateName(string projectId, string deidentifyTemplateId)
-        {
-            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
-            DeidentifyTemplateId = gax::GaxPreconditions.CheckNotNull(deidentifyTemplateId, nameof(deidentifyTemplateId));
-        }
-
-        /// <summary>
-        /// The project ID. Never <c>null</c>.
-        /// </summary>
-        public string ProjectId { get; }
-
-        /// <summary>
-        /// The deidentifyTemplate ID. Never <c>null</c>.
-        /// </summary>
-        public string DeidentifyTemplateId { get; }
-
-        /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc />
-        public override string ToString() => s_template.Expand(ProjectId, DeidentifyTemplateId);
-
-        /// <inheritdoc />
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as ProjectDeidentifyTemplateName);
-
-        /// <inheritdoc />
-        public bool Equals(ProjectDeidentifyTemplateName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc />
-        public static bool operator ==(ProjectDeidentifyTemplateName a, ProjectDeidentifyTemplateName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc />
-        public static bool operator !=(ProjectDeidentifyTemplateName a, ProjectDeidentifyTemplateName b) => !(a == b);
-    }
-
-    /// <summary>
-    /// Resource name for the 'organization_inspect_template' resource.
-    /// </summary>
-    public sealed partial class OrganizationInspectTemplateName : gax::IResourceName, sys::IEquatable<OrganizationInspectTemplateName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("organizations/{organization}/inspectTemplates/{inspect_template}");
-
-        /// <summary>
-        /// Parses the given organization_inspect_template resource name in string form into a new
-        /// <see cref="OrganizationInspectTemplateName"/> instance.
-        /// </summary>
-        /// <param name="organizationInspectTemplateName">The organization_inspect_template resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="OrganizationInspectTemplateName"/> if successful.</returns>
-        public static OrganizationInspectTemplateName Parse(string organizationInspectTemplateName)
-        {
-            gax::GaxPreconditions.CheckNotNull(organizationInspectTemplateName, nameof(organizationInspectTemplateName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(organizationInspectTemplateName);
-            return new OrganizationInspectTemplateName(resourceName[0], resourceName[1]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given organization_inspect_template resource name in string form into a new
-        /// <see cref="OrganizationInspectTemplateName"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="organizationInspectTemplateName"/> is null,
-        /// as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="organizationInspectTemplateName">The organization_inspect_template resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="OrganizationInspectTemplateName"/>,
-        /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string organizationInspectTemplateName, out OrganizationInspectTemplateName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(organizationInspectTemplateName, nameof(organizationInspectTemplateName));
-            gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(organizationInspectTemplateName, out resourceName))
-            {
-                result = new OrganizationInspectTemplateName(resourceName[0], resourceName[1]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="OrganizationInspectTemplateName"/> resource name class
-        /// from its component parts.
-        /// </summary>
-        /// <param name="organizationId">The organization ID. Must not be <c>null</c>.</param>
-        /// <param name="inspectTemplateId">The inspectTemplate ID. Must not be <c>null</c>.</param>
-        public OrganizationInspectTemplateName(string organizationId, string inspectTemplateId)
-        {
-            OrganizationId = gax::GaxPreconditions.CheckNotNull(organizationId, nameof(organizationId));
-            InspectTemplateId = gax::GaxPreconditions.CheckNotNull(inspectTemplateId, nameof(inspectTemplateId));
-        }
-
-        /// <summary>
-        /// The organization ID. Never <c>null</c>.
-        /// </summary>
-        public string OrganizationId { get; }
-
-        /// <summary>
-        /// The inspectTemplate ID. Never <c>null</c>.
-        /// </summary>
-        public string InspectTemplateId { get; }
-
-        /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc />
-        public override string ToString() => s_template.Expand(OrganizationId, InspectTemplateId);
-
-        /// <inheritdoc />
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as OrganizationInspectTemplateName);
-
-        /// <inheritdoc />
-        public bool Equals(OrganizationInspectTemplateName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc />
-        public static bool operator ==(OrganizationInspectTemplateName a, OrganizationInspectTemplateName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc />
-        public static bool operator !=(OrganizationInspectTemplateName a, OrganizationInspectTemplateName b) => !(a == b);
-    }
-
-    /// <summary>
-    /// Resource name for the 'project_inspect_template' resource.
-    /// </summary>
-    public sealed partial class ProjectInspectTemplateName : gax::IResourceName, sys::IEquatable<ProjectInspectTemplateName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/inspectTemplates/{inspect_template}");
-
-        /// <summary>
-        /// Parses the given project_inspect_template resource name in string form into a new
-        /// <see cref="ProjectInspectTemplateName"/> instance.
-        /// </summary>
-        /// <param name="projectInspectTemplateName">The project_inspect_template resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="ProjectInspectTemplateName"/> if successful.</returns>
-        public static ProjectInspectTemplateName Parse(string projectInspectTemplateName)
-        {
-            gax::GaxPreconditions.CheckNotNull(projectInspectTemplateName, nameof(projectInspectTemplateName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(projectInspectTemplateName);
-            return new ProjectInspectTemplateName(resourceName[0], resourceName[1]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given project_inspect_template resource name in string form into a new
-        /// <see cref="ProjectInspectTemplateName"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectInspectTemplateName"/> is null,
-        /// as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="projectInspectTemplateName">The project_inspect_template resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="ProjectInspectTemplateName"/>,
-        /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string projectInspectTemplateName, out ProjectInspectTemplateName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(projectInspectTemplateName, nameof(projectInspectTemplateName));
-            gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(projectInspectTemplateName, out resourceName))
-            {
-                result = new ProjectInspectTemplateName(resourceName[0], resourceName[1]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="ProjectInspectTemplateName"/> resource name class
-        /// from its component parts.
-        /// </summary>
-        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
-        /// <param name="inspectTemplateId">The inspectTemplate ID. Must not be <c>null</c>.</param>
-        public ProjectInspectTemplateName(string projectId, string inspectTemplateId)
-        {
-            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
-            InspectTemplateId = gax::GaxPreconditions.CheckNotNull(inspectTemplateId, nameof(inspectTemplateId));
-        }
-
-        /// <summary>
-        /// The project ID. Never <c>null</c>.
-        /// </summary>
-        public string ProjectId { get; }
-
-        /// <summary>
-        /// The inspectTemplate ID. Never <c>null</c>.
-        /// </summary>
-        public string InspectTemplateId { get; }
-
-        /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc />
-        public override string ToString() => s_template.Expand(ProjectId, InspectTemplateId);
-
-        /// <inheritdoc />
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as ProjectInspectTemplateName);
-
-        /// <inheritdoc />
-        public bool Equals(ProjectInspectTemplateName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc />
-        public static bool operator ==(ProjectInspectTemplateName a, ProjectInspectTemplateName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc />
-        public static bool operator !=(ProjectInspectTemplateName a, ProjectInspectTemplateName b) => !(a == b);
-    }
-
-    /// <summary>
-    /// Resource name for the 'project_job_trigger' resource.
-    /// </summary>
-    public sealed partial class ProjectJobTriggerName : gax::IResourceName, sys::IEquatable<ProjectJobTriggerName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/jobTriggers/{job_trigger}");
-
-        /// <summary>
-        /// Parses the given project_job_trigger resource name in string form into a new
-        /// <see cref="ProjectJobTriggerName"/> instance.
-        /// </summary>
-        /// <param name="projectJobTriggerName">The project_job_trigger resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="ProjectJobTriggerName"/> if successful.</returns>
-        public static ProjectJobTriggerName Parse(string projectJobTriggerName)
-        {
-            gax::GaxPreconditions.CheckNotNull(projectJobTriggerName, nameof(projectJobTriggerName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(projectJobTriggerName);
-            return new ProjectJobTriggerName(resourceName[0], resourceName[1]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given project_job_trigger resource name in string form into a new
-        /// <see cref="ProjectJobTriggerName"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectJobTriggerName"/> is null,
-        /// as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="projectJobTriggerName">The project_job_trigger resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="ProjectJobTriggerName"/>,
-        /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string projectJobTriggerName, out ProjectJobTriggerName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(projectJobTriggerName, nameof(projectJobTriggerName));
-            gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(projectJobTriggerName, out resourceName))
-            {
-                result = new ProjectJobTriggerName(resourceName[0], resourceName[1]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="ProjectJobTriggerName"/> resource name class
-        /// from its component parts.
-        /// </summary>
-        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
-        /// <param name="jobTriggerId">The jobTrigger ID. Must not be <c>null</c>.</param>
-        public ProjectJobTriggerName(string projectId, string jobTriggerId)
-        {
-            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
-            JobTriggerId = gax::GaxPreconditions.CheckNotNull(jobTriggerId, nameof(jobTriggerId));
-        }
-
-        /// <summary>
-        /// The project ID. Never <c>null</c>.
-        /// </summary>
-        public string ProjectId { get; }
-
-        /// <summary>
-        /// The jobTrigger ID. Never <c>null</c>.
-        /// </summary>
-        public string JobTriggerId { get; }
-
-        /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc />
-        public override string ToString() => s_template.Expand(ProjectId, JobTriggerId);
-
-        /// <inheritdoc />
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as ProjectJobTriggerName);
-
-        /// <inheritdoc />
-        public bool Equals(ProjectJobTriggerName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc />
-        public static bool operator ==(ProjectJobTriggerName a, ProjectJobTriggerName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc />
-        public static bool operator !=(ProjectJobTriggerName a, ProjectJobTriggerName b) => !(a == b);
-    }
-
-    /// <summary>
-    /// Resource name for the 'dlp_job' resource.
-    /// </summary>
-    public sealed partial class DlpJobName : gax::IResourceName, sys::IEquatable<DlpJobName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/dlpJobs/{dlp_job}");
-
-        /// <summary>
-        /// Parses the given dlp_job resource name in string form into a new
-        /// <see cref="DlpJobName"/> instance.
-        /// </summary>
-        /// <param name="dlpJobName">The dlp_job resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="DlpJobName"/> if successful.</returns>
-        public static DlpJobName Parse(string dlpJobName)
-        {
-            gax::GaxPreconditions.CheckNotNull(dlpJobName, nameof(dlpJobName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(dlpJobName);
-            return new DlpJobName(resourceName[0], resourceName[1]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given dlp_job resource name in string form into a new
-        /// <see cref="DlpJobName"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="dlpJobName"/> is null,
-        /// as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="dlpJobName">The dlp_job resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="DlpJobName"/>,
-        /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string dlpJobName, out DlpJobName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(dlpJobName, nameof(dlpJobName));
-            gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(dlpJobName, out resourceName))
-            {
-                result = new DlpJobName(resourceName[0], resourceName[1]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="DlpJobName"/> resource name class
-        /// from its component parts.
-        /// </summary>
-        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
-        /// <param name="dlpJobId">The dlpJob ID. Must not be <c>null</c>.</param>
-        public DlpJobName(string projectId, string dlpJobId)
-        {
-            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
-            DlpJobId = gax::GaxPreconditions.CheckNotNull(dlpJobId, nameof(dlpJobId));
-        }
-
-        /// <summary>
-        /// The project ID. Never <c>null</c>.
-        /// </summary>
-        public string ProjectId { get; }
-
-        /// <summary>
-        /// The dlpJob ID. Never <c>null</c>.
-        /// </summary>
-        public string DlpJobId { get; }
-
-        /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc />
-        public override string ToString() => s_template.Expand(ProjectId, DlpJobId);
-
-        /// <inheritdoc />
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as DlpJobName);
-
-        /// <inheritdoc />
-        public bool Equals(DlpJobName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc />
-        public static bool operator ==(DlpJobName a, DlpJobName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc />
-        public static bool operator !=(DlpJobName a, DlpJobName b) => !(a == b);
-    }
-
-    /// <summary>
-    /// Resource name for the 'organization_stored_info_type' resource.
-    /// </summary>
-    public sealed partial class OrganizationStoredInfoTypeName : gax::IResourceName, sys::IEquatable<OrganizationStoredInfoTypeName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("organizations/{organization}/storedInfoTypes/{stored_info_type}");
-
-        /// <summary>
-        /// Parses the given organization_stored_info_type resource name in string form into a new
-        /// <see cref="OrganizationStoredInfoTypeName"/> instance.
-        /// </summary>
-        /// <param name="organizationStoredInfoTypeName">The organization_stored_info_type resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="OrganizationStoredInfoTypeName"/> if successful.</returns>
-        public static OrganizationStoredInfoTypeName Parse(string organizationStoredInfoTypeName)
-        {
-            gax::GaxPreconditions.CheckNotNull(organizationStoredInfoTypeName, nameof(organizationStoredInfoTypeName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(organizationStoredInfoTypeName);
-            return new OrganizationStoredInfoTypeName(resourceName[0], resourceName[1]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given organization_stored_info_type resource name in string form into a new
-        /// <see cref="OrganizationStoredInfoTypeName"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="organizationStoredInfoTypeName"/> is null,
-        /// as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="organizationStoredInfoTypeName">The organization_stored_info_type resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="OrganizationStoredInfoTypeName"/>,
-        /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string organizationStoredInfoTypeName, out OrganizationStoredInfoTypeName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(organizationStoredInfoTypeName, nameof(organizationStoredInfoTypeName));
-            gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(organizationStoredInfoTypeName, out resourceName))
-            {
-                result = new OrganizationStoredInfoTypeName(resourceName[0], resourceName[1]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="OrganizationStoredInfoTypeName"/> resource name class
-        /// from its component parts.
-        /// </summary>
-        /// <param name="organizationId">The organization ID. Must not be <c>null</c>.</param>
-        /// <param name="storedInfoTypeId">The storedInfoType ID. Must not be <c>null</c>.</param>
-        public OrganizationStoredInfoTypeName(string organizationId, string storedInfoTypeId)
-        {
-            OrganizationId = gax::GaxPreconditions.CheckNotNull(organizationId, nameof(organizationId));
-            StoredInfoTypeId = gax::GaxPreconditions.CheckNotNull(storedInfoTypeId, nameof(storedInfoTypeId));
-        }
-
-        /// <summary>
-        /// The organization ID. Never <c>null</c>.
-        /// </summary>
-        public string OrganizationId { get; }
-
-        /// <summary>
-        /// The storedInfoType ID. Never <c>null</c>.
-        /// </summary>
-        public string StoredInfoTypeId { get; }
-
-        /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc />
-        public override string ToString() => s_template.Expand(OrganizationId, StoredInfoTypeId);
-
-        /// <inheritdoc />
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as OrganizationStoredInfoTypeName);
-
-        /// <inheritdoc />
-        public bool Equals(OrganizationStoredInfoTypeName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc />
-        public static bool operator ==(OrganizationStoredInfoTypeName a, OrganizationStoredInfoTypeName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc />
-        public static bool operator !=(OrganizationStoredInfoTypeName a, OrganizationStoredInfoTypeName b) => !(a == b);
-    }
-
-    /// <summary>
-    /// Resource name for the 'project_stored_info_type' resource.
-    /// </summary>
-    public sealed partial class ProjectStoredInfoTypeName : gax::IResourceName, sys::IEquatable<ProjectStoredInfoTypeName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/storedInfoTypes/{stored_info_type}");
-
-        /// <summary>
-        /// Parses the given project_stored_info_type resource name in string form into a new
-        /// <see cref="ProjectStoredInfoTypeName"/> instance.
-        /// </summary>
-        /// <param name="projectStoredInfoTypeName">The project_stored_info_type resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="ProjectStoredInfoTypeName"/> if successful.</returns>
-        public static ProjectStoredInfoTypeName Parse(string projectStoredInfoTypeName)
-        {
-            gax::GaxPreconditions.CheckNotNull(projectStoredInfoTypeName, nameof(projectStoredInfoTypeName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(projectStoredInfoTypeName);
-            return new ProjectStoredInfoTypeName(resourceName[0], resourceName[1]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given project_stored_info_type resource name in string form into a new
-        /// <see cref="ProjectStoredInfoTypeName"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectStoredInfoTypeName"/> is null,
-        /// as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="projectStoredInfoTypeName">The project_stored_info_type resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="ProjectStoredInfoTypeName"/>,
-        /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string projectStoredInfoTypeName, out ProjectStoredInfoTypeName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(projectStoredInfoTypeName, nameof(projectStoredInfoTypeName));
-            gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(projectStoredInfoTypeName, out resourceName))
-            {
-                result = new ProjectStoredInfoTypeName(resourceName[0], resourceName[1]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="ProjectStoredInfoTypeName"/> resource name class
-        /// from its component parts.
-        /// </summary>
-        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
-        /// <param name="storedInfoTypeId">The storedInfoType ID. Must not be <c>null</c>.</param>
-        public ProjectStoredInfoTypeName(string projectId, string storedInfoTypeId)
-        {
-            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
-            StoredInfoTypeId = gax::GaxPreconditions.CheckNotNull(storedInfoTypeId, nameof(storedInfoTypeId));
-        }
-
-        /// <summary>
-        /// The project ID. Never <c>null</c>.
-        /// </summary>
-        public string ProjectId { get; }
-
-        /// <summary>
-        /// The storedInfoType ID. Never <c>null</c>.
-        /// </summary>
-        public string StoredInfoTypeId { get; }
-
-        /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc />
-        public override string ToString() => s_template.Expand(ProjectId, StoredInfoTypeId);
-
-        /// <inheritdoc />
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as ProjectStoredInfoTypeName);
-
-        /// <inheritdoc />
-        public bool Equals(ProjectStoredInfoTypeName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc />
-        public static bool operator ==(ProjectStoredInfoTypeName a, ProjectStoredInfoTypeName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc />
-        public static bool operator !=(ProjectStoredInfoTypeName a, ProjectStoredInfoTypeName b) => !(a == b);
-    }
-
-    /// <summary>
     /// Resource name which will contain one of a choice of resource names.
     /// </summary>
     /// <remarks>
@@ -962,6 +226,98 @@ namespace Google.Cloud.Dlp.V2
     }
 
     /// <summary>
+    /// Resource name for the 'dlp_job' resource.
+    /// </summary>
+    public sealed partial class DlpJobName : gax::IResourceName, sys::IEquatable<DlpJobName>
+    {
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/dlpJobs/{dlp_job}");
+
+        /// <summary>
+        /// Parses the given dlp_job resource name in string form into a new
+        /// <see cref="DlpJobName"/> instance.
+        /// </summary>
+        /// <param name="dlpJobName">The dlp_job resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="DlpJobName"/> if successful.</returns>
+        public static DlpJobName Parse(string dlpJobName)
+        {
+            gax::GaxPreconditions.CheckNotNull(dlpJobName, nameof(dlpJobName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(dlpJobName);
+            return new DlpJobName(resourceName[0], resourceName[1]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given dlp_job resource name in string form into a new
+        /// <see cref="DlpJobName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="dlpJobName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="dlpJobName">The dlp_job resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="DlpJobName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string dlpJobName, out DlpJobName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(dlpJobName, nameof(dlpJobName));
+            gax::TemplatedResourceName resourceName;
+            if (s_template.TryParseName(dlpJobName, out resourceName))
+            {
+                result = new DlpJobName(resourceName[0], resourceName[1]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="DlpJobName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
+        /// <param name="dlpJobId">The dlpJob ID. Must not be <c>null</c>.</param>
+        public DlpJobName(string projectId, string dlpJobId)
+        {
+            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
+            DlpJobId = gax::GaxPreconditions.CheckNotNull(dlpJobId, nameof(dlpJobId));
+        }
+
+        /// <summary>
+        /// The project ID. Never <c>null</c>.
+        /// </summary>
+        public string ProjectId { get; }
+
+        /// <summary>
+        /// The dlpJob ID. Never <c>null</c>.
+        /// </summary>
+        public string DlpJobId { get; }
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(ProjectId, DlpJobId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as DlpJobName);
+
+        /// <inheritdoc />
+        public bool Equals(DlpJobName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(DlpJobName a, DlpJobName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(DlpJobName a, DlpJobName b) => !(a == b);
+    }
+
+    /// <summary>
     /// Resource name which will contain one of a choice of resource names.
     /// </summary>
     /// <remarks>
@@ -1163,6 +519,650 @@ namespace Google.Cloud.Dlp.V2
 
         /// <inheritdoc />
         public static bool operator !=(InspectTemplateNameOneof a, InspectTemplateNameOneof b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name for the 'organization_deidentify_template' resource.
+    /// </summary>
+    public sealed partial class OrganizationDeidentifyTemplateName : gax::IResourceName, sys::IEquatable<OrganizationDeidentifyTemplateName>
+    {
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("organizations/{organization}/deidentifyTemplates/{deidentify_template}");
+
+        /// <summary>
+        /// Parses the given organization_deidentify_template resource name in string form into a new
+        /// <see cref="OrganizationDeidentifyTemplateName"/> instance.
+        /// </summary>
+        /// <param name="organizationDeidentifyTemplateName">The organization_deidentify_template resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="OrganizationDeidentifyTemplateName"/> if successful.</returns>
+        public static OrganizationDeidentifyTemplateName Parse(string organizationDeidentifyTemplateName)
+        {
+            gax::GaxPreconditions.CheckNotNull(organizationDeidentifyTemplateName, nameof(organizationDeidentifyTemplateName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(organizationDeidentifyTemplateName);
+            return new OrganizationDeidentifyTemplateName(resourceName[0], resourceName[1]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given organization_deidentify_template resource name in string form into a new
+        /// <see cref="OrganizationDeidentifyTemplateName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="organizationDeidentifyTemplateName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="organizationDeidentifyTemplateName">The organization_deidentify_template resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="OrganizationDeidentifyTemplateName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string organizationDeidentifyTemplateName, out OrganizationDeidentifyTemplateName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(organizationDeidentifyTemplateName, nameof(organizationDeidentifyTemplateName));
+            gax::TemplatedResourceName resourceName;
+            if (s_template.TryParseName(organizationDeidentifyTemplateName, out resourceName))
+            {
+                result = new OrganizationDeidentifyTemplateName(resourceName[0], resourceName[1]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="OrganizationDeidentifyTemplateName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="organizationId">The organization ID. Must not be <c>null</c>.</param>
+        /// <param name="deidentifyTemplateId">The deidentifyTemplate ID. Must not be <c>null</c>.</param>
+        public OrganizationDeidentifyTemplateName(string organizationId, string deidentifyTemplateId)
+        {
+            OrganizationId = gax::GaxPreconditions.CheckNotNull(organizationId, nameof(organizationId));
+            DeidentifyTemplateId = gax::GaxPreconditions.CheckNotNull(deidentifyTemplateId, nameof(deidentifyTemplateId));
+        }
+
+        /// <summary>
+        /// The organization ID. Never <c>null</c>.
+        /// </summary>
+        public string OrganizationId { get; }
+
+        /// <summary>
+        /// The deidentifyTemplate ID. Never <c>null</c>.
+        /// </summary>
+        public string DeidentifyTemplateId { get; }
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(OrganizationId, DeidentifyTemplateId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as OrganizationDeidentifyTemplateName);
+
+        /// <inheritdoc />
+        public bool Equals(OrganizationDeidentifyTemplateName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(OrganizationDeidentifyTemplateName a, OrganizationDeidentifyTemplateName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(OrganizationDeidentifyTemplateName a, OrganizationDeidentifyTemplateName b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name for the 'organization_inspect_template' resource.
+    /// </summary>
+    public sealed partial class OrganizationInspectTemplateName : gax::IResourceName, sys::IEquatable<OrganizationInspectTemplateName>
+    {
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("organizations/{organization}/inspectTemplates/{inspect_template}");
+
+        /// <summary>
+        /// Parses the given organization_inspect_template resource name in string form into a new
+        /// <see cref="OrganizationInspectTemplateName"/> instance.
+        /// </summary>
+        /// <param name="organizationInspectTemplateName">The organization_inspect_template resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="OrganizationInspectTemplateName"/> if successful.</returns>
+        public static OrganizationInspectTemplateName Parse(string organizationInspectTemplateName)
+        {
+            gax::GaxPreconditions.CheckNotNull(organizationInspectTemplateName, nameof(organizationInspectTemplateName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(organizationInspectTemplateName);
+            return new OrganizationInspectTemplateName(resourceName[0], resourceName[1]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given organization_inspect_template resource name in string form into a new
+        /// <see cref="OrganizationInspectTemplateName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="organizationInspectTemplateName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="organizationInspectTemplateName">The organization_inspect_template resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="OrganizationInspectTemplateName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string organizationInspectTemplateName, out OrganizationInspectTemplateName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(organizationInspectTemplateName, nameof(organizationInspectTemplateName));
+            gax::TemplatedResourceName resourceName;
+            if (s_template.TryParseName(organizationInspectTemplateName, out resourceName))
+            {
+                result = new OrganizationInspectTemplateName(resourceName[0], resourceName[1]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="OrganizationInspectTemplateName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="organizationId">The organization ID. Must not be <c>null</c>.</param>
+        /// <param name="inspectTemplateId">The inspectTemplate ID. Must not be <c>null</c>.</param>
+        public OrganizationInspectTemplateName(string organizationId, string inspectTemplateId)
+        {
+            OrganizationId = gax::GaxPreconditions.CheckNotNull(organizationId, nameof(organizationId));
+            InspectTemplateId = gax::GaxPreconditions.CheckNotNull(inspectTemplateId, nameof(inspectTemplateId));
+        }
+
+        /// <summary>
+        /// The organization ID. Never <c>null</c>.
+        /// </summary>
+        public string OrganizationId { get; }
+
+        /// <summary>
+        /// The inspectTemplate ID. Never <c>null</c>.
+        /// </summary>
+        public string InspectTemplateId { get; }
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(OrganizationId, InspectTemplateId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as OrganizationInspectTemplateName);
+
+        /// <inheritdoc />
+        public bool Equals(OrganizationInspectTemplateName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(OrganizationInspectTemplateName a, OrganizationInspectTemplateName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(OrganizationInspectTemplateName a, OrganizationInspectTemplateName b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name for the 'organization_stored_info_type' resource.
+    /// </summary>
+    public sealed partial class OrganizationStoredInfoTypeName : gax::IResourceName, sys::IEquatable<OrganizationStoredInfoTypeName>
+    {
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("organizations/{organization}/storedInfoTypes/{stored_info_type}");
+
+        /// <summary>
+        /// Parses the given organization_stored_info_type resource name in string form into a new
+        /// <see cref="OrganizationStoredInfoTypeName"/> instance.
+        /// </summary>
+        /// <param name="organizationStoredInfoTypeName">The organization_stored_info_type resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="OrganizationStoredInfoTypeName"/> if successful.</returns>
+        public static OrganizationStoredInfoTypeName Parse(string organizationStoredInfoTypeName)
+        {
+            gax::GaxPreconditions.CheckNotNull(organizationStoredInfoTypeName, nameof(organizationStoredInfoTypeName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(organizationStoredInfoTypeName);
+            return new OrganizationStoredInfoTypeName(resourceName[0], resourceName[1]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given organization_stored_info_type resource name in string form into a new
+        /// <see cref="OrganizationStoredInfoTypeName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="organizationStoredInfoTypeName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="organizationStoredInfoTypeName">The organization_stored_info_type resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="OrganizationStoredInfoTypeName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string organizationStoredInfoTypeName, out OrganizationStoredInfoTypeName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(organizationStoredInfoTypeName, nameof(organizationStoredInfoTypeName));
+            gax::TemplatedResourceName resourceName;
+            if (s_template.TryParseName(organizationStoredInfoTypeName, out resourceName))
+            {
+                result = new OrganizationStoredInfoTypeName(resourceName[0], resourceName[1]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="OrganizationStoredInfoTypeName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="organizationId">The organization ID. Must not be <c>null</c>.</param>
+        /// <param name="storedInfoTypeId">The storedInfoType ID. Must not be <c>null</c>.</param>
+        public OrganizationStoredInfoTypeName(string organizationId, string storedInfoTypeId)
+        {
+            OrganizationId = gax::GaxPreconditions.CheckNotNull(organizationId, nameof(organizationId));
+            StoredInfoTypeId = gax::GaxPreconditions.CheckNotNull(storedInfoTypeId, nameof(storedInfoTypeId));
+        }
+
+        /// <summary>
+        /// The organization ID. Never <c>null</c>.
+        /// </summary>
+        public string OrganizationId { get; }
+
+        /// <summary>
+        /// The storedInfoType ID. Never <c>null</c>.
+        /// </summary>
+        public string StoredInfoTypeId { get; }
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(OrganizationId, StoredInfoTypeId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as OrganizationStoredInfoTypeName);
+
+        /// <inheritdoc />
+        public bool Equals(OrganizationStoredInfoTypeName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(OrganizationStoredInfoTypeName a, OrganizationStoredInfoTypeName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(OrganizationStoredInfoTypeName a, OrganizationStoredInfoTypeName b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name for the 'project_deidentify_template' resource.
+    /// </summary>
+    public sealed partial class ProjectDeidentifyTemplateName : gax::IResourceName, sys::IEquatable<ProjectDeidentifyTemplateName>
+    {
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/deidentifyTemplates/{deidentify_template}");
+
+        /// <summary>
+        /// Parses the given project_deidentify_template resource name in string form into a new
+        /// <see cref="ProjectDeidentifyTemplateName"/> instance.
+        /// </summary>
+        /// <param name="projectDeidentifyTemplateName">The project_deidentify_template resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="ProjectDeidentifyTemplateName"/> if successful.</returns>
+        public static ProjectDeidentifyTemplateName Parse(string projectDeidentifyTemplateName)
+        {
+            gax::GaxPreconditions.CheckNotNull(projectDeidentifyTemplateName, nameof(projectDeidentifyTemplateName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(projectDeidentifyTemplateName);
+            return new ProjectDeidentifyTemplateName(resourceName[0], resourceName[1]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given project_deidentify_template resource name in string form into a new
+        /// <see cref="ProjectDeidentifyTemplateName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectDeidentifyTemplateName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="projectDeidentifyTemplateName">The project_deidentify_template resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="ProjectDeidentifyTemplateName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string projectDeidentifyTemplateName, out ProjectDeidentifyTemplateName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(projectDeidentifyTemplateName, nameof(projectDeidentifyTemplateName));
+            gax::TemplatedResourceName resourceName;
+            if (s_template.TryParseName(projectDeidentifyTemplateName, out resourceName))
+            {
+                result = new ProjectDeidentifyTemplateName(resourceName[0], resourceName[1]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="ProjectDeidentifyTemplateName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
+        /// <param name="deidentifyTemplateId">The deidentifyTemplate ID. Must not be <c>null</c>.</param>
+        public ProjectDeidentifyTemplateName(string projectId, string deidentifyTemplateId)
+        {
+            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
+            DeidentifyTemplateId = gax::GaxPreconditions.CheckNotNull(deidentifyTemplateId, nameof(deidentifyTemplateId));
+        }
+
+        /// <summary>
+        /// The project ID. Never <c>null</c>.
+        /// </summary>
+        public string ProjectId { get; }
+
+        /// <summary>
+        /// The deidentifyTemplate ID. Never <c>null</c>.
+        /// </summary>
+        public string DeidentifyTemplateId { get; }
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(ProjectId, DeidentifyTemplateId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as ProjectDeidentifyTemplateName);
+
+        /// <inheritdoc />
+        public bool Equals(ProjectDeidentifyTemplateName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(ProjectDeidentifyTemplateName a, ProjectDeidentifyTemplateName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(ProjectDeidentifyTemplateName a, ProjectDeidentifyTemplateName b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name for the 'project_inspect_template' resource.
+    /// </summary>
+    public sealed partial class ProjectInspectTemplateName : gax::IResourceName, sys::IEquatable<ProjectInspectTemplateName>
+    {
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/inspectTemplates/{inspect_template}");
+
+        /// <summary>
+        /// Parses the given project_inspect_template resource name in string form into a new
+        /// <see cref="ProjectInspectTemplateName"/> instance.
+        /// </summary>
+        /// <param name="projectInspectTemplateName">The project_inspect_template resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="ProjectInspectTemplateName"/> if successful.</returns>
+        public static ProjectInspectTemplateName Parse(string projectInspectTemplateName)
+        {
+            gax::GaxPreconditions.CheckNotNull(projectInspectTemplateName, nameof(projectInspectTemplateName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(projectInspectTemplateName);
+            return new ProjectInspectTemplateName(resourceName[0], resourceName[1]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given project_inspect_template resource name in string form into a new
+        /// <see cref="ProjectInspectTemplateName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectInspectTemplateName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="projectInspectTemplateName">The project_inspect_template resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="ProjectInspectTemplateName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string projectInspectTemplateName, out ProjectInspectTemplateName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(projectInspectTemplateName, nameof(projectInspectTemplateName));
+            gax::TemplatedResourceName resourceName;
+            if (s_template.TryParseName(projectInspectTemplateName, out resourceName))
+            {
+                result = new ProjectInspectTemplateName(resourceName[0], resourceName[1]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="ProjectInspectTemplateName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
+        /// <param name="inspectTemplateId">The inspectTemplate ID. Must not be <c>null</c>.</param>
+        public ProjectInspectTemplateName(string projectId, string inspectTemplateId)
+        {
+            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
+            InspectTemplateId = gax::GaxPreconditions.CheckNotNull(inspectTemplateId, nameof(inspectTemplateId));
+        }
+
+        /// <summary>
+        /// The project ID. Never <c>null</c>.
+        /// </summary>
+        public string ProjectId { get; }
+
+        /// <summary>
+        /// The inspectTemplate ID. Never <c>null</c>.
+        /// </summary>
+        public string InspectTemplateId { get; }
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(ProjectId, InspectTemplateId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as ProjectInspectTemplateName);
+
+        /// <inheritdoc />
+        public bool Equals(ProjectInspectTemplateName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(ProjectInspectTemplateName a, ProjectInspectTemplateName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(ProjectInspectTemplateName a, ProjectInspectTemplateName b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name for the 'project_job_trigger' resource.
+    /// </summary>
+    public sealed partial class ProjectJobTriggerName : gax::IResourceName, sys::IEquatable<ProjectJobTriggerName>
+    {
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/jobTriggers/{job_trigger}");
+
+        /// <summary>
+        /// Parses the given project_job_trigger resource name in string form into a new
+        /// <see cref="ProjectJobTriggerName"/> instance.
+        /// </summary>
+        /// <param name="projectJobTriggerName">The project_job_trigger resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="ProjectJobTriggerName"/> if successful.</returns>
+        public static ProjectJobTriggerName Parse(string projectJobTriggerName)
+        {
+            gax::GaxPreconditions.CheckNotNull(projectJobTriggerName, nameof(projectJobTriggerName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(projectJobTriggerName);
+            return new ProjectJobTriggerName(resourceName[0], resourceName[1]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given project_job_trigger resource name in string form into a new
+        /// <see cref="ProjectJobTriggerName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectJobTriggerName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="projectJobTriggerName">The project_job_trigger resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="ProjectJobTriggerName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string projectJobTriggerName, out ProjectJobTriggerName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(projectJobTriggerName, nameof(projectJobTriggerName));
+            gax::TemplatedResourceName resourceName;
+            if (s_template.TryParseName(projectJobTriggerName, out resourceName))
+            {
+                result = new ProjectJobTriggerName(resourceName[0], resourceName[1]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="ProjectJobTriggerName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
+        /// <param name="jobTriggerId">The jobTrigger ID. Must not be <c>null</c>.</param>
+        public ProjectJobTriggerName(string projectId, string jobTriggerId)
+        {
+            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
+            JobTriggerId = gax::GaxPreconditions.CheckNotNull(jobTriggerId, nameof(jobTriggerId));
+        }
+
+        /// <summary>
+        /// The project ID. Never <c>null</c>.
+        /// </summary>
+        public string ProjectId { get; }
+
+        /// <summary>
+        /// The jobTrigger ID. Never <c>null</c>.
+        /// </summary>
+        public string JobTriggerId { get; }
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(ProjectId, JobTriggerId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as ProjectJobTriggerName);
+
+        /// <inheritdoc />
+        public bool Equals(ProjectJobTriggerName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(ProjectJobTriggerName a, ProjectJobTriggerName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(ProjectJobTriggerName a, ProjectJobTriggerName b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name for the 'project_stored_info_type' resource.
+    /// </summary>
+    public sealed partial class ProjectStoredInfoTypeName : gax::IResourceName, sys::IEquatable<ProjectStoredInfoTypeName>
+    {
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/storedInfoTypes/{stored_info_type}");
+
+        /// <summary>
+        /// Parses the given project_stored_info_type resource name in string form into a new
+        /// <see cref="ProjectStoredInfoTypeName"/> instance.
+        /// </summary>
+        /// <param name="projectStoredInfoTypeName">The project_stored_info_type resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="ProjectStoredInfoTypeName"/> if successful.</returns>
+        public static ProjectStoredInfoTypeName Parse(string projectStoredInfoTypeName)
+        {
+            gax::GaxPreconditions.CheckNotNull(projectStoredInfoTypeName, nameof(projectStoredInfoTypeName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(projectStoredInfoTypeName);
+            return new ProjectStoredInfoTypeName(resourceName[0], resourceName[1]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given project_stored_info_type resource name in string form into a new
+        /// <see cref="ProjectStoredInfoTypeName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectStoredInfoTypeName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="projectStoredInfoTypeName">The project_stored_info_type resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="ProjectStoredInfoTypeName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string projectStoredInfoTypeName, out ProjectStoredInfoTypeName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(projectStoredInfoTypeName, nameof(projectStoredInfoTypeName));
+            gax::TemplatedResourceName resourceName;
+            if (s_template.TryParseName(projectStoredInfoTypeName, out resourceName))
+            {
+                result = new ProjectStoredInfoTypeName(resourceName[0], resourceName[1]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="ProjectStoredInfoTypeName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
+        /// <param name="storedInfoTypeId">The storedInfoType ID. Must not be <c>null</c>.</param>
+        public ProjectStoredInfoTypeName(string projectId, string storedInfoTypeId)
+        {
+            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
+            StoredInfoTypeId = gax::GaxPreconditions.CheckNotNull(storedInfoTypeId, nameof(storedInfoTypeId));
+        }
+
+        /// <summary>
+        /// The project ID. Never <c>null</c>.
+        /// </summary>
+        public string ProjectId { get; }
+
+        /// <summary>
+        /// The storedInfoType ID. Never <c>null</c>.
+        /// </summary>
+        public string StoredInfoTypeId { get; }
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(ProjectId, StoredInfoTypeId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as ProjectStoredInfoTypeName);
+
+        /// <inheritdoc />
+        public bool Equals(ProjectStoredInfoTypeName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(ProjectStoredInfoTypeName a, ProjectStoredInfoTypeName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(ProjectStoredInfoTypeName a, ProjectStoredInfoTypeName b) => !(a == b);
     }
 
     /// <summary>

--- a/apis/Google.Cloud.Firestore.V1Beta1/Google.Cloud.Firestore.V1Beta1/ResourceNames.cs
+++ b/apis/Google.Cloud.Firestore.V1Beta1/Google.Cloud.Firestore.V1Beta1/ResourceNames.cs
@@ -21,289 +21,6 @@ using linq = System.Linq;
 namespace Google.Cloud.Firestore.V1Beta1
 {
     /// <summary>
-    /// Resource name for the 'database_root' resource.
-    /// </summary>
-    public sealed partial class DatabaseRootName : gax::IResourceName, sys::IEquatable<DatabaseRootName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/databases/{database}");
-
-        /// <summary>
-        /// Parses the given database_root resource name in string form into a new
-        /// <see cref="DatabaseRootName"/> instance.
-        /// </summary>
-        /// <param name="databaseRootName">The database_root resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="DatabaseRootName"/> if successful.</returns>
-        public static DatabaseRootName Parse(string databaseRootName)
-        {
-            gax::GaxPreconditions.CheckNotNull(databaseRootName, nameof(databaseRootName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(databaseRootName);
-            return new DatabaseRootName(resourceName[0], resourceName[1]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given database_root resource name in string form into a new
-        /// <see cref="DatabaseRootName"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="databaseRootName"/> is null,
-        /// as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="databaseRootName">The database_root resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="DatabaseRootName"/>,
-        /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string databaseRootName, out DatabaseRootName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(databaseRootName, nameof(databaseRootName));
-            gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(databaseRootName, out resourceName))
-            {
-                result = new DatabaseRootName(resourceName[0], resourceName[1]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="DatabaseRootName"/> resource name class
-        /// from its component parts.
-        /// </summary>
-        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
-        /// <param name="databaseId">The database ID. Must not be <c>null</c>.</param>
-        public DatabaseRootName(string projectId, string databaseId)
-        {
-            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
-            DatabaseId = gax::GaxPreconditions.CheckNotNull(databaseId, nameof(databaseId));
-        }
-
-        /// <summary>
-        /// The project ID. Never <c>null</c>.
-        /// </summary>
-        public string ProjectId { get; }
-
-        /// <summary>
-        /// The database ID. Never <c>null</c>.
-        /// </summary>
-        public string DatabaseId { get; }
-
-        /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc />
-        public override string ToString() => s_template.Expand(ProjectId, DatabaseId);
-
-        /// <inheritdoc />
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as DatabaseRootName);
-
-        /// <inheritdoc />
-        public bool Equals(DatabaseRootName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc />
-        public static bool operator ==(DatabaseRootName a, DatabaseRootName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc />
-        public static bool operator !=(DatabaseRootName a, DatabaseRootName b) => !(a == b);
-    }
-
-    /// <summary>
-    /// Resource name for the 'document_root' resource.
-    /// </summary>
-    public sealed partial class DocumentRootName : gax::IResourceName, sys::IEquatable<DocumentRootName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/databases/{database}/documents");
-
-        /// <summary>
-        /// Parses the given document_root resource name in string form into a new
-        /// <see cref="DocumentRootName"/> instance.
-        /// </summary>
-        /// <param name="documentRootName">The document_root resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="DocumentRootName"/> if successful.</returns>
-        public static DocumentRootName Parse(string documentRootName)
-        {
-            gax::GaxPreconditions.CheckNotNull(documentRootName, nameof(documentRootName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(documentRootName);
-            return new DocumentRootName(resourceName[0], resourceName[1]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given document_root resource name in string form into a new
-        /// <see cref="DocumentRootName"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="documentRootName"/> is null,
-        /// as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="documentRootName">The document_root resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="DocumentRootName"/>,
-        /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string documentRootName, out DocumentRootName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(documentRootName, nameof(documentRootName));
-            gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(documentRootName, out resourceName))
-            {
-                result = new DocumentRootName(resourceName[0], resourceName[1]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="DocumentRootName"/> resource name class
-        /// from its component parts.
-        /// </summary>
-        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
-        /// <param name="databaseId">The database ID. Must not be <c>null</c>.</param>
-        public DocumentRootName(string projectId, string databaseId)
-        {
-            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
-            DatabaseId = gax::GaxPreconditions.CheckNotNull(databaseId, nameof(databaseId));
-        }
-
-        /// <summary>
-        /// The project ID. Never <c>null</c>.
-        /// </summary>
-        public string ProjectId { get; }
-
-        /// <summary>
-        /// The database ID. Never <c>null</c>.
-        /// </summary>
-        public string DatabaseId { get; }
-
-        /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc />
-        public override string ToString() => s_template.Expand(ProjectId, DatabaseId);
-
-        /// <inheritdoc />
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as DocumentRootName);
-
-        /// <inheritdoc />
-        public bool Equals(DocumentRootName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc />
-        public static bool operator ==(DocumentRootName a, DocumentRootName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc />
-        public static bool operator !=(DocumentRootName a, DocumentRootName b) => !(a == b);
-    }
-
-    /// <summary>
-    /// Resource name for the 'document_path' resource.
-    /// </summary>
-    public sealed partial class DocumentPathName : gax::IResourceName, sys::IEquatable<DocumentPathName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/databases/{database}/documents/{document_path=**}");
-
-        /// <summary>
-        /// Parses the given document_path resource name in string form into a new
-        /// <see cref="DocumentPathName"/> instance.
-        /// </summary>
-        /// <param name="documentPathName">The document_path resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="DocumentPathName"/> if successful.</returns>
-        public static DocumentPathName Parse(string documentPathName)
-        {
-            gax::GaxPreconditions.CheckNotNull(documentPathName, nameof(documentPathName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(documentPathName);
-            return new DocumentPathName(resourceName[0], resourceName[1], resourceName[2]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given document_path resource name in string form into a new
-        /// <see cref="DocumentPathName"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="documentPathName"/> is null,
-        /// as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="documentPathName">The document_path resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="DocumentPathName"/>,
-        /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string documentPathName, out DocumentPathName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(documentPathName, nameof(documentPathName));
-            gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(documentPathName, out resourceName))
-            {
-                result = new DocumentPathName(resourceName[0], resourceName[1], resourceName[2]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="DocumentPathName"/> resource name class
-        /// from its component parts.
-        /// </summary>
-        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
-        /// <param name="databaseId">The database ID. Must not be <c>null</c>.</param>
-        /// <param name="documentPathId">The documentPath ID. Must not be <c>null</c>.</param>
-        public DocumentPathName(string projectId, string databaseId, string documentPathId)
-        {
-            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
-            DatabaseId = gax::GaxPreconditions.CheckNotNull(databaseId, nameof(databaseId));
-            DocumentPathId = gax::GaxPreconditions.CheckNotNull(documentPathId, nameof(documentPathId));
-        }
-
-        /// <summary>
-        /// The project ID. Never <c>null</c>.
-        /// </summary>
-        public string ProjectId { get; }
-
-        /// <summary>
-        /// The database ID. Never <c>null</c>.
-        /// </summary>
-        public string DatabaseId { get; }
-
-        /// <summary>
-        /// The documentPath ID. Never <c>null</c>.
-        /// </summary>
-        public string DocumentPathId { get; }
-
-        /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc />
-        public override string ToString() => s_template.Expand(ProjectId, DatabaseId, DocumentPathId);
-
-        /// <inheritdoc />
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as DocumentPathName);
-
-        /// <inheritdoc />
-        public bool Equals(DocumentPathName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc />
-        public static bool operator ==(DocumentPathName a, DocumentPathName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc />
-        public static bool operator !=(DocumentPathName a, DocumentPathName b) => !(a == b);
-    }
-
-    /// <summary>
     /// Resource name for the 'any_path' resource.
     /// </summary>
     public sealed partial class AnyPathName : gax::IResourceName, sys::IEquatable<AnyPathName>
@@ -407,6 +124,289 @@ namespace Google.Cloud.Firestore.V1Beta1
 
         /// <inheritdoc />
         public static bool operator !=(AnyPathName a, AnyPathName b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name for the 'database_root' resource.
+    /// </summary>
+    public sealed partial class DatabaseRootName : gax::IResourceName, sys::IEquatable<DatabaseRootName>
+    {
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/databases/{database}");
+
+        /// <summary>
+        /// Parses the given database_root resource name in string form into a new
+        /// <see cref="DatabaseRootName"/> instance.
+        /// </summary>
+        /// <param name="databaseRootName">The database_root resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="DatabaseRootName"/> if successful.</returns>
+        public static DatabaseRootName Parse(string databaseRootName)
+        {
+            gax::GaxPreconditions.CheckNotNull(databaseRootName, nameof(databaseRootName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(databaseRootName);
+            return new DatabaseRootName(resourceName[0], resourceName[1]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given database_root resource name in string form into a new
+        /// <see cref="DatabaseRootName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="databaseRootName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="databaseRootName">The database_root resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="DatabaseRootName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string databaseRootName, out DatabaseRootName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(databaseRootName, nameof(databaseRootName));
+            gax::TemplatedResourceName resourceName;
+            if (s_template.TryParseName(databaseRootName, out resourceName))
+            {
+                result = new DatabaseRootName(resourceName[0], resourceName[1]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="DatabaseRootName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
+        /// <param name="databaseId">The database ID. Must not be <c>null</c>.</param>
+        public DatabaseRootName(string projectId, string databaseId)
+        {
+            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
+            DatabaseId = gax::GaxPreconditions.CheckNotNull(databaseId, nameof(databaseId));
+        }
+
+        /// <summary>
+        /// The project ID. Never <c>null</c>.
+        /// </summary>
+        public string ProjectId { get; }
+
+        /// <summary>
+        /// The database ID. Never <c>null</c>.
+        /// </summary>
+        public string DatabaseId { get; }
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(ProjectId, DatabaseId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as DatabaseRootName);
+
+        /// <inheritdoc />
+        public bool Equals(DatabaseRootName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(DatabaseRootName a, DatabaseRootName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(DatabaseRootName a, DatabaseRootName b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name for the 'document_path' resource.
+    /// </summary>
+    public sealed partial class DocumentPathName : gax::IResourceName, sys::IEquatable<DocumentPathName>
+    {
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/databases/{database}/documents/{document_path=**}");
+
+        /// <summary>
+        /// Parses the given document_path resource name in string form into a new
+        /// <see cref="DocumentPathName"/> instance.
+        /// </summary>
+        /// <param name="documentPathName">The document_path resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="DocumentPathName"/> if successful.</returns>
+        public static DocumentPathName Parse(string documentPathName)
+        {
+            gax::GaxPreconditions.CheckNotNull(documentPathName, nameof(documentPathName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(documentPathName);
+            return new DocumentPathName(resourceName[0], resourceName[1], resourceName[2]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given document_path resource name in string form into a new
+        /// <see cref="DocumentPathName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="documentPathName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="documentPathName">The document_path resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="DocumentPathName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string documentPathName, out DocumentPathName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(documentPathName, nameof(documentPathName));
+            gax::TemplatedResourceName resourceName;
+            if (s_template.TryParseName(documentPathName, out resourceName))
+            {
+                result = new DocumentPathName(resourceName[0], resourceName[1], resourceName[2]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="DocumentPathName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
+        /// <param name="databaseId">The database ID. Must not be <c>null</c>.</param>
+        /// <param name="documentPathId">The documentPath ID. Must not be <c>null</c>.</param>
+        public DocumentPathName(string projectId, string databaseId, string documentPathId)
+        {
+            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
+            DatabaseId = gax::GaxPreconditions.CheckNotNull(databaseId, nameof(databaseId));
+            DocumentPathId = gax::GaxPreconditions.CheckNotNull(documentPathId, nameof(documentPathId));
+        }
+
+        /// <summary>
+        /// The project ID. Never <c>null</c>.
+        /// </summary>
+        public string ProjectId { get; }
+
+        /// <summary>
+        /// The database ID. Never <c>null</c>.
+        /// </summary>
+        public string DatabaseId { get; }
+
+        /// <summary>
+        /// The documentPath ID. Never <c>null</c>.
+        /// </summary>
+        public string DocumentPathId { get; }
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(ProjectId, DatabaseId, DocumentPathId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as DocumentPathName);
+
+        /// <inheritdoc />
+        public bool Equals(DocumentPathName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(DocumentPathName a, DocumentPathName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(DocumentPathName a, DocumentPathName b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name for the 'document_root' resource.
+    /// </summary>
+    public sealed partial class DocumentRootName : gax::IResourceName, sys::IEquatable<DocumentRootName>
+    {
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/databases/{database}/documents");
+
+        /// <summary>
+        /// Parses the given document_root resource name in string form into a new
+        /// <see cref="DocumentRootName"/> instance.
+        /// </summary>
+        /// <param name="documentRootName">The document_root resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="DocumentRootName"/> if successful.</returns>
+        public static DocumentRootName Parse(string documentRootName)
+        {
+            gax::GaxPreconditions.CheckNotNull(documentRootName, nameof(documentRootName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(documentRootName);
+            return new DocumentRootName(resourceName[0], resourceName[1]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given document_root resource name in string form into a new
+        /// <see cref="DocumentRootName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="documentRootName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="documentRootName">The document_root resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="DocumentRootName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string documentRootName, out DocumentRootName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(documentRootName, nameof(documentRootName));
+            gax::TemplatedResourceName resourceName;
+            if (s_template.TryParseName(documentRootName, out resourceName))
+            {
+                result = new DocumentRootName(resourceName[0], resourceName[1]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="DocumentRootName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
+        /// <param name="databaseId">The database ID. Must not be <c>null</c>.</param>
+        public DocumentRootName(string projectId, string databaseId)
+        {
+            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
+            DatabaseId = gax::GaxPreconditions.CheckNotNull(databaseId, nameof(databaseId));
+        }
+
+        /// <summary>
+        /// The project ID. Never <c>null</c>.
+        /// </summary>
+        public string ProjectId { get; }
+
+        /// <summary>
+        /// The database ID. Never <c>null</c>.
+        /// </summary>
+        public string DatabaseId { get; }
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(ProjectId, DatabaseId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as DocumentRootName);
+
+        /// <inheritdoc />
+        public bool Equals(DocumentRootName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(DocumentRootName a, DocumentRootName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(DocumentRootName a, DocumentRootName b) => !(a == b);
     }
 
 

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/ResourceNames.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/ResourceNames.cs
@@ -21,44 +21,44 @@ using linq = System.Linq;
 namespace Google.Cloud.Kms.V1
 {
     /// <summary>
-    /// Resource name for the 'key_ring' resource.
+    /// Resource name for the 'crypto_key' resource.
     /// </summary>
-    public sealed partial class KeyRingName : gax::IResourceName, sys::IEquatable<KeyRingName>
+    public sealed partial class CryptoKeyName : gax::IResourceName, sys::IEquatable<CryptoKeyName>
     {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/locations/{location}/keyRings/{key_ring}");
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/locations/{location}/keyRings/{key_ring}/cryptoKeys/{crypto_key}");
 
         /// <summary>
-        /// Parses the given key_ring resource name in string form into a new
-        /// <see cref="KeyRingName"/> instance.
+        /// Parses the given crypto_key resource name in string form into a new
+        /// <see cref="CryptoKeyName"/> instance.
         /// </summary>
-        /// <param name="keyRingName">The key_ring resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="KeyRingName"/> if successful.</returns>
-        public static KeyRingName Parse(string keyRingName)
+        /// <param name="cryptoKeyName">The crypto_key resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="CryptoKeyName"/> if successful.</returns>
+        public static CryptoKeyName Parse(string cryptoKeyName)
         {
-            gax::GaxPreconditions.CheckNotNull(keyRingName, nameof(keyRingName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(keyRingName);
-            return new KeyRingName(resourceName[0], resourceName[1], resourceName[2]);
+            gax::GaxPreconditions.CheckNotNull(cryptoKeyName, nameof(cryptoKeyName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(cryptoKeyName);
+            return new CryptoKeyName(resourceName[0], resourceName[1], resourceName[2], resourceName[3]);
         }
 
         /// <summary>
-        /// Tries to parse the given key_ring resource name in string form into a new
-        /// <see cref="KeyRingName"/> instance.
+        /// Tries to parse the given crypto_key resource name in string form into a new
+        /// <see cref="CryptoKeyName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="keyRingName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="cryptoKeyName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
-        /// <param name="keyRingName">The key_ring resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="KeyRingName"/>,
+        /// <param name="cryptoKeyName">The crypto_key resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="CryptoKeyName"/>,
         /// or <c>null</c> if parsing fails.</param>
         /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string keyRingName, out KeyRingName result)
+        public static bool TryParse(string cryptoKeyName, out CryptoKeyName result)
         {
-            gax::GaxPreconditions.CheckNotNull(keyRingName, nameof(keyRingName));
+            gax::GaxPreconditions.CheckNotNull(cryptoKeyName, nameof(cryptoKeyName));
             gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(keyRingName, out resourceName))
+            if (s_template.TryParseName(cryptoKeyName, out resourceName))
             {
-                result = new KeyRingName(resourceName[0], resourceName[1], resourceName[2]);
+                result = new CryptoKeyName(resourceName[0], resourceName[1], resourceName[2], resourceName[3]);
                 return true;
             }
             else
@@ -69,17 +69,19 @@ namespace Google.Cloud.Kms.V1
         }
 
         /// <summary>
-        /// Constructs a new instance of the <see cref="KeyRingName"/> resource name class
+        /// Constructs a new instance of the <see cref="CryptoKeyName"/> resource name class
         /// from its component parts.
         /// </summary>
         /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
         /// <param name="locationId">The location ID. Must not be <c>null</c>.</param>
         /// <param name="keyRingId">The keyRing ID. Must not be <c>null</c>.</param>
-        public KeyRingName(string projectId, string locationId, string keyRingId)
+        /// <param name="cryptoKeyId">The cryptoKey ID. Must not be <c>null</c>.</param>
+        public CryptoKeyName(string projectId, string locationId, string keyRingId, string cryptoKeyId)
         {
             ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
             LocationId = gax::GaxPreconditions.CheckNotNull(locationId, nameof(locationId));
             KeyRingId = gax::GaxPreconditions.CheckNotNull(keyRingId, nameof(keyRingId));
+            CryptoKeyId = gax::GaxPreconditions.CheckNotNull(cryptoKeyId, nameof(cryptoKeyId));
         }
 
         /// <summary>
@@ -97,26 +99,31 @@ namespace Google.Cloud.Kms.V1
         /// </summary>
         public string KeyRingId { get; }
 
+        /// <summary>
+        /// The cryptoKey ID. Never <c>null</c>.
+        /// </summary>
+        public string CryptoKeyId { get; }
+
         /// <inheritdoc />
         public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
 
         /// <inheritdoc />
-        public override string ToString() => s_template.Expand(ProjectId, LocationId, KeyRingId);
+        public override string ToString() => s_template.Expand(ProjectId, LocationId, KeyRingId, CryptoKeyId);
 
         /// <inheritdoc />
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as KeyRingName);
+        public override bool Equals(object obj) => Equals(obj as CryptoKeyName);
 
         /// <inheritdoc />
-        public bool Equals(KeyRingName other) => ToString() == other?.ToString();
+        public bool Equals(CryptoKeyName other) => ToString() == other?.ToString();
 
         /// <inheritdoc />
-        public static bool operator ==(KeyRingName a, KeyRingName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+        public static bool operator ==(CryptoKeyName a, CryptoKeyName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
 
         /// <inheritdoc />
-        public static bool operator !=(KeyRingName a, KeyRingName b) => !(a == b);
+        public static bool operator !=(CryptoKeyName a, CryptoKeyName b) => !(a == b);
     }
 
     /// <summary>
@@ -223,204 +230,6 @@ namespace Google.Cloud.Kms.V1
 
         /// <inheritdoc />
         public static bool operator !=(CryptoKeyPathName a, CryptoKeyPathName b) => !(a == b);
-    }
-
-    /// <summary>
-    /// Resource name for the 'location' resource.
-    /// </summary>
-    public sealed partial class LocationName : gax::IResourceName, sys::IEquatable<LocationName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/locations/{location}");
-
-        /// <summary>
-        /// Parses the given location resource name in string form into a new
-        /// <see cref="LocationName"/> instance.
-        /// </summary>
-        /// <param name="locationName">The location resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="LocationName"/> if successful.</returns>
-        public static LocationName Parse(string locationName)
-        {
-            gax::GaxPreconditions.CheckNotNull(locationName, nameof(locationName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(locationName);
-            return new LocationName(resourceName[0], resourceName[1]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given location resource name in string form into a new
-        /// <see cref="LocationName"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="locationName"/> is null,
-        /// as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="locationName">The location resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="LocationName"/>,
-        /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string locationName, out LocationName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(locationName, nameof(locationName));
-            gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(locationName, out resourceName))
-            {
-                result = new LocationName(resourceName[0], resourceName[1]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="LocationName"/> resource name class
-        /// from its component parts.
-        /// </summary>
-        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
-        /// <param name="locationId">The location ID. Must not be <c>null</c>.</param>
-        public LocationName(string projectId, string locationId)
-        {
-            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
-            LocationId = gax::GaxPreconditions.CheckNotNull(locationId, nameof(locationId));
-        }
-
-        /// <summary>
-        /// The project ID. Never <c>null</c>.
-        /// </summary>
-        public string ProjectId { get; }
-
-        /// <summary>
-        /// The location ID. Never <c>null</c>.
-        /// </summary>
-        public string LocationId { get; }
-
-        /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc />
-        public override string ToString() => s_template.Expand(ProjectId, LocationId);
-
-        /// <inheritdoc />
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as LocationName);
-
-        /// <inheritdoc />
-        public bool Equals(LocationName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc />
-        public static bool operator ==(LocationName a, LocationName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc />
-        public static bool operator !=(LocationName a, LocationName b) => !(a == b);
-    }
-
-    /// <summary>
-    /// Resource name for the 'crypto_key' resource.
-    /// </summary>
-    public sealed partial class CryptoKeyName : gax::IResourceName, sys::IEquatable<CryptoKeyName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/locations/{location}/keyRings/{key_ring}/cryptoKeys/{crypto_key}");
-
-        /// <summary>
-        /// Parses the given crypto_key resource name in string form into a new
-        /// <see cref="CryptoKeyName"/> instance.
-        /// </summary>
-        /// <param name="cryptoKeyName">The crypto_key resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="CryptoKeyName"/> if successful.</returns>
-        public static CryptoKeyName Parse(string cryptoKeyName)
-        {
-            gax::GaxPreconditions.CheckNotNull(cryptoKeyName, nameof(cryptoKeyName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(cryptoKeyName);
-            return new CryptoKeyName(resourceName[0], resourceName[1], resourceName[2], resourceName[3]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given crypto_key resource name in string form into a new
-        /// <see cref="CryptoKeyName"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="cryptoKeyName"/> is null,
-        /// as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="cryptoKeyName">The crypto_key resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="CryptoKeyName"/>,
-        /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string cryptoKeyName, out CryptoKeyName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(cryptoKeyName, nameof(cryptoKeyName));
-            gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(cryptoKeyName, out resourceName))
-            {
-                result = new CryptoKeyName(resourceName[0], resourceName[1], resourceName[2], resourceName[3]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="CryptoKeyName"/> resource name class
-        /// from its component parts.
-        /// </summary>
-        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
-        /// <param name="locationId">The location ID. Must not be <c>null</c>.</param>
-        /// <param name="keyRingId">The keyRing ID. Must not be <c>null</c>.</param>
-        /// <param name="cryptoKeyId">The cryptoKey ID. Must not be <c>null</c>.</param>
-        public CryptoKeyName(string projectId, string locationId, string keyRingId, string cryptoKeyId)
-        {
-            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
-            LocationId = gax::GaxPreconditions.CheckNotNull(locationId, nameof(locationId));
-            KeyRingId = gax::GaxPreconditions.CheckNotNull(keyRingId, nameof(keyRingId));
-            CryptoKeyId = gax::GaxPreconditions.CheckNotNull(cryptoKeyId, nameof(cryptoKeyId));
-        }
-
-        /// <summary>
-        /// The project ID. Never <c>null</c>.
-        /// </summary>
-        public string ProjectId { get; }
-
-        /// <summary>
-        /// The location ID. Never <c>null</c>.
-        /// </summary>
-        public string LocationId { get; }
-
-        /// <summary>
-        /// The keyRing ID. Never <c>null</c>.
-        /// </summary>
-        public string KeyRingId { get; }
-
-        /// <summary>
-        /// The cryptoKey ID. Never <c>null</c>.
-        /// </summary>
-        public string CryptoKeyId { get; }
-
-        /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc />
-        public override string ToString() => s_template.Expand(ProjectId, LocationId, KeyRingId, CryptoKeyId);
-
-        /// <inheritdoc />
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as CryptoKeyName);
-
-        /// <inheritdoc />
-        public bool Equals(CryptoKeyName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc />
-        public static bool operator ==(CryptoKeyName a, CryptoKeyName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc />
-        public static bool operator !=(CryptoKeyName a, CryptoKeyName b) => !(a == b);
     }
 
     /// <summary>
@@ -738,6 +547,197 @@ namespace Google.Cloud.Kms.V1
 
         /// <inheritdoc />
         public static bool operator !=(KeyNameOneof a, KeyNameOneof b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name for the 'key_ring' resource.
+    /// </summary>
+    public sealed partial class KeyRingName : gax::IResourceName, sys::IEquatable<KeyRingName>
+    {
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/locations/{location}/keyRings/{key_ring}");
+
+        /// <summary>
+        /// Parses the given key_ring resource name in string form into a new
+        /// <see cref="KeyRingName"/> instance.
+        /// </summary>
+        /// <param name="keyRingName">The key_ring resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="KeyRingName"/> if successful.</returns>
+        public static KeyRingName Parse(string keyRingName)
+        {
+            gax::GaxPreconditions.CheckNotNull(keyRingName, nameof(keyRingName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(keyRingName);
+            return new KeyRingName(resourceName[0], resourceName[1], resourceName[2]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given key_ring resource name in string form into a new
+        /// <see cref="KeyRingName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="keyRingName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="keyRingName">The key_ring resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="KeyRingName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string keyRingName, out KeyRingName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(keyRingName, nameof(keyRingName));
+            gax::TemplatedResourceName resourceName;
+            if (s_template.TryParseName(keyRingName, out resourceName))
+            {
+                result = new KeyRingName(resourceName[0], resourceName[1], resourceName[2]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="KeyRingName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
+        /// <param name="locationId">The location ID. Must not be <c>null</c>.</param>
+        /// <param name="keyRingId">The keyRing ID. Must not be <c>null</c>.</param>
+        public KeyRingName(string projectId, string locationId, string keyRingId)
+        {
+            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
+            LocationId = gax::GaxPreconditions.CheckNotNull(locationId, nameof(locationId));
+            KeyRingId = gax::GaxPreconditions.CheckNotNull(keyRingId, nameof(keyRingId));
+        }
+
+        /// <summary>
+        /// The project ID. Never <c>null</c>.
+        /// </summary>
+        public string ProjectId { get; }
+
+        /// <summary>
+        /// The location ID. Never <c>null</c>.
+        /// </summary>
+        public string LocationId { get; }
+
+        /// <summary>
+        /// The keyRing ID. Never <c>null</c>.
+        /// </summary>
+        public string KeyRingId { get; }
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(ProjectId, LocationId, KeyRingId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as KeyRingName);
+
+        /// <inheritdoc />
+        public bool Equals(KeyRingName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(KeyRingName a, KeyRingName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(KeyRingName a, KeyRingName b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name for the 'location' resource.
+    /// </summary>
+    public sealed partial class LocationName : gax::IResourceName, sys::IEquatable<LocationName>
+    {
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/locations/{location}");
+
+        /// <summary>
+        /// Parses the given location resource name in string form into a new
+        /// <see cref="LocationName"/> instance.
+        /// </summary>
+        /// <param name="locationName">The location resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="LocationName"/> if successful.</returns>
+        public static LocationName Parse(string locationName)
+        {
+            gax::GaxPreconditions.CheckNotNull(locationName, nameof(locationName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(locationName);
+            return new LocationName(resourceName[0], resourceName[1]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given location resource name in string form into a new
+        /// <see cref="LocationName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="locationName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="locationName">The location resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="LocationName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string locationName, out LocationName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(locationName, nameof(locationName));
+            gax::TemplatedResourceName resourceName;
+            if (s_template.TryParseName(locationName, out resourceName))
+            {
+                result = new LocationName(resourceName[0], resourceName[1]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="LocationName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
+        /// <param name="locationId">The location ID. Must not be <c>null</c>.</param>
+        public LocationName(string projectId, string locationId)
+        {
+            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
+            LocationId = gax::GaxPreconditions.CheckNotNull(locationId, nameof(locationId));
+        }
+
+        /// <summary>
+        /// The project ID. Never <c>null</c>.
+        /// </summary>
+        public string ProjectId { get; }
+
+        /// <summary>
+        /// The location ID. Never <c>null</c>.
+        /// </summary>
+        public string LocationId { get; }
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(ProjectId, LocationId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as LocationName);
+
+        /// <inheritdoc />
+        public bool Equals(LocationName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(LocationName a, LocationName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(LocationName a, LocationName b) => !(a == b);
     }
 
 

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.Tests/ConfigServiceV2ClientTest.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.Tests/ConfigServiceV2ClientTest.g.cs
@@ -44,7 +44,7 @@ namespace Google.Cloud.Logging.V2.Tests
             LogSink expectedResponse = new LogSink
             {
                 Name = "name3373707",
-                DestinationAsResourceName = new ProjectName("[PROJECT]"),
+                DestinationAsResourceName = new BillingName("[BILLING_ACCOUNT]"),
                 Filter = "filter-1274492040",
                 WriterIdentity = "writerIdentity775638794",
                 IncludeChildren = true,
@@ -69,7 +69,7 @@ namespace Google.Cloud.Logging.V2.Tests
             LogSink expectedResponse = new LogSink
             {
                 Name = "name3373707",
-                DestinationAsResourceName = new ProjectName("[PROJECT]"),
+                DestinationAsResourceName = new BillingName("[BILLING_ACCOUNT]"),
                 Filter = "filter-1274492040",
                 WriterIdentity = "writerIdentity775638794",
                 IncludeChildren = true,
@@ -94,7 +94,7 @@ namespace Google.Cloud.Logging.V2.Tests
             LogSink expectedResponse = new LogSink
             {
                 Name = "name3373707",
-                DestinationAsResourceName = new ProjectName("[PROJECT]"),
+                DestinationAsResourceName = new BillingName("[BILLING_ACCOUNT]"),
                 Filter = "filter-1274492040",
                 WriterIdentity = "writerIdentity775638794",
                 IncludeChildren = true,
@@ -118,7 +118,7 @@ namespace Google.Cloud.Logging.V2.Tests
             LogSink expectedResponse = new LogSink
             {
                 Name = "name3373707",
-                DestinationAsResourceName = new ProjectName("[PROJECT]"),
+                DestinationAsResourceName = new BillingName("[BILLING_ACCOUNT]"),
                 Filter = "filter-1274492040",
                 WriterIdentity = "writerIdentity775638794",
                 IncludeChildren = true,
@@ -143,7 +143,7 @@ namespace Google.Cloud.Logging.V2.Tests
             LogSink expectedResponse = new LogSink
             {
                 Name = "name3373707",
-                DestinationAsResourceName = new ProjectName("[PROJECT]"),
+                DestinationAsResourceName = new BillingName("[BILLING_ACCOUNT]"),
                 Filter = "filter-1274492040",
                 WriterIdentity = "writerIdentity775638794",
                 IncludeChildren = true,
@@ -170,7 +170,7 @@ namespace Google.Cloud.Logging.V2.Tests
             LogSink expectedResponse = new LogSink
             {
                 Name = "name3373707",
-                DestinationAsResourceName = new ProjectName("[PROJECT]"),
+                DestinationAsResourceName = new BillingName("[BILLING_ACCOUNT]"),
                 Filter = "filter-1274492040",
                 WriterIdentity = "writerIdentity775638794",
                 IncludeChildren = true,
@@ -197,7 +197,7 @@ namespace Google.Cloud.Logging.V2.Tests
             LogSink expectedResponse = new LogSink
             {
                 Name = "name3373707",
-                DestinationAsResourceName = new ProjectName("[PROJECT]"),
+                DestinationAsResourceName = new BillingName("[BILLING_ACCOUNT]"),
                 Filter = "filter-1274492040",
                 WriterIdentity = "writerIdentity775638794",
                 IncludeChildren = true,
@@ -222,7 +222,7 @@ namespace Google.Cloud.Logging.V2.Tests
             LogSink expectedResponse = new LogSink
             {
                 Name = "name3373707",
-                DestinationAsResourceName = new ProjectName("[PROJECT]"),
+                DestinationAsResourceName = new BillingName("[BILLING_ACCOUNT]"),
                 Filter = "filter-1274492040",
                 WriterIdentity = "writerIdentity775638794",
                 IncludeChildren = true,
@@ -248,7 +248,7 @@ namespace Google.Cloud.Logging.V2.Tests
             LogSink expectedResponse = new LogSink
             {
                 Name = "name3373707",
-                DestinationAsResourceName = new ProjectName("[PROJECT]"),
+                DestinationAsResourceName = new BillingName("[BILLING_ACCOUNT]"),
                 Filter = "filter-1274492040",
                 WriterIdentity = "writerIdentity775638794",
                 IncludeChildren = true,
@@ -277,7 +277,7 @@ namespace Google.Cloud.Logging.V2.Tests
             LogSink expectedResponse = new LogSink
             {
                 Name = "name3373707",
-                DestinationAsResourceName = new ProjectName("[PROJECT]"),
+                DestinationAsResourceName = new BillingName("[BILLING_ACCOUNT]"),
                 Filter = "filter-1274492040",
                 WriterIdentity = "writerIdentity775638794",
                 IncludeChildren = true,
@@ -305,7 +305,7 @@ namespace Google.Cloud.Logging.V2.Tests
             LogSink expectedResponse = new LogSink
             {
                 Name = "name3373707",
-                DestinationAsResourceName = new ProjectName("[PROJECT]"),
+                DestinationAsResourceName = new BillingName("[BILLING_ACCOUNT]"),
                 Filter = "filter-1274492040",
                 WriterIdentity = "writerIdentity775638794",
                 IncludeChildren = true,
@@ -332,7 +332,7 @@ namespace Google.Cloud.Logging.V2.Tests
             LogSink expectedResponse = new LogSink
             {
                 Name = "name3373707",
-                DestinationAsResourceName = new ProjectName("[PROJECT]"),
+                DestinationAsResourceName = new BillingName("[BILLING_ACCOUNT]"),
                 Filter = "filter-1274492040",
                 WriterIdentity = "writerIdentity775638794",
                 IncludeChildren = true,
@@ -359,7 +359,7 @@ namespace Google.Cloud.Logging.V2.Tests
             LogSink expectedResponse = new LogSink
             {
                 Name = "name3373707",
-                DestinationAsResourceName = new ProjectName("[PROJECT]"),
+                DestinationAsResourceName = new BillingName("[BILLING_ACCOUNT]"),
                 Filter = "filter-1274492040",
                 WriterIdentity = "writerIdentity775638794",
                 IncludeChildren = true,
@@ -384,7 +384,7 @@ namespace Google.Cloud.Logging.V2.Tests
             LogSink expectedResponse = new LogSink
             {
                 Name = "name3373707",
-                DestinationAsResourceName = new ProjectName("[PROJECT]"),
+                DestinationAsResourceName = new BillingName("[BILLING_ACCOUNT]"),
                 Filter = "filter-1274492040",
                 WriterIdentity = "writerIdentity775638794",
                 IncludeChildren = true,

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/ResourceNames.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/ResourceNames.cs
@@ -22,1181 +22,6 @@ using linq = System.Linq;
 namespace Google.Cloud.Logging.V2
 {
     /// <summary>
-    /// Resource name for the 'project' resource.
-    /// </summary>
-    public sealed partial class ProjectName : gax::IResourceName, sys::IEquatable<ProjectName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}");
-
-        /// <summary>
-        /// Parses the given project resource name in string form into a new
-        /// <see cref="ProjectName"/> instance.
-        /// </summary>
-        /// <param name="projectName">The project resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="ProjectName"/> if successful.</returns>
-        public static ProjectName Parse(string projectName)
-        {
-            gax::GaxPreconditions.CheckNotNull(projectName, nameof(projectName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(projectName);
-            return new ProjectName(resourceName[0]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given project resource name in string form into a new
-        /// <see cref="ProjectName"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectName"/> is null,
-        /// as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="projectName">The project resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="ProjectName"/>,
-        /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string projectName, out ProjectName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(projectName, nameof(projectName));
-            gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(projectName, out resourceName))
-            {
-                result = new ProjectName(resourceName[0]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="ProjectName"/> resource name class
-        /// from its component parts.
-        /// </summary>
-        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
-        public ProjectName(string projectId)
-        {
-            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
-        }
-
-        /// <summary>
-        /// The project ID. Never <c>null</c>.
-        /// </summary>
-        public string ProjectId { get; }
-
-        /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc />
-        public override string ToString() => s_template.Expand(ProjectId);
-
-        /// <inheritdoc />
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as ProjectName);
-
-        /// <inheritdoc />
-        public bool Equals(ProjectName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc />
-        public static bool operator ==(ProjectName a, ProjectName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc />
-        public static bool operator !=(ProjectName a, ProjectName b) => !(a == b);
-    }
-
-    /// <summary>
-    /// Resource name for the 'log' resource.
-    /// </summary>
-    public sealed partial class LogName : gax::IResourceName, sys::IEquatable<LogName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/logs/{log}");
-
-        /// <summary>
-        /// Parses the given log resource name in string form into a new
-        /// <see cref="LogName"/> instance.
-        /// </summary>
-        /// <param name="logName">The log resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="LogName"/> if successful.</returns>
-        public static LogName Parse(string logName)
-        {
-            gax::GaxPreconditions.CheckNotNull(logName, nameof(logName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(logName);
-            return new LogName(resourceName[0], resourceName[1]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given log resource name in string form into a new
-        /// <see cref="LogName"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="logName"/> is null,
-        /// as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="logName">The log resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="LogName"/>,
-        /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string logName, out LogName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(logName, nameof(logName));
-            gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(logName, out resourceName))
-            {
-                result = new LogName(resourceName[0], resourceName[1]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="LogName"/> resource name class
-        /// from its component parts.
-        /// </summary>
-        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
-        /// <param name="logId">The log ID. Must not be <c>null</c>.</param>
-        public LogName(string projectId, string logId)
-        {
-            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
-            LogId = gax::GaxPreconditions.CheckNotNull(logId, nameof(logId));
-        }
-
-        /// <summary>
-        /// The project ID. Never <c>null</c>.
-        /// </summary>
-        public string ProjectId { get; }
-
-        /// <summary>
-        /// The log ID. Never <c>null</c>.
-        /// </summary>
-        public string LogId { get; }
-
-        /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc />
-        public override string ToString() => s_template.Expand(ProjectId, LogId);
-
-        /// <inheritdoc />
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as LogName);
-
-        /// <inheritdoc />
-        public bool Equals(LogName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc />
-        public static bool operator ==(LogName a, LogName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc />
-        public static bool operator !=(LogName a, LogName b) => !(a == b);
-    }
-
-    /// <summary>
-    /// Resource name for the 'sink' resource.
-    /// </summary>
-    public sealed partial class SinkName : gax::IResourceName, sys::IEquatable<SinkName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/sinks/{sink}");
-
-        /// <summary>
-        /// Parses the given sink resource name in string form into a new
-        /// <see cref="SinkName"/> instance.
-        /// </summary>
-        /// <param name="sinkName">The sink resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="SinkName"/> if successful.</returns>
-        public static SinkName Parse(string sinkName)
-        {
-            gax::GaxPreconditions.CheckNotNull(sinkName, nameof(sinkName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(sinkName);
-            return new SinkName(resourceName[0], resourceName[1]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given sink resource name in string form into a new
-        /// <see cref="SinkName"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="sinkName"/> is null,
-        /// as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="sinkName">The sink resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="SinkName"/>,
-        /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string sinkName, out SinkName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(sinkName, nameof(sinkName));
-            gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(sinkName, out resourceName))
-            {
-                result = new SinkName(resourceName[0], resourceName[1]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="SinkName"/> resource name class
-        /// from its component parts.
-        /// </summary>
-        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
-        /// <param name="sinkId">The sink ID. Must not be <c>null</c>.</param>
-        public SinkName(string projectId, string sinkId)
-        {
-            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
-            SinkId = gax::GaxPreconditions.CheckNotNull(sinkId, nameof(sinkId));
-        }
-
-        /// <summary>
-        /// The project ID. Never <c>null</c>.
-        /// </summary>
-        public string ProjectId { get; }
-
-        /// <summary>
-        /// The sink ID. Never <c>null</c>.
-        /// </summary>
-        public string SinkId { get; }
-
-        /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc />
-        public override string ToString() => s_template.Expand(ProjectId, SinkId);
-
-        /// <inheritdoc />
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as SinkName);
-
-        /// <inheritdoc />
-        public bool Equals(SinkName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc />
-        public static bool operator ==(SinkName a, SinkName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc />
-        public static bool operator !=(SinkName a, SinkName b) => !(a == b);
-    }
-
-    /// <summary>
-    /// Resource name for the 'metric' resource.
-    /// </summary>
-    public sealed partial class MetricName : gax::IResourceName, sys::IEquatable<MetricName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/metrics/{metric}");
-
-        /// <summary>
-        /// Parses the given metric resource name in string form into a new
-        /// <see cref="MetricName"/> instance.
-        /// </summary>
-        /// <param name="metricName">The metric resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="MetricName"/> if successful.</returns>
-        public static MetricName Parse(string metricName)
-        {
-            gax::GaxPreconditions.CheckNotNull(metricName, nameof(metricName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(metricName);
-            return new MetricName(resourceName[0], resourceName[1]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given metric resource name in string form into a new
-        /// <see cref="MetricName"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="metricName"/> is null,
-        /// as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="metricName">The metric resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="MetricName"/>,
-        /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string metricName, out MetricName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(metricName, nameof(metricName));
-            gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(metricName, out resourceName))
-            {
-                result = new MetricName(resourceName[0], resourceName[1]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="MetricName"/> resource name class
-        /// from its component parts.
-        /// </summary>
-        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
-        /// <param name="metricId">The metric ID. Must not be <c>null</c>.</param>
-        public MetricName(string projectId, string metricId)
-        {
-            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
-            MetricId = gax::GaxPreconditions.CheckNotNull(metricId, nameof(metricId));
-        }
-
-        /// <summary>
-        /// The project ID. Never <c>null</c>.
-        /// </summary>
-        public string ProjectId { get; }
-
-        /// <summary>
-        /// The metric ID. Never <c>null</c>.
-        /// </summary>
-        public string MetricId { get; }
-
-        /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc />
-        public override string ToString() => s_template.Expand(ProjectId, MetricId);
-
-        /// <inheritdoc />
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as MetricName);
-
-        /// <inheritdoc />
-        public bool Equals(MetricName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc />
-        public static bool operator ==(MetricName a, MetricName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc />
-        public static bool operator !=(MetricName a, MetricName b) => !(a == b);
-    }
-
-    /// <summary>
-    /// Resource name for the 'exclusion' resource.
-    /// </summary>
-    public sealed partial class ExclusionName : gax::IResourceName, sys::IEquatable<ExclusionName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/exclusions/{exclusion}");
-
-        /// <summary>
-        /// Parses the given exclusion resource name in string form into a new
-        /// <see cref="ExclusionName"/> instance.
-        /// </summary>
-        /// <param name="exclusionName">The exclusion resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="ExclusionName"/> if successful.</returns>
-        public static ExclusionName Parse(string exclusionName)
-        {
-            gax::GaxPreconditions.CheckNotNull(exclusionName, nameof(exclusionName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(exclusionName);
-            return new ExclusionName(resourceName[0], resourceName[1]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given exclusion resource name in string form into a new
-        /// <see cref="ExclusionName"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="exclusionName"/> is null,
-        /// as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="exclusionName">The exclusion resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="ExclusionName"/>,
-        /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string exclusionName, out ExclusionName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(exclusionName, nameof(exclusionName));
-            gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(exclusionName, out resourceName))
-            {
-                result = new ExclusionName(resourceName[0], resourceName[1]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="ExclusionName"/> resource name class
-        /// from its component parts.
-        /// </summary>
-        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
-        /// <param name="exclusionId">The exclusion ID. Must not be <c>null</c>.</param>
-        public ExclusionName(string projectId, string exclusionId)
-        {
-            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
-            ExclusionId = gax::GaxPreconditions.CheckNotNull(exclusionId, nameof(exclusionId));
-        }
-
-        /// <summary>
-        /// The project ID. Never <c>null</c>.
-        /// </summary>
-        public string ProjectId { get; }
-
-        /// <summary>
-        /// The exclusion ID. Never <c>null</c>.
-        /// </summary>
-        public string ExclusionId { get; }
-
-        /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc />
-        public override string ToString() => s_template.Expand(ProjectId, ExclusionId);
-
-        /// <inheritdoc />
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as ExclusionName);
-
-        /// <inheritdoc />
-        public bool Equals(ExclusionName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc />
-        public static bool operator ==(ExclusionName a, ExclusionName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc />
-        public static bool operator !=(ExclusionName a, ExclusionName b) => !(a == b);
-    }
-
-    /// <summary>
-    /// Resource name for the 'organization' resource.
-    /// </summary>
-    public sealed partial class OrganizationName : gax::IResourceName, sys::IEquatable<OrganizationName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("organizations/{organization}");
-
-        /// <summary>
-        /// Parses the given organization resource name in string form into a new
-        /// <see cref="OrganizationName"/> instance.
-        /// </summary>
-        /// <param name="organizationName">The organization resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="OrganizationName"/> if successful.</returns>
-        public static OrganizationName Parse(string organizationName)
-        {
-            gax::GaxPreconditions.CheckNotNull(organizationName, nameof(organizationName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(organizationName);
-            return new OrganizationName(resourceName[0]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given organization resource name in string form into a new
-        /// <see cref="OrganizationName"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="organizationName"/> is null,
-        /// as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="organizationName">The organization resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="OrganizationName"/>,
-        /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string organizationName, out OrganizationName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(organizationName, nameof(organizationName));
-            gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(organizationName, out resourceName))
-            {
-                result = new OrganizationName(resourceName[0]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="OrganizationName"/> resource name class
-        /// from its component parts.
-        /// </summary>
-        /// <param name="organizationId">The organization ID. Must not be <c>null</c>.</param>
-        public OrganizationName(string organizationId)
-        {
-            OrganizationId = gax::GaxPreconditions.CheckNotNull(organizationId, nameof(organizationId));
-        }
-
-        /// <summary>
-        /// The organization ID. Never <c>null</c>.
-        /// </summary>
-        public string OrganizationId { get; }
-
-        /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc />
-        public override string ToString() => s_template.Expand(OrganizationId);
-
-        /// <inheritdoc />
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as OrganizationName);
-
-        /// <inheritdoc />
-        public bool Equals(OrganizationName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc />
-        public static bool operator ==(OrganizationName a, OrganizationName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc />
-        public static bool operator !=(OrganizationName a, OrganizationName b) => !(a == b);
-    }
-
-    /// <summary>
-    /// Resource name for the 'organization_log' resource.
-    /// </summary>
-    public sealed partial class OrganizationLogName : gax::IResourceName, sys::IEquatable<OrganizationLogName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("organizations/{organization}/logs/{log}");
-
-        /// <summary>
-        /// Parses the given organization_log resource name in string form into a new
-        /// <see cref="OrganizationLogName"/> instance.
-        /// </summary>
-        /// <param name="organizationLogName">The organization_log resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="OrganizationLogName"/> if successful.</returns>
-        public static OrganizationLogName Parse(string organizationLogName)
-        {
-            gax::GaxPreconditions.CheckNotNull(organizationLogName, nameof(organizationLogName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(organizationLogName);
-            return new OrganizationLogName(resourceName[0], resourceName[1]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given organization_log resource name in string form into a new
-        /// <see cref="OrganizationLogName"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="organizationLogName"/> is null,
-        /// as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="organizationLogName">The organization_log resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="OrganizationLogName"/>,
-        /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string organizationLogName, out OrganizationLogName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(organizationLogName, nameof(organizationLogName));
-            gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(organizationLogName, out resourceName))
-            {
-                result = new OrganizationLogName(resourceName[0], resourceName[1]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="OrganizationLogName"/> resource name class
-        /// from its component parts.
-        /// </summary>
-        /// <param name="organizationId">The organization ID. Must not be <c>null</c>.</param>
-        /// <param name="logId">The log ID. Must not be <c>null</c>.</param>
-        public OrganizationLogName(string organizationId, string logId)
-        {
-            OrganizationId = gax::GaxPreconditions.CheckNotNull(organizationId, nameof(organizationId));
-            LogId = gax::GaxPreconditions.CheckNotNull(logId, nameof(logId));
-        }
-
-        /// <summary>
-        /// The organization ID. Never <c>null</c>.
-        /// </summary>
-        public string OrganizationId { get; }
-
-        /// <summary>
-        /// The log ID. Never <c>null</c>.
-        /// </summary>
-        public string LogId { get; }
-
-        /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc />
-        public override string ToString() => s_template.Expand(OrganizationId, LogId);
-
-        /// <inheritdoc />
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as OrganizationLogName);
-
-        /// <inheritdoc />
-        public bool Equals(OrganizationLogName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc />
-        public static bool operator ==(OrganizationLogName a, OrganizationLogName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc />
-        public static bool operator !=(OrganizationLogName a, OrganizationLogName b) => !(a == b);
-    }
-
-    /// <summary>
-    /// Resource name for the 'organization_sink' resource.
-    /// </summary>
-    public sealed partial class OrganizationSinkName : gax::IResourceName, sys::IEquatable<OrganizationSinkName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("organizations/{organization}/sinks/{sink}");
-
-        /// <summary>
-        /// Parses the given organization_sink resource name in string form into a new
-        /// <see cref="OrganizationSinkName"/> instance.
-        /// </summary>
-        /// <param name="organizationSinkName">The organization_sink resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="OrganizationSinkName"/> if successful.</returns>
-        public static OrganizationSinkName Parse(string organizationSinkName)
-        {
-            gax::GaxPreconditions.CheckNotNull(organizationSinkName, nameof(organizationSinkName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(organizationSinkName);
-            return new OrganizationSinkName(resourceName[0], resourceName[1]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given organization_sink resource name in string form into a new
-        /// <see cref="OrganizationSinkName"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="organizationSinkName"/> is null,
-        /// as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="organizationSinkName">The organization_sink resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="OrganizationSinkName"/>,
-        /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string organizationSinkName, out OrganizationSinkName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(organizationSinkName, nameof(organizationSinkName));
-            gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(organizationSinkName, out resourceName))
-            {
-                result = new OrganizationSinkName(resourceName[0], resourceName[1]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="OrganizationSinkName"/> resource name class
-        /// from its component parts.
-        /// </summary>
-        /// <param name="organizationId">The organization ID. Must not be <c>null</c>.</param>
-        /// <param name="sinkId">The sink ID. Must not be <c>null</c>.</param>
-        public OrganizationSinkName(string organizationId, string sinkId)
-        {
-            OrganizationId = gax::GaxPreconditions.CheckNotNull(organizationId, nameof(organizationId));
-            SinkId = gax::GaxPreconditions.CheckNotNull(sinkId, nameof(sinkId));
-        }
-
-        /// <summary>
-        /// The organization ID. Never <c>null</c>.
-        /// </summary>
-        public string OrganizationId { get; }
-
-        /// <summary>
-        /// The sink ID. Never <c>null</c>.
-        /// </summary>
-        public string SinkId { get; }
-
-        /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc />
-        public override string ToString() => s_template.Expand(OrganizationId, SinkId);
-
-        /// <inheritdoc />
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as OrganizationSinkName);
-
-        /// <inheritdoc />
-        public bool Equals(OrganizationSinkName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc />
-        public static bool operator ==(OrganizationSinkName a, OrganizationSinkName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc />
-        public static bool operator !=(OrganizationSinkName a, OrganizationSinkName b) => !(a == b);
-    }
-
-    /// <summary>
-    /// Resource name for the 'organization_exclusion' resource.
-    /// </summary>
-    public sealed partial class OrganizationExclusionName : gax::IResourceName, sys::IEquatable<OrganizationExclusionName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("organizations/{organization}/exclusions/{exclusion}");
-
-        /// <summary>
-        /// Parses the given organization_exclusion resource name in string form into a new
-        /// <see cref="OrganizationExclusionName"/> instance.
-        /// </summary>
-        /// <param name="organizationExclusionName">The organization_exclusion resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="OrganizationExclusionName"/> if successful.</returns>
-        public static OrganizationExclusionName Parse(string organizationExclusionName)
-        {
-            gax::GaxPreconditions.CheckNotNull(organizationExclusionName, nameof(organizationExclusionName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(organizationExclusionName);
-            return new OrganizationExclusionName(resourceName[0], resourceName[1]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given organization_exclusion resource name in string form into a new
-        /// <see cref="OrganizationExclusionName"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="organizationExclusionName"/> is null,
-        /// as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="organizationExclusionName">The organization_exclusion resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="OrganizationExclusionName"/>,
-        /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string organizationExclusionName, out OrganizationExclusionName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(organizationExclusionName, nameof(organizationExclusionName));
-            gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(organizationExclusionName, out resourceName))
-            {
-                result = new OrganizationExclusionName(resourceName[0], resourceName[1]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="OrganizationExclusionName"/> resource name class
-        /// from its component parts.
-        /// </summary>
-        /// <param name="organizationId">The organization ID. Must not be <c>null</c>.</param>
-        /// <param name="exclusionId">The exclusion ID. Must not be <c>null</c>.</param>
-        public OrganizationExclusionName(string organizationId, string exclusionId)
-        {
-            OrganizationId = gax::GaxPreconditions.CheckNotNull(organizationId, nameof(organizationId));
-            ExclusionId = gax::GaxPreconditions.CheckNotNull(exclusionId, nameof(exclusionId));
-        }
-
-        /// <summary>
-        /// The organization ID. Never <c>null</c>.
-        /// </summary>
-        public string OrganizationId { get; }
-
-        /// <summary>
-        /// The exclusion ID. Never <c>null</c>.
-        /// </summary>
-        public string ExclusionId { get; }
-
-        /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc />
-        public override string ToString() => s_template.Expand(OrganizationId, ExclusionId);
-
-        /// <inheritdoc />
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as OrganizationExclusionName);
-
-        /// <inheritdoc />
-        public bool Equals(OrganizationExclusionName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc />
-        public static bool operator ==(OrganizationExclusionName a, OrganizationExclusionName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc />
-        public static bool operator !=(OrganizationExclusionName a, OrganizationExclusionName b) => !(a == b);
-    }
-
-    /// <summary>
-    /// Resource name for the 'folder' resource.
-    /// </summary>
-    public sealed partial class FolderName : gax::IResourceName, sys::IEquatable<FolderName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("folders/{folder}");
-
-        /// <summary>
-        /// Parses the given folder resource name in string form into a new
-        /// <see cref="FolderName"/> instance.
-        /// </summary>
-        /// <param name="folderName">The folder resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="FolderName"/> if successful.</returns>
-        public static FolderName Parse(string folderName)
-        {
-            gax::GaxPreconditions.CheckNotNull(folderName, nameof(folderName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(folderName);
-            return new FolderName(resourceName[0]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given folder resource name in string form into a new
-        /// <see cref="FolderName"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="folderName"/> is null,
-        /// as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="folderName">The folder resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="FolderName"/>,
-        /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string folderName, out FolderName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(folderName, nameof(folderName));
-            gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(folderName, out resourceName))
-            {
-                result = new FolderName(resourceName[0]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="FolderName"/> resource name class
-        /// from its component parts.
-        /// </summary>
-        /// <param name="folderId">The folder ID. Must not be <c>null</c>.</param>
-        public FolderName(string folderId)
-        {
-            FolderId = gax::GaxPreconditions.CheckNotNull(folderId, nameof(folderId));
-        }
-
-        /// <summary>
-        /// The folder ID. Never <c>null</c>.
-        /// </summary>
-        public string FolderId { get; }
-
-        /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc />
-        public override string ToString() => s_template.Expand(FolderId);
-
-        /// <inheritdoc />
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as FolderName);
-
-        /// <inheritdoc />
-        public bool Equals(FolderName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc />
-        public static bool operator ==(FolderName a, FolderName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc />
-        public static bool operator !=(FolderName a, FolderName b) => !(a == b);
-    }
-
-    /// <summary>
-    /// Resource name for the 'folder_log' resource.
-    /// </summary>
-    public sealed partial class FolderLogName : gax::IResourceName, sys::IEquatable<FolderLogName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("folders/{folder}/logs/{log}");
-
-        /// <summary>
-        /// Parses the given folder_log resource name in string form into a new
-        /// <see cref="FolderLogName"/> instance.
-        /// </summary>
-        /// <param name="folderLogName">The folder_log resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="FolderLogName"/> if successful.</returns>
-        public static FolderLogName Parse(string folderLogName)
-        {
-            gax::GaxPreconditions.CheckNotNull(folderLogName, nameof(folderLogName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(folderLogName);
-            return new FolderLogName(resourceName[0], resourceName[1]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given folder_log resource name in string form into a new
-        /// <see cref="FolderLogName"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="folderLogName"/> is null,
-        /// as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="folderLogName">The folder_log resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="FolderLogName"/>,
-        /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string folderLogName, out FolderLogName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(folderLogName, nameof(folderLogName));
-            gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(folderLogName, out resourceName))
-            {
-                result = new FolderLogName(resourceName[0], resourceName[1]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="FolderLogName"/> resource name class
-        /// from its component parts.
-        /// </summary>
-        /// <param name="folderId">The folder ID. Must not be <c>null</c>.</param>
-        /// <param name="logId">The log ID. Must not be <c>null</c>.</param>
-        public FolderLogName(string folderId, string logId)
-        {
-            FolderId = gax::GaxPreconditions.CheckNotNull(folderId, nameof(folderId));
-            LogId = gax::GaxPreconditions.CheckNotNull(logId, nameof(logId));
-        }
-
-        /// <summary>
-        /// The folder ID. Never <c>null</c>.
-        /// </summary>
-        public string FolderId { get; }
-
-        /// <summary>
-        /// The log ID. Never <c>null</c>.
-        /// </summary>
-        public string LogId { get; }
-
-        /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc />
-        public override string ToString() => s_template.Expand(FolderId, LogId);
-
-        /// <inheritdoc />
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as FolderLogName);
-
-        /// <inheritdoc />
-        public bool Equals(FolderLogName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc />
-        public static bool operator ==(FolderLogName a, FolderLogName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc />
-        public static bool operator !=(FolderLogName a, FolderLogName b) => !(a == b);
-    }
-
-    /// <summary>
-    /// Resource name for the 'folder_sink' resource.
-    /// </summary>
-    public sealed partial class FolderSinkName : gax::IResourceName, sys::IEquatable<FolderSinkName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("folders/{folder}/sinks/{sink}");
-
-        /// <summary>
-        /// Parses the given folder_sink resource name in string form into a new
-        /// <see cref="FolderSinkName"/> instance.
-        /// </summary>
-        /// <param name="folderSinkName">The folder_sink resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="FolderSinkName"/> if successful.</returns>
-        public static FolderSinkName Parse(string folderSinkName)
-        {
-            gax::GaxPreconditions.CheckNotNull(folderSinkName, nameof(folderSinkName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(folderSinkName);
-            return new FolderSinkName(resourceName[0], resourceName[1]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given folder_sink resource name in string form into a new
-        /// <see cref="FolderSinkName"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="folderSinkName"/> is null,
-        /// as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="folderSinkName">The folder_sink resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="FolderSinkName"/>,
-        /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string folderSinkName, out FolderSinkName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(folderSinkName, nameof(folderSinkName));
-            gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(folderSinkName, out resourceName))
-            {
-                result = new FolderSinkName(resourceName[0], resourceName[1]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="FolderSinkName"/> resource name class
-        /// from its component parts.
-        /// </summary>
-        /// <param name="folderId">The folder ID. Must not be <c>null</c>.</param>
-        /// <param name="sinkId">The sink ID. Must not be <c>null</c>.</param>
-        public FolderSinkName(string folderId, string sinkId)
-        {
-            FolderId = gax::GaxPreconditions.CheckNotNull(folderId, nameof(folderId));
-            SinkId = gax::GaxPreconditions.CheckNotNull(sinkId, nameof(sinkId));
-        }
-
-        /// <summary>
-        /// The folder ID. Never <c>null</c>.
-        /// </summary>
-        public string FolderId { get; }
-
-        /// <summary>
-        /// The sink ID. Never <c>null</c>.
-        /// </summary>
-        public string SinkId { get; }
-
-        /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc />
-        public override string ToString() => s_template.Expand(FolderId, SinkId);
-
-        /// <inheritdoc />
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as FolderSinkName);
-
-        /// <inheritdoc />
-        public bool Equals(FolderSinkName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc />
-        public static bool operator ==(FolderSinkName a, FolderSinkName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc />
-        public static bool operator !=(FolderSinkName a, FolderSinkName b) => !(a == b);
-    }
-
-    /// <summary>
-    /// Resource name for the 'folder_exclusion' resource.
-    /// </summary>
-    public sealed partial class FolderExclusionName : gax::IResourceName, sys::IEquatable<FolderExclusionName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("folders/{folder}/exclusions/{exclusion}");
-
-        /// <summary>
-        /// Parses the given folder_exclusion resource name in string form into a new
-        /// <see cref="FolderExclusionName"/> instance.
-        /// </summary>
-        /// <param name="folderExclusionName">The folder_exclusion resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="FolderExclusionName"/> if successful.</returns>
-        public static FolderExclusionName Parse(string folderExclusionName)
-        {
-            gax::GaxPreconditions.CheckNotNull(folderExclusionName, nameof(folderExclusionName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(folderExclusionName);
-            return new FolderExclusionName(resourceName[0], resourceName[1]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given folder_exclusion resource name in string form into a new
-        /// <see cref="FolderExclusionName"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="folderExclusionName"/> is null,
-        /// as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="folderExclusionName">The folder_exclusion resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="FolderExclusionName"/>,
-        /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string folderExclusionName, out FolderExclusionName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(folderExclusionName, nameof(folderExclusionName));
-            gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(folderExclusionName, out resourceName))
-            {
-                result = new FolderExclusionName(resourceName[0], resourceName[1]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="FolderExclusionName"/> resource name class
-        /// from its component parts.
-        /// </summary>
-        /// <param name="folderId">The folder ID. Must not be <c>null</c>.</param>
-        /// <param name="exclusionId">The exclusion ID. Must not be <c>null</c>.</param>
-        public FolderExclusionName(string folderId, string exclusionId)
-        {
-            FolderId = gax::GaxPreconditions.CheckNotNull(folderId, nameof(folderId));
-            ExclusionId = gax::GaxPreconditions.CheckNotNull(exclusionId, nameof(exclusionId));
-        }
-
-        /// <summary>
-        /// The folder ID. Never <c>null</c>.
-        /// </summary>
-        public string FolderId { get; }
-
-        /// <summary>
-        /// The exclusion ID. Never <c>null</c>.
-        /// </summary>
-        public string ExclusionId { get; }
-
-        /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc />
-        public override string ToString() => s_template.Expand(FolderId, ExclusionId);
-
-        /// <inheritdoc />
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as FolderExclusionName);
-
-        /// <inheritdoc />
-        public bool Equals(FolderExclusionName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc />
-        public static bool operator ==(FolderExclusionName a, FolderExclusionName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc />
-        public static bool operator !=(FolderExclusionName a, FolderExclusionName b) => !(a == b);
-    }
-
-    /// <summary>
     /// Resource name for the 'billing' resource.
     /// </summary>
     public sealed partial class BillingName : gax::IResourceName, sys::IEquatable<BillingName>
@@ -1279,6 +104,98 @@ namespace Google.Cloud.Logging.V2
 
         /// <inheritdoc />
         public static bool operator !=(BillingName a, BillingName b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name for the 'billing_exclusion' resource.
+    /// </summary>
+    public sealed partial class BillingExclusionName : gax::IResourceName, sys::IEquatable<BillingExclusionName>
+    {
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("billingAccounts/{billing_account}/exclusions/{exclusion}");
+
+        /// <summary>
+        /// Parses the given billing_exclusion resource name in string form into a new
+        /// <see cref="BillingExclusionName"/> instance.
+        /// </summary>
+        /// <param name="billingExclusionName">The billing_exclusion resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="BillingExclusionName"/> if successful.</returns>
+        public static BillingExclusionName Parse(string billingExclusionName)
+        {
+            gax::GaxPreconditions.CheckNotNull(billingExclusionName, nameof(billingExclusionName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(billingExclusionName);
+            return new BillingExclusionName(resourceName[0], resourceName[1]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given billing_exclusion resource name in string form into a new
+        /// <see cref="BillingExclusionName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="billingExclusionName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="billingExclusionName">The billing_exclusion resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="BillingExclusionName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string billingExclusionName, out BillingExclusionName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(billingExclusionName, nameof(billingExclusionName));
+            gax::TemplatedResourceName resourceName;
+            if (s_template.TryParseName(billingExclusionName, out resourceName))
+            {
+                result = new BillingExclusionName(resourceName[0], resourceName[1]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="BillingExclusionName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="billingAccountId">The billingAccount ID. Must not be <c>null</c>.</param>
+        /// <param name="exclusionId">The exclusion ID. Must not be <c>null</c>.</param>
+        public BillingExclusionName(string billingAccountId, string exclusionId)
+        {
+            BillingAccountId = gax::GaxPreconditions.CheckNotNull(billingAccountId, nameof(billingAccountId));
+            ExclusionId = gax::GaxPreconditions.CheckNotNull(exclusionId, nameof(exclusionId));
+        }
+
+        /// <summary>
+        /// The billingAccount ID. Never <c>null</c>.
+        /// </summary>
+        public string BillingAccountId { get; }
+
+        /// <summary>
+        /// The exclusion ID. Never <c>null</c>.
+        /// </summary>
+        public string ExclusionId { get; }
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(BillingAccountId, ExclusionId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as BillingExclusionName);
+
+        /// <inheritdoc />
+        public bool Equals(BillingExclusionName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(BillingExclusionName a, BillingExclusionName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(BillingExclusionName a, BillingExclusionName b) => !(a == b);
     }
 
     /// <summary>
@@ -1466,44 +383,44 @@ namespace Google.Cloud.Logging.V2
     }
 
     /// <summary>
-    /// Resource name for the 'billing_exclusion' resource.
+    /// Resource name for the 'exclusion' resource.
     /// </summary>
-    public sealed partial class BillingExclusionName : gax::IResourceName, sys::IEquatable<BillingExclusionName>
+    public sealed partial class ExclusionName : gax::IResourceName, sys::IEquatable<ExclusionName>
     {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("billingAccounts/{billing_account}/exclusions/{exclusion}");
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/exclusions/{exclusion}");
 
         /// <summary>
-        /// Parses the given billing_exclusion resource name in string form into a new
-        /// <see cref="BillingExclusionName"/> instance.
+        /// Parses the given exclusion resource name in string form into a new
+        /// <see cref="ExclusionName"/> instance.
         /// </summary>
-        /// <param name="billingExclusionName">The billing_exclusion resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="BillingExclusionName"/> if successful.</returns>
-        public static BillingExclusionName Parse(string billingExclusionName)
+        /// <param name="exclusionName">The exclusion resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="ExclusionName"/> if successful.</returns>
+        public static ExclusionName Parse(string exclusionName)
         {
-            gax::GaxPreconditions.CheckNotNull(billingExclusionName, nameof(billingExclusionName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(billingExclusionName);
-            return new BillingExclusionName(resourceName[0], resourceName[1]);
+            gax::GaxPreconditions.CheckNotNull(exclusionName, nameof(exclusionName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(exclusionName);
+            return new ExclusionName(resourceName[0], resourceName[1]);
         }
 
         /// <summary>
-        /// Tries to parse the given billing_exclusion resource name in string form into a new
-        /// <see cref="BillingExclusionName"/> instance.
+        /// Tries to parse the given exclusion resource name in string form into a new
+        /// <see cref="ExclusionName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="billingExclusionName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="exclusionName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
-        /// <param name="billingExclusionName">The billing_exclusion resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="BillingExclusionName"/>,
+        /// <param name="exclusionName">The exclusion resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="ExclusionName"/>,
         /// or <c>null</c> if parsing fails.</param>
         /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string billingExclusionName, out BillingExclusionName result)
+        public static bool TryParse(string exclusionName, out ExclusionName result)
         {
-            gax::GaxPreconditions.CheckNotNull(billingExclusionName, nameof(billingExclusionName));
+            gax::GaxPreconditions.CheckNotNull(exclusionName, nameof(exclusionName));
             gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(billingExclusionName, out resourceName))
+            if (s_template.TryParseName(exclusionName, out resourceName))
             {
-                result = new BillingExclusionName(resourceName[0], resourceName[1]);
+                result = new ExclusionName(resourceName[0], resourceName[1]);
                 return true;
             }
             else
@@ -1514,21 +431,21 @@ namespace Google.Cloud.Logging.V2
         }
 
         /// <summary>
-        /// Constructs a new instance of the <see cref="BillingExclusionName"/> resource name class
+        /// Constructs a new instance of the <see cref="ExclusionName"/> resource name class
         /// from its component parts.
         /// </summary>
-        /// <param name="billingAccountId">The billingAccount ID. Must not be <c>null</c>.</param>
+        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
         /// <param name="exclusionId">The exclusion ID. Must not be <c>null</c>.</param>
-        public BillingExclusionName(string billingAccountId, string exclusionId)
+        public ExclusionName(string projectId, string exclusionId)
         {
-            BillingAccountId = gax::GaxPreconditions.CheckNotNull(billingAccountId, nameof(billingAccountId));
+            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
             ExclusionId = gax::GaxPreconditions.CheckNotNull(exclusionId, nameof(exclusionId));
         }
 
         /// <summary>
-        /// The billingAccount ID. Never <c>null</c>.
+        /// The project ID. Never <c>null</c>.
         /// </summary>
-        public string BillingAccountId { get; }
+        public string ProjectId { get; }
 
         /// <summary>
         /// The exclusion ID. Never <c>null</c>.
@@ -1539,558 +456,22 @@ namespace Google.Cloud.Logging.V2
         public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
 
         /// <inheritdoc />
-        public override string ToString() => s_template.Expand(BillingAccountId, ExclusionId);
+        public override string ToString() => s_template.Expand(ProjectId, ExclusionId);
 
         /// <inheritdoc />
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as BillingExclusionName);
+        public override bool Equals(object obj) => Equals(obj as ExclusionName);
 
         /// <inheritdoc />
-        public bool Equals(BillingExclusionName other) => ToString() == other?.ToString();
+        public bool Equals(ExclusionName other) => ToString() == other?.ToString();
 
         /// <inheritdoc />
-        public static bool operator ==(BillingExclusionName a, BillingExclusionName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+        public static bool operator ==(ExclusionName a, ExclusionName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
 
         /// <inheritdoc />
-        public static bool operator !=(BillingExclusionName a, BillingExclusionName b) => !(a == b);
-    }
-
-    /// <summary>
-    /// Resource name which will contain one of a choice of resource names.
-    /// </summary>
-    /// <remarks>
-    /// This resource name will contain one of the following:
-    /// <list type="bullet">
-    /// <item><description>ProjectName: A resource of type 'project'.</description></item>
-    /// <item><description>OrganizationName: A resource of type 'organization'.</description></item>
-    /// <item><description>FolderName: A resource of type 'folder'.</description></item>
-    /// <item><description>BillingName: A resource of type 'billing'.</description></item>
-    /// </list>
-    /// </remarks>
-    public sealed partial class ParentNameOneof : gax::IResourceName, sys::IEquatable<ParentNameOneof>
-    {
-        /// <summary>
-        /// The possible contents of <see cref="ParentNameOneof"/>.
-        /// </summary>
-        public enum OneofType
-        {
-            /// <summary>
-            /// A resource of an unknown type.
-            /// </summary>
-            Unknown = 0,
-
-            /// <summary>
-            /// A resource of type 'project'.
-            /// </summary>
-            ProjectName = 1,
-
-            /// <summary>
-            /// A resource of type 'organization'.
-            /// </summary>
-            OrganizationName = 2,
-
-            /// <summary>
-            /// A resource of type 'folder'.
-            /// </summary>
-            FolderName = 3,
-
-            /// <summary>
-            /// A resource of type 'billing'.
-            /// </summary>
-            BillingName = 4,
-        }
-
-        /// <summary>
-        /// Parses a resource name in string form into a new <see cref="ParentNameOneof"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// To parse successfully the resource name must be one of the following:
-        /// <list type="bullet">
-        /// <item><description>ProjectName: A resource of type 'project'.</description></item>
-        /// <item><description>OrganizationName: A resource of type 'organization'.</description></item>
-        /// <item><description>FolderName: A resource of type 'folder'.</description></item>
-        /// <item><description>BillingName: A resource of type 'billing'.</description></item>
-        /// </list>
-        /// Or an <see cref="gax::UnknownResourceName"/> if <paramref name="allowUnknown"/> is <c>true</c>.
-        /// </remarks>
-        /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="allowUnknown">If true, will successfully parse an unknown resource name
-        /// into an <see cref="gax::UnknownResourceName"/>; otherwise will throw an
-        /// <see cref="sys::ArgumentException"/> if an unknown resource name is given.</param>
-        /// <returns>The parsed <see cref="ParentNameOneof"/> if successful.</returns>
-        public static ParentNameOneof Parse(string name, bool allowUnknown)
-        {
-            ParentNameOneof result;
-            if (TryParse(name, allowUnknown, out result))
-            {
-                return result;
-            }
-            throw new sys::ArgumentException("Invalid name", nameof(name));
-        }
-
-        /// <summary>
-        /// Tries to parse a resource name in string form into a new <see cref="ParentNameOneof"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// To parse successfully the resource name must be one of the following:
-        /// <list type="bullet">
-        /// <item><description>ProjectName: A resource of type 'project'.</description></item>
-        /// <item><description>OrganizationName: A resource of type 'organization'.</description></item>
-        /// <item><description>FolderName: A resource of type 'folder'.</description></item>
-        /// <item><description>BillingName: A resource of type 'billing'.</description></item>
-        /// </list>
-        /// Or an <see cref="gax::UnknownResourceName"/> if <paramref name="allowUnknown"/> is <c>true</c>.
-        /// </remarks>
-        /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="allowUnknown">If true, will successfully parse an unknown resource name
-        /// into an <see cref="gax::UnknownResourceName"/>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="ParentNameOneof"/>,
-        /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string name, bool allowUnknown, out ParentNameOneof result)
-        {
-            gax::GaxPreconditions.CheckNotNull(name, nameof(name));
-            ProjectName projectName;
-            if (ProjectName.TryParse(name, out projectName))
-            {
-                result = new ParentNameOneof(OneofType.ProjectName, projectName);
-                return true;
-            }
-            OrganizationName organizationName;
-            if (OrganizationName.TryParse(name, out organizationName))
-            {
-                result = new ParentNameOneof(OneofType.OrganizationName, organizationName);
-                return true;
-            }
-            FolderName folderName;
-            if (FolderName.TryParse(name, out folderName))
-            {
-                result = new ParentNameOneof(OneofType.FolderName, folderName);
-                return true;
-            }
-            BillingName billingName;
-            if (BillingName.TryParse(name, out billingName))
-            {
-                result = new ParentNameOneof(OneofType.BillingName, billingName);
-                return true;
-            }
-            if (allowUnknown)
-            {
-                gax::UnknownResourceName unknownResourceName;
-                if (gax::UnknownResourceName.TryParse(name, out unknownResourceName))
-                {
-                    result = new ParentNameOneof(OneofType.Unknown, unknownResourceName);
-                    return true;
-                }
-            }
-            result = null;
-            return false;
-        }
-
-        /// <summary>
-        /// Construct a new instance of <see cref="ParentNameOneof"/> from the provided <see cref="ProjectName"/>
-        /// </summary>
-        /// <param name="projectName">The <see cref="ProjectName"/> to be contained within
-        /// the returned <see cref="ParentNameOneof"/>. Must not be <c>null</c>.</param>
-        /// <returns>A new <see cref="ParentNameOneof"/>, containing <paramref name="projectName"/>.</returns>
-        public static ParentNameOneof From(ProjectName projectName) => new ParentNameOneof(OneofType.ProjectName, projectName);
-
-        /// <summary>
-        /// Construct a new instance of <see cref="ParentNameOneof"/> from the provided <see cref="OrganizationName"/>
-        /// </summary>
-        /// <param name="organizationName">The <see cref="OrganizationName"/> to be contained within
-        /// the returned <see cref="ParentNameOneof"/>. Must not be <c>null</c>.</param>
-        /// <returns>A new <see cref="ParentNameOneof"/>, containing <paramref name="organizationName"/>.</returns>
-        public static ParentNameOneof From(OrganizationName organizationName) => new ParentNameOneof(OneofType.OrganizationName, organizationName);
-
-        /// <summary>
-        /// Construct a new instance of <see cref="ParentNameOneof"/> from the provided <see cref="FolderName"/>
-        /// </summary>
-        /// <param name="folderName">The <see cref="FolderName"/> to be contained within
-        /// the returned <see cref="ParentNameOneof"/>. Must not be <c>null</c>.</param>
-        /// <returns>A new <see cref="ParentNameOneof"/>, containing <paramref name="folderName"/>.</returns>
-        public static ParentNameOneof From(FolderName folderName) => new ParentNameOneof(OneofType.FolderName, folderName);
-
-        /// <summary>
-        /// Construct a new instance of <see cref="ParentNameOneof"/> from the provided <see cref="BillingName"/>
-        /// </summary>
-        /// <param name="billingName">The <see cref="BillingName"/> to be contained within
-        /// the returned <see cref="ParentNameOneof"/>. Must not be <c>null</c>.</param>
-        /// <returns>A new <see cref="ParentNameOneof"/>, containing <paramref name="billingName"/>.</returns>
-        public static ParentNameOneof From(BillingName billingName) => new ParentNameOneof(OneofType.BillingName, billingName);
-
-        private static bool IsValid(OneofType type, gax::IResourceName name)
-        {
-            switch (type)
-            {
-                case OneofType.Unknown: return true; // Anything goes with Unknown.
-                case OneofType.ProjectName: return name is ProjectName;
-                case OneofType.OrganizationName: return name is OrganizationName;
-                case OneofType.FolderName: return name is FolderName;
-                case OneofType.BillingName: return name is BillingName;
-                default: return false;
-            }
-        }
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="ParentNameOneof"/> resource name class
-        /// from a suitable <see cref="gax::IResourceName"/> instance.
-        /// </summary>
-        public ParentNameOneof(OneofType type, gax::IResourceName name)
-        {
-            Type = gax::GaxPreconditions.CheckEnumValue<OneofType>(type, nameof(type));
-            Name = gax::GaxPreconditions.CheckNotNull(name, nameof(name));
-            if (!IsValid(type, name))
-            {
-                throw new sys::ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
-            }
-        }
-
-        /// <summary>
-        /// The <see cref="OneofType"/> of the Name contained in this instance.
-        /// </summary>
-        public OneofType Type { get; }
-
-        /// <summary>
-        /// The <see cref="gax::IResourceName"/> contained in this instance.
-        /// </summary>
-        public gax::IResourceName Name { get; }
-
-        private T CheckAndReturn<T>(OneofType type)
-        {
-            if (Type != type)
-            {
-                throw new sys::InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
-            }
-            return (T)Name;
-        }
-
-        /// <summary>
-        /// Get the contained <see cref="gax::IResourceName"/> as <see cref="ProjectName"/>.
-        /// </summary>
-        /// <remarks>
-        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
-        /// contain an instance of <see cref="ProjectName"/>.
-        /// </remarks>
-        public ProjectName ProjectName => CheckAndReturn<ProjectName>(OneofType.ProjectName);
-
-        /// <summary>
-        /// Get the contained <see cref="gax::IResourceName"/> as <see cref="OrganizationName"/>.
-        /// </summary>
-        /// <remarks>
-        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
-        /// contain an instance of <see cref="OrganizationName"/>.
-        /// </remarks>
-        public OrganizationName OrganizationName => CheckAndReturn<OrganizationName>(OneofType.OrganizationName);
-
-        /// <summary>
-        /// Get the contained <see cref="gax::IResourceName"/> as <see cref="FolderName"/>.
-        /// </summary>
-        /// <remarks>
-        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
-        /// contain an instance of <see cref="FolderName"/>.
-        /// </remarks>
-        public FolderName FolderName => CheckAndReturn<FolderName>(OneofType.FolderName);
-
-        /// <summary>
-        /// Get the contained <see cref="gax::IResourceName"/> as <see cref="BillingName"/>.
-        /// </summary>
-        /// <remarks>
-        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
-        /// contain an instance of <see cref="BillingName"/>.
-        /// </remarks>
-        public BillingName BillingName => CheckAndReturn<BillingName>(OneofType.BillingName);
-
-        /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Oneof;
-
-        /// <inheritdoc />
-        public override string ToString() => Name.ToString();
-
-        /// <inheritdoc />
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as ParentNameOneof);
-
-        /// <inheritdoc />
-        public bool Equals(ParentNameOneof other) => ToString() == other?.ToString();
-
-        /// <inheritdoc />
-        public static bool operator ==(ParentNameOneof a, ParentNameOneof b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc />
-        public static bool operator !=(ParentNameOneof a, ParentNameOneof b) => !(a == b);
-    }
-
-    /// <summary>
-    /// Resource name which will contain one of a choice of resource names.
-    /// </summary>
-    /// <remarks>
-    /// This resource name will contain one of the following:
-    /// <list type="bullet">
-    /// <item><description>SinkName: A resource of type 'sink'.</description></item>
-    /// <item><description>OrganizationSinkName: A resource of type 'organization_sink'.</description></item>
-    /// <item><description>FolderSinkName: A resource of type 'folder_sink'.</description></item>
-    /// <item><description>BillingSinkName: A resource of type 'billing_sink'.</description></item>
-    /// </list>
-    /// </remarks>
-    public sealed partial class SinkNameOneof : gax::IResourceName, sys::IEquatable<SinkNameOneof>
-    {
-        /// <summary>
-        /// The possible contents of <see cref="SinkNameOneof"/>.
-        /// </summary>
-        public enum OneofType
-        {
-            /// <summary>
-            /// A resource of an unknown type.
-            /// </summary>
-            Unknown = 0,
-
-            /// <summary>
-            /// A resource of type 'sink'.
-            /// </summary>
-            SinkName = 1,
-
-            /// <summary>
-            /// A resource of type 'organization_sink'.
-            /// </summary>
-            OrganizationSinkName = 2,
-
-            /// <summary>
-            /// A resource of type 'folder_sink'.
-            /// </summary>
-            FolderSinkName = 3,
-
-            /// <summary>
-            /// A resource of type 'billing_sink'.
-            /// </summary>
-            BillingSinkName = 4,
-        }
-
-        /// <summary>
-        /// Parses a resource name in string form into a new <see cref="SinkNameOneof"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// To parse successfully the resource name must be one of the following:
-        /// <list type="bullet">
-        /// <item><description>SinkName: A resource of type 'sink'.</description></item>
-        /// <item><description>OrganizationSinkName: A resource of type 'organization_sink'.</description></item>
-        /// <item><description>FolderSinkName: A resource of type 'folder_sink'.</description></item>
-        /// <item><description>BillingSinkName: A resource of type 'billing_sink'.</description></item>
-        /// </list>
-        /// Or an <see cref="gax::UnknownResourceName"/> if <paramref name="allowUnknown"/> is <c>true</c>.
-        /// </remarks>
-        /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="allowUnknown">If true, will successfully parse an unknown resource name
-        /// into an <see cref="gax::UnknownResourceName"/>; otherwise will throw an
-        /// <see cref="sys::ArgumentException"/> if an unknown resource name is given.</param>
-        /// <returns>The parsed <see cref="SinkNameOneof"/> if successful.</returns>
-        public static SinkNameOneof Parse(string name, bool allowUnknown)
-        {
-            SinkNameOneof result;
-            if (TryParse(name, allowUnknown, out result))
-            {
-                return result;
-            }
-            throw new sys::ArgumentException("Invalid name", nameof(name));
-        }
-
-        /// <summary>
-        /// Tries to parse a resource name in string form into a new <see cref="SinkNameOneof"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// To parse successfully the resource name must be one of the following:
-        /// <list type="bullet">
-        /// <item><description>SinkName: A resource of type 'sink'.</description></item>
-        /// <item><description>OrganizationSinkName: A resource of type 'organization_sink'.</description></item>
-        /// <item><description>FolderSinkName: A resource of type 'folder_sink'.</description></item>
-        /// <item><description>BillingSinkName: A resource of type 'billing_sink'.</description></item>
-        /// </list>
-        /// Or an <see cref="gax::UnknownResourceName"/> if <paramref name="allowUnknown"/> is <c>true</c>.
-        /// </remarks>
-        /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="allowUnknown">If true, will successfully parse an unknown resource name
-        /// into an <see cref="gax::UnknownResourceName"/>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="SinkNameOneof"/>,
-        /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string name, bool allowUnknown, out SinkNameOneof result)
-        {
-            gax::GaxPreconditions.CheckNotNull(name, nameof(name));
-            SinkName sinkName;
-            if (SinkName.TryParse(name, out sinkName))
-            {
-                result = new SinkNameOneof(OneofType.SinkName, sinkName);
-                return true;
-            }
-            OrganizationSinkName organizationSinkName;
-            if (OrganizationSinkName.TryParse(name, out organizationSinkName))
-            {
-                result = new SinkNameOneof(OneofType.OrganizationSinkName, organizationSinkName);
-                return true;
-            }
-            FolderSinkName folderSinkName;
-            if (FolderSinkName.TryParse(name, out folderSinkName))
-            {
-                result = new SinkNameOneof(OneofType.FolderSinkName, folderSinkName);
-                return true;
-            }
-            BillingSinkName billingSinkName;
-            if (BillingSinkName.TryParse(name, out billingSinkName))
-            {
-                result = new SinkNameOneof(OneofType.BillingSinkName, billingSinkName);
-                return true;
-            }
-            if (allowUnknown)
-            {
-                gax::UnknownResourceName unknownResourceName;
-                if (gax::UnknownResourceName.TryParse(name, out unknownResourceName))
-                {
-                    result = new SinkNameOneof(OneofType.Unknown, unknownResourceName);
-                    return true;
-                }
-            }
-            result = null;
-            return false;
-        }
-
-        /// <summary>
-        /// Construct a new instance of <see cref="SinkNameOneof"/> from the provided <see cref="SinkName"/>
-        /// </summary>
-        /// <param name="sinkName">The <see cref="SinkName"/> to be contained within
-        /// the returned <see cref="SinkNameOneof"/>. Must not be <c>null</c>.</param>
-        /// <returns>A new <see cref="SinkNameOneof"/>, containing <paramref name="sinkName"/>.</returns>
-        public static SinkNameOneof From(SinkName sinkName) => new SinkNameOneof(OneofType.SinkName, sinkName);
-
-        /// <summary>
-        /// Construct a new instance of <see cref="SinkNameOneof"/> from the provided <see cref="OrganizationSinkName"/>
-        /// </summary>
-        /// <param name="organizationSinkName">The <see cref="OrganizationSinkName"/> to be contained within
-        /// the returned <see cref="SinkNameOneof"/>. Must not be <c>null</c>.</param>
-        /// <returns>A new <see cref="SinkNameOneof"/>, containing <paramref name="organizationSinkName"/>.</returns>
-        public static SinkNameOneof From(OrganizationSinkName organizationSinkName) => new SinkNameOneof(OneofType.OrganizationSinkName, organizationSinkName);
-
-        /// <summary>
-        /// Construct a new instance of <see cref="SinkNameOneof"/> from the provided <see cref="FolderSinkName"/>
-        /// </summary>
-        /// <param name="folderSinkName">The <see cref="FolderSinkName"/> to be contained within
-        /// the returned <see cref="SinkNameOneof"/>. Must not be <c>null</c>.</param>
-        /// <returns>A new <see cref="SinkNameOneof"/>, containing <paramref name="folderSinkName"/>.</returns>
-        public static SinkNameOneof From(FolderSinkName folderSinkName) => new SinkNameOneof(OneofType.FolderSinkName, folderSinkName);
-
-        /// <summary>
-        /// Construct a new instance of <see cref="SinkNameOneof"/> from the provided <see cref="BillingSinkName"/>
-        /// </summary>
-        /// <param name="billingSinkName">The <see cref="BillingSinkName"/> to be contained within
-        /// the returned <see cref="SinkNameOneof"/>. Must not be <c>null</c>.</param>
-        /// <returns>A new <see cref="SinkNameOneof"/>, containing <paramref name="billingSinkName"/>.</returns>
-        public static SinkNameOneof From(BillingSinkName billingSinkName) => new SinkNameOneof(OneofType.BillingSinkName, billingSinkName);
-
-        private static bool IsValid(OneofType type, gax::IResourceName name)
-        {
-            switch (type)
-            {
-                case OneofType.Unknown: return true; // Anything goes with Unknown.
-                case OneofType.SinkName: return name is SinkName;
-                case OneofType.OrganizationSinkName: return name is OrganizationSinkName;
-                case OneofType.FolderSinkName: return name is FolderSinkName;
-                case OneofType.BillingSinkName: return name is BillingSinkName;
-                default: return false;
-            }
-        }
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="SinkNameOneof"/> resource name class
-        /// from a suitable <see cref="gax::IResourceName"/> instance.
-        /// </summary>
-        public SinkNameOneof(OneofType type, gax::IResourceName name)
-        {
-            Type = gax::GaxPreconditions.CheckEnumValue<OneofType>(type, nameof(type));
-            Name = gax::GaxPreconditions.CheckNotNull(name, nameof(name));
-            if (!IsValid(type, name))
-            {
-                throw new sys::ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
-            }
-        }
-
-        /// <summary>
-        /// The <see cref="OneofType"/> of the Name contained in this instance.
-        /// </summary>
-        public OneofType Type { get; }
-
-        /// <summary>
-        /// The <see cref="gax::IResourceName"/> contained in this instance.
-        /// </summary>
-        public gax::IResourceName Name { get; }
-
-        private T CheckAndReturn<T>(OneofType type)
-        {
-            if (Type != type)
-            {
-                throw new sys::InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
-            }
-            return (T)Name;
-        }
-
-        /// <summary>
-        /// Get the contained <see cref="gax::IResourceName"/> as <see cref="SinkName"/>.
-        /// </summary>
-        /// <remarks>
-        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
-        /// contain an instance of <see cref="SinkName"/>.
-        /// </remarks>
-        public SinkName SinkName => CheckAndReturn<SinkName>(OneofType.SinkName);
-
-        /// <summary>
-        /// Get the contained <see cref="gax::IResourceName"/> as <see cref="OrganizationSinkName"/>.
-        /// </summary>
-        /// <remarks>
-        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
-        /// contain an instance of <see cref="OrganizationSinkName"/>.
-        /// </remarks>
-        public OrganizationSinkName OrganizationSinkName => CheckAndReturn<OrganizationSinkName>(OneofType.OrganizationSinkName);
-
-        /// <summary>
-        /// Get the contained <see cref="gax::IResourceName"/> as <see cref="FolderSinkName"/>.
-        /// </summary>
-        /// <remarks>
-        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
-        /// contain an instance of <see cref="FolderSinkName"/>.
-        /// </remarks>
-        public FolderSinkName FolderSinkName => CheckAndReturn<FolderSinkName>(OneofType.FolderSinkName);
-
-        /// <summary>
-        /// Get the contained <see cref="gax::IResourceName"/> as <see cref="BillingSinkName"/>.
-        /// </summary>
-        /// <remarks>
-        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
-        /// contain an instance of <see cref="BillingSinkName"/>.
-        /// </remarks>
-        public BillingSinkName BillingSinkName => CheckAndReturn<BillingSinkName>(OneofType.BillingSinkName);
-
-        /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Oneof;
-
-        /// <inheritdoc />
-        public override string ToString() => Name.ToString();
-
-        /// <inheritdoc />
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as SinkNameOneof);
-
-        /// <inheritdoc />
-        public bool Equals(SinkNameOneof other) => ToString() == other?.ToString();
-
-        /// <inheritdoc />
-        public static bool operator ==(SinkNameOneof a, SinkNameOneof b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc />
-        public static bool operator !=(SinkNameOneof a, SinkNameOneof b) => !(a == b);
+        public static bool operator !=(ExclusionName a, ExclusionName b) => !(a == b);
     }
 
     /// <summary>
@@ -2362,6 +743,459 @@ namespace Google.Cloud.Logging.V2
     }
 
     /// <summary>
+    /// Resource name for the 'folder' resource.
+    /// </summary>
+    public sealed partial class FolderName : gax::IResourceName, sys::IEquatable<FolderName>
+    {
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("folders/{folder}");
+
+        /// <summary>
+        /// Parses the given folder resource name in string form into a new
+        /// <see cref="FolderName"/> instance.
+        /// </summary>
+        /// <param name="folderName">The folder resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="FolderName"/> if successful.</returns>
+        public static FolderName Parse(string folderName)
+        {
+            gax::GaxPreconditions.CheckNotNull(folderName, nameof(folderName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(folderName);
+            return new FolderName(resourceName[0]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given folder resource name in string form into a new
+        /// <see cref="FolderName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="folderName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="folderName">The folder resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="FolderName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string folderName, out FolderName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(folderName, nameof(folderName));
+            gax::TemplatedResourceName resourceName;
+            if (s_template.TryParseName(folderName, out resourceName))
+            {
+                result = new FolderName(resourceName[0]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="FolderName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="folderId">The folder ID. Must not be <c>null</c>.</param>
+        public FolderName(string folderId)
+        {
+            FolderId = gax::GaxPreconditions.CheckNotNull(folderId, nameof(folderId));
+        }
+
+        /// <summary>
+        /// The folder ID. Never <c>null</c>.
+        /// </summary>
+        public string FolderId { get; }
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(FolderId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as FolderName);
+
+        /// <inheritdoc />
+        public bool Equals(FolderName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(FolderName a, FolderName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(FolderName a, FolderName b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name for the 'folder_exclusion' resource.
+    /// </summary>
+    public sealed partial class FolderExclusionName : gax::IResourceName, sys::IEquatable<FolderExclusionName>
+    {
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("folders/{folder}/exclusions/{exclusion}");
+
+        /// <summary>
+        /// Parses the given folder_exclusion resource name in string form into a new
+        /// <see cref="FolderExclusionName"/> instance.
+        /// </summary>
+        /// <param name="folderExclusionName">The folder_exclusion resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="FolderExclusionName"/> if successful.</returns>
+        public static FolderExclusionName Parse(string folderExclusionName)
+        {
+            gax::GaxPreconditions.CheckNotNull(folderExclusionName, nameof(folderExclusionName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(folderExclusionName);
+            return new FolderExclusionName(resourceName[0], resourceName[1]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given folder_exclusion resource name in string form into a new
+        /// <see cref="FolderExclusionName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="folderExclusionName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="folderExclusionName">The folder_exclusion resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="FolderExclusionName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string folderExclusionName, out FolderExclusionName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(folderExclusionName, nameof(folderExclusionName));
+            gax::TemplatedResourceName resourceName;
+            if (s_template.TryParseName(folderExclusionName, out resourceName))
+            {
+                result = new FolderExclusionName(resourceName[0], resourceName[1]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="FolderExclusionName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="folderId">The folder ID. Must not be <c>null</c>.</param>
+        /// <param name="exclusionId">The exclusion ID. Must not be <c>null</c>.</param>
+        public FolderExclusionName(string folderId, string exclusionId)
+        {
+            FolderId = gax::GaxPreconditions.CheckNotNull(folderId, nameof(folderId));
+            ExclusionId = gax::GaxPreconditions.CheckNotNull(exclusionId, nameof(exclusionId));
+        }
+
+        /// <summary>
+        /// The folder ID. Never <c>null</c>.
+        /// </summary>
+        public string FolderId { get; }
+
+        /// <summary>
+        /// The exclusion ID. Never <c>null</c>.
+        /// </summary>
+        public string ExclusionId { get; }
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(FolderId, ExclusionId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as FolderExclusionName);
+
+        /// <inheritdoc />
+        public bool Equals(FolderExclusionName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(FolderExclusionName a, FolderExclusionName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(FolderExclusionName a, FolderExclusionName b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name for the 'folder_log' resource.
+    /// </summary>
+    public sealed partial class FolderLogName : gax::IResourceName, sys::IEquatable<FolderLogName>
+    {
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("folders/{folder}/logs/{log}");
+
+        /// <summary>
+        /// Parses the given folder_log resource name in string form into a new
+        /// <see cref="FolderLogName"/> instance.
+        /// </summary>
+        /// <param name="folderLogName">The folder_log resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="FolderLogName"/> if successful.</returns>
+        public static FolderLogName Parse(string folderLogName)
+        {
+            gax::GaxPreconditions.CheckNotNull(folderLogName, nameof(folderLogName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(folderLogName);
+            return new FolderLogName(resourceName[0], resourceName[1]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given folder_log resource name in string form into a new
+        /// <see cref="FolderLogName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="folderLogName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="folderLogName">The folder_log resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="FolderLogName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string folderLogName, out FolderLogName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(folderLogName, nameof(folderLogName));
+            gax::TemplatedResourceName resourceName;
+            if (s_template.TryParseName(folderLogName, out resourceName))
+            {
+                result = new FolderLogName(resourceName[0], resourceName[1]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="FolderLogName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="folderId">The folder ID. Must not be <c>null</c>.</param>
+        /// <param name="logId">The log ID. Must not be <c>null</c>.</param>
+        public FolderLogName(string folderId, string logId)
+        {
+            FolderId = gax::GaxPreconditions.CheckNotNull(folderId, nameof(folderId));
+            LogId = gax::GaxPreconditions.CheckNotNull(logId, nameof(logId));
+        }
+
+        /// <summary>
+        /// The folder ID. Never <c>null</c>.
+        /// </summary>
+        public string FolderId { get; }
+
+        /// <summary>
+        /// The log ID. Never <c>null</c>.
+        /// </summary>
+        public string LogId { get; }
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(FolderId, LogId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as FolderLogName);
+
+        /// <inheritdoc />
+        public bool Equals(FolderLogName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(FolderLogName a, FolderLogName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(FolderLogName a, FolderLogName b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name for the 'folder_sink' resource.
+    /// </summary>
+    public sealed partial class FolderSinkName : gax::IResourceName, sys::IEquatable<FolderSinkName>
+    {
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("folders/{folder}/sinks/{sink}");
+
+        /// <summary>
+        /// Parses the given folder_sink resource name in string form into a new
+        /// <see cref="FolderSinkName"/> instance.
+        /// </summary>
+        /// <param name="folderSinkName">The folder_sink resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="FolderSinkName"/> if successful.</returns>
+        public static FolderSinkName Parse(string folderSinkName)
+        {
+            gax::GaxPreconditions.CheckNotNull(folderSinkName, nameof(folderSinkName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(folderSinkName);
+            return new FolderSinkName(resourceName[0], resourceName[1]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given folder_sink resource name in string form into a new
+        /// <see cref="FolderSinkName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="folderSinkName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="folderSinkName">The folder_sink resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="FolderSinkName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string folderSinkName, out FolderSinkName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(folderSinkName, nameof(folderSinkName));
+            gax::TemplatedResourceName resourceName;
+            if (s_template.TryParseName(folderSinkName, out resourceName))
+            {
+                result = new FolderSinkName(resourceName[0], resourceName[1]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="FolderSinkName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="folderId">The folder ID. Must not be <c>null</c>.</param>
+        /// <param name="sinkId">The sink ID. Must not be <c>null</c>.</param>
+        public FolderSinkName(string folderId, string sinkId)
+        {
+            FolderId = gax::GaxPreconditions.CheckNotNull(folderId, nameof(folderId));
+            SinkId = gax::GaxPreconditions.CheckNotNull(sinkId, nameof(sinkId));
+        }
+
+        /// <summary>
+        /// The folder ID. Never <c>null</c>.
+        /// </summary>
+        public string FolderId { get; }
+
+        /// <summary>
+        /// The sink ID. Never <c>null</c>.
+        /// </summary>
+        public string SinkId { get; }
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(FolderId, SinkId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as FolderSinkName);
+
+        /// <inheritdoc />
+        public bool Equals(FolderSinkName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(FolderSinkName a, FolderSinkName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(FolderSinkName a, FolderSinkName b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name for the 'log' resource.
+    /// </summary>
+    public sealed partial class LogName : gax::IResourceName, sys::IEquatable<LogName>
+    {
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/logs/{log}");
+
+        /// <summary>
+        /// Parses the given log resource name in string form into a new
+        /// <see cref="LogName"/> instance.
+        /// </summary>
+        /// <param name="logName">The log resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="LogName"/> if successful.</returns>
+        public static LogName Parse(string logName)
+        {
+            gax::GaxPreconditions.CheckNotNull(logName, nameof(logName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(logName);
+            return new LogName(resourceName[0], resourceName[1]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given log resource name in string form into a new
+        /// <see cref="LogName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="logName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="logName">The log resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="LogName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string logName, out LogName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(logName, nameof(logName));
+            gax::TemplatedResourceName resourceName;
+            if (s_template.TryParseName(logName, out resourceName))
+            {
+                result = new LogName(resourceName[0], resourceName[1]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="LogName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
+        /// <param name="logId">The log ID. Must not be <c>null</c>.</param>
+        public LogName(string projectId, string logId)
+        {
+            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
+            LogId = gax::GaxPreconditions.CheckNotNull(logId, nameof(logId));
+        }
+
+        /// <summary>
+        /// The project ID. Never <c>null</c>.
+        /// </summary>
+        public string ProjectId { get; }
+
+        /// <summary>
+        /// The log ID. Never <c>null</c>.
+        /// </summary>
+        public string LogId { get; }
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(ProjectId, LogId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as LogName);
+
+        /// <inheritdoc />
+        public bool Equals(LogName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(LogName a, LogName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(LogName a, LogName b) => !(a == b);
+    }
+
+    /// <summary>
     /// Resource name which will contain one of a choice of resource names.
     /// </summary>
     /// <remarks>
@@ -2630,6 +1464,98 @@ namespace Google.Cloud.Logging.V2
     }
 
     /// <summary>
+    /// Resource name for the 'metric' resource.
+    /// </summary>
+    public sealed partial class MetricName : gax::IResourceName, sys::IEquatable<MetricName>
+    {
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/metrics/{metric}");
+
+        /// <summary>
+        /// Parses the given metric resource name in string form into a new
+        /// <see cref="MetricName"/> instance.
+        /// </summary>
+        /// <param name="metricName">The metric resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="MetricName"/> if successful.</returns>
+        public static MetricName Parse(string metricName)
+        {
+            gax::GaxPreconditions.CheckNotNull(metricName, nameof(metricName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(metricName);
+            return new MetricName(resourceName[0], resourceName[1]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given metric resource name in string form into a new
+        /// <see cref="MetricName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="metricName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="metricName">The metric resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="MetricName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string metricName, out MetricName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(metricName, nameof(metricName));
+            gax::TemplatedResourceName resourceName;
+            if (s_template.TryParseName(metricName, out resourceName))
+            {
+                result = new MetricName(resourceName[0], resourceName[1]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="MetricName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
+        /// <param name="metricId">The metric ID. Must not be <c>null</c>.</param>
+        public MetricName(string projectId, string metricId)
+        {
+            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
+            MetricId = gax::GaxPreconditions.CheckNotNull(metricId, nameof(metricId));
+        }
+
+        /// <summary>
+        /// The project ID. Never <c>null</c>.
+        /// </summary>
+        public string ProjectId { get; }
+
+        /// <summary>
+        /// The metric ID. Never <c>null</c>.
+        /// </summary>
+        public string MetricId { get; }
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(ProjectId, MetricId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as MetricName);
+
+        /// <inheritdoc />
+        public bool Equals(MetricName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(MetricName a, MetricName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(MetricName a, MetricName b) => !(a == b);
+    }
+
+    /// <summary>
     /// Resource name which will contain one of a choice of resource names.
     /// </summary>
     /// <remarks>
@@ -2799,6 +1725,1080 @@ namespace Google.Cloud.Logging.V2
 
         /// <inheritdoc />
         public static bool operator !=(MetricNameOneof a, MetricNameOneof b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name for the 'organization' resource.
+    /// </summary>
+    public sealed partial class OrganizationName : gax::IResourceName, sys::IEquatable<OrganizationName>
+    {
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("organizations/{organization}");
+
+        /// <summary>
+        /// Parses the given organization resource name in string form into a new
+        /// <see cref="OrganizationName"/> instance.
+        /// </summary>
+        /// <param name="organizationName">The organization resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="OrganizationName"/> if successful.</returns>
+        public static OrganizationName Parse(string organizationName)
+        {
+            gax::GaxPreconditions.CheckNotNull(organizationName, nameof(organizationName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(organizationName);
+            return new OrganizationName(resourceName[0]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given organization resource name in string form into a new
+        /// <see cref="OrganizationName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="organizationName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="organizationName">The organization resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="OrganizationName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string organizationName, out OrganizationName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(organizationName, nameof(organizationName));
+            gax::TemplatedResourceName resourceName;
+            if (s_template.TryParseName(organizationName, out resourceName))
+            {
+                result = new OrganizationName(resourceName[0]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="OrganizationName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="organizationId">The organization ID. Must not be <c>null</c>.</param>
+        public OrganizationName(string organizationId)
+        {
+            OrganizationId = gax::GaxPreconditions.CheckNotNull(organizationId, nameof(organizationId));
+        }
+
+        /// <summary>
+        /// The organization ID. Never <c>null</c>.
+        /// </summary>
+        public string OrganizationId { get; }
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(OrganizationId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as OrganizationName);
+
+        /// <inheritdoc />
+        public bool Equals(OrganizationName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(OrganizationName a, OrganizationName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(OrganizationName a, OrganizationName b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name for the 'organization_exclusion' resource.
+    /// </summary>
+    public sealed partial class OrganizationExclusionName : gax::IResourceName, sys::IEquatable<OrganizationExclusionName>
+    {
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("organizations/{organization}/exclusions/{exclusion}");
+
+        /// <summary>
+        /// Parses the given organization_exclusion resource name in string form into a new
+        /// <see cref="OrganizationExclusionName"/> instance.
+        /// </summary>
+        /// <param name="organizationExclusionName">The organization_exclusion resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="OrganizationExclusionName"/> if successful.</returns>
+        public static OrganizationExclusionName Parse(string organizationExclusionName)
+        {
+            gax::GaxPreconditions.CheckNotNull(organizationExclusionName, nameof(organizationExclusionName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(organizationExclusionName);
+            return new OrganizationExclusionName(resourceName[0], resourceName[1]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given organization_exclusion resource name in string form into a new
+        /// <see cref="OrganizationExclusionName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="organizationExclusionName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="organizationExclusionName">The organization_exclusion resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="OrganizationExclusionName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string organizationExclusionName, out OrganizationExclusionName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(organizationExclusionName, nameof(organizationExclusionName));
+            gax::TemplatedResourceName resourceName;
+            if (s_template.TryParseName(organizationExclusionName, out resourceName))
+            {
+                result = new OrganizationExclusionName(resourceName[0], resourceName[1]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="OrganizationExclusionName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="organizationId">The organization ID. Must not be <c>null</c>.</param>
+        /// <param name="exclusionId">The exclusion ID. Must not be <c>null</c>.</param>
+        public OrganizationExclusionName(string organizationId, string exclusionId)
+        {
+            OrganizationId = gax::GaxPreconditions.CheckNotNull(organizationId, nameof(organizationId));
+            ExclusionId = gax::GaxPreconditions.CheckNotNull(exclusionId, nameof(exclusionId));
+        }
+
+        /// <summary>
+        /// The organization ID. Never <c>null</c>.
+        /// </summary>
+        public string OrganizationId { get; }
+
+        /// <summary>
+        /// The exclusion ID. Never <c>null</c>.
+        /// </summary>
+        public string ExclusionId { get; }
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(OrganizationId, ExclusionId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as OrganizationExclusionName);
+
+        /// <inheritdoc />
+        public bool Equals(OrganizationExclusionName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(OrganizationExclusionName a, OrganizationExclusionName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(OrganizationExclusionName a, OrganizationExclusionName b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name for the 'organization_log' resource.
+    /// </summary>
+    public sealed partial class OrganizationLogName : gax::IResourceName, sys::IEquatable<OrganizationLogName>
+    {
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("organizations/{organization}/logs/{log}");
+
+        /// <summary>
+        /// Parses the given organization_log resource name in string form into a new
+        /// <see cref="OrganizationLogName"/> instance.
+        /// </summary>
+        /// <param name="organizationLogName">The organization_log resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="OrganizationLogName"/> if successful.</returns>
+        public static OrganizationLogName Parse(string organizationLogName)
+        {
+            gax::GaxPreconditions.CheckNotNull(organizationLogName, nameof(organizationLogName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(organizationLogName);
+            return new OrganizationLogName(resourceName[0], resourceName[1]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given organization_log resource name in string form into a new
+        /// <see cref="OrganizationLogName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="organizationLogName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="organizationLogName">The organization_log resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="OrganizationLogName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string organizationLogName, out OrganizationLogName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(organizationLogName, nameof(organizationLogName));
+            gax::TemplatedResourceName resourceName;
+            if (s_template.TryParseName(organizationLogName, out resourceName))
+            {
+                result = new OrganizationLogName(resourceName[0], resourceName[1]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="OrganizationLogName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="organizationId">The organization ID. Must not be <c>null</c>.</param>
+        /// <param name="logId">The log ID. Must not be <c>null</c>.</param>
+        public OrganizationLogName(string organizationId, string logId)
+        {
+            OrganizationId = gax::GaxPreconditions.CheckNotNull(organizationId, nameof(organizationId));
+            LogId = gax::GaxPreconditions.CheckNotNull(logId, nameof(logId));
+        }
+
+        /// <summary>
+        /// The organization ID. Never <c>null</c>.
+        /// </summary>
+        public string OrganizationId { get; }
+
+        /// <summary>
+        /// The log ID. Never <c>null</c>.
+        /// </summary>
+        public string LogId { get; }
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(OrganizationId, LogId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as OrganizationLogName);
+
+        /// <inheritdoc />
+        public bool Equals(OrganizationLogName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(OrganizationLogName a, OrganizationLogName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(OrganizationLogName a, OrganizationLogName b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name for the 'organization_sink' resource.
+    /// </summary>
+    public sealed partial class OrganizationSinkName : gax::IResourceName, sys::IEquatable<OrganizationSinkName>
+    {
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("organizations/{organization}/sinks/{sink}");
+
+        /// <summary>
+        /// Parses the given organization_sink resource name in string form into a new
+        /// <see cref="OrganizationSinkName"/> instance.
+        /// </summary>
+        /// <param name="organizationSinkName">The organization_sink resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="OrganizationSinkName"/> if successful.</returns>
+        public static OrganizationSinkName Parse(string organizationSinkName)
+        {
+            gax::GaxPreconditions.CheckNotNull(organizationSinkName, nameof(organizationSinkName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(organizationSinkName);
+            return new OrganizationSinkName(resourceName[0], resourceName[1]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given organization_sink resource name in string form into a new
+        /// <see cref="OrganizationSinkName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="organizationSinkName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="organizationSinkName">The organization_sink resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="OrganizationSinkName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string organizationSinkName, out OrganizationSinkName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(organizationSinkName, nameof(organizationSinkName));
+            gax::TemplatedResourceName resourceName;
+            if (s_template.TryParseName(organizationSinkName, out resourceName))
+            {
+                result = new OrganizationSinkName(resourceName[0], resourceName[1]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="OrganizationSinkName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="organizationId">The organization ID. Must not be <c>null</c>.</param>
+        /// <param name="sinkId">The sink ID. Must not be <c>null</c>.</param>
+        public OrganizationSinkName(string organizationId, string sinkId)
+        {
+            OrganizationId = gax::GaxPreconditions.CheckNotNull(organizationId, nameof(organizationId));
+            SinkId = gax::GaxPreconditions.CheckNotNull(sinkId, nameof(sinkId));
+        }
+
+        /// <summary>
+        /// The organization ID. Never <c>null</c>.
+        /// </summary>
+        public string OrganizationId { get; }
+
+        /// <summary>
+        /// The sink ID. Never <c>null</c>.
+        /// </summary>
+        public string SinkId { get; }
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(OrganizationId, SinkId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as OrganizationSinkName);
+
+        /// <inheritdoc />
+        public bool Equals(OrganizationSinkName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(OrganizationSinkName a, OrganizationSinkName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(OrganizationSinkName a, OrganizationSinkName b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name which will contain one of a choice of resource names.
+    /// </summary>
+    /// <remarks>
+    /// This resource name will contain one of the following:
+    /// <list type="bullet">
+    /// <item><description>ProjectName: A resource of type 'project'.</description></item>
+    /// <item><description>OrganizationName: A resource of type 'organization'.</description></item>
+    /// <item><description>FolderName: A resource of type 'folder'.</description></item>
+    /// <item><description>BillingName: A resource of type 'billing'.</description></item>
+    /// </list>
+    /// </remarks>
+    public sealed partial class ParentNameOneof : gax::IResourceName, sys::IEquatable<ParentNameOneof>
+    {
+        /// <summary>
+        /// The possible contents of <see cref="ParentNameOneof"/>.
+        /// </summary>
+        public enum OneofType
+        {
+            /// <summary>
+            /// A resource of an unknown type.
+            /// </summary>
+            Unknown = 0,
+
+            /// <summary>
+            /// A resource of type 'project'.
+            /// </summary>
+            ProjectName = 1,
+
+            /// <summary>
+            /// A resource of type 'organization'.
+            /// </summary>
+            OrganizationName = 2,
+
+            /// <summary>
+            /// A resource of type 'folder'.
+            /// </summary>
+            FolderName = 3,
+
+            /// <summary>
+            /// A resource of type 'billing'.
+            /// </summary>
+            BillingName = 4,
+        }
+
+        /// <summary>
+        /// Parses a resource name in string form into a new <see cref="ParentNameOneof"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully the resource name must be one of the following:
+        /// <list type="bullet">
+        /// <item><description>ProjectName: A resource of type 'project'.</description></item>
+        /// <item><description>OrganizationName: A resource of type 'organization'.</description></item>
+        /// <item><description>FolderName: A resource of type 'folder'.</description></item>
+        /// <item><description>BillingName: A resource of type 'billing'.</description></item>
+        /// </list>
+        /// Or an <see cref="gax::UnknownResourceName"/> if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnknown">If true, will successfully parse an unknown resource name
+        /// into an <see cref="gax::UnknownResourceName"/>; otherwise will throw an
+        /// <see cref="sys::ArgumentException"/> if an unknown resource name is given.</param>
+        /// <returns>The parsed <see cref="ParentNameOneof"/> if successful.</returns>
+        public static ParentNameOneof Parse(string name, bool allowUnknown)
+        {
+            ParentNameOneof result;
+            if (TryParse(name, allowUnknown, out result))
+            {
+                return result;
+            }
+            throw new sys::ArgumentException("Invalid name", nameof(name));
+        }
+
+        /// <summary>
+        /// Tries to parse a resource name in string form into a new <see cref="ParentNameOneof"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully the resource name must be one of the following:
+        /// <list type="bullet">
+        /// <item><description>ProjectName: A resource of type 'project'.</description></item>
+        /// <item><description>OrganizationName: A resource of type 'organization'.</description></item>
+        /// <item><description>FolderName: A resource of type 'folder'.</description></item>
+        /// <item><description>BillingName: A resource of type 'billing'.</description></item>
+        /// </list>
+        /// Or an <see cref="gax::UnknownResourceName"/> if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnknown">If true, will successfully parse an unknown resource name
+        /// into an <see cref="gax::UnknownResourceName"/>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="ParentNameOneof"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string name, bool allowUnknown, out ParentNameOneof result)
+        {
+            gax::GaxPreconditions.CheckNotNull(name, nameof(name));
+            ProjectName projectName;
+            if (ProjectName.TryParse(name, out projectName))
+            {
+                result = new ParentNameOneof(OneofType.ProjectName, projectName);
+                return true;
+            }
+            OrganizationName organizationName;
+            if (OrganizationName.TryParse(name, out organizationName))
+            {
+                result = new ParentNameOneof(OneofType.OrganizationName, organizationName);
+                return true;
+            }
+            FolderName folderName;
+            if (FolderName.TryParse(name, out folderName))
+            {
+                result = new ParentNameOneof(OneofType.FolderName, folderName);
+                return true;
+            }
+            BillingName billingName;
+            if (BillingName.TryParse(name, out billingName))
+            {
+                result = new ParentNameOneof(OneofType.BillingName, billingName);
+                return true;
+            }
+            if (allowUnknown)
+            {
+                gax::UnknownResourceName unknownResourceName;
+                if (gax::UnknownResourceName.TryParse(name, out unknownResourceName))
+                {
+                    result = new ParentNameOneof(OneofType.Unknown, unknownResourceName);
+                    return true;
+                }
+            }
+            result = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Construct a new instance of <see cref="ParentNameOneof"/> from the provided <see cref="ProjectName"/>
+        /// </summary>
+        /// <param name="projectName">The <see cref="ProjectName"/> to be contained within
+        /// the returned <see cref="ParentNameOneof"/>. Must not be <c>null</c>.</param>
+        /// <returns>A new <see cref="ParentNameOneof"/>, containing <paramref name="projectName"/>.</returns>
+        public static ParentNameOneof From(ProjectName projectName) => new ParentNameOneof(OneofType.ProjectName, projectName);
+
+        /// <summary>
+        /// Construct a new instance of <see cref="ParentNameOneof"/> from the provided <see cref="OrganizationName"/>
+        /// </summary>
+        /// <param name="organizationName">The <see cref="OrganizationName"/> to be contained within
+        /// the returned <see cref="ParentNameOneof"/>. Must not be <c>null</c>.</param>
+        /// <returns>A new <see cref="ParentNameOneof"/>, containing <paramref name="organizationName"/>.</returns>
+        public static ParentNameOneof From(OrganizationName organizationName) => new ParentNameOneof(OneofType.OrganizationName, organizationName);
+
+        /// <summary>
+        /// Construct a new instance of <see cref="ParentNameOneof"/> from the provided <see cref="FolderName"/>
+        /// </summary>
+        /// <param name="folderName">The <see cref="FolderName"/> to be contained within
+        /// the returned <see cref="ParentNameOneof"/>. Must not be <c>null</c>.</param>
+        /// <returns>A new <see cref="ParentNameOneof"/>, containing <paramref name="folderName"/>.</returns>
+        public static ParentNameOneof From(FolderName folderName) => new ParentNameOneof(OneofType.FolderName, folderName);
+
+        /// <summary>
+        /// Construct a new instance of <see cref="ParentNameOneof"/> from the provided <see cref="BillingName"/>
+        /// </summary>
+        /// <param name="billingName">The <see cref="BillingName"/> to be contained within
+        /// the returned <see cref="ParentNameOneof"/>. Must not be <c>null</c>.</param>
+        /// <returns>A new <see cref="ParentNameOneof"/>, containing <paramref name="billingName"/>.</returns>
+        public static ParentNameOneof From(BillingName billingName) => new ParentNameOneof(OneofType.BillingName, billingName);
+
+        private static bool IsValid(OneofType type, gax::IResourceName name)
+        {
+            switch (type)
+            {
+                case OneofType.Unknown: return true; // Anything goes with Unknown.
+                case OneofType.ProjectName: return name is ProjectName;
+                case OneofType.OrganizationName: return name is OrganizationName;
+                case OneofType.FolderName: return name is FolderName;
+                case OneofType.BillingName: return name is BillingName;
+                default: return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="ParentNameOneof"/> resource name class
+        /// from a suitable <see cref="gax::IResourceName"/> instance.
+        /// </summary>
+        public ParentNameOneof(OneofType type, gax::IResourceName name)
+        {
+            Type = gax::GaxPreconditions.CheckEnumValue<OneofType>(type, nameof(type));
+            Name = gax::GaxPreconditions.CheckNotNull(name, nameof(name));
+            if (!IsValid(type, name))
+            {
+                throw new sys::ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
+            }
+        }
+
+        /// <summary>
+        /// The <see cref="OneofType"/> of the Name contained in this instance.
+        /// </summary>
+        public OneofType Type { get; }
+
+        /// <summary>
+        /// The <see cref="gax::IResourceName"/> contained in this instance.
+        /// </summary>
+        public gax::IResourceName Name { get; }
+
+        private T CheckAndReturn<T>(OneofType type)
+        {
+            if (Type != type)
+            {
+                throw new sys::InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
+            }
+            return (T)Name;
+        }
+
+        /// <summary>
+        /// Get the contained <see cref="gax::IResourceName"/> as <see cref="ProjectName"/>.
+        /// </summary>
+        /// <remarks>
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
+        /// contain an instance of <see cref="ProjectName"/>.
+        /// </remarks>
+        public ProjectName ProjectName => CheckAndReturn<ProjectName>(OneofType.ProjectName);
+
+        /// <summary>
+        /// Get the contained <see cref="gax::IResourceName"/> as <see cref="OrganizationName"/>.
+        /// </summary>
+        /// <remarks>
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
+        /// contain an instance of <see cref="OrganizationName"/>.
+        /// </remarks>
+        public OrganizationName OrganizationName => CheckAndReturn<OrganizationName>(OneofType.OrganizationName);
+
+        /// <summary>
+        /// Get the contained <see cref="gax::IResourceName"/> as <see cref="FolderName"/>.
+        /// </summary>
+        /// <remarks>
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
+        /// contain an instance of <see cref="FolderName"/>.
+        /// </remarks>
+        public FolderName FolderName => CheckAndReturn<FolderName>(OneofType.FolderName);
+
+        /// <summary>
+        /// Get the contained <see cref="gax::IResourceName"/> as <see cref="BillingName"/>.
+        /// </summary>
+        /// <remarks>
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
+        /// contain an instance of <see cref="BillingName"/>.
+        /// </remarks>
+        public BillingName BillingName => CheckAndReturn<BillingName>(OneofType.BillingName);
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Oneof;
+
+        /// <inheritdoc />
+        public override string ToString() => Name.ToString();
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as ParentNameOneof);
+
+        /// <inheritdoc />
+        public bool Equals(ParentNameOneof other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(ParentNameOneof a, ParentNameOneof b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(ParentNameOneof a, ParentNameOneof b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name for the 'project' resource.
+    /// </summary>
+    public sealed partial class ProjectName : gax::IResourceName, sys::IEquatable<ProjectName>
+    {
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}");
+
+        /// <summary>
+        /// Parses the given project resource name in string form into a new
+        /// <see cref="ProjectName"/> instance.
+        /// </summary>
+        /// <param name="projectName">The project resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="ProjectName"/> if successful.</returns>
+        public static ProjectName Parse(string projectName)
+        {
+            gax::GaxPreconditions.CheckNotNull(projectName, nameof(projectName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(projectName);
+            return new ProjectName(resourceName[0]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given project resource name in string form into a new
+        /// <see cref="ProjectName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="projectName">The project resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="ProjectName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string projectName, out ProjectName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(projectName, nameof(projectName));
+            gax::TemplatedResourceName resourceName;
+            if (s_template.TryParseName(projectName, out resourceName))
+            {
+                result = new ProjectName(resourceName[0]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="ProjectName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
+        public ProjectName(string projectId)
+        {
+            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
+        }
+
+        /// <summary>
+        /// The project ID. Never <c>null</c>.
+        /// </summary>
+        public string ProjectId { get; }
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(ProjectId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as ProjectName);
+
+        /// <inheritdoc />
+        public bool Equals(ProjectName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(ProjectName a, ProjectName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(ProjectName a, ProjectName b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name for the 'sink' resource.
+    /// </summary>
+    public sealed partial class SinkName : gax::IResourceName, sys::IEquatable<SinkName>
+    {
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/sinks/{sink}");
+
+        /// <summary>
+        /// Parses the given sink resource name in string form into a new
+        /// <see cref="SinkName"/> instance.
+        /// </summary>
+        /// <param name="sinkName">The sink resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="SinkName"/> if successful.</returns>
+        public static SinkName Parse(string sinkName)
+        {
+            gax::GaxPreconditions.CheckNotNull(sinkName, nameof(sinkName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(sinkName);
+            return new SinkName(resourceName[0], resourceName[1]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given sink resource name in string form into a new
+        /// <see cref="SinkName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="sinkName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="sinkName">The sink resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="SinkName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string sinkName, out SinkName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(sinkName, nameof(sinkName));
+            gax::TemplatedResourceName resourceName;
+            if (s_template.TryParseName(sinkName, out resourceName))
+            {
+                result = new SinkName(resourceName[0], resourceName[1]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="SinkName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
+        /// <param name="sinkId">The sink ID. Must not be <c>null</c>.</param>
+        public SinkName(string projectId, string sinkId)
+        {
+            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
+            SinkId = gax::GaxPreconditions.CheckNotNull(sinkId, nameof(sinkId));
+        }
+
+        /// <summary>
+        /// The project ID. Never <c>null</c>.
+        /// </summary>
+        public string ProjectId { get; }
+
+        /// <summary>
+        /// The sink ID. Never <c>null</c>.
+        /// </summary>
+        public string SinkId { get; }
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(ProjectId, SinkId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as SinkName);
+
+        /// <inheritdoc />
+        public bool Equals(SinkName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(SinkName a, SinkName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(SinkName a, SinkName b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name which will contain one of a choice of resource names.
+    /// </summary>
+    /// <remarks>
+    /// This resource name will contain one of the following:
+    /// <list type="bullet">
+    /// <item><description>SinkName: A resource of type 'sink'.</description></item>
+    /// <item><description>OrganizationSinkName: A resource of type 'organization_sink'.</description></item>
+    /// <item><description>FolderSinkName: A resource of type 'folder_sink'.</description></item>
+    /// <item><description>BillingSinkName: A resource of type 'billing_sink'.</description></item>
+    /// </list>
+    /// </remarks>
+    public sealed partial class SinkNameOneof : gax::IResourceName, sys::IEquatable<SinkNameOneof>
+    {
+        /// <summary>
+        /// The possible contents of <see cref="SinkNameOneof"/>.
+        /// </summary>
+        public enum OneofType
+        {
+            /// <summary>
+            /// A resource of an unknown type.
+            /// </summary>
+            Unknown = 0,
+
+            /// <summary>
+            /// A resource of type 'sink'.
+            /// </summary>
+            SinkName = 1,
+
+            /// <summary>
+            /// A resource of type 'organization_sink'.
+            /// </summary>
+            OrganizationSinkName = 2,
+
+            /// <summary>
+            /// A resource of type 'folder_sink'.
+            /// </summary>
+            FolderSinkName = 3,
+
+            /// <summary>
+            /// A resource of type 'billing_sink'.
+            /// </summary>
+            BillingSinkName = 4,
+        }
+
+        /// <summary>
+        /// Parses a resource name in string form into a new <see cref="SinkNameOneof"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully the resource name must be one of the following:
+        /// <list type="bullet">
+        /// <item><description>SinkName: A resource of type 'sink'.</description></item>
+        /// <item><description>OrganizationSinkName: A resource of type 'organization_sink'.</description></item>
+        /// <item><description>FolderSinkName: A resource of type 'folder_sink'.</description></item>
+        /// <item><description>BillingSinkName: A resource of type 'billing_sink'.</description></item>
+        /// </list>
+        /// Or an <see cref="gax::UnknownResourceName"/> if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnknown">If true, will successfully parse an unknown resource name
+        /// into an <see cref="gax::UnknownResourceName"/>; otherwise will throw an
+        /// <see cref="sys::ArgumentException"/> if an unknown resource name is given.</param>
+        /// <returns>The parsed <see cref="SinkNameOneof"/> if successful.</returns>
+        public static SinkNameOneof Parse(string name, bool allowUnknown)
+        {
+            SinkNameOneof result;
+            if (TryParse(name, allowUnknown, out result))
+            {
+                return result;
+            }
+            throw new sys::ArgumentException("Invalid name", nameof(name));
+        }
+
+        /// <summary>
+        /// Tries to parse a resource name in string form into a new <see cref="SinkNameOneof"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// To parse successfully the resource name must be one of the following:
+        /// <list type="bullet">
+        /// <item><description>SinkName: A resource of type 'sink'.</description></item>
+        /// <item><description>OrganizationSinkName: A resource of type 'organization_sink'.</description></item>
+        /// <item><description>FolderSinkName: A resource of type 'folder_sink'.</description></item>
+        /// <item><description>BillingSinkName: A resource of type 'billing_sink'.</description></item>
+        /// </list>
+        /// Or an <see cref="gax::UnknownResourceName"/> if <paramref name="allowUnknown"/> is <c>true</c>.
+        /// </remarks>
+        /// <param name="name">The resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="allowUnknown">If true, will successfully parse an unknown resource name
+        /// into an <see cref="gax::UnknownResourceName"/>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="SinkNameOneof"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string name, bool allowUnknown, out SinkNameOneof result)
+        {
+            gax::GaxPreconditions.CheckNotNull(name, nameof(name));
+            SinkName sinkName;
+            if (SinkName.TryParse(name, out sinkName))
+            {
+                result = new SinkNameOneof(OneofType.SinkName, sinkName);
+                return true;
+            }
+            OrganizationSinkName organizationSinkName;
+            if (OrganizationSinkName.TryParse(name, out organizationSinkName))
+            {
+                result = new SinkNameOneof(OneofType.OrganizationSinkName, organizationSinkName);
+                return true;
+            }
+            FolderSinkName folderSinkName;
+            if (FolderSinkName.TryParse(name, out folderSinkName))
+            {
+                result = new SinkNameOneof(OneofType.FolderSinkName, folderSinkName);
+                return true;
+            }
+            BillingSinkName billingSinkName;
+            if (BillingSinkName.TryParse(name, out billingSinkName))
+            {
+                result = new SinkNameOneof(OneofType.BillingSinkName, billingSinkName);
+                return true;
+            }
+            if (allowUnknown)
+            {
+                gax::UnknownResourceName unknownResourceName;
+                if (gax::UnknownResourceName.TryParse(name, out unknownResourceName))
+                {
+                    result = new SinkNameOneof(OneofType.Unknown, unknownResourceName);
+                    return true;
+                }
+            }
+            result = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Construct a new instance of <see cref="SinkNameOneof"/> from the provided <see cref="SinkName"/>
+        /// </summary>
+        /// <param name="sinkName">The <see cref="SinkName"/> to be contained within
+        /// the returned <see cref="SinkNameOneof"/>. Must not be <c>null</c>.</param>
+        /// <returns>A new <see cref="SinkNameOneof"/>, containing <paramref name="sinkName"/>.</returns>
+        public static SinkNameOneof From(SinkName sinkName) => new SinkNameOneof(OneofType.SinkName, sinkName);
+
+        /// <summary>
+        /// Construct a new instance of <see cref="SinkNameOneof"/> from the provided <see cref="OrganizationSinkName"/>
+        /// </summary>
+        /// <param name="organizationSinkName">The <see cref="OrganizationSinkName"/> to be contained within
+        /// the returned <see cref="SinkNameOneof"/>. Must not be <c>null</c>.</param>
+        /// <returns>A new <see cref="SinkNameOneof"/>, containing <paramref name="organizationSinkName"/>.</returns>
+        public static SinkNameOneof From(OrganizationSinkName organizationSinkName) => new SinkNameOneof(OneofType.OrganizationSinkName, organizationSinkName);
+
+        /// <summary>
+        /// Construct a new instance of <see cref="SinkNameOneof"/> from the provided <see cref="FolderSinkName"/>
+        /// </summary>
+        /// <param name="folderSinkName">The <see cref="FolderSinkName"/> to be contained within
+        /// the returned <see cref="SinkNameOneof"/>. Must not be <c>null</c>.</param>
+        /// <returns>A new <see cref="SinkNameOneof"/>, containing <paramref name="folderSinkName"/>.</returns>
+        public static SinkNameOneof From(FolderSinkName folderSinkName) => new SinkNameOneof(OneofType.FolderSinkName, folderSinkName);
+
+        /// <summary>
+        /// Construct a new instance of <see cref="SinkNameOneof"/> from the provided <see cref="BillingSinkName"/>
+        /// </summary>
+        /// <param name="billingSinkName">The <see cref="BillingSinkName"/> to be contained within
+        /// the returned <see cref="SinkNameOneof"/>. Must not be <c>null</c>.</param>
+        /// <returns>A new <see cref="SinkNameOneof"/>, containing <paramref name="billingSinkName"/>.</returns>
+        public static SinkNameOneof From(BillingSinkName billingSinkName) => new SinkNameOneof(OneofType.BillingSinkName, billingSinkName);
+
+        private static bool IsValid(OneofType type, gax::IResourceName name)
+        {
+            switch (type)
+            {
+                case OneofType.Unknown: return true; // Anything goes with Unknown.
+                case OneofType.SinkName: return name is SinkName;
+                case OneofType.OrganizationSinkName: return name is OrganizationSinkName;
+                case OneofType.FolderSinkName: return name is FolderSinkName;
+                case OneofType.BillingSinkName: return name is BillingSinkName;
+                default: return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="SinkNameOneof"/> resource name class
+        /// from a suitable <see cref="gax::IResourceName"/> instance.
+        /// </summary>
+        public SinkNameOneof(OneofType type, gax::IResourceName name)
+        {
+            Type = gax::GaxPreconditions.CheckEnumValue<OneofType>(type, nameof(type));
+            Name = gax::GaxPreconditions.CheckNotNull(name, nameof(name));
+            if (!IsValid(type, name))
+            {
+                throw new sys::ArgumentException($"Mismatched OneofType '{type}' and resource name '{name}'");
+            }
+        }
+
+        /// <summary>
+        /// The <see cref="OneofType"/> of the Name contained in this instance.
+        /// </summary>
+        public OneofType Type { get; }
+
+        /// <summary>
+        /// The <see cref="gax::IResourceName"/> contained in this instance.
+        /// </summary>
+        public gax::IResourceName Name { get; }
+
+        private T CheckAndReturn<T>(OneofType type)
+        {
+            if (Type != type)
+            {
+                throw new sys::InvalidOperationException($"Requested type {type}, but this one-of contains type {Type}");
+            }
+            return (T)Name;
+        }
+
+        /// <summary>
+        /// Get the contained <see cref="gax::IResourceName"/> as <see cref="SinkName"/>.
+        /// </summary>
+        /// <remarks>
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
+        /// contain an instance of <see cref="SinkName"/>.
+        /// </remarks>
+        public SinkName SinkName => CheckAndReturn<SinkName>(OneofType.SinkName);
+
+        /// <summary>
+        /// Get the contained <see cref="gax::IResourceName"/> as <see cref="OrganizationSinkName"/>.
+        /// </summary>
+        /// <remarks>
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
+        /// contain an instance of <see cref="OrganizationSinkName"/>.
+        /// </remarks>
+        public OrganizationSinkName OrganizationSinkName => CheckAndReturn<OrganizationSinkName>(OneofType.OrganizationSinkName);
+
+        /// <summary>
+        /// Get the contained <see cref="gax::IResourceName"/> as <see cref="FolderSinkName"/>.
+        /// </summary>
+        /// <remarks>
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
+        /// contain an instance of <see cref="FolderSinkName"/>.
+        /// </remarks>
+        public FolderSinkName FolderSinkName => CheckAndReturn<FolderSinkName>(OneofType.FolderSinkName);
+
+        /// <summary>
+        /// Get the contained <see cref="gax::IResourceName"/> as <see cref="BillingSinkName"/>.
+        /// </summary>
+        /// <remarks>
+        /// An <see cref="sys::InvalidOperationException"/> will be thrown if this does not
+        /// contain an instance of <see cref="BillingSinkName"/>.
+        /// </remarks>
+        public BillingSinkName BillingSinkName => CheckAndReturn<BillingSinkName>(OneofType.BillingSinkName);
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Oneof;
+
+        /// <inheritdoc />
+        public override string ToString() => Name.ToString();
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as SinkNameOneof);
+
+        /// <inheritdoc />
+        public bool Equals(SinkNameOneof other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(SinkNameOneof a, SinkNameOneof b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(SinkNameOneof a, SinkNameOneof b) => !(a == b);
     }
 
 

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/ResourceNames.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/ResourceNames.cs
@@ -21,91 +21,6 @@ using linq = System.Linq;
 namespace Google.Cloud.Monitoring.V3
 {
     /// <summary>
-    /// Resource name for the 'project' resource.
-    /// </summary>
-    public sealed partial class ProjectName : gax::IResourceName, sys::IEquatable<ProjectName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}");
-
-        /// <summary>
-        /// Parses the given project resource name in string form into a new
-        /// <see cref="ProjectName"/> instance.
-        /// </summary>
-        /// <param name="projectName">The project resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="ProjectName"/> if successful.</returns>
-        public static ProjectName Parse(string projectName)
-        {
-            gax::GaxPreconditions.CheckNotNull(projectName, nameof(projectName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(projectName);
-            return new ProjectName(resourceName[0]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given project resource name in string form into a new
-        /// <see cref="ProjectName"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectName"/> is null,
-        /// as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="projectName">The project resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="ProjectName"/>,
-        /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string projectName, out ProjectName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(projectName, nameof(projectName));
-            gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(projectName, out resourceName))
-            {
-                result = new ProjectName(resourceName[0]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="ProjectName"/> resource name class
-        /// from its component parts.
-        /// </summary>
-        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
-        public ProjectName(string projectId)
-        {
-            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
-        }
-
-        /// <summary>
-        /// The project ID. Never <c>null</c>.
-        /// </summary>
-        public string ProjectId { get; }
-
-        /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc />
-        public override string ToString() => s_template.Expand(ProjectId);
-
-        /// <inheritdoc />
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as ProjectName);
-
-        /// <inheritdoc />
-        public bool Equals(ProjectName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc />
-        public static bool operator ==(ProjectName a, ProjectName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc />
-        public static bool operator !=(ProjectName a, ProjectName b) => !(a == b);
-    }
-
-    /// <summary>
     /// Resource name for the 'alert_policy' resource.
     /// </summary>
     public sealed partial class AlertPolicyName : gax::IResourceName, sys::IEquatable<AlertPolicyName>
@@ -754,6 +669,91 @@ namespace Google.Cloud.Monitoring.V3
 
         /// <inheritdoc />
         public static bool operator !=(NotificationChannelDescriptorName a, NotificationChannelDescriptorName b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name for the 'project' resource.
+    /// </summary>
+    public sealed partial class ProjectName : gax::IResourceName, sys::IEquatable<ProjectName>
+    {
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}");
+
+        /// <summary>
+        /// Parses the given project resource name in string form into a new
+        /// <see cref="ProjectName"/> instance.
+        /// </summary>
+        /// <param name="projectName">The project resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="ProjectName"/> if successful.</returns>
+        public static ProjectName Parse(string projectName)
+        {
+            gax::GaxPreconditions.CheckNotNull(projectName, nameof(projectName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(projectName);
+            return new ProjectName(resourceName[0]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given project resource name in string form into a new
+        /// <see cref="ProjectName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="projectName">The project resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="ProjectName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string projectName, out ProjectName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(projectName, nameof(projectName));
+            gax::TemplatedResourceName resourceName;
+            if (s_template.TryParseName(projectName, out resourceName))
+            {
+                result = new ProjectName(resourceName[0]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="ProjectName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
+        public ProjectName(string projectId)
+        {
+            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
+        }
+
+        /// <summary>
+        /// The project ID. Never <c>null</c>.
+        /// </summary>
+        public string ProjectId { get; }
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(ProjectId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as ProjectName);
+
+        /// <inheritdoc />
+        public bool Equals(ProjectName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(ProjectName a, ProjectName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(ProjectName a, ProjectName b) => !(a == b);
     }
 
     /// <summary>

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1/ResourceNames.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1/ResourceNames.cs
@@ -21,44 +21,44 @@ using linq = System.Linq;
 namespace Google.Cloud.OsLogin.V1
 {
     /// <summary>
-    /// Resource name for the 'user' resource.
+    /// Resource name for the 'fingerprint' resource.
     /// </summary>
-    public sealed partial class UserName : gax::IResourceName, sys::IEquatable<UserName>
+    public sealed partial class FingerprintName : gax::IResourceName, sys::IEquatable<FingerprintName>
     {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("users/{user}");
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("users/{user}/sshPublicKeys/{fingerprint}");
 
         /// <summary>
-        /// Parses the given user resource name in string form into a new
-        /// <see cref="UserName"/> instance.
+        /// Parses the given fingerprint resource name in string form into a new
+        /// <see cref="FingerprintName"/> instance.
         /// </summary>
-        /// <param name="userName">The user resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="UserName"/> if successful.</returns>
-        public static UserName Parse(string userName)
+        /// <param name="fingerprintName">The fingerprint resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="FingerprintName"/> if successful.</returns>
+        public static FingerprintName Parse(string fingerprintName)
         {
-            gax::GaxPreconditions.CheckNotNull(userName, nameof(userName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(userName);
-            return new UserName(resourceName[0]);
+            gax::GaxPreconditions.CheckNotNull(fingerprintName, nameof(fingerprintName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(fingerprintName);
+            return new FingerprintName(resourceName[0], resourceName[1]);
         }
 
         /// <summary>
-        /// Tries to parse the given user resource name in string form into a new
-        /// <see cref="UserName"/> instance.
+        /// Tries to parse the given fingerprint resource name in string form into a new
+        /// <see cref="FingerprintName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="userName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="fingerprintName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
-        /// <param name="userName">The user resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="UserName"/>,
+        /// <param name="fingerprintName">The fingerprint resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="FingerprintName"/>,
         /// or <c>null</c> if parsing fails.</param>
         /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string userName, out UserName result)
+        public static bool TryParse(string fingerprintName, out FingerprintName result)
         {
-            gax::GaxPreconditions.CheckNotNull(userName, nameof(userName));
+            gax::GaxPreconditions.CheckNotNull(fingerprintName, nameof(fingerprintName));
             gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(userName, out resourceName))
+            if (s_template.TryParseName(fingerprintName, out resourceName))
             {
-                result = new UserName(resourceName[0]);
+                result = new FingerprintName(resourceName[0], resourceName[1]);
                 return true;
             }
             else
@@ -69,13 +69,15 @@ namespace Google.Cloud.OsLogin.V1
         }
 
         /// <summary>
-        /// Constructs a new instance of the <see cref="UserName"/> resource name class
+        /// Constructs a new instance of the <see cref="FingerprintName"/> resource name class
         /// from its component parts.
         /// </summary>
         /// <param name="userId">The user ID. Must not be <c>null</c>.</param>
-        public UserName(string userId)
+        /// <param name="fingerprintId">The fingerprint ID. Must not be <c>null</c>.</param>
+        public FingerprintName(string userId, string fingerprintId)
         {
             UserId = gax::GaxPreconditions.CheckNotNull(userId, nameof(userId));
+            FingerprintId = gax::GaxPreconditions.CheckNotNull(fingerprintId, nameof(fingerprintId));
         }
 
         /// <summary>
@@ -83,26 +85,31 @@ namespace Google.Cloud.OsLogin.V1
         /// </summary>
         public string UserId { get; }
 
+        /// <summary>
+        /// The fingerprint ID. Never <c>null</c>.
+        /// </summary>
+        public string FingerprintId { get; }
+
         /// <inheritdoc />
         public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
 
         /// <inheritdoc />
-        public override string ToString() => s_template.Expand(UserId);
+        public override string ToString() => s_template.Expand(UserId, FingerprintId);
 
         /// <inheritdoc />
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as UserName);
+        public override bool Equals(object obj) => Equals(obj as FingerprintName);
 
         /// <inheritdoc />
-        public bool Equals(UserName other) => ToString() == other?.ToString();
+        public bool Equals(FingerprintName other) => ToString() == other?.ToString();
 
         /// <inheritdoc />
-        public static bool operator ==(UserName a, UserName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+        public static bool operator ==(FingerprintName a, FingerprintName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
 
         /// <inheritdoc />
-        public static bool operator !=(UserName a, UserName b) => !(a == b);
+        public static bool operator !=(FingerprintName a, FingerprintName b) => !(a == b);
     }
 
     /// <summary>
@@ -198,44 +205,44 @@ namespace Google.Cloud.OsLogin.V1
     }
 
     /// <summary>
-    /// Resource name for the 'fingerprint' resource.
+    /// Resource name for the 'user' resource.
     /// </summary>
-    public sealed partial class FingerprintName : gax::IResourceName, sys::IEquatable<FingerprintName>
+    public sealed partial class UserName : gax::IResourceName, sys::IEquatable<UserName>
     {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("users/{user}/sshPublicKeys/{fingerprint}");
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("users/{user}");
 
         /// <summary>
-        /// Parses the given fingerprint resource name in string form into a new
-        /// <see cref="FingerprintName"/> instance.
+        /// Parses the given user resource name in string form into a new
+        /// <see cref="UserName"/> instance.
         /// </summary>
-        /// <param name="fingerprintName">The fingerprint resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="FingerprintName"/> if successful.</returns>
-        public static FingerprintName Parse(string fingerprintName)
+        /// <param name="userName">The user resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="UserName"/> if successful.</returns>
+        public static UserName Parse(string userName)
         {
-            gax::GaxPreconditions.CheckNotNull(fingerprintName, nameof(fingerprintName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(fingerprintName);
-            return new FingerprintName(resourceName[0], resourceName[1]);
+            gax::GaxPreconditions.CheckNotNull(userName, nameof(userName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(userName);
+            return new UserName(resourceName[0]);
         }
 
         /// <summary>
-        /// Tries to parse the given fingerprint resource name in string form into a new
-        /// <see cref="FingerprintName"/> instance.
+        /// Tries to parse the given user resource name in string form into a new
+        /// <see cref="UserName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="fingerprintName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="userName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
-        /// <param name="fingerprintName">The fingerprint resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="FingerprintName"/>,
+        /// <param name="userName">The user resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="UserName"/>,
         /// or <c>null</c> if parsing fails.</param>
         /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string fingerprintName, out FingerprintName result)
+        public static bool TryParse(string userName, out UserName result)
         {
-            gax::GaxPreconditions.CheckNotNull(fingerprintName, nameof(fingerprintName));
+            gax::GaxPreconditions.CheckNotNull(userName, nameof(userName));
             gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(fingerprintName, out resourceName))
+            if (s_template.TryParseName(userName, out resourceName))
             {
-                result = new FingerprintName(resourceName[0], resourceName[1]);
+                result = new UserName(resourceName[0]);
                 return true;
             }
             else
@@ -246,15 +253,13 @@ namespace Google.Cloud.OsLogin.V1
         }
 
         /// <summary>
-        /// Constructs a new instance of the <see cref="FingerprintName"/> resource name class
+        /// Constructs a new instance of the <see cref="UserName"/> resource name class
         /// from its component parts.
         /// </summary>
         /// <param name="userId">The user ID. Must not be <c>null</c>.</param>
-        /// <param name="fingerprintId">The fingerprint ID. Must not be <c>null</c>.</param>
-        public FingerprintName(string userId, string fingerprintId)
+        public UserName(string userId)
         {
             UserId = gax::GaxPreconditions.CheckNotNull(userId, nameof(userId));
-            FingerprintId = gax::GaxPreconditions.CheckNotNull(fingerprintId, nameof(fingerprintId));
         }
 
         /// <summary>
@@ -262,31 +267,26 @@ namespace Google.Cloud.OsLogin.V1
         /// </summary>
         public string UserId { get; }
 
-        /// <summary>
-        /// The fingerprint ID. Never <c>null</c>.
-        /// </summary>
-        public string FingerprintId { get; }
-
         /// <inheritdoc />
         public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
 
         /// <inheritdoc />
-        public override string ToString() => s_template.Expand(UserId, FingerprintId);
+        public override string ToString() => s_template.Expand(UserId);
 
         /// <inheritdoc />
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as FingerprintName);
+        public override bool Equals(object obj) => Equals(obj as UserName);
 
         /// <inheritdoc />
-        public bool Equals(FingerprintName other) => ToString() == other?.ToString();
+        public bool Equals(UserName other) => ToString() == other?.ToString();
 
         /// <inheritdoc />
-        public static bool operator ==(FingerprintName a, FingerprintName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+        public static bool operator ==(UserName a, UserName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
 
         /// <inheritdoc />
-        public static bool operator !=(FingerprintName a, FingerprintName b) => !(a == b);
+        public static bool operator !=(UserName a, UserName b) => !(a == b);
     }
 
 

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/ResourceNames.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/ResourceNames.cs
@@ -21,44 +21,44 @@ using linq = System.Linq;
 namespace Google.Cloud.OsLogin.V1Beta
 {
     /// <summary>
-    /// Resource name for the 'user' resource.
+    /// Resource name for the 'fingerprint' resource.
     /// </summary>
-    public sealed partial class UserName : gax::IResourceName, sys::IEquatable<UserName>
+    public sealed partial class FingerprintName : gax::IResourceName, sys::IEquatable<FingerprintName>
     {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("users/{user}");
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("users/{user}/sshPublicKeys/{fingerprint}");
 
         /// <summary>
-        /// Parses the given user resource name in string form into a new
-        /// <see cref="UserName"/> instance.
+        /// Parses the given fingerprint resource name in string form into a new
+        /// <see cref="FingerprintName"/> instance.
         /// </summary>
-        /// <param name="userName">The user resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="UserName"/> if successful.</returns>
-        public static UserName Parse(string userName)
+        /// <param name="fingerprintName">The fingerprint resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="FingerprintName"/> if successful.</returns>
+        public static FingerprintName Parse(string fingerprintName)
         {
-            gax::GaxPreconditions.CheckNotNull(userName, nameof(userName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(userName);
-            return new UserName(resourceName[0]);
+            gax::GaxPreconditions.CheckNotNull(fingerprintName, nameof(fingerprintName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(fingerprintName);
+            return new FingerprintName(resourceName[0], resourceName[1]);
         }
 
         /// <summary>
-        /// Tries to parse the given user resource name in string form into a new
-        /// <see cref="UserName"/> instance.
+        /// Tries to parse the given fingerprint resource name in string form into a new
+        /// <see cref="FingerprintName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="userName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="fingerprintName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
-        /// <param name="userName">The user resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="UserName"/>,
+        /// <param name="fingerprintName">The fingerprint resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="FingerprintName"/>,
         /// or <c>null</c> if parsing fails.</param>
         /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string userName, out UserName result)
+        public static bool TryParse(string fingerprintName, out FingerprintName result)
         {
-            gax::GaxPreconditions.CheckNotNull(userName, nameof(userName));
+            gax::GaxPreconditions.CheckNotNull(fingerprintName, nameof(fingerprintName));
             gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(userName, out resourceName))
+            if (s_template.TryParseName(fingerprintName, out resourceName))
             {
-                result = new UserName(resourceName[0]);
+                result = new FingerprintName(resourceName[0], resourceName[1]);
                 return true;
             }
             else
@@ -69,13 +69,15 @@ namespace Google.Cloud.OsLogin.V1Beta
         }
 
         /// <summary>
-        /// Constructs a new instance of the <see cref="UserName"/> resource name class
+        /// Constructs a new instance of the <see cref="FingerprintName"/> resource name class
         /// from its component parts.
         /// </summary>
         /// <param name="userId">The user ID. Must not be <c>null</c>.</param>
-        public UserName(string userId)
+        /// <param name="fingerprintId">The fingerprint ID. Must not be <c>null</c>.</param>
+        public FingerprintName(string userId, string fingerprintId)
         {
             UserId = gax::GaxPreconditions.CheckNotNull(userId, nameof(userId));
+            FingerprintId = gax::GaxPreconditions.CheckNotNull(fingerprintId, nameof(fingerprintId));
         }
 
         /// <summary>
@@ -83,26 +85,31 @@ namespace Google.Cloud.OsLogin.V1Beta
         /// </summary>
         public string UserId { get; }
 
+        /// <summary>
+        /// The fingerprint ID. Never <c>null</c>.
+        /// </summary>
+        public string FingerprintId { get; }
+
         /// <inheritdoc />
         public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
 
         /// <inheritdoc />
-        public override string ToString() => s_template.Expand(UserId);
+        public override string ToString() => s_template.Expand(UserId, FingerprintId);
 
         /// <inheritdoc />
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as UserName);
+        public override bool Equals(object obj) => Equals(obj as FingerprintName);
 
         /// <inheritdoc />
-        public bool Equals(UserName other) => ToString() == other?.ToString();
+        public bool Equals(FingerprintName other) => ToString() == other?.ToString();
 
         /// <inheritdoc />
-        public static bool operator ==(UserName a, UserName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+        public static bool operator ==(FingerprintName a, FingerprintName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
 
         /// <inheritdoc />
-        public static bool operator !=(UserName a, UserName b) => !(a == b);
+        public static bool operator !=(FingerprintName a, FingerprintName b) => !(a == b);
     }
 
     /// <summary>
@@ -198,44 +205,44 @@ namespace Google.Cloud.OsLogin.V1Beta
     }
 
     /// <summary>
-    /// Resource name for the 'fingerprint' resource.
+    /// Resource name for the 'user' resource.
     /// </summary>
-    public sealed partial class FingerprintName : gax::IResourceName, sys::IEquatable<FingerprintName>
+    public sealed partial class UserName : gax::IResourceName, sys::IEquatable<UserName>
     {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("users/{user}/sshPublicKeys/{fingerprint}");
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("users/{user}");
 
         /// <summary>
-        /// Parses the given fingerprint resource name in string form into a new
-        /// <see cref="FingerprintName"/> instance.
+        /// Parses the given user resource name in string form into a new
+        /// <see cref="UserName"/> instance.
         /// </summary>
-        /// <param name="fingerprintName">The fingerprint resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="FingerprintName"/> if successful.</returns>
-        public static FingerprintName Parse(string fingerprintName)
+        /// <param name="userName">The user resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="UserName"/> if successful.</returns>
+        public static UserName Parse(string userName)
         {
-            gax::GaxPreconditions.CheckNotNull(fingerprintName, nameof(fingerprintName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(fingerprintName);
-            return new FingerprintName(resourceName[0], resourceName[1]);
+            gax::GaxPreconditions.CheckNotNull(userName, nameof(userName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(userName);
+            return new UserName(resourceName[0]);
         }
 
         /// <summary>
-        /// Tries to parse the given fingerprint resource name in string form into a new
-        /// <see cref="FingerprintName"/> instance.
+        /// Tries to parse the given user resource name in string form into a new
+        /// <see cref="UserName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="fingerprintName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="userName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
-        /// <param name="fingerprintName">The fingerprint resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="FingerprintName"/>,
+        /// <param name="userName">The user resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="UserName"/>,
         /// or <c>null</c> if parsing fails.</param>
         /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string fingerprintName, out FingerprintName result)
+        public static bool TryParse(string userName, out UserName result)
         {
-            gax::GaxPreconditions.CheckNotNull(fingerprintName, nameof(fingerprintName));
+            gax::GaxPreconditions.CheckNotNull(userName, nameof(userName));
             gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(fingerprintName, out resourceName))
+            if (s_template.TryParseName(userName, out resourceName))
             {
-                result = new FingerprintName(resourceName[0], resourceName[1]);
+                result = new UserName(resourceName[0]);
                 return true;
             }
             else
@@ -246,15 +253,13 @@ namespace Google.Cloud.OsLogin.V1Beta
         }
 
         /// <summary>
-        /// Constructs a new instance of the <see cref="FingerprintName"/> resource name class
+        /// Constructs a new instance of the <see cref="UserName"/> resource name class
         /// from its component parts.
         /// </summary>
         /// <param name="userId">The user ID. Must not be <c>null</c>.</param>
-        /// <param name="fingerprintId">The fingerprint ID. Must not be <c>null</c>.</param>
-        public FingerprintName(string userId, string fingerprintId)
+        public UserName(string userId)
         {
             UserId = gax::GaxPreconditions.CheckNotNull(userId, nameof(userId));
-            FingerprintId = gax::GaxPreconditions.CheckNotNull(fingerprintId, nameof(fingerprintId));
         }
 
         /// <summary>
@@ -262,31 +267,26 @@ namespace Google.Cloud.OsLogin.V1Beta
         /// </summary>
         public string UserId { get; }
 
-        /// <summary>
-        /// The fingerprint ID. Never <c>null</c>.
-        /// </summary>
-        public string FingerprintId { get; }
-
         /// <inheritdoc />
         public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
 
         /// <inheritdoc />
-        public override string ToString() => s_template.Expand(UserId, FingerprintId);
+        public override string ToString() => s_template.Expand(UserId);
 
         /// <inheritdoc />
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as FingerprintName);
+        public override bool Equals(object obj) => Equals(obj as UserName);
 
         /// <inheritdoc />
-        public bool Equals(FingerprintName other) => ToString() == other?.ToString();
+        public bool Equals(UserName other) => ToString() == other?.ToString();
 
         /// <inheritdoc />
-        public static bool operator ==(FingerprintName a, FingerprintName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+        public static bool operator ==(UserName a, UserName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
 
         /// <inheritdoc />
-        public static bool operator !=(FingerprintName a, FingerprintName b) => !(a == b);
+        public static bool operator !=(UserName a, UserName b) => !(a == b);
     }
 
 

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/ResourceNames.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/ResourceNames.cs
@@ -23,6 +23,78 @@ using linq = System.Linq;
 namespace Google.Cloud.PubSub.V1
 {
     /// <summary>
+    /// Resource name to represent the fixed string "_deleted-topic_".
+    /// </summary>
+    public sealed partial class DeletedTopicNameFixed : gax::IResourceName, sys::IEquatable<DeletedTopicNameFixed>
+    {
+        /// <summary>
+        /// The fixed string value: "_deleted-topic_".
+        /// </summary>
+        public const string FixedValue = "_deleted-topic_";
+
+        /// <summary>
+        /// An instance of <see cref="DeletedTopicNameFixed"/>.
+        /// </summary>
+        public static DeletedTopicNameFixed Instance => new DeletedTopicNameFixed();
+
+        /// <summary>
+        /// Parses the given string into a new <see cref="DeletedTopicNameFixed"/> instance.
+        /// Only succeeds if the string is equal to "_deleted-topic_".
+        /// </summary>
+        public static DeletedTopicNameFixed Parse(string deletedTopicNameFixed)
+        {
+            DeletedTopicNameFixed result;
+            if (!TryParse(deletedTopicNameFixed, out result))
+            {
+                throw new sys::ArgumentException($"Invalid resource name, must be \"{FixedValue}\"", nameof(deletedTopicNameFixed));
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Tries to parse the given string into a new <see cref="DeletedTopicNameFixed"/> instance.
+        /// Only succeeds if the string is equal to "_deleted-topic_".
+        /// </summary>
+        public static bool TryParse(string deletedTopicNameFixed, out DeletedTopicNameFixed result)
+        {
+            gax::GaxPreconditions.CheckNotNull(deletedTopicNameFixed, nameof(deletedTopicNameFixed));
+            if (deletedTopicNameFixed == FixedValue)
+            {
+                result = Instance;
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        private DeletedTopicNameFixed() { }
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Fixed;
+
+        /// <inheritdoc />
+        public override string ToString() => FixedValue;
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as DeletedTopicNameFixed);
+
+        /// <inheritdoc />
+        public bool Equals(DeletedTopicNameFixed other) => other != null;
+
+        /// <inheritdoc />
+        public static bool operator ==(DeletedTopicNameFixed a, DeletedTopicNameFixed b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(DeletedTopicNameFixed a, DeletedTopicNameFixed b) => !(a == b);
+    }
+
+    /// <summary>
     /// Resource name for the 'snapshot' resource.
     /// </summary>
     public sealed partial class SnapshotName : gax::IResourceName, sys::IEquatable<SnapshotName>
@@ -500,78 +572,6 @@ namespace Google.Cloud.PubSub.V1
 
         /// <inheritdoc />
         public static bool operator !=(TopicNameOneof a, TopicNameOneof b) => !(a == b);
-    }
-
-    /// <summary>
-    /// Resource name to represent the fixed string "_deleted-topic_".
-    /// </summary>
-    public sealed partial class DeletedTopicNameFixed : gax::IResourceName, sys::IEquatable<DeletedTopicNameFixed>
-    {
-        /// <summary>
-        /// The fixed string value: "_deleted-topic_".
-        /// </summary>
-        public const string FixedValue = "_deleted-topic_";
-
-        /// <summary>
-        /// An instance of <see cref="DeletedTopicNameFixed"/>.
-        /// </summary>
-        public static DeletedTopicNameFixed Instance => new DeletedTopicNameFixed();
-
-        /// <summary>
-        /// Parses the given string into a new <see cref="DeletedTopicNameFixed"/> instance.
-        /// Only succeeds if the string is equal to "_deleted-topic_".
-        /// </summary>
-        public static DeletedTopicNameFixed Parse(string deletedTopicNameFixed)
-        {
-            DeletedTopicNameFixed result;
-            if (!TryParse(deletedTopicNameFixed, out result))
-            {
-                throw new sys::ArgumentException($"Invalid resource name, must be \"{FixedValue}\"", nameof(deletedTopicNameFixed));
-            }
-            return result;
-        }
-
-        /// <summary>
-        /// Tries to parse the given string into a new <see cref="DeletedTopicNameFixed"/> instance.
-        /// Only succeeds if the string is equal to "_deleted-topic_".
-        /// </summary>
-        public static bool TryParse(string deletedTopicNameFixed, out DeletedTopicNameFixed result)
-        {
-            gax::GaxPreconditions.CheckNotNull(deletedTopicNameFixed, nameof(deletedTopicNameFixed));
-            if (deletedTopicNameFixed == FixedValue)
-            {
-                result = Instance;
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        private DeletedTopicNameFixed() { }
-
-        /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Fixed;
-
-        /// <inheritdoc />
-        public override string ToString() => FixedValue;
-
-        /// <inheritdoc />
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as DeletedTopicNameFixed);
-
-        /// <inheritdoc />
-        public bool Equals(DeletedTopicNameFixed other) => other != null;
-
-        /// <inheritdoc />
-        public static bool operator ==(DeletedTopicNameFixed a, DeletedTopicNameFixed b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc />
-        public static bool operator !=(DeletedTopicNameFixed a, DeletedTopicNameFixed b) => !(a == b);
     }
 
 

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1/ResourceNames.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1/ResourceNames.cs
@@ -21,98 +21,6 @@ using linq = System.Linq;
 namespace Google.Cloud.Redis.V1
 {
     /// <summary>
-    /// Resource name for the 'location' resource.
-    /// </summary>
-    public sealed partial class LocationName : gax::IResourceName, sys::IEquatable<LocationName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/locations/{location}");
-
-        /// <summary>
-        /// Parses the given location resource name in string form into a new
-        /// <see cref="LocationName"/> instance.
-        /// </summary>
-        /// <param name="locationName">The location resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="LocationName"/> if successful.</returns>
-        public static LocationName Parse(string locationName)
-        {
-            gax::GaxPreconditions.CheckNotNull(locationName, nameof(locationName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(locationName);
-            return new LocationName(resourceName[0], resourceName[1]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given location resource name in string form into a new
-        /// <see cref="LocationName"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="locationName"/> is null,
-        /// as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="locationName">The location resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="LocationName"/>,
-        /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string locationName, out LocationName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(locationName, nameof(locationName));
-            gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(locationName, out resourceName))
-            {
-                result = new LocationName(resourceName[0], resourceName[1]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="LocationName"/> resource name class
-        /// from its component parts.
-        /// </summary>
-        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
-        /// <param name="locationId">The location ID. Must not be <c>null</c>.</param>
-        public LocationName(string projectId, string locationId)
-        {
-            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
-            LocationId = gax::GaxPreconditions.CheckNotNull(locationId, nameof(locationId));
-        }
-
-        /// <summary>
-        /// The project ID. Never <c>null</c>.
-        /// </summary>
-        public string ProjectId { get; }
-
-        /// <summary>
-        /// The location ID. Never <c>null</c>.
-        /// </summary>
-        public string LocationId { get; }
-
-        /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc />
-        public override string ToString() => s_template.Expand(ProjectId, LocationId);
-
-        /// <inheritdoc />
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as LocationName);
-
-        /// <inheritdoc />
-        public bool Equals(LocationName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc />
-        public static bool operator ==(LocationName a, LocationName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc />
-        public static bool operator !=(LocationName a, LocationName b) => !(a == b);
-    }
-
-    /// <summary>
     /// Resource name for the 'instance' resource.
     /// </summary>
     public sealed partial class InstanceName : gax::IResourceName, sys::IEquatable<InstanceName>
@@ -209,6 +117,98 @@ namespace Google.Cloud.Redis.V1
 
         /// <inheritdoc />
         public static bool operator !=(InstanceName a, InstanceName b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name for the 'location' resource.
+    /// </summary>
+    public sealed partial class LocationName : gax::IResourceName, sys::IEquatable<LocationName>
+    {
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/locations/{location}");
+
+        /// <summary>
+        /// Parses the given location resource name in string form into a new
+        /// <see cref="LocationName"/> instance.
+        /// </summary>
+        /// <param name="locationName">The location resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="LocationName"/> if successful.</returns>
+        public static LocationName Parse(string locationName)
+        {
+            gax::GaxPreconditions.CheckNotNull(locationName, nameof(locationName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(locationName);
+            return new LocationName(resourceName[0], resourceName[1]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given location resource name in string form into a new
+        /// <see cref="LocationName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="locationName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="locationName">The location resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="LocationName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string locationName, out LocationName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(locationName, nameof(locationName));
+            gax::TemplatedResourceName resourceName;
+            if (s_template.TryParseName(locationName, out resourceName))
+            {
+                result = new LocationName(resourceName[0], resourceName[1]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="LocationName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
+        /// <param name="locationId">The location ID. Must not be <c>null</c>.</param>
+        public LocationName(string projectId, string locationId)
+        {
+            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
+            LocationId = gax::GaxPreconditions.CheckNotNull(locationId, nameof(locationId));
+        }
+
+        /// <summary>
+        /// The project ID. Never <c>null</c>.
+        /// </summary>
+        public string ProjectId { get; }
+
+        /// <summary>
+        /// The location ID. Never <c>null</c>.
+        /// </summary>
+        public string LocationId { get; }
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(ProjectId, LocationId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as LocationName);
+
+        /// <inheritdoc />
+        public bool Equals(LocationName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(LocationName a, LocationName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(LocationName a, LocationName b) => !(a == b);
     }
 
 

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1/ResourceNames.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1/ResourceNames.cs
@@ -21,98 +21,6 @@ using linq = System.Linq;
 namespace Google.Cloud.Redis.V1Beta1
 {
     /// <summary>
-    /// Resource name for the 'location' resource.
-    /// </summary>
-    public sealed partial class LocationName : gax::IResourceName, sys::IEquatable<LocationName>
-    {
-        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/locations/{location}");
-
-        /// <summary>
-        /// Parses the given location resource name in string form into a new
-        /// <see cref="LocationName"/> instance.
-        /// </summary>
-        /// <param name="locationName">The location resource name in string form. Must not be <c>null</c>.</param>
-        /// <returns>The parsed <see cref="LocationName"/> if successful.</returns>
-        public static LocationName Parse(string locationName)
-        {
-            gax::GaxPreconditions.CheckNotNull(locationName, nameof(locationName));
-            gax::TemplatedResourceName resourceName = s_template.ParseName(locationName);
-            return new LocationName(resourceName[0], resourceName[1]);
-        }
-
-        /// <summary>
-        /// Tries to parse the given location resource name in string form into a new
-        /// <see cref="LocationName"/> instance.
-        /// </summary>
-        /// <remarks>
-        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="locationName"/> is null,
-        /// as this would usually indicate a programming error rather than a data error.
-        /// </remarks>
-        /// <param name="locationName">The location resource name in string form. Must not be <c>null</c>.</param>
-        /// <param name="result">When this method returns, the parsed <see cref="LocationName"/>,
-        /// or <c>null</c> if parsing fails.</param>
-        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
-        public static bool TryParse(string locationName, out LocationName result)
-        {
-            gax::GaxPreconditions.CheckNotNull(locationName, nameof(locationName));
-            gax::TemplatedResourceName resourceName;
-            if (s_template.TryParseName(locationName, out resourceName))
-            {
-                result = new LocationName(resourceName[0], resourceName[1]);
-                return true;
-            }
-            else
-            {
-                result = null;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="LocationName"/> resource name class
-        /// from its component parts.
-        /// </summary>
-        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
-        /// <param name="locationId">The location ID. Must not be <c>null</c>.</param>
-        public LocationName(string projectId, string locationId)
-        {
-            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
-            LocationId = gax::GaxPreconditions.CheckNotNull(locationId, nameof(locationId));
-        }
-
-        /// <summary>
-        /// The project ID. Never <c>null</c>.
-        /// </summary>
-        public string ProjectId { get; }
-
-        /// <summary>
-        /// The location ID. Never <c>null</c>.
-        /// </summary>
-        public string LocationId { get; }
-
-        /// <inheritdoc />
-        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
-
-        /// <inheritdoc />
-        public override string ToString() => s_template.Expand(ProjectId, LocationId);
-
-        /// <inheritdoc />
-        public override int GetHashCode() => ToString().GetHashCode();
-
-        /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as LocationName);
-
-        /// <inheritdoc />
-        public bool Equals(LocationName other) => ToString() == other?.ToString();
-
-        /// <inheritdoc />
-        public static bool operator ==(LocationName a, LocationName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
-
-        /// <inheritdoc />
-        public static bool operator !=(LocationName a, LocationName b) => !(a == b);
-    }
-
-    /// <summary>
     /// Resource name for the 'instance' resource.
     /// </summary>
     public sealed partial class InstanceName : gax::IResourceName, sys::IEquatable<InstanceName>
@@ -209,6 +117,98 @@ namespace Google.Cloud.Redis.V1Beta1
 
         /// <inheritdoc />
         public static bool operator !=(InstanceName a, InstanceName b) => !(a == b);
+    }
+
+    /// <summary>
+    /// Resource name for the 'location' resource.
+    /// </summary>
+    public sealed partial class LocationName : gax::IResourceName, sys::IEquatable<LocationName>
+    {
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}/locations/{location}");
+
+        /// <summary>
+        /// Parses the given location resource name in string form into a new
+        /// <see cref="LocationName"/> instance.
+        /// </summary>
+        /// <param name="locationName">The location resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="LocationName"/> if successful.</returns>
+        public static LocationName Parse(string locationName)
+        {
+            gax::GaxPreconditions.CheckNotNull(locationName, nameof(locationName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(locationName);
+            return new LocationName(resourceName[0], resourceName[1]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given location resource name in string form into a new
+        /// <see cref="LocationName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="locationName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="locationName">The location resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="LocationName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string locationName, out LocationName result)
+        {
+            gax::GaxPreconditions.CheckNotNull(locationName, nameof(locationName));
+            gax::TemplatedResourceName resourceName;
+            if (s_template.TryParseName(locationName, out resourceName))
+            {
+                result = new LocationName(resourceName[0], resourceName[1]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="LocationName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
+        /// <param name="locationId">The location ID. Must not be <c>null</c>.</param>
+        public LocationName(string projectId, string locationId)
+        {
+            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
+            LocationId = gax::GaxPreconditions.CheckNotNull(locationId, nameof(locationId));
+        }
+
+        /// <summary>
+        /// The project ID. Never <c>null</c>.
+        /// </summary>
+        public string ProjectId { get; }
+
+        /// <summary>
+        /// The location ID. Never <c>null</c>.
+        /// </summary>
+        public string LocationId { get; }
+
+        /// <inheritdoc />
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(ProjectId, LocationId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as LocationName);
+
+        /// <inheritdoc />
+        public bool Equals(LocationName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(LocationName a, LocationName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(LocationName a, LocationName b) => !(a == b);
     }
 
 


### PR DESCRIPTION
This change is *just* reordering elements within ResourceNames. This should be a one-time change (at least until we change generator); resource name ordering will now be stable.