### PR TITLE
Remove Clock/Scheduler from SessionPoolOptions

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SessionPoolOptionsTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SessionPoolOptionsTests.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
 using System;
 using System.Reflection;
@@ -24,14 +23,12 @@ namespace Google.Cloud.Spanner.V1.PoolRewrite.Tests
     {
         public static TheoryData<string, object> ValidPropertyValues = new TheoryData<string, object>
         {
-            { nameof(SessionPoolOptions.Clock), SystemClock.Instance },
             { nameof(SessionPoolOptions.IdleSessionRefreshDelay), TimeSpan.FromSeconds(1) },
             { nameof(SessionPoolOptions.MaintenanceLoopDelay), TimeSpan.FromSeconds(1) },
             { nameof(SessionPoolOptions.MaximumActiveSessions), 1 },
             { nameof(SessionPoolOptions.MaximumConcurrentSessionCreates), 5 },
             { nameof(SessionPoolOptions.MinimumPooledSessions), 0 },
             { nameof(SessionPoolOptions.PoolEvictionDelay), TimeSpan.FromSeconds(1) },
-            { nameof(SessionPoolOptions.Scheduler), SystemScheduler.Instance },
             { nameof(SessionPoolOptions.SessionEvictionJitter), RetrySettings.NoJitter },
             { nameof(SessionPoolOptions.SessionRefreshJitter), RetrySettings.NoJitter },
             { nameof(SessionPoolOptions.WaitOnResourcesExhausted), ResourcesExhaustedBehavior.Fail },
@@ -40,14 +37,12 @@ namespace Google.Cloud.Spanner.V1.PoolRewrite.Tests
 
         public static TheoryData<string, object> InvalidPropertyValues = new TheoryData<string, object>
         {
-            { nameof(SessionPoolOptions.Clock), null },
             { nameof(SessionPoolOptions.IdleSessionRefreshDelay), TimeSpan.FromSeconds(0) },
             { nameof(SessionPoolOptions.MaintenanceLoopDelay), TimeSpan.FromSeconds(0) },
             { nameof(SessionPoolOptions.MaximumActiveSessions), 0 },
             { nameof(SessionPoolOptions.MaximumConcurrentSessionCreates), 0 },
             { nameof(SessionPoolOptions.MinimumPooledSessions), -1 },
             { nameof(SessionPoolOptions.PoolEvictionDelay), TimeSpan.FromSeconds(0) },
-            { nameof(SessionPoolOptions.Scheduler), null },
             { nameof(SessionPoolOptions.SessionEvictionJitter), null },
             { nameof(SessionPoolOptions.SessionRefreshJitter), null },
             { nameof(SessionPoolOptions.WaitOnResourcesExhausted), (ResourcesExhaustedBehavior) 10 },

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SessionPoolTests.DetachedSessionPoolTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SessionPoolTests.DetachedSessionPoolTests.cs
@@ -29,7 +29,7 @@ namespace Google.Cloud.Spanner.V1.PoolRewrite.Tests
             public void ReleaseDetachedSession_NoDelete()
             {
                 var logger = new InMemoryLogger();
-                var mock = new Mock<SpannerClient>(MockBehavior.Strict);
+                var mock = SpannerClientHelpers.CreateMockClient();
                 var pool = new SessionPool(mock.Object, new SessionPoolOptions(), logger);
                 var session = pool.RecreateSession(s_sampleSessionName, s_sampleTransactionId, ModeOneofCase.ReadOnly);
 
@@ -42,7 +42,7 @@ namespace Google.Cloud.Spanner.V1.PoolRewrite.Tests
             public void ReleaseDetachedSession_Delete()
             {
                 var logger = new InMemoryLogger();
-                var mock = new Mock<SpannerClient>(MockBehavior.Strict);
+                var mock = SpannerClientHelpers.CreateMockClient();
                 // We will force the session to be deleted, so check it happens in the mock.
                 mock.Setup(client => client.DeleteSessionAsync(new DeleteSessionRequest { SessionName = s_sampleSessionName }, null))
                     .Returns(Task.FromResult(0))

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SessionPoolTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SessionPoolTests.cs
@@ -32,7 +32,7 @@ namespace Google.Cloud.Spanner.V1.PoolRewrite.Tests
         public void RecreateSession()
         {
             var logger = new InMemoryLogger();
-            var mock = new Mock<SpannerClient>();
+            var mock = SpannerClientHelpers.CreateMockClient();
             var pool = new SessionPool(mock.Object, new SessionPoolOptions(), logger);
 
             var mode = ModeOneofCase.ReadOnly;

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SpannerClientHelpers.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SpannerClientHelpers.cs
@@ -1,0 +1,39 @@
+﻿// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax.Testing;
+using Moq;
+
+namespace Google.Cloud.Spanner.V1.PoolRewrite.Tests
+{
+    /// <summary>
+    /// Helpers for tests that need SpannerClient instances.
+    /// </summary>
+    internal static class SpannerClientHelpers
+    {
+        /// <summary>
+        /// Creates a mock SpannerClient configured with settings that include a fake clock
+        /// and a fake scheduler.
+        /// </summary>
+        internal static Mock<SpannerClient> CreateMockClient(MockBehavior behavior = MockBehavior.Strict)
+        {
+            var settings = SpannerSettings.GetDefault();
+            settings.Clock = new FakeClock();
+            settings.Scheduler = new FakeScheduler();
+            var mock = new Mock<SpannerClient>(behavior);
+            mock.SetupProperty(client => client.Settings, settings);
+            return mock;
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/PoolRewrite/PooledSession.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/PoolRewrite/PooledSession.cs
@@ -109,7 +109,7 @@ namespace Google.Cloud.Spanner.V1.PoolRewrite
         internal static PooledSession FromSessionName(SessionPool.ISessionPool pool, SessionName sessionName)
         {
             var options = pool.Options;
-            var now = options.Clock.GetCurrentDateTimeUtc();
+            var now = pool.Clock.GetCurrentDateTimeUtc();
             var refreshDelay = options.SessionRefreshJitter.GetDelay(options.IdleSessionRefreshDelay);
             var evictionDelay = options.SessionEvictionJitter.GetDelay(options.PoolEvictionDelay);
             return new PooledSession(pool, sessionName, transactionId: null, ModeOneofCase.None, now + evictionDelay, now.Ticks + refreshDelay.Ticks);
@@ -127,12 +127,12 @@ namespace Google.Cloud.Spanner.V1.PoolRewrite
         /// <summary>
         /// Indicates whether the associated session has expired and should be evicted from the pool.
         /// </summary>
-        internal bool ShouldBeEvicted => _pool.Options.Clock.GetCurrentDateTimeUtc() > _evictionTime;
+        internal bool ShouldBeEvicted => _pool.Clock.GetCurrentDateTimeUtc() > _evictionTime;
 
         /// <summary>
         /// Indicates whether the associated session should be refreshed due to inactivity.
         /// </summary>
-        internal bool RequiresRefresh => _pool.Options.Clock.GetCurrentDateTimeUtc().Ticks > RefreshTicks;
+        internal bool RequiresRefresh => _pool.Clock.GetCurrentDateTimeUtc().Ticks > RefreshTicks;
 
         /// <summary>
         /// Indicates the next refresh time; only used by tests.
@@ -303,7 +303,7 @@ namespace Google.Cloud.Spanner.V1.PoolRewrite
         private void UpdateRefreshTime()
         {
             var options = _pool.Options;
-            var nowTicks = options.Clock.GetCurrentDateTimeUtc().Ticks;
+            var nowTicks = _pool.Clock.GetCurrentDateTimeUtc().Ticks;
             var refreshDelay = options.SessionRefreshJitter.GetDelay(options.IdleSessionRefreshDelay);
             Interlocked.Exchange(ref _refreshTicks, nowTicks + refreshDelay.Ticks);
         }

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/PoolRewrite/SessionPool.ISessionPool.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/PoolRewrite/SessionPool.ISessionPool.cs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 
+using Google.Api.Gax;
+
 namespace Google.Cloud.Spanner.V1.PoolRewrite
 {
     public partial class SessionPool
@@ -23,6 +25,7 @@ namespace Google.Cloud.Spanner.V1.PoolRewrite
         internal interface ISessionPool
         {
             SpannerClient Client { get; }
+            IClock Clock { get; }
             void Release(PooledSession session, bool deleteSession);
             SessionPoolOptions Options { get; }
         }

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/PoolRewrite/SessionPool.SessionPoolBase.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/PoolRewrite/SessionPool.SessionPoolBase.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Api.Gax;
+
 namespace Google.Cloud.Spanner.V1.PoolRewrite
 {
     public partial class SessionPool
@@ -22,6 +24,7 @@ namespace Google.Cloud.Spanner.V1.PoolRewrite
         private abstract class SessionPoolBase : ISessionPool
         {
             public SpannerClient Client => Parent._client;
+            public IClock Clock => Parent._clock;
             public SessionPoolOptions Options => Parent.Options;
             protected SessionPool Parent { get; }
             public abstract void Release(PooledSession session, bool deleteSession);

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/PoolRewrite/SessionPool.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/PoolRewrite/SessionPool.cs
@@ -36,10 +36,10 @@ namespace Google.Cloud.Spanner.V1.PoolRewrite
     public sealed partial class SessionPool
     {
         private readonly ISessionPool _detachedSessionPool;
-
         private readonly Logger _logger;
-
         private readonly SpannerClient _client;
+        private readonly IClock _clock;
+        private readonly IScheduler _scheduler;
 
         /// <summary>
         /// The options governing this session pool.
@@ -56,6 +56,8 @@ namespace Google.Cloud.Spanner.V1.PoolRewrite
         public SessionPool(SpannerClient client, SessionPoolOptions options, Logger logger)
         {
             _client = GaxPreconditions.CheckNotNull(client, nameof(client));
+            _clock = _client.Settings.Clock ?? SystemClock.Instance;
+            _scheduler = _client.Settings.Scheduler ?? SystemScheduler.Instance;
             Options = GaxPreconditions.CheckNotNull(options, nameof(options));
             _logger = logger ?? Logger.DefaultLogger;
             _detachedSessionPool = new DetachedSessionPool(this);

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/PoolRewrite/SessionPoolOptions.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/PoolRewrite/SessionPoolOptions.cs
@@ -35,8 +35,6 @@ namespace Google.Cloud.Spanner.V1.PoolRewrite
         private int _maximumConcurrentSessionCreates = 10;
         private RetrySettings.IJitter _sessionRefreshJitter = new ProportionalRandomJitter(0.1);
         private RetrySettings.IJitter _sessionEvictionJitter = new ProportionalRandomJitter(0.1);
-        private IClock _clock = SystemClock.Instance;
-        private IScheduler _scheduler= SystemScheduler.Instance;
 
         /// <summary>
         /// Constructs a new <see cref="SessionPoolOptions"/> with default values.
@@ -201,24 +199,6 @@ namespace Google.Cloud.Spanner.V1.PoolRewrite
         {
             get => _sessionEvictionJitter;
             set => _sessionEvictionJitter = GaxPreconditions.CheckNotNull(value, nameof(value));
-        }
-
-        /// <summary>
-        /// Clock used for timings; can be replaced for testing.
-        /// </summary>
-        internal IClock Clock
-        {
-            get => _clock;
-            set => _clock = GaxPreconditions.CheckNotNull(value, nameof(value));
-        }
-
-        /// <summary>
-        /// Scheduler used for delays (e.g. the pool maintenance loop); can be replaced for testing.
-        /// </summary>
-        internal IScheduler Scheduler
-        {
-            get => _scheduler;
-            set => _scheduler = GaxPreconditions.CheckNotNull(value, nameof(value));
         }
 
         // TODO: Move to GAX if we find we need it in other libraries. (We have CheckNonNegative already.)


### PR DESCRIPTION
They're already present in SpannerClient.Settings, and it's useful to only have one source of truth.
However, it's also useful to only default to the system clock/scheduler in one place, so we do that in SessionPool.

This also changes how we handle mocking SpannerClient, as we now need to make sure we always have settings available.

The introduction of the scheduler field in SessionPool isn't strictly needed right now, but goes naturally with the other changes.