### PR TITLE
Reverting back to using dotcover.exe directly.

### DIFF
--- a/.kokoro/runintegrationtests.sh
+++ b/.kokoro/runintegrationtests.sh
@@ -20,16 +20,12 @@ report_flags="--upload_commit $KOKORO_GITHUB_COMMIT --upload_build $KOKORO_BUILD
 # of whether we're about to create any.
 rm -rf coverage
 
-# Temporarily disable coverage. For some reason, 4 net452 unit tests are taking
-# 50 minutes each, in a way that's hard to reproduce locally. Get back to green
-# builds while we investigate.
-#
-# if [[ -f "$KOKORO_KEYSTORE_DIR/73609_codecov-token" ]]
-# then
-#  export CODECOV_TOKEN=$(cat "$KOKORO_KEYSTORE_DIR/73609_codecov-token")
-#  script_flags=--coverage
-#  report_flags="--upload $report_flags"
-# fi
+if [[ -f "$KOKORO_KEYSTORE_DIR/73609_codecov-token" ]]
+then
+ export CODECOV_TOKEN=$(cat "$KOKORO_KEYSTORE_DIR/73609_codecov-token")
+ script_flags=--coverage
+ report_flags="--upload $report_flags"
+fi
 
 # Build the libraries and run unit tests, optionally with coverage.
 ./build.sh $script_flags

--- a/apis/Google.Cloud.Asset.V1Beta1/Google.Cloud.Asset.V1Beta1.Snippets/Google.Cloud.Asset.V1Beta1.Snippets.csproj
+++ b/apis/Google.Cloud.Asset.V1Beta1/Google.Cloud.Asset.V1Beta1.Snippets/Google.Cloud.Asset.V1Beta1.Snippets.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Asset.V1Beta1/Google.Cloud.Asset.V1Beta1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Asset.V1Beta1/Google.Cloud.Asset.V1Beta1.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Asset.V1Beta1.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Asset.V1Beta1/Google.Cloud.Asset.V1Beta1.Tests/Google.Cloud.Asset.V1Beta1.Tests.csproj
+++ b/apis/Google.Cloud.Asset.V1Beta1/Google.Cloud.Asset.V1Beta1.Tests/Google.Cloud.Asset.V1Beta1.Tests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Asset.V1Beta1/Google.Cloud.Asset.V1Beta1.Tests/coverage.xml
+++ b/apis/Google.Cloud.Asset.V1Beta1/Google.Cloud.Asset.V1Beta1.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Asset.V1Beta1.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.Snippets/Google.Cloud.BigQuery.DataTransfer.V1.Snippets.csproj
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.Snippets/Google.Cloud.BigQuery.DataTransfer.V1.Snippets.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.BigQuery.DataTransfer.V1.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.Tests/Google.Cloud.BigQuery.DataTransfer.V1.Tests.csproj
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.Tests/Google.Cloud.BigQuery.DataTransfer.V1.Tests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.Tests/coverage.xml
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.BigQuery.DataTransfer.V1.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/Google.Cloud.BigQuery.V2.IntegrationTests.csproj
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/Google.Cloud.BigQuery.V2.IntegrationTests.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/coverage.xml
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.BigQuery.V2.IntegrationTests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Snippets/Google.Cloud.BigQuery.V2.Snippets.csproj
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Snippets/Google.Cloud.BigQuery.V2.Snippets.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Snippets/coverage.xml
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.BigQuery.V2.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/Google.Cloud.BigQuery.V2.Tests.csproj
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/Google.Cloud.BigQuery.V2.Tests.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/coverage.xml
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.BigQuery.V2.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.Snippets/Google.Cloud.Bigtable.Admin.V2.Snippets.csproj
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.Snippets/Google.Cloud.Bigtable.Admin.V2.Snippets.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -14,5 +16,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Bigtable.Admin.V2.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.Tests/Google.Cloud.Bigtable.Admin.V2.Tests.csproj
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.Tests/Google.Cloud.Bigtable.Admin.V2.Tests.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.Tests/coverage.xml
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -14,5 +16,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Bigtable.Admin.V2.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.IntegrationTests/Google.Cloud.Bigtable.V2.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.IntegrationTests/Google.Cloud.Bigtable.V2.IntegrationTests.csproj
@@ -21,7 +21,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.IntegrationTests/coverage.xml
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.IntegrationTests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -14,5 +16,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Bigtable.V2.IntegrationTests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Snippets/Google.Cloud.Bigtable.V2.Snippets.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Snippets/Google.Cloud.Bigtable.V2.Snippets.csproj
@@ -21,7 +21,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -14,5 +16,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Bigtable.V2.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/Google.Cloud.Bigtable.V2.Tests.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/Google.Cloud.Bigtable.V2.Tests.csproj
@@ -21,7 +21,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/coverage.xml
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -14,5 +16,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Bigtable.V2.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.Snippets/Google.Cloud.Container.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.Snippets/Google.Cloud.Container.V1.Snippets.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Container.V1.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.Tests/Google.Cloud.Container.V1.Tests.csproj
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.Tests/Google.Cloud.Container.V1.Tests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.Tests/coverage.xml
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Container.V1.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.Snippets/Google.Cloud.Dataproc.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.Snippets/Google.Cloud.Dataproc.V1.Snippets.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Dataproc.V1.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.Tests/Google.Cloud.Dataproc.V1.Tests.csproj
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.Tests/Google.Cloud.Dataproc.V1.Tests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.Tests/coverage.xml
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Dataproc.V1.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/Google.Cloud.Datastore.V1.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/Google.Cloud.Datastore.V1.IntegrationTests.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/coverage.xml
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Datastore.V1.IntegrationTests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/Google.Cloud.Datastore.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/Google.Cloud.Datastore.V1.Snippets.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Datastore.V1.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Tests/Google.Cloud.Datastore.V1.Tests.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Tests/Google.Cloud.Datastore.V1.Tests.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Tests/coverage.xml
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Datastore.V1.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2.Snippets/Google.Cloud.Debugger.V2.Snippets.csproj
+++ b/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2.Snippets/Google.Cloud.Debugger.V2.Snippets.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Debugger.V2.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2.Tests/Google.Cloud.Debugger.V2.Tests.csproj
+++ b/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2.Tests/Google.Cloud.Debugger.V2.Tests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2.Tests/coverage.xml
+++ b/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Debugger.V2.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.DevTools.Common/Google.Cloud.DevTools.Common.Tests/Google.Cloud.DevTools.Common.Tests.csproj
+++ b/apis/Google.Cloud.DevTools.Common/Google.Cloud.DevTools.Common.Tests/Google.Cloud.DevTools.Common.Tests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.DevTools.Common/Google.Cloud.DevTools.Common.Tests/coverage.xml
+++ b/apis/Google.Cloud.DevTools.Common/Google.Cloud.DevTools.Common.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.DevTools.Common.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/Google.Cloud.Diagnostics.AspNet.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/Google.Cloud.Diagnostics.AspNet.IntegrationTests.csproj
@@ -22,7 +22,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/coverage.xml
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -14,5 +16,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Diagnostics.AspNet.IntegrationTests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Snippets/Google.Cloud.Diagnostics.AspNet.Snippets.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Snippets/Google.Cloud.Diagnostics.AspNet.Snippets.csproj
@@ -22,7 +22,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -14,5 +16,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Diagnostics.AspNet.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/Google.Cloud.Diagnostics.AspNet.Tests.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/Google.Cloud.Diagnostics.AspNet.Tests.csproj
@@ -22,7 +22,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/coverage.xml
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -14,5 +16,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Diagnostics.AspNet.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore.Analyzers/Google.Cloud.Diagnostics.AspNetCore.Analyzers.Tests/Google.Cloud.Diagnostics.AspNetCore.Analyzers.Tests.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore.Analyzers/Google.Cloud.Diagnostics.AspNetCore.Analyzers.Tests/Google.Cloud.Diagnostics.AspNetCore.Analyzers.Tests.csproj
@@ -21,7 +21,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore.Analyzers/Google.Cloud.Diagnostics.AspNetCore.Analyzers.Tests/coverage.xml
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore.Analyzers/Google.Cloud.Diagnostics.AspNetCore.Analyzers.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Diagnostics.AspNetCore.Analyzers.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests.csproj
@@ -28,7 +28,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/coverage.xml
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -14,5 +16,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/Google.Cloud.Diagnostics.AspNetCore.Snippets.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/Google.Cloud.Diagnostics.AspNetCore.Snippets.csproj
@@ -30,7 +30,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -14,5 +16,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Diagnostics.AspNetCore.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Google.Cloud.Diagnostics.AspNetCore.Tests.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Google.Cloud.Diagnostics.AspNetCore.Tests.csproj
@@ -22,7 +22,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/coverage.xml
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -14,5 +16,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Diagnostics.AspNetCore.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Google.Cloud.Diagnostics.Common.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Google.Cloud.Diagnostics.Common.IntegrationTests.csproj
@@ -21,7 +21,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/coverage.xml
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Diagnostics.Common.IntegrationTests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Google.Cloud.Diagnostics.Common.Tests.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Google.Cloud.Diagnostics.Common.Tests.csproj
@@ -21,7 +21,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/coverage.xml
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Diagnostics.Common.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/Google.Cloud.Dialogflow.V2.Snippets.csproj
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/Google.Cloud.Dialogflow.V2.Snippets.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Dialogflow.V2.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Tests/Google.Cloud.Dialogflow.V2.Tests.csproj
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Tests/Google.Cloud.Dialogflow.V2.Tests.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Tests/coverage.xml
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Dialogflow.V2.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.Snippets/Google.Cloud.Dlp.V2.Snippets.csproj
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.Snippets/Google.Cloud.Dlp.V2.Snippets.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Dlp.V2.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.Tests/Google.Cloud.Dlp.V2.Tests.csproj
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.Tests/Google.Cloud.Dlp.V2.Tests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.Tests/coverage.xml
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Dlp.V2.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.EntityFrameworkCore.Spanner/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests.csproj
+++ b/apis/Google.Cloud.EntityFrameworkCore.Spanner/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests.csproj
@@ -28,7 +28,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.EntityFrameworkCore.Spanner/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/coverage.xml
+++ b/apis/Google.Cloud.EntityFrameworkCore.Spanner/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -23,5 +25,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.EntityFrameworkCore.Spanner.IntegrationTests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.EntityFrameworkCore.Spanner/Google.Cloud.EntityFrameworkCore.Spanner.Snippets/Google.Cloud.EntityFrameworkCore.Spanner.Snippets.csproj
+++ b/apis/Google.Cloud.EntityFrameworkCore.Spanner/Google.Cloud.EntityFrameworkCore.Spanner.Snippets/Google.Cloud.EntityFrameworkCore.Spanner.Snippets.csproj
@@ -25,7 +25,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.EntityFrameworkCore.Spanner/Google.Cloud.EntityFrameworkCore.Spanner.Snippets/coverage.xml
+++ b/apis/Google.Cloud.EntityFrameworkCore.Spanner/Google.Cloud.EntityFrameworkCore.Spanner.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -23,5 +25,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.EntityFrameworkCore.Spanner.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.Snippets/Google.Cloud.ErrorReporting.V1Beta1.Snippets.csproj
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.Snippets/Google.Cloud.ErrorReporting.V1Beta1.Snippets.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.ErrorReporting.V1Beta1.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.Tests/Google.Cloud.ErrorReporting.V1Beta1.Tests.csproj
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.Tests/Google.Cloud.ErrorReporting.V1Beta1.Tests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.Tests/coverage.xml
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.ErrorReporting.V1Beta1.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Firestore.V1Beta1/Google.Cloud.Firestore.V1Beta1.Snippets/Google.Cloud.Firestore.V1Beta1.Snippets.csproj
+++ b/apis/Google.Cloud.Firestore.V1Beta1/Google.Cloud.Firestore.V1Beta1.Snippets/Google.Cloud.Firestore.V1Beta1.Snippets.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Firestore.V1Beta1/Google.Cloud.Firestore.V1Beta1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Firestore.V1Beta1/Google.Cloud.Firestore.V1Beta1.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Firestore.V1Beta1.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Firestore.V1Beta1/Google.Cloud.Firestore.V1Beta1.Tests/Google.Cloud.Firestore.V1Beta1.Tests.csproj
+++ b/apis/Google.Cloud.Firestore.V1Beta1/Google.Cloud.Firestore.V1Beta1.Tests/Google.Cloud.Firestore.V1Beta1.Tests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Firestore.V1Beta1/Google.Cloud.Firestore.V1Beta1.Tests/coverage.xml
+++ b/apis/Google.Cloud.Firestore.V1Beta1/Google.Cloud.Firestore.V1Beta1.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Firestore.V1Beta1.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/Google.Cloud.Firestore.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/Google.Cloud.Firestore.IntegrationTests.csproj
@@ -22,7 +22,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/coverage.xml
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -14,5 +16,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Firestore.IntegrationTests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/Google.Cloud.Firestore.Snippets.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/Google.Cloud.Firestore.Snippets.csproj
@@ -22,7 +22,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -14,5 +16,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Firestore.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Google.Cloud.Firestore.Tests.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Google.Cloud.Firestore.Tests.csproj
@@ -22,7 +22,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/coverage.xml
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -14,5 +16,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Firestore.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.Tests/Google.Cloud.Iam.V1.Tests.csproj
+++ b/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.Tests/Google.Cloud.Iam.V1.Tests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.Tests/coverage.xml
+++ b/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Iam.V1.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.Snippets/Google.Cloud.Kms.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.Snippets/Google.Cloud.Kms.V1.Snippets.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Kms.V1.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.Tests/Google.Cloud.Kms.V1.Tests.csproj
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.Tests/Google.Cloud.Kms.V1.Tests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.Tests/coverage.xml
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Kms.V1.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.Snippets/Google.Cloud.Language.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.Snippets/Google.Cloud.Language.V1.Snippets.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Language.V1.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.Tests/Google.Cloud.Language.V1.Tests.csproj
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.Tests/Google.Cloud.Language.V1.Tests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.Tests/coverage.xml
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Language.V1.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.IntegrationTests/Google.Cloud.Logging.Log4Net.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.IntegrationTests/Google.Cloud.Logging.Log4Net.IntegrationTests.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.IntegrationTests/coverage.xml
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.IntegrationTests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Logging.Log4Net.IntegrationTests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Snippets/Google.Cloud.Logging.Log4Net.Snippets.csproj
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Snippets/Google.Cloud.Logging.Log4Net.Snippets.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Logging.Log4Net.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Tests/Google.Cloud.Logging.Log4Net.Tests.csproj
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Tests/Google.Cloud.Logging.Log4Net.Tests.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Tests/coverage.xml
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Logging.Log4Net.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.IntegrationTests/Google.Cloud.Logging.NLog.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.IntegrationTests/Google.Cloud.Logging.NLog.IntegrationTests.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.IntegrationTests/coverage.xml
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.IntegrationTests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Logging.NLog.IntegrationTests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.Snippets/Google.Cloud.Logging.NLog.Snippets.csproj
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.Snippets/Google.Cloud.Logging.NLog.Snippets.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Logging.NLog.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.Tests/Google.Cloud.Logging.NLog.Tests.csproj
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.Tests/Google.Cloud.Logging.NLog.Tests.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.Tests/coverage.xml
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Logging.NLog.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.Snippets/Google.Cloud.Logging.V2.Snippets.csproj
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.Snippets/Google.Cloud.Logging.V2.Snippets.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Logging.V2.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.Tests/Google.Cloud.Logging.V2.Tests.csproj
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.Tests/Google.Cloud.Logging.V2.Tests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.Tests/coverage.xml
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Logging.V2.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1.IntegrationTests/Google.Cloud.Metadata.V1.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1.IntegrationTests/Google.Cloud.Metadata.V1.IntegrationTests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1.IntegrationTests/coverage.xml
+++ b/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1.IntegrationTests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Metadata.V1.IntegrationTests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1.Snippets/Google.Cloud.Metadata.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1.Snippets/Google.Cloud.Metadata.V1.Snippets.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Metadata.V1.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1.Tests/Google.Cloud.Metadata.V1.Tests.csproj
+++ b/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1.Tests/Google.Cloud.Metadata.V1.Tests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1.Tests/coverage.xml
+++ b/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Metadata.V1.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/Google.Cloud.Monitoring.V3.Snippets.csproj
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/Google.Cloud.Monitoring.V3.Snippets.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Monitoring.V3.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Tests/Google.Cloud.Monitoring.V3.Tests.csproj
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Tests/Google.Cloud.Monitoring.V3.Tests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Tests/coverage.xml
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Monitoring.V3.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.Snippets/Google.Cloud.OsLogin.V1.Snippets.csproj
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.Snippets/Google.Cloud.OsLogin.V1.Snippets.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -14,5 +16,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.OsLogin.V1.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.Tests/Google.Cloud.OsLogin.V1.Tests.csproj
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.Tests/Google.Cloud.OsLogin.V1.Tests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.Tests/coverage.xml
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -14,5 +16,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.OsLogin.V1.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.Snippets/Google.Cloud.OsLogin.V1Beta.Snippets.csproj
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.Snippets/Google.Cloud.OsLogin.V1Beta.Snippets.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.Snippets/coverage.xml
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -14,5 +16,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.OsLogin.V1Beta.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.Tests/Google.Cloud.OsLogin.V1Beta.Tests.csproj
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.Tests/Google.Cloud.OsLogin.V1Beta.Tests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.Tests/coverage.xml
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -14,5 +16,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.OsLogin.V1Beta.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.IntegrationTests/Google.Cloud.PubSub.V1.IntegrationTests.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.IntegrationTests/Google.Cloud.PubSub.V1.IntegrationTests.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.IntegrationTests/coverage.xml
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.IntegrationTests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.PubSub.V1.IntegrationTests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/Google.Cloud.PubSub.V1.Snippets.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/Google.Cloud.PubSub.V1.Snippets.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.PubSub.V1.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Tests/Google.Cloud.PubSub.V1.Tests.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Tests/Google.Cloud.PubSub.V1.Tests.csproj
@@ -24,7 +24,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Tests/coverage.xml
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.PubSub.V1.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.Snippets/Google.Cloud.Redis.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.Snippets/Google.Cloud.Redis.V1.Snippets.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Redis.V1.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.Tests/Google.Cloud.Redis.V1.Tests.csproj
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.Tests/Google.Cloud.Redis.V1.Tests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.Tests/coverage.xml
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Redis.V1.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.Snippets/Google.Cloud.Redis.V1Beta1.Snippets.csproj
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.Snippets/Google.Cloud.Redis.V1Beta1.Snippets.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Redis.V1Beta1.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.Tests/Google.Cloud.Redis.V1Beta1.Tests.csproj
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.Tests/Google.Cloud.Redis.V1Beta1.Tests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.Tests/coverage.xml
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Redis.V1Beta1.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.Snippets/Google.Cloud.Spanner.Admin.Database.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.Snippets/Google.Cloud.Spanner.Admin.Database.V1.Snippets.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -14,5 +16,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Spanner.Admin.Database.V1.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.Tests/Google.Cloud.Spanner.Admin.Database.V1.Tests.csproj
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.Tests/Google.Cloud.Spanner.Admin.Database.V1.Tests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.Tests/coverage.xml
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -14,5 +16,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Spanner.Admin.Database.V1.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.Snippets/Google.Cloud.Spanner.Admin.Instance.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.Snippets/Google.Cloud.Spanner.Admin.Instance.V1.Snippets.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -14,5 +16,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Spanner.Admin.Instance.V1.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.Tests/Google.Cloud.Spanner.Admin.Instance.V1.Tests.csproj
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.Tests/Google.Cloud.Spanner.Admin.Instance.V1.Tests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.Tests/coverage.xml
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -14,5 +16,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Spanner.Admin.Instance.V1.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/Google.Cloud.Spanner.Data.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/Google.Cloud.Spanner.Data.IntegrationTests.csproj
@@ -23,7 +23,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/coverage.xml
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -20,5 +22,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Spanner.Data.IntegrationTests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/Google.Cloud.Spanner.Data.Snippets.csproj
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/Google.Cloud.Spanner.Data.Snippets.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -20,5 +22,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Spanner.Data.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/Google.Cloud.Spanner.Data.Tests.csproj
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/Google.Cloud.Spanner.Data.Tests.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/coverage.xml
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -20,5 +22,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Spanner.Data.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.Snippets/Google.Cloud.Spanner.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.Snippets/Google.Cloud.Spanner.V1.Snippets.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -14,5 +16,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Spanner.V1.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.Tests/Google.Cloud.Spanner.V1.Tests.csproj
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.Tests/Google.Cloud.Spanner.V1.Tests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.Tests/coverage.xml
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -14,5 +16,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Spanner.V1.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.Snippets/Google.Cloud.Speech.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.Snippets/Google.Cloud.Speech.V1.Snippets.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Speech.V1.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.Tests/Google.Cloud.Speech.V1.Tests.csproj
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.Tests/Google.Cloud.Speech.V1.Tests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.Tests/coverage.xml
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Speech.V1.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.Snippets/Google.Cloud.Speech.V1P1Beta1.Snippets.csproj
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.Snippets/Google.Cloud.Speech.V1P1Beta1.Snippets.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Speech.V1P1Beta1.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.Tests/Google.Cloud.Speech.V1P1Beta1.Tests.csproj
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.Tests/Google.Cloud.Speech.V1P1Beta1.Tests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.Tests/coverage.xml
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Speech.V1P1Beta1.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/Google.Cloud.Storage.V1.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/Google.Cloud.Storage.V1.IntegrationTests.csproj
@@ -22,7 +22,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/coverage.xml
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Storage.V1.IntegrationTests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Snippets/Google.Cloud.Storage.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Snippets/Google.Cloud.Storage.V1.Snippets.csproj
@@ -22,7 +22,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Storage.V1.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/Google.Cloud.Storage.V1.Tests.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/Google.Cloud.Storage.V1.Tests.csproj
@@ -22,7 +22,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/coverage.xml
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Storage.V1.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Tasks.V2Beta2/Google.Cloud.Tasks.V2Beta2.Snippets/Google.Cloud.Tasks.V2Beta2.Snippets.csproj
+++ b/apis/Google.Cloud.Tasks.V2Beta2/Google.Cloud.Tasks.V2Beta2.Snippets/Google.Cloud.Tasks.V2Beta2.Snippets.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Tasks.V2Beta2/Google.Cloud.Tasks.V2Beta2.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Tasks.V2Beta2/Google.Cloud.Tasks.V2Beta2.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Tasks.V2Beta2.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Tasks.V2Beta2/Google.Cloud.Tasks.V2Beta2.Tests/Google.Cloud.Tasks.V2Beta2.Tests.csproj
+++ b/apis/Google.Cloud.Tasks.V2Beta2/Google.Cloud.Tasks.V2Beta2.Tests/Google.Cloud.Tasks.V2Beta2.Tests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Tasks.V2Beta2/Google.Cloud.Tasks.V2Beta2.Tests/coverage.xml
+++ b/apis/Google.Cloud.Tasks.V2Beta2/Google.Cloud.Tasks.V2Beta2.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Tasks.V2Beta2.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.Snippets/Google.Cloud.Tasks.V2Beta3.Snippets.csproj
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.Snippets/Google.Cloud.Tasks.V2Beta3.Snippets.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Tasks.V2Beta3.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.Tests/Google.Cloud.Tasks.V2Beta3.Tests.csproj
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.Tests/Google.Cloud.Tasks.V2Beta3.Tests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.Tests/coverage.xml
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Tasks.V2Beta3.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.Snippets/Google.Cloud.TextToSpeech.V1.Snippets.csproj
+++ b/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.Snippets/Google.Cloud.TextToSpeech.V1.Snippets.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.TextToSpeech.V1.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.Tests/Google.Cloud.TextToSpeech.V1.Tests.csproj
+++ b/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.Tests/Google.Cloud.TextToSpeech.V1.Tests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.Tests/coverage.xml
+++ b/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.TextToSpeech.V1.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.Snippets/Google.Cloud.Trace.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.Snippets/Google.Cloud.Trace.V1.Snippets.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Trace.V1.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.Tests/Google.Cloud.Trace.V1.Tests.csproj
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.Tests/Google.Cloud.Trace.V1.Tests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.Tests/coverage.xml
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Trace.V1.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.Snippets/Google.Cloud.Trace.V2.Snippets.csproj
+++ b/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.Snippets/Google.Cloud.Trace.V2.Snippets.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Trace.V2.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.Tests/Google.Cloud.Trace.V2.Tests.csproj
+++ b/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.Tests/Google.Cloud.Trace.V2.Tests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.Tests/coverage.xml
+++ b/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Trace.V2.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.IntegrationTests/Google.Cloud.Translation.V2.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.IntegrationTests/Google.Cloud.Translation.V2.IntegrationTests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.IntegrationTests/coverage.xml
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.IntegrationTests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Translation.V2.IntegrationTests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.Snippets/Google.Cloud.Translation.V2.Snippets.csproj
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.Snippets/Google.Cloud.Translation.V2.Snippets.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Translation.V2.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.Tests/Google.Cloud.Translation.V2.Tests.csproj
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.Tests/Google.Cloud.Translation.V2.Tests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.Tests/coverage.xml
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Translation.V2.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1.Snippets/Google.Cloud.VideoIntelligence.V1.Snippets.csproj
+++ b/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1.Snippets/Google.Cloud.VideoIntelligence.V1.Snippets.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.VideoIntelligence.V1.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1.Tests/Google.Cloud.VideoIntelligence.V1.Tests.csproj
+++ b/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1.Tests/Google.Cloud.VideoIntelligence.V1.Tests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1.Tests/coverage.xml
+++ b/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.VideoIntelligence.V1.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.IntegrationTests/Google.Cloud.Vision.V1.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.IntegrationTests/Google.Cloud.Vision.V1.IntegrationTests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.IntegrationTests/coverage.xml
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.IntegrationTests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Vision.V1.IntegrationTests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Snippets/Google.Cloud.Vision.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Snippets/Google.Cloud.Vision.V1.Snippets.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Vision.V1.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Tests/Google.Cloud.Vision.V1.Tests.csproj
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Tests/Google.Cloud.Vision.V1.Tests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Tests/coverage.xml
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Vision.V1.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Vision.V1P1Beta1/Google.Cloud.Vision.V1P1Beta1.IntegrationTests/Google.Cloud.Vision.V1P1Beta1.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Vision.V1P1Beta1/Google.Cloud.Vision.V1P1Beta1.IntegrationTests/Google.Cloud.Vision.V1P1Beta1.IntegrationTests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Vision.V1P1Beta1/Google.Cloud.Vision.V1P1Beta1.IntegrationTests/coverage.xml
+++ b/apis/Google.Cloud.Vision.V1P1Beta1/Google.Cloud.Vision.V1P1Beta1.IntegrationTests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Vision.V1P1Beta1.IntegrationTests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Vision.V1P1Beta1/Google.Cloud.Vision.V1P1Beta1.Snippets/Google.Cloud.Vision.V1P1Beta1.Snippets.csproj
+++ b/apis/Google.Cloud.Vision.V1P1Beta1/Google.Cloud.Vision.V1P1Beta1.Snippets/Google.Cloud.Vision.V1P1Beta1.Snippets.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Vision.V1P1Beta1/Google.Cloud.Vision.V1P1Beta1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Vision.V1P1Beta1/Google.Cloud.Vision.V1P1Beta1.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Vision.V1P1Beta1.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Vision.V1P1Beta1/Google.Cloud.Vision.V1P1Beta1.Tests/Google.Cloud.Vision.V1P1Beta1.Tests.csproj
+++ b/apis/Google.Cloud.Vision.V1P1Beta1/Google.Cloud.Vision.V1P1Beta1.Tests/Google.Cloud.Vision.V1P1Beta1.Tests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Vision.V1P1Beta1/Google.Cloud.Vision.V1P1Beta1.Tests/coverage.xml
+++ b/apis/Google.Cloud.Vision.V1P1Beta1/Google.Cloud.Vision.V1P1Beta1.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Vision.V1P1Beta1.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Vision.V1P2Beta1/Google.Cloud.Vision.V1P2Beta1.IntegrationTests/Google.Cloud.Vision.V1P2Beta1.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Vision.V1P2Beta1/Google.Cloud.Vision.V1P2Beta1.IntegrationTests/Google.Cloud.Vision.V1P2Beta1.IntegrationTests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Vision.V1P2Beta1/Google.Cloud.Vision.V1P2Beta1.IntegrationTests/coverage.xml
+++ b/apis/Google.Cloud.Vision.V1P2Beta1/Google.Cloud.Vision.V1P2Beta1.IntegrationTests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Vision.V1P2Beta1.IntegrationTests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Vision.V1P2Beta1/Google.Cloud.Vision.V1P2Beta1.Snippets/Google.Cloud.Vision.V1P2Beta1.Snippets.csproj
+++ b/apis/Google.Cloud.Vision.V1P2Beta1/Google.Cloud.Vision.V1P2Beta1.Snippets/Google.Cloud.Vision.V1P2Beta1.Snippets.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Vision.V1P2Beta1/Google.Cloud.Vision.V1P2Beta1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Vision.V1P2Beta1/Google.Cloud.Vision.V1P2Beta1.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Vision.V1P2Beta1.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.Cloud.Vision.V1P2Beta1/Google.Cloud.Vision.V1P2Beta1.Tests/Google.Cloud.Vision.V1P2Beta1.Tests.csproj
+++ b/apis/Google.Cloud.Vision.V1P2Beta1/Google.Cloud.Vision.V1P2Beta1.Tests/Google.Cloud.Vision.V1P2Beta1.Tests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Vision.V1P2Beta1/Google.Cloud.Vision.V1P2Beta1.Tests/coverage.xml
+++ b/apis/Google.Cloud.Vision.V1P2Beta1/Google.Cloud.Vision.V1P2Beta1.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.Cloud.Vision.V1P2Beta1.Tests.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.LongRunning/Google.LongRunning.Snippets/Google.LongRunning.Snippets.csproj
+++ b/apis/Google.LongRunning/Google.LongRunning.Snippets/Google.LongRunning.Snippets.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.LongRunning/Google.LongRunning.Snippets/coverage.xml
+++ b/apis/Google.LongRunning/Google.LongRunning.Snippets/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.LongRunning.Snippets.dvcr</Output>
 </CoverageParams>

--- a/apis/Google.LongRunning/Google.LongRunning.Tests/Google.LongRunning.Tests.csproj
+++ b/apis/Google.LongRunning/Google.LongRunning.Tests/Google.LongRunning.Tests.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2018.2.0" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.LongRunning/Google.LongRunning.Tests/coverage.xml
+++ b/apis/Google.LongRunning/Google.LongRunning.Tests/coverage.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <Filters>
     <IncludeFilters>
       <FilterEntry>
@@ -11,5 +13,6 @@
     <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
     <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
   </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
   <Output>../../../coverage/Google.LongRunning.Tests.dvcr</Output>
 </CoverageParams>

--- a/build.sh
+++ b/build.sh
@@ -46,6 +46,7 @@ while (( "$#" )); do
   elif [[ "$1" == "--coverage" ]]
   then
     runcoverage=true
+    install_dotcover
     mkdir -p coverage
   else
     apis+=($1)
@@ -135,7 +136,7 @@ then
     if [[ "$runcoverage" = true && -f "$testdir/coverage.xml" ]]
     then
       echo "(Running with coverage)"
-      (cd "$testdir"; dotnet dotcover test -c Release --no-build --dcXML=coverage.xml)    
+      (cd "$testdir"; $DOTCOVER cover "coverage.xml" /ReturnTargetExitCode)
     else
       dotnet test -c Release --no-build $testproject
     fi

--- a/runintegrationtests.sh
+++ b/runintegrationtests.sh
@@ -20,6 +20,7 @@ while (( "$#" )); do
     RETRY_ARG=yes
   elif [[ "$1" == "--coverage" ]]
   then
+    install_dotcover
     mkdir -p coverage
     COVERAGE_ARG=yes
   elif [[ "$1" == "--smoke" ]]
@@ -103,7 +104,7 @@ do
     dotnet run -p $testdir -- $TEST_PROJECT || echo "$testdir" >> $FAILURE_TEMP_FILE
   elif [[ "$COVERAGE_ARG" == "yes" && -f "$testdir/coverage.xml" ]]
   then
-    (cd $testdir; dotnet dotcover test -c Release --no-build --dcXML=coverage.xml || echo "$testdir" >> $FAILURE_TEMP_FILE)
+    (cd $testdir; $DOTCOVER cover "coverage.xml" /ReturnTargetExitCode || echo "$testdir" >> $FAILURE_TEMP_FILE)
   else
     (cd $testdir; dotnet test -c Release --no-build || echo "$testdir" >> $FAILURE_TEMP_FILE)
   fi

--- a/tools/Google.Cloud.Tools.ProjectGenerator/Program.cs
+++ b/tools/Google.Cloud.Tools.ProjectGenerator/Program.cs
@@ -461,10 +461,6 @@ namespace Google.Cloud.Tools.ProjectGenerator
                 );
             string project = Path.GetFileName(directory);
             var dependenciesElement = CreateDependenciesElement(project, dependencies, api.IsReleaseVersion, testProject: true, apiNames: apiNames);
-            // Include dotCover CLI tool for dotnet
-            dependenciesElement.Add(new XElement("DotNetCliToolReference",
-                new XAttribute("Include", "JetBrains.dotCover.CommandLineTools"),
-                new XAttribute("Version", "2018.2.0")));
             // Allow test projects to use dynamic...
             dependenciesElement.Add(new XElement("Reference",
                 new XAttribute("Condition", "'$(TargetFramework)' == 'net452'"),
@@ -481,6 +477,9 @@ namespace Google.Cloud.Tools.ProjectGenerator
             {
                 return;
             }
+            var targetExecutable = new XElement("TargetExecutable", "C:/Program Files/dotnet/dotnet.exe");
+            var targetArguments = new XElement("TargetArguments",
+                $"test --no-build -c Release");
             var filters = new XElement("Filters", new XElement("IncludeFilters",
                 new XElement("FilterEntry", new XElement("ModuleMask", api.Id)),
                 // Allow tests to contribute coverage to project dependencies, but not package dependencies
@@ -495,10 +494,14 @@ namespace Google.Cloud.Tools.ProjectGenerator
                 new XElement("AttributeFilterEntry", "System.Diagnostics.DebuggerNonUserCodeAttribute")
             );
             var output = new XElement("Output", $"../../../coverage/{Path.GetFileName(directory)}.dvcr");
+            var workingDir = new XElement("TargetWorkingDir", ".");
 
             var doc = new XElement("CoverageParams",
+                targetExecutable,
+                targetArguments,
                 filters,
                 attributeFilters,
+                workingDir,
                 output
             );
 

--- a/tools/Google.Cloud.Tools.ProjectGenerator/Program.cs
+++ b/tools/Google.Cloud.Tools.ProjectGenerator/Program.cs
@@ -478,8 +478,7 @@ namespace Google.Cloud.Tools.ProjectGenerator
                 return;
             }
             var targetExecutable = new XElement("TargetExecutable", "C:/Program Files/dotnet/dotnet.exe");
-            var targetArguments = new XElement("TargetArguments",
-                $"test --no-build -c Release");
+            var targetArguments = new XElement("TargetArguments", "test --no-build -c Release");
             var filters = new XElement("Filters", new XElement("IncludeFilters",
                 new XElement("FilterEntry", new XElement("ModuleMask", api.Id)),
                 // Allow tests to contribute coverage to project dependencies, but not package dependencies

--- a/toolversions.sh
+++ b/toolversions.sh
@@ -7,7 +7,7 @@ declare -r REPO_ROOT=$(readlink -f $(dirname ${BASH_SOURCE}))
 declare -r TOOL_PACKAGES=$REPO_ROOT/packages
 
 declare -r DOCFX_VERSION=2.39.1
-declare -r DOTCOVER_VERSION=2018.2.0
+declare -r DOTCOVER_VERSION=2018.2.3
 declare -r REPORTGENERATOR_VERSION=2.4.5.0
 declare -r PROTOC_VERSION=3.6.0
 declare -r GRPC_VERSION=1.12.0


### PR DESCRIPTION
As well as reactivating coverage in kokoro.
The last commit only contains the regenerated project and coverage.xml files.

I'm testing as much of this as I can on the Kokoro VM now. Will update here with results.