### PR TITLE
Lifecycle methods for TargetedSessionPool

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SessionPoolTests.TargetedSessionPoolTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SessionPoolTests.TargetedSessionPoolTests.cs
@@ -352,7 +352,7 @@ namespace Google.Cloud.Spanner.V1.PoolRewrite.Tests
                 });
             }
 
-            [Fact]
+            [Fact(Skip="Currently flaky on CI. Fixing via GAX changes")]
             public async Task WaitForPoolAsync_Normal()
             {
                 var pool = CreatePool(false);

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/PoolRewrite/SessionPool.TargetedSessionPool.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/PoolRewrite/SessionPool.TargetedSessionPool.cs
@@ -408,7 +408,18 @@ namespace Google.Cloud.Spanner.V1.PoolRewrite
                     ReleaseInactiveSession(session, maybeCreateReadWriteTransaction: true);
                 }
             }
-            
+
+            internal void MaintainPool()
+            {
+                if (Shutdown)
+                {
+                    return;
+                }
+                EvictAndRefreshSessions();
+                StartAcquisitionTasksIfNecessary(ActiveSessionCount);
+                Parent._logger.Debug(() => $"After maintenance: {GetStatisticsSnapshot()}");
+            }
+
             private void EvictAndRefreshSessions()
             {
                 LinkedList<PooledSession> sessionsToEvict = new LinkedList<PooledSession>();


### PR DESCRIPTION
(Worth reviewing one commit at a time.)

We need a better way of getting FakeScheduler to effectively stop at particular times for this test. We effectively want to be able to run until time X, check stuff, then run again until time Y etc. The lack of this functionality explains the flakiness. (No idea how flaky it'll be in CI.)