### PR TITLE
Fix description of Firestore.V1Beta1 package

### DIFF
--- a/apis/Google.Cloud.Firestore.V1Beta1/Google.Cloud.Firestore.V1Beta1/Google.Cloud.Firestore.V1Beta1.csproj
+++ b/apis/Google.Cloud.Firestore.V1Beta1/Google.Cloud.Firestore.V1Beta1/Google.Cloud.Firestore.V1Beta1.csproj
@@ -10,7 +10,7 @@
     <SignAssembly>true</SignAssembly>
     <Deterministic>true</Deterministic>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Description>Low-level Google client library to access the Firestore API. Users are recommended to use the Google.Cloud.Firestore.Data package instead.</Description>
+    <Description>Low-level Google client library to access the Firestore API. Users are recommended to use the Google.Cloud.Firestore package instead.</Description>
     <PackageTags>firestore;firebase;Google;Cloud</PackageTags>
     <Copyright>Copyright 2018 Google LLC</Copyright>
     <Authors>Google Inc.</Authors>

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -352,7 +352,7 @@
     "productUrl": "https://firebase.google.com",
     "version": "1.0.0-beta11",
     "type": "grpc",
-    "description": "Low-level Google client library to access the Firestore API. Users are recommended to use the Google.Cloud.Firestore.Data package instead.",
+    "description": "Low-level Google client library to access the Firestore API. Users are recommended to use the Google.Cloud.Firestore package instead.",
     "tags": [ "firestore", "firebase" ],
     "dependencies": {
       "Google.LongRunning": "1.0.0"


### PR DESCRIPTION
This referred to Google.Cloud.Firestore.Data, rather than just Google.Cloud.Firestore.