### PR TITLE
Use - instead of / for dotcover command line argument

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -136,7 +136,7 @@ then
     if [[ "$runcoverage" = true && -f "$testdir/coverage.xml" ]]
     then
       echo "(Running with coverage)"
-      (cd "$testdir"; $DOTCOVER cover "coverage.xml" /ReturnTargetExitCode)
+      (cd "$testdir"; $DOTCOVER cover "coverage.xml" -ReturnTargetExitCode)
     else
       dotnet test -c Release --no-build $testproject
     fi

--- a/runintegrationtests.sh
+++ b/runintegrationtests.sh
@@ -104,7 +104,7 @@ do
     dotnet run -p $testdir -- $TEST_PROJECT || echo "$testdir" >> $FAILURE_TEMP_FILE
   elif [[ "$COVERAGE_ARG" == "yes" && -f "$testdir/coverage.xml" ]]
   then
-    (cd $testdir; $DOTCOVER cover "coverage.xml" /ReturnTargetExitCode || echo "$testdir" >> $FAILURE_TEMP_FILE)
+    (cd $testdir; $DOTCOVER cover "coverage.xml" -ReturnTargetExitCode || echo "$testdir" >> $FAILURE_TEMP_FILE)
   else
     (cd $testdir; dotnet test -c Release --no-build || echo "$testdir" >> $FAILURE_TEMP_FILE)
   fi


### PR DESCRIPTION
I believe / used to work, but it looks like it doesn't in the latest
version. - seems to work fine.