### PR TITLE
Deactivating coverage in AppVeyor so it won't clash with coverage from Kokoro.

### DIFF
--- a/appveyor.sh
+++ b/appveyor.sh
@@ -11,12 +11,11 @@ bash generateprojects.sh && git diff --exit-code
 if [[ -z "$APPVEYOR_PULL_REQUEST_NUMBER" ]]
 then
   # Not in a pull request.
-  # Run a full build (no --diff) with tests and coverage, then create and upload coverage report.
-  ./build.sh --coverage
-  ./createcoveragereport.sh --upload --upload_reportname unittests
+  # Run a full build (no --diff) with tests. Don't do any coverage so it
+  # won't clash with coverage generated through Kokoro.
+  ./build.sh
 else
-  # We're in a pull request. Don't do any coverage; just
-  # build and run tests.
+  # We're in a pull request. Just build and run tests for the changes.
   ./build.sh --diff
 fi
 


### PR DESCRIPTION
Since we now have flagged coverage from Kokoro, both for unittests and integrationtests, if we run coverage from AppVeyor, which only includes unittests, we'll be bouncing back and forth from unittests only coverage (around 50%) and unittests+integrationtests coverage (around 70%).