### PR TITLE
Only use Result/Wait on the result of Task.Run

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.cs
@@ -257,7 +257,7 @@ namespace Google.Cloud.Spanner.Data
 
         /// <inheritdoc />
         public override int ExecuteNonQuery() =>
-            ExecuteNonQueryAsync(_synchronousCancellationTokenSource.Token).ResultWithUnwrappedExceptions();
+            Task.Run(() => ExecuteNonQueryAsync(_synchronousCancellationTokenSource.Token)).ResultWithUnwrappedExceptions();
 
         /// <summary>
         /// Executes the command against the <see cref="SpannerConnection"/>.
@@ -280,7 +280,7 @@ namespace Google.Cloud.Spanner.Data
 
         /// <inheritdoc />
         public override object ExecuteScalar() =>
-            ExecuteScalarAsync(_synchronousCancellationTokenSource.Token).ResultWithUnwrappedExceptions();
+            Task.Run(() => ExecuteScalarAsync(_synchronousCancellationTokenSource.Token)).ResultWithUnwrappedExceptions();
 
         /// <summary>
         /// Executes the query and returns the first column of the first row in the result set returned by the query.
@@ -375,7 +375,7 @@ namespace Google.Cloud.Spanner.Data
 
         /// <inheritdoc />
         protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior) =>
-            CreateExecutableCommand().ExecuteDbDataReaderAsync(behavior, null, _synchronousCancellationTokenSource.Token).ResultWithUnwrappedExceptions();
+            Task.Run(() => CreateExecutableCommand().ExecuteDbDataReaderAsync(behavior, null, _synchronousCancellationTokenSource.Token)).ResultWithUnwrappedExceptions();
 
         /// <inheritdoc />
         protected override Task<DbDataReader> ExecuteDbDataReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken) =>
@@ -394,7 +394,7 @@ namespace Google.Cloud.Spanner.Data
         /// </remarks>
         /// <returns>A lower bound for the number of rows affected.</returns>
         public long ExecutePartitionedUpdate() =>
-            ExecutePartitionedUpdateAsync(_synchronousCancellationTokenSource.Token).ResultWithUnwrappedExceptions();
+            Task.Run(() => ExecutePartitionedUpdateAsync(_synchronousCancellationTokenSource.Token)).ResultWithUnwrappedExceptions();
 
         /// <summary>
         /// Executes this command as a partitioned update. The command must be a generalized DML command;

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDataAdapter.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDataAdapter.cs
@@ -19,6 +19,7 @@ using System.ComponentModel;
 using System.Data;
 using System.Data.Common;
 using System.Threading;
+using System.Threading.Tasks;
 using Google.Api.Gax;
 #endif
 
@@ -228,8 +229,7 @@ namespace Google.Cloud.Spanner.Data
             var spannerDataReader = dataReader as SpannerDataReader;
             if (spannerDataReader != null && AutoCreateCommands && _parsedParameterCollection.Count == 0)
             {
-                var readerMetadata =
-                    spannerDataReader.PopulateMetadataAsync(CancellationToken.None).ResultWithUnwrappedExceptions();
+                var readerMetadata = spannerDataReader.PopulateMetadata();
                 foreach (var field in readerMetadata.RowType.Fields)
                 {
                     _parsedParameterCollection.Add(


### PR DESCRIPTION
(There are some more implementation notes in the comments.)

Potential further work:

- A Roslyn analyzer to catch this sort of thing
- New GAX methods that call Task.Run for us instead
- WaitWithUnwrappedExceptions accepting a timeout