### PR TITLE
Deflake tests using a new scheduler

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/AssemblyInfo.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+﻿// Copyright 2018 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using Google.Cloud.ClientTesting;
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
+// Uncomment these to run the tests in a predictable order. (By fixture name, then by test case within the fixture.)
+// [assembly: TestCollectionOrderer(AlphabeticalOrderer.TypeName, AlphabeticalOrderer.AssemblyName)]
+// [assembly: TestCaseOrderer(AlphabeticalOrderer.TypeName, AlphabeticalOrderer.AssemblyName)]

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/FakeScheduler.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/FakeScheduler.cs
@@ -1,0 +1,424 @@
+﻿// Copyright 2018 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is only temporarily in this project, while we pin down the changes.
+// Those changes will be backported to Google.Api.Gax.Testing.
+
+using Google.Api.Gax;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using FakeClock = Google.Api.Gax.Testing.FakeClock;
+
+namespace Google.Cloud.Spanner.V1.PoolRewrite.Tests
+{
+    /// <summary>
+    /// Experimental - please read remarks. Fake implementation of <see cref="IScheduler" />, designed to work with
+    /// <see cref="FakeClock"/>.
+    /// </summary>
+    /// <remarks>
+    /// This class is currently hard to use robustly, and cancellation in particular is hard.
+    /// The API and behavior may change in future versions without a major version bump - in other words,
+    /// this is not considered part of the stable API of the package.
+    /// </remarks>
+    public sealed class FakeScheduler : IScheduler
+    {
+        /// <summary>
+        /// How long the scheduler can run in real time before timing out.
+        /// </summary>
+        public TimeSpan RealTimeTimeout { get; set; } = TimeSpan.FromSeconds(10);
+
+        /// <summary>
+        /// How long the scheduler can run in simulated time before timing out.
+        /// </summary>
+        public TimeSpan SimulatedTimeTimeout { get; set; } = TimeSpan.FromDays(10);
+
+        /// <summary>
+        /// When running the scheduler, we pause until no more tasks have been scheduled
+        /// for a certain time, to allow continuations to execute before the clock is advanced.
+        /// By default this is 10ms, but tests which expect a greater amount of processing
+        /// may increase this.
+        /// </summary>
+        public TimeSpan IdleTimeBeforeAdvancing { get; set; } = TimeSpan.FromMilliseconds(10);
+
+        /// <summary>
+        /// Time to allow test code to execute continuations after the scheduler loop has completed.
+        /// This is a one-time delay per RunAsync/RunAndPause call, to reduce flakiness.
+        /// </summary>
+        public TimeSpan PostLoopSettleTime { get; set; } = TimeSpan.FromMilliseconds(100);
+
+        /// <summary>
+        /// The clock associated with this scheduler. The clock is advanced as the scheduler runs.
+        /// </summary>
+        public FakeClock Clock { get; }
+
+        private readonly object _monitor = new object();
+        private LinkedList<DelayTimer> _actions = new LinkedList<DelayTimer>();
+        private bool _stopped;
+
+        /// <summary>
+        /// Constructs a fake scheduler which works with the given clock.
+        /// </summary>
+        /// <param name="clock">Fake clock to observe for timing purposes.</param>
+        public FakeScheduler(FakeClock clock)
+        {
+            Clock = GaxPreconditions.CheckNotNull(clock, nameof(clock));
+        }
+
+        /// <summary>
+        /// Constructs a fake scheduler with a new fake clock starting at 0 ticks.
+        /// </summary>
+        public FakeScheduler() : this(new FakeClock(0L))
+        {
+        }
+
+        // Defaulting cancellation token makes it simpler to use for some tests.
+        /// <inheritdoc />
+        public Task Delay(TimeSpan delay, CancellationToken cancellationToken = default(CancellationToken)) =>
+            AddTimer(Clock.GetCurrentDateTimeUtc() + delay, cancellationToken);
+
+        /// <summary>
+        /// Specialization of <see cref="Run{T}(Func{T})"/> for tasks, to prevent a common usage error.
+        /// </summary>
+        /// <remarks>
+        /// If you pass in a delegate which returns a task, that's almost always because you want to run it
+        /// until that task completes - which is what <see cref="RunAsync(Func{Task})"/> does.
+        /// </remarks>
+        /// <param name="taskProvider">A task provider.</param>
+        [Obsolete("Use RunAsync to run a function returning a task", true)]
+        public void Run(Func<Task> taskProvider)
+        {
+            throw new InvalidOperationException("Use RunAsync to run a function returning a task");
+        }
+
+        /// <summary>
+        /// Specialization of <see cref="Run{T}(Func{T})"/> for tasks, to prevent a common usage error.
+        /// </summary>
+        /// <remarks>
+        /// If you pass in a delegate which returns a task, that's almost always because you want to run it
+        /// until that task completes - which is what <see cref="RunAsync{T}(Func{Task{T}})"/> does.
+        /// </remarks>
+        /// <param name="taskProvider">A task provider.</param>
+        [Obsolete("Use RunAsync to run a function returning a task", true)]
+        public void Run<T>(Func<Task<T>> taskProvider)
+        {
+            throw new InvalidOperationException("Use RunAsync to run a function returning a task");
+        }
+
+        /// <summary>
+        /// <para>
+        /// Invokes the given action in a separate thread, and then runs the scheduler until one of four conditions is met:
+        /// </para>
+        /// <list type="bullet">
+        ///   <item>The action completes successfully</item>
+        ///   <item>The action completes with an exception</item>
+        ///   <item><see cref="RealTimeTimeout"/> of real time has elapsed</item>
+        ///   <item><see cref="SimulatedTimeTimeout"/> of simulated time has elapsed</item>
+        /// </list>
+        /// <para>
+        /// Only the first of these results in the method completing normally; otherwise, an exception is thrown.
+        /// If the action completes with an exception, that exception is the result of the method.
+        /// If the action has effectively hung, the thread is not terminated; it is expected that the test will
+        /// fail without the broken method causing any more harm.
+        /// </para>
+        /// </summary>
+        /// <exception cref="SchedulerTimeoutException">The scheduler timed out.</exception>
+        /// <param name="action">The action to execute with the scheduler.</param>
+        public void Run(Action action) => Run(() => { action(); return 1; });
+
+        /// <summary>
+        /// <para>
+        /// Invokes the given action in a separate thread, and then runs the scheduler until one of four conditions is met:
+        /// </para>
+        /// <list type="bullet">
+        ///   <item>The action completes successfully</item>
+        ///   <item>The action completes with an exception</item>
+        ///   <item><see cref="RealTimeTimeout"/> of real time has elapsed</item>
+        ///   <item><see cref="SimulatedTimeTimeout"/> of simulated time has elapsed</item>
+        /// </list>
+        /// <para>
+        /// Only the first of these results in the method completing normally; otherwise, an exception is thrown.
+        /// If the action completes with an exception, that exception is the result of the method.
+        /// If the action has effectively hung, the thread is not terminated; it is expected that the test will
+        /// fail without the broken method causing any more harm.
+        /// </para>
+        /// </summary>
+        /// <exception cref="SchedulerTimeoutException">The scheduler timed out.</exception>
+        /// <param name="func">The function to execute with the scheduler.</param>
+        public T Run<T>(Func<T> func) => RunAsync(() => Task.FromResult(func())).Result;
+
+        /// <summary>
+        /// <para>
+        /// Invokes the given action in a separate thread, and then runs the scheduler until one of four conditions is met:
+        /// </para>
+        /// <list type="bullet">
+        ///   <item>The action completes successfully</item>
+        ///   <item>The action completes with an exception</item>
+        ///   <item><see cref="RealTimeTimeout"/> of real time has elapsed</item>
+        ///   <item><see cref="SimulatedTimeTimeout"/> of simulated time has elapsed</item>
+        /// </list>
+        /// <para>
+        /// Only the first of these results in the method completing normally; otherwise, an exception is thrown.
+        /// If the action completes with an exception, that exception is the result of the method.
+        /// If the action has effectively hung, the thread is not terminated; it is expected that the test will
+        /// fail without the broken method causing any more harm.
+        /// </para>
+        /// </summary>
+        /// <exception cref="SchedulerTimeoutException">The scheduler timed out.</exception>
+        /// <param name="taskProvider">A delegate providing an asynchronous action to execute with the scheduler.</param>
+        public Task RunAsync(Func<Task> taskProvider) => RunAsync(async () => { await taskProvider().ConfigureAwait(false); return 0; });
+
+        /// <summary>
+        /// Runs a task in a separate thread, and the scheduler alongside it to simulate sleeping and delaying.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The task provider is run in a separate thread, so that even synchronous task providers (e.g. using 
+        /// <see cref="Task.FromResult{TResult}(TResult)"/>) work appropriately. The scheduler is run
+        /// until one of four conditions is met:
+        /// </para>
+        /// <list type="bullet">
+        ///   <item>The task completes successfully</item>
+        ///   <item>The task completes with an exception</item>
+        ///   <item><see cref="RealTimeTimeout"/> of real time has elapsed</item>
+        ///   <item><see cref="SimulatedTimeTimeout"/> of simulated time has elapsed</item>
+        /// </list>
+        /// <para>
+        /// Only the first of these results in the method completing normally; otherwise, an exception is thrown.
+        /// If the task completes with an exception, that exception is the result of the method.
+        /// If the task has effectively hung, the thread is not terminated; it is expected that the test will
+        /// fail without the broken method causing any more harm.
+        /// </para>
+        /// </remarks>
+        /// <exception cref="SchedulerTimeoutException">The scheduler timed out.</exception>
+        /// <param name="taskProvider">A delegate providing an asynchronous function to execute with the scheduler.</param>
+        public async Task<T> RunAsync<T>(Func<Task<T>> taskProvider)
+        {
+            var funcTask = Task.Run(taskProvider);
+            var simulatedTimeTask = StartLoopAsync(Clock.GetCurrentDateTimeUtc() + SimulatedTimeTimeout, true);
+            var delayTask = Task.Delay(RealTimeTimeout);
+            await Task.WhenAny(funcTask, simulatedTimeTask, delayTask).ConfigureAwait(false);
+            // Allow the test code a little more time to execute, just in case we're waiting for slow logging etc.
+            await Task.WhenAny(funcTask, Task.Delay(PostLoopSettleTime)).ConfigureAwait(false);
+            lock (_monitor)
+            {
+                _stopped = true;
+                Monitor.PulseAll(_monitor);
+            }
+            if (funcTask.IsCompleted)
+            {
+                return await funcTask.ConfigureAwait(false);
+            }
+            else if (delayTask.IsCompleted)
+            {
+                throw new SchedulerTimeoutException("Real time time-out; deadlock in user code?");
+            }
+            else if (simulatedTimeTask.IsCompleted)
+            {
+                throw new SchedulerTimeoutException("Simulated time time-out; busy loop in user code?");
+            }
+            else
+            {
+                throw new InvalidOperationException($"Unexpected return from Task.WhenAny - none of the expected tasks completed.");
+            }
+        }
+
+        /// <summary>
+        /// Runs the scheduler for the given number of seconds. If the task completes normally,
+        /// the clock should have advanced by the given number of seconds.
+        /// </summary>
+        /// <param name="seconds">How many seconds (in simulated time) to run for</param>
+        /// <returns>A task which will complete when scheduler has processed tasks up until
+        /// the given time.</returns>
+        public Task RunAndPauseForSeconds(int seconds) => RunAndPause(TimeSpan.FromSeconds(seconds));
+
+        /// <summary>
+        /// Runs the scheduler for the given amount of time. If the task completes normally,
+        /// the clock should have advanced by the given TimeSpan.
+        /// </summary>
+        /// <param name="time">How long (in simulated time) to run for</param>
+        /// <returns>A task which will complete when scheduler has processed tasks up until
+        /// the given time.</returns>
+        public async Task RunAndPause(TimeSpan time)
+        {
+            var simulatedTimeTask = StartLoopAsync(Clock.GetCurrentDateTimeUtc() + time, false);
+            var delayTask = Task.Delay(RealTimeTimeout);
+            var completedTask = await Task.WhenAny(simulatedTimeTask, delayTask).ConfigureAwait(false);
+            if (completedTask == delayTask)
+            {
+                throw new SchedulerTimeoutException("Real time time-out; deadlock in user code?");
+            }
+            // Let any finally-released tasks a bit of time to execute before returning.
+            await Task.Delay(PostLoopSettleTime).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Runs the inner loop of the scheduler. If the returned task completes normally, the clock will be
+        /// set to <paramref name="simulatedTimeout"/>.
+        /// </summary>
+        /// <param name="simulatedTimeout">Maximum time to run for. Delays scheduled for later than this
+        /// time will not be executed.</param>
+        /// <param name="runTestCode">true if test code is running as well, and should be given some extra time to
+        /// execute on each iteration. false if only the scheduled tasks are running.</param>
+        private Task StartLoopAsync(DateTime simulatedTimeout, bool runTestCode) =>
+            Task.Run(() =>
+            {
+                // In-method protection against infinite loops. Each caller provides the actual timeout check,
+                // throwing an exception appropriately.
+                DateTime realDeadline = DateTime.UtcNow + RealTimeTimeout + TimeSpan.FromSeconds(2);
+
+                DateTime nextClockTime = Clock.GetCurrentDateTimeUtc();
+
+                while (nextClockTime <= simulatedTimeout)
+                {
+                    // Pointless on the first iteration, but on later iterations this will
+                    // be the time of the next timer waiting to execute.
+                    Clock.AdvanceTo(nextClockTime);
+
+                    // Return if the test has completed already (not necessarily successfully)
+                    lock (_monitor)
+                    {
+                        if (_stopped)
+                        {
+                            return;
+                        }
+                    }
+
+                    var now = Clock.GetCurrentDateTimeUtc();
+                    // Find all timers that are due now.
+                    List<DelayTimer> timers = new List<DelayTimer>();
+                    lock (_monitor)
+                    {
+                        while (_actions.Count != 0 && _actions.First.Value.ScheduledTime <= now)
+                        {
+                            timers.Add(_actions.First.Value);
+                            _actions.RemoveFirst();
+                        }
+                    }
+                    
+                    // Release all due, non-cancelled timers. (A cancelled TCS will ignore this.)
+                    timers.ForEach(t => t.CompletionSource.TrySetResult(0));
+
+                    lock (_monitor)
+                    {
+                        // If the test code is running (RunAsync) give that a bit of time - wait for at least
+                        // one more delay to be scheduled, or the test to complete.
+                        if (runTestCode)
+                        {
+                            while (!_stopped && _actions.Count == 0)
+                            {
+                                if (!Monitor.Wait(_monitor, RealTimeTimeout + TimeSpan.FromSeconds(2)))
+                                {
+                                    throw new SchedulerTimeoutException("Scheduler timed out (real time)");
+                                }
+                            }
+                        }
+
+                        if (_stopped)
+                        {
+                            break;
+                        }
+
+                        // Give some time for tasks to execute.
+                        // Repeats until no further delays are created within IdleTimeBeforeAdvancing.
+                        // It would be much better to track all created Tasks and make sure they've all completed;
+                        // But that's fairly invasive.
+                        while (DateTime.UtcNow < realDeadline && Monitor.Wait(_monitor, IdleTimeBeforeAdvancing)) ;
+
+                        // We don't expect this to be observed, as the calling code will probably have timed
+                        // out already, but it's clearer than returning normally.
+                        if (DateTime.UtcNow >= realDeadline)
+                        {
+                            throw new SchedulerTimeoutException("Scheduler timed out (real time)");
+                        }
+
+                        // If we have a new timer, and if it should be released before (or at) the timeout,
+                        // go round the loop again.
+                        if (_actions.Count != 0 && _actions.First.Value.ScheduledTime <= simulatedTimeout)
+                        {
+                            nextClockTime = _actions.First.Value.ScheduledTime;
+                            continue;
+                        }
+                        else
+                        {
+                            // Either we're idle, or the next timer is beyond our simulated timeout, so
+                            // quit the loop.
+                            break;
+                        }
+                    }
+                }
+                Clock.AdvanceTo(simulatedTimeout);
+            });
+
+        private Task AddTimer(DateTime scheduledTime, CancellationToken cancellationToken)
+        {
+            var timer = new DelayTimer(scheduledTime, new TaskCompletionSource<int>(), cancellationToken);
+
+            lock (_monitor)
+            {
+                var node = _actions.First;
+                while (node != null)
+                {
+                    if (node.Value.ScheduledTime > scheduledTime)
+                    {
+                        _actions.AddBefore(node, timer);
+                        break;
+                    }
+                    node = node.Next;
+                }
+                if (node == null)
+                {
+                    _actions.AddLast(timer);
+                }
+                Monitor.PulseAll(_monitor);
+            }
+            return timer.CompletionSource.Task;
+        }
+
+        private sealed class DelayTimer
+        {
+            internal DateTime ScheduledTime { get; }
+            internal TaskCompletionSource<int> CompletionSource { get; }
+
+            internal DelayTimer(DateTime scheduledTime, TaskCompletionSource<int> tcs, CancellationToken cancellationToken)
+            {
+                ScheduledTime = scheduledTime;
+                CompletionSource = tcs;
+                if (cancellationToken.CanBeCanceled)
+                {
+                    cancellationToken.Register(() => CompletionSource.TrySetCanceled());
+                }
+            }
+        }
+
+        /// <summary>
+        /// Exception designed not to be caught by tests (which may deliberately expect a timeout of another kind, for example).
+        /// This exception indicates that the scheduler timed out either in simulated time (e.g. a busy loop with a condition
+        /// never being satisfied) or in wall time (e.g. user code was waiting for a task which was never going to complete, due
+        /// to a deadlock).
+        /// </summary>
+        public sealed class SchedulerTimeoutException : Exception
+        {
+            /// <summary>
+            /// Constructs a new exception with the given message.
+            /// </summary>
+            /// <param name="message">Message for the exception.</param>
+            public SchedulerTimeoutException(string message) : base(message)
+            {
+            }
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SessionPoolTests.SessionTestingSpannerClient.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SessionPoolTests.SessionTestingSpannerClient.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using Google.Api.Gax.Grpc;
-using Google.Api.Gax.Testing;
 using Google.Cloud.ClientTesting;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
@@ -22,6 +21,8 @@ using System;
 using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
+
+using FakeClock = Google.Api.Gax.Testing.FakeClock;
 
 namespace Google.Cloud.Spanner.V1.PoolRewrite.Tests
 {
@@ -36,7 +37,15 @@ namespace Google.Cloud.Spanner.V1.PoolRewrite.Tests
             public TimeSpan BeginTransactionDelay { get; set; } = TimeSpan.FromSeconds(1);
             public TimeSpan ExecuteSqlDelay { get; set; } = TimeSpan.FromSeconds(1);
             public TimeSpan DeleteSessionDelay { get; set; } = TimeSpan.FromSeconds(1);
-            public FakeScheduler Scheduler { get; } = new FakeScheduler();
+            // We do quite a bit of work in our continuations, so allow a bit longer than the default of 10ms.
+            // Ditto allow a bit longer than normal for any test assertions to complete; this is particularly
+            // relevant in tests that generate a lot of logs.
+            // This will increase test times, but reduce flakiness.
+            public FakeScheduler Scheduler { get; } = new FakeScheduler
+            {
+                IdleTimeBeforeAdvancing = TimeSpan.FromMilliseconds(200),
+                PostLoopSettleTime = TimeSpan.FromMilliseconds(200),
+            };
             public FakeClock Clock => Scheduler.Clock;
             public InMemoryLogger Logger { get; } = new InMemoryLogger();
             public int SessionsCreated => Interlocked.CompareExchange(ref _sessionCounter, 0, 0);

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SessionPoolTests.TargetedSessionPoolTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SessionPoolTests.TargetedSessionPoolTests.cs
@@ -31,6 +31,18 @@ namespace Google.Cloud.Spanner.V1.PoolRewrite.Tests
         /// Tests for <see cref="SessionPool.TargetedSessionPool" />, mostly
         /// involving direct construction of the pool to avoid any maintenance loops etc.
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The tests use the scheduler in different ways. Some are slightly "interactive" - we
+        /// want the scheduler to be triggering while we wait for tasks to complete (e.g. session
+        /// acquisition, or waiting for the pool to be up to size). These use FakeScheduler.RunAsync.
+        /// </para>
+        /// <para>
+        /// Other tasks start asynchronous tasks running, then allow the scheduler to advance up to a
+        /// certain time before stopping... at which point we're back in control and can make assertions
+        /// without further tasks completing. These use FakeScheduler.RunAndPause.
+        /// </para>
+        /// </remarks>
         public sealed class TargetedSessionPoolTests
         {
             private static readonly DatabaseName s_databaseName = new DatabaseName("project", "instance", "database");
@@ -82,13 +94,7 @@ namespace Google.Cloud.Spanner.V1.PoolRewrite.Tests
                 Assert.Equal(0, stats.ReadPoolCount);
                 Assert.Equal(0, stats.ReadWritePoolCount);
 
-                await client.Scheduler.RunAsync(async () =>
-                {
-                    // This is unfortunate, but basically our fake task scheduler doesn't know how long to wait for
-                    // (in terms of other tasks being scheduled) before moving on.
-                    Thread.Sleep(2000);
-                    await client.Scheduler.Delay(TimeSpan.FromSeconds(15));
-                });
+                await client.Scheduler.RunAndPauseForSeconds(15);
 
                 stats = pool.GetStatisticsSnapshot();
                 
@@ -111,11 +117,7 @@ namespace Google.Cloud.Spanner.V1.PoolRewrite.Tests
                 await client.Scheduler.RunAsync(async () =>
                 {
                     // Acquire all 100 possible active sessions, so we don't get any more behind the scenes.
-                    var sessions = new List<PooledSession>();
-                    for (int i = 0; i < 100; i++)
-                    {
-                        sessions.Add(await pool.AcquireSessionAsync(new TransactionOptions(), default));
-                    }
+                    var sessions = await AcquireAllSessionsAsync(pool);
 
                     var firstSession = sessions[0];
                     await client.Scheduler.Delay(TimeSpan.FromMinutes(10)); // Not long enough to require a refresh
@@ -148,11 +150,7 @@ namespace Google.Cloud.Spanner.V1.PoolRewrite.Tests
                 await client.Scheduler.RunAsync(async () =>
                 {
                     // Acquire all 100 possible active sessions, so we don't get any more behind the scenes.
-                    var sessions = new List<PooledSession>();
-                    for (int i = 0; i < 100; i++)
-                    {
-                        sessions.Add(await pool.AcquireSessionAsync(new TransactionOptions(), default));
-                    }
+                    var sessions = await AcquireAllSessionsAsync(pool);
 
                     var firstSession = sessions[0];
                     await client.Scheduler.Delay(TimeSpan.FromMinutes(20)); // So a refresh is required
@@ -226,6 +224,10 @@ namespace Google.Cloud.Spanner.V1.PoolRewrite.Tests
                         await pool.AcquireSessionAsync(new TransactionOptions(), default);
                     }
                 });
+                var stats = pool.GetStatisticsSnapshot();
+                Assert.Equal(0, stats.ReadPoolCount);
+                Assert.Equal(0, stats.ReadWritePoolCount);
+                Assert.Equal(100, stats.ActiveSessionCount);
             }
 
             [Fact]
@@ -244,6 +246,10 @@ namespace Google.Cloud.Spanner.V1.PoolRewrite.Tests
                     // running etc.
                     await Task.WhenAll(tasks);
                 });
+                var stats = pool.GetStatisticsSnapshot();
+                Assert.Equal(0, stats.ReadPoolCount);
+                Assert.Equal(0, stats.ReadWritePoolCount);
+                Assert.Equal(100, stats.ActiveSessionCount);
             }
 
             [Fact]
@@ -295,23 +301,16 @@ namespace Google.Cloud.Spanner.V1.PoolRewrite.Tests
                 pool.Options.WriteSessionsFraction = 1; // Just for simplicity.
                 var client = (SessionTestingSpannerClient)pool.Client;
 
-                await client.Scheduler.RunAsync(async () =>
-                {
-                    await client.Scheduler.Delay(TimeSpan.FromMinutes(1));
-                    // Allow any pending tasks to execute.
-                    Thread.Sleep(2000);
+                var stats = pool.GetStatisticsSnapshot();
+                Assert.Equal(0, stats.ReadWritePoolCount);
 
-                    var stats = pool.GetStatisticsSnapshot();
-                    Assert.Equal(0, stats.ReadWritePoolCount);
+                pool.MaintainPool();
 
-                    pool.MaintainPool();
+                // Give it time to bring the pool up to size.
+                await client.Scheduler.RunAndPauseForSeconds(30);
 
-                    await client.Scheduler.Delay(TimeSpan.FromMinutes(1));
-                    Thread.Sleep(2000);
-
-                    stats = pool.GetStatisticsSnapshot();
-                    Assert.Equal(10, stats.ReadWritePoolCount);
-                });
+                stats = pool.GetStatisticsSnapshot();
+                Assert.Equal(10, stats.ReadWritePoolCount);
             }
 
             [Fact]
@@ -320,24 +319,23 @@ namespace Google.Cloud.Spanner.V1.PoolRewrite.Tests
                 var pool = CreatePool(true);
                 var client = (SessionTestingSpannerClient)pool.Client;
 
+                // Give the pool a minute to fill up
+                await client.Scheduler.RunAndPauseForSeconds(60);
+                Assert.Equal(10, pool.GetStatisticsSnapshot().ReadWritePoolCount);
+
+                // Let all the sessions idle out.
+                await client.Scheduler.RunAndPause(TimeSpan.FromMinutes(20));
+
+                var timeBeforeMaintenance = client.Clock.GetCurrentDateTimeUtc();
+
+                // Start everything refreshing.
+                pool.MaintainPool();
+
+                // Give the refresh tasks time to run.
+                await client.Scheduler.RunAndPauseForSeconds(60);
+
                 await client.Scheduler.RunAsync(async () =>
                 {
-                    await client.Scheduler.Delay(TimeSpan.FromMinutes(1));
-                    // Allow any pending tasks to execute.
-                    Thread.Sleep(2000);
-
-                    // Let all the sessions idle out.
-                    await client.Scheduler.Delay(TimeSpan.FromMinutes(20));
-
-                    var timeBeforeMaintenance = client.Clock.GetCurrentDateTimeUtc();
-
-                    // Start everything refreshing.
-                    pool.MaintainPool();
-
-                    // Give the refresh tasks time to run.
-                    await client.Scheduler.Delay(TimeSpan.FromMinutes(1));
-                    Thread.Sleep(2000);
-
                     var session = await pool.AcquireSessionAsync(new TransactionOptions(), default);
                     Assert.InRange(session.RefreshTimeForTest, timeBeforeMaintenance.AddMinutes(15), client.Clock.GetCurrentDateTimeUtc().AddMinutes(15));
 
@@ -353,39 +351,36 @@ namespace Google.Cloud.Spanner.V1.PoolRewrite.Tests
                 var pool = CreatePool(true);
                 var client = (SessionTestingSpannerClient)pool.Client;
 
-                await client.Scheduler.RunAsync(async () =>
-                {
-                    await client.Scheduler.Delay(TimeSpan.FromMinutes(1));
-                    // Allow any pending tasks to execute.
-                    Thread.Sleep(2000);
+                // Give the pool a minute to fill up
+                await client.Scheduler.RunAndPauseForSeconds(60);
+                Assert.Equal(10, pool.GetStatisticsSnapshot().ReadWritePoolCount);
 
-                    // Let all the sessions go beyond their eviction time.
-                    await client.Scheduler.Delay(TimeSpan.FromMinutes(101));
+                // Let all the sessions go beyond their eviction time.
+                await client.Scheduler.RunAndPause(TimeSpan.FromMinutes(101));
 
-                    var timeBeforeMaintenance = client.Clock.GetCurrentDateTimeUtc();
+                // Start everything refreshing.
+                var timeBeforeMaintenance = client.Clock.GetCurrentDateTimeUtc();
+                pool.MaintainPool();
 
-                    // Start everything refreshing.
-                    pool.MaintainPool();
+                // Give the eviction and reacquisition tasks time to run.
+                await client.Scheduler.RunAndPauseForSeconds(60);
+                Assert.Equal(10, pool.GetStatisticsSnapshot().ReadWritePoolCount);
 
-                    // Give the eviction and reacquisition tasks time to run.
-                    await client.Scheduler.Delay(TimeSpan.FromMinutes(1));
-                    Thread.Sleep(2000);
+                // Pool should be full aagain
+                var stats = pool.GetStatisticsSnapshot();
+                Assert.Equal(10, stats.ReadPoolCount + stats.ReadWritePoolCount);
 
-                    // The newly created session should have an appropriate refresh time.
-                    var session = await pool.AcquireSessionAsync(new TransactionOptions(), default);
-                    Assert.InRange(session.RefreshTimeForTest, timeBeforeMaintenance.AddMinutes(15), client.Clock.GetCurrentDateTimeUtc().AddMinutes(15));
-                    session.ReleaseToPool(false);
+                // The newly created session should have an appropriate refresh time.
+                // (We don't need to let the scheduler run, as we're getting it from the pool.)
+                var session = await pool.AcquireSessionAsync(new TransactionOptions(), default);
+                Assert.InRange(session.RefreshTimeForTest, timeBeforeMaintenance.AddMinutes(15), client.Clock.GetCurrentDateTimeUtc().AddMinutes(15));
 
-                    // Pool should be full again.
-                    var stats = pool.GetStatisticsSnapshot();
-                    Assert.Equal(10, stats.ReadPoolCount + stats.ReadWritePoolCount);
-
-                    // All the previous sessions should be evicted, and the pool refilled.
-                    Assert.Equal(20, client.SessionsCreated);
-                });
+                // All the previous sessions should have been evicted, so in total we've created 20 sessions.
+                Assert.Equal(20, client.SessionsCreated);
+                Assert.Equal(10, client.SessionsDeleted);
             }
 
-            [Fact(Skip="Currently flaky on CI. Fixing via GAX changes")]
+            [Fact]
             public async Task WaitForPoolAsync_Normal()
             {
                 var pool = CreatePool(false);
@@ -399,12 +394,15 @@ namespace Google.Cloud.Spanner.V1.PoolRewrite.Tests
                     await pool.WaitForPoolAsync(default);
 
                     // We allow 20 session creates at a time, and each takes 5 seconds.
-                    // We'll need at least 6 read/write sessions too, but those will be taken from the first 20
-                    // as we err on the side of over-creating read/write transactions. (When the first 20
-                    // all return, they'll all notice we have no transactions.) That won't slow down the
-                    // second set of creations.
+                    // We'll need at least 6 read/write sessions too. In reality, all 20 initially-created
+                    // sessions will have read/write transactions created for them, because they'll all check that
+                    // before any transactions are created.
+                    // We're loose when checking the elapsed time, as on slow CI machines it can take around half
+                    // a second for a released SemaphoreSlim to be acquired again, which means we don't start the second
+                    // session creation batch  until the virtual clock has advanced for the transaction creation.
                     var timeAfter = client.Clock.GetCurrentDateTimeUtc();
-                    Assert.Equal(TimeSpan.FromSeconds(10), timeAfter - timeBefore);
+                    var elapsedSeconds = (timeAfter - timeBefore).TotalSeconds;
+                    Assert.InRange(elapsedSeconds, 10, 11);
                     var stats = pool.GetStatisticsSnapshot();
                     Assert.Equal(10, stats.ReadPoolCount);
                     Assert.Equal(20, stats.ReadWritePoolCount);
@@ -419,29 +417,29 @@ namespace Google.Cloud.Spanner.V1.PoolRewrite.Tests
                 pool.MaintainPool();
                 var client = (SessionTestingSpannerClient)pool.Client;
 
-                await client.Scheduler.RunAsync(async () =>
-                {
-                    var timeBefore = client.Clock.GetCurrentDateTimeUtc();
-                    var cts = new CancellationTokenSource();
-                    var task1 = pool.WaitForPoolAsync(cts.Token);
-                    var task2 = pool.WaitForPoolAsync(default);
+                var timeBefore = client.Clock.GetCurrentDateTimeUtc();
+                var cts = new CancellationTokenSource();
+                var task1 = pool.WaitForPoolAsync(cts.Token);
+                var task2 = pool.WaitForPoolAsync(default);
 
-                    await client.Scheduler.Delay(TimeSpan.FromSeconds(8));
-                    
-                    Assert.Equal(TaskStatus.WaitingForActivation, task1.Status);
-                    Assert.Equal(TaskStatus.WaitingForActivation, task2.Status);
+                await client.Scheduler.RunAndPauseForSeconds(8);
 
-                    // If we cancel one cancelation token, that task will fail,
-                    // but the other won't.
-                    cts.Cancel();
-                    await client.Scheduler.Delay(TimeSpan.FromSeconds(1));
-                    Thread.Sleep(1000);
-                    Assert.Equal(TaskStatus.Canceled, task1.Status);
-                    Assert.Equal(TaskStatus.WaitingForActivation, task2.Status);
+                Assert.Equal(TaskStatus.WaitingForActivation, task1.Status);
+                Assert.Equal(TaskStatus.WaitingForActivation, task2.Status);
+                
+                // If we cancel one cancelation token, that task will fail,
+                // but the other won't.
+                cts.Cancel();
+                await client.Scheduler.RunAndPauseForSeconds(1);
+                Assert.Equal(TaskStatus.Canceled, task1.Status);
+                Assert.Equal(TaskStatus.WaitingForActivation, task2.Status);
 
-                    // The uncancelled task completes normally
-                    await task2;
-                });
+                // Two seconds later (i.e. 11 seconds after starting), the uncancelled task completes normally.
+                // It may well complete after 10 (virtual) seconds, but it depends on how quickly the SemaphoreSlim
+                // is acquired for the second batch.
+                await client.Scheduler.RunAndPauseForSeconds(2);
+                // Just await this normally to avoid race conditions for when it completes
+                await task2;
             }
 
             [Fact]
@@ -482,7 +480,12 @@ namespace Google.Cloud.Spanner.V1.PoolRewrite.Tests
                 var pool = CreatePool(false);
                 var client = (SessionTestingSpannerClient)pool.Client;
                 client.FailAllRpcs = true;
+                // We can end up with a lot of log entries, which take a while to write to disk
+                // before the task becomes faulted.
+                client.Scheduler.PostLoopSettleTime = TimeSpan.FromMilliseconds(500);
 
+                // We could probably do this without the scheduler, given that the tasks
+                // will fail immediately, but it feels odd not to use it.
                 await client.Scheduler.RunAsync(async () =>
                 {
                     var task = pool.WaitForPoolAsync(default);
@@ -500,23 +503,21 @@ namespace Google.Cloud.Spanner.V1.PoolRewrite.Tests
                 pool.Options.MaximumActiveSessions = 10; // Same as minimum pool size
                 var client = (SessionTestingSpannerClient)pool.Client;
 
-                await client.Scheduler.RunAsync(async () =>
-                {
-                    var session = await pool.AcquireSessionAsync(new TransactionOptions(), default);
+                var sessionTask = pool.AcquireSessionAsync(new TransactionOptions(), default);
+                var waitTask = pool.WaitForPoolAsync(default);
 
-                    Task task = pool.WaitForPoolAsync(default);
+                // Even if we wait for a minute, the WaitForPoolAsync task can't complete due to
+                // the limit on MaximumActiveSessions.
+                await client.Scheduler.RunAndPauseForSeconds(60);
 
-                    // Wait a bit - but nothing should happen, because we can't get any more sessions
-                    await client.Scheduler.Delay(TimeSpan.FromSeconds(10));
-                    Thread.Sleep(1000);
-                    // Having acquired a session, we can't reach the minimum pool size
-                    Assert.Equal(TaskStatus.WaitingForActivation, task.Status);
+                Assert.Equal(TaskStatus.RanToCompletion, sessionTask.Status);
+                Assert.Equal(TaskStatus.WaitingForActivation, waitTask.Status);
 
-                    session.ReleaseToPool(false);
-
-                    // Now the pool can be full again.
-                    await task;
-                });
+                // Releasing the session puts it back in the pool directly (with no delays to schedule)
+                sessionTask.Result.ReleaseToPool(false);
+                // We don't check the status directly, as we need continuations to run, but it should
+                // complete pretty quickly. (The timeout is just to avoid the test hanging if there's a bug.)
+                waitTask.Wait(1000);
             }
 
             [Fact]
@@ -531,7 +532,10 @@ namespace Google.Cloud.Spanner.V1.PoolRewrite.Tests
 
                     // Shut down the pool, but keep one active session for now
                     Task task = pool.ShutdownPoolAsync(default);
-                    await client.Scheduler.Delay(TimeSpan.FromMinutes(1));
+                    // Note: only a 20 second delay to avoid a real-time timeout. The shutdown task
+                    // will schedule a timer once per second, so if we have a 200ms delay per iteration,
+                    // that means we spend 4 seconds here. That's okay, but we don't want it to be more.
+                    await client.Scheduler.Delay(TimeSpan.FromSeconds(20));
                     var stats = pool.GetStatisticsSnapshot();
                     Assert.Equal(true, stats.Shutdown);
                     Assert.Equal(1, stats.ActiveSessionCount);
@@ -578,19 +582,18 @@ namespace Google.Cloud.Spanner.V1.PoolRewrite.Tests
                 {
                     await pool.WaitForPoolAsync(default);
                     await pool.ShutdownPoolAsync(default);
-                    // TODO: Is this the right exception? It feels appropriate.
                     await Assert.ThrowsAsync<InvalidOperationException>(() => pool.AcquireSessionAsync(new TransactionOptions(), default));
                 });
             }
 
             private async Task<List<PooledSession>> AcquireAllSessionsAsync(TargetedSessionPool pool)
             {
-                List<PooledSession> sessions = new List<PooledSession>();
-                for (int i = 0; i < pool.Options.MaximumActiveSessions; i++)
-                {
-                    sessions.Add(await pool.AcquireSessionAsync(new TransactionOptions(), default));
-                }
-                return sessions;
+                var tasks = Enumerable
+                    .Range(0, pool.Options.MaximumActiveSessions)
+                    .Select(_ => pool.AcquireSessionAsync(new TransactionOptions(), default))
+                    .ToList();
+                await Task.WhenAll(tasks);
+                return tasks.Select(t => t.Result).ToList();
             }
         }
     }


### PR DESCRIPTION
The first commit of this PR is just from #2632. I'll wait until that's in before merging this. (I'll rebase so that we don't have extra merge commits etc.)

The second commit is trivial.

The third commit, um, isn't trivial. I'd suggest taking it in this order:

- Review the FakeScheduler API (but not implementation) to see what you can do with it
- Review the changes to the tests (which are mostly about changing how *some* of the tests interact with FakeScheduler)
- Review the FakeScheduler implementation