### PR TITLE
DetachedSessionPool and first parts of SessionPool, around "detached" sessions

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SessionPoolTests.DetachedSessionPoolTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SessionPoolTests.DetachedSessionPoolTests.cs
@@ -1,0 +1,62 @@
+﻿// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Moq;
+using System.Threading.Tasks;
+using Xunit;
+using static Google.Cloud.Spanner.V1.TransactionOptions;
+
+namespace Google.Cloud.Spanner.V1.PoolRewrite.Tests
+{
+    public partial class SessionPoolTests
+    {
+        // Note: we can't created a DetachedSessionPool directly, but we can create a SessionPool
+        // and recreate a session.
+        public sealed class DetachedSessionPoolTests
+        {
+            [Fact]
+            public void ReleaseDetachedSession_NoDelete()
+            {
+                var logger = new InMemoryLogger();
+                var mock = new Mock<SpannerClient>(MockBehavior.Strict);
+                var pool = new SessionPool(mock.Object, new SessionPoolOptions(), logger);
+                var session = pool.RecreateSession(s_sampleSessionName, s_sampleTransactionId, ModeOneofCase.ReadOnly);
+
+                // No calls to DeleteSession
+                session.ReleaseToPool(false);
+                logger.AssertNoWarningsOrErrors();
+            }
+
+            [Fact]
+            public void ReleaseDetachedSession_Delete()
+            {
+                var logger = new InMemoryLogger();
+                var mock = new Mock<SpannerClient>(MockBehavior.Strict);
+                // We will force the session to be deleted, so check it happens in the mock.
+                mock.Setup(client => client.DeleteSessionAsync(new DeleteSessionRequest { SessionName = s_sampleSessionName }, null))
+                    .Returns(Task.FromResult(0))
+                    .Verifiable();
+
+                var pool = new SessionPool(mock.Object, new SessionPoolOptions(), logger);
+                var session = pool.RecreateSession(s_sampleSessionName, s_sampleTransactionId, ModeOneofCase.ReadOnly);
+
+                // Logically, the deletion happens asynchronously. However, everything completes synchronously so we don't need
+                // to sleep or anything to wait for the call to come through.
+                session.ReleaseToPool(true);
+                logger.AssertNoWarningsOrErrors();
+                mock.Verify();
+            }
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/PoolRewrite/SessionPool.DetachedSessionPool.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/PoolRewrite/SessionPool.DetachedSessionPool.cs
@@ -1,0 +1,42 @@
+﻿// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Google.Cloud.Spanner.V1.PoolRewrite
+{
+    public partial class SessionPool
+    {
+        // TODO: Rename? (Name doesn't matter much as it's a private class.)
+
+        /// <summary>
+        /// A "session pool" for sessions that aren't really pooled. This is used by
+        /// <see cref="SessionPool.RecreateSession(SessionName, Protobuf.ByteString, TransactionOptions.ModeOneofCase)"/>.
+        /// We need to have it in *a* pool so that we can use <see cref="PooledSession"/>, and we need to be able to
+        /// delete the session if requested (so we need to know our parent), but that's all.
+        /// </summary>
+        private sealed class DetachedSessionPool : SessionPoolBase
+        {
+            internal DetachedSessionPool(SessionPool parent) : base(parent)
+            {
+            }
+
+            public override void Release(PooledSession session, bool deleteSession)
+            {
+                if (deleteSession)
+                {
+                    Parent.DeleteSessionFireAndForget(session);
+                }
+            }
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/PoolRewrite/SessionPool.SessionPoolBase.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/PoolRewrite/SessionPool.SessionPoolBase.cs
@@ -1,0 +1,31 @@
+﻿// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Google.Cloud.Spanner.V1.PoolRewrite
+{
+    public partial class SessionPool
+    {
+        /// <summary>
+        /// Trivial base class for TargetedSessionPool and DetachedSessionPool.
+        /// </summary>
+        private abstract class SessionPoolBase : ISessionPool
+        {
+            public SpannerClient Client => Parent.Client;
+            public SessionPoolOptions Options => Parent.Options;
+            protected SessionPool Parent { get; }
+            public abstract void Release(PooledSession session, bool deleteSession);
+            protected SessionPoolBase(SessionPool parent) => Parent = parent;
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/PoolRewrite/SessionPool.SessionPoolBase.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/PoolRewrite/SessionPool.SessionPoolBase.cs
@@ -21,7 +21,7 @@ namespace Google.Cloud.Spanner.V1.PoolRewrite
         /// </summary>
         private abstract class SessionPoolBase : ISessionPool
         {
-            public SpannerClient Client => Parent.Client;
+            public SpannerClient Client => Parent._client;
             public SessionPoolOptions Options => Parent.Options;
             protected SessionPool Parent { get; }
             public abstract void Release(PooledSession session, bool deleteSession);

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/PoolRewrite/SessionPool.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/PoolRewrite/SessionPool.cs
@@ -39,12 +39,13 @@ namespace Google.Cloud.Spanner.V1.PoolRewrite
 
         private readonly Logger _logger;
 
+        private readonly SpannerClient _client;
+
         /// <summary>
         /// The options governing this session pool.
         /// </summary>
         public SessionPoolOptions Options { get; }
 
-        internal SpannerClient Client { get; }
 
         /// <summary>
         /// Creates a session pool for the given client.
@@ -54,7 +55,7 @@ namespace Google.Cloud.Spanner.V1.PoolRewrite
         /// <param name="logger">The logger to use. May be null, in which case the default logger is used.</param>
         public SessionPool(SpannerClient client, SessionPoolOptions options, Logger logger)
         {
-            Client = GaxPreconditions.CheckNotNull(client, nameof(client));
+            _client = GaxPreconditions.CheckNotNull(client, nameof(client));
             Options = GaxPreconditions.CheckNotNull(options, nameof(options));
             _logger = logger ?? Logger.DefaultLogger;
             _detachedSessionPool = new DetachedSessionPool(this);
@@ -103,7 +104,7 @@ namespace Google.Cloud.Spanner.V1.PoolRewrite
         {
             try
             {
-                await Client.DeleteSessionAsync(new DeleteSessionRequest { SessionName = session.SessionName }).ConfigureAwait(false);
+                await _client.DeleteSessionAsync(new DeleteSessionRequest { SessionName = session.SessionName }).ConfigureAwait(false);
             }
             catch (RpcException e)
             {


### PR DESCRIPTION
Some of the using directives in SessionPool will be unnecessary for now, but it's easier to include them all
than work out exactly what's needed.