### PR TITLE
[Bigtable] Smart retries logic for reads to account for request without RowSet

### DIFF
--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/BigtableReadRowsRequestManagerTest.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/BigtableReadRowsRequestManagerTest.cs
@@ -232,7 +232,44 @@ namespace Google.Cloud.Bigtable.V2.Tests
             // Assert that BuildUpdatedRequest did not modify the original RowSet.
             Assert.Equal(originalRequest, originalRequestClone);
         }
-        
+
+        /// <summary>
+        /// Test rows limit only request scenario for <see cref="BigtableReadRowsRequestManager.BuildUpdatedRequest()"/>
+        /// </summary>
+        [Fact]
+        public void TestRowsLimitOnlyRequest()
+        {
+            BigtableByteString lastFoundKey = "row015";
+
+            ReadRowsRequest originalRequest = new ReadRowsRequest { RowsLimit = 1000 };
+
+            BigtableReadRowsRequestManager underTest = new BigtableReadRowsRequestManager(originalRequest);
+            Assert.Equal(originalRequest, underTest.BuildUpdatedRequest());
+            underTest.LastFoundKey = lastFoundKey;
+            underTest.IncrementRowsReadSoFar(10);
+
+            ReadRowsRequest updatedRequest = CreateRowRangeRequest(RowRange.Open(lastFoundKey, null));
+            updatedRequest.RowsLimit = 990;
+            Assert.Equal(updatedRequest, underTest.BuildUpdatedRequest());
+        }
+
+        /// <summary>
+        /// Test request with no parameters scenario for <see cref="BigtableReadRowsRequestManager.BuildUpdatedRequest()"/>
+        /// </summary>
+        [Fact]
+        public void TestDefaultRequest()
+        {
+            BigtableByteString lastFoundKey = "row015";
+
+            ReadRowsRequest originalRequest = new ReadRowsRequest ();
+
+            BigtableReadRowsRequestManager underTest = new BigtableReadRowsRequestManager(originalRequest);
+            Assert.Equal(originalRequest, underTest.BuildUpdatedRequest());
+            underTest.LastFoundKey = lastFoundKey;
+
+            Assert.Equal(CreateRowRangeRequest(RowRange.Open(lastFoundKey, null)), underTest.BuildUpdatedRequest());
+        }
+
         /// <summary>
         /// For this test we will assume that the table contains sequentially numbered rowkeys from "row000" to "row999"
         /// </summary>

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableReadRowsRequestManager.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableReadRowsRequestManager.cs
@@ -94,34 +94,44 @@ namespace Google.Cloud.Bigtable.V2
                 return originalRows;
             }
 
-            RowSet newRowSet = new RowSet
-            {
-                RowKeys = { originalRows.RowKeys.Where(key => !StartKeyIsAlreadyRead(key)) }
-            };
+            RowSet newRowSet;
 
-            foreach (RowRange rowRange in originalRows.RowRanges)
+            if (originalRows != null)
             {
-                RowRange.EndKeyOneofCase endKeyOneofCase = rowRange.EndKeyCase;
-                if (endKeyOneofCase == RowRange.EndKeyOneofCase.EndKeyClosed &&
-                    EndKeyIsAlreadyRead(rowRange.EndKeyClosed)
-                    || endKeyOneofCase == RowRange.EndKeyOneofCase.EndKeyOpen &&
-                    EndKeyIsAlreadyRead(rowRange.EndKeyOpen))
+                newRowSet = new RowSet
                 {
-                    continue;
-                }
+                    RowKeys = {originalRows.RowKeys.Where(key => !StartKeyIsAlreadyRead(key))}
+                };
 
-                RowRange.StartKeyOneofCase startKeyOneofCase = rowRange.StartKeyCase;
-                RowRange newRange = rowRange;
-                if (startKeyOneofCase == RowRange.StartKeyOneofCase.StartKeyClosed &&
-                    StartKeyIsAlreadyRead(rowRange.StartKeyClosed)
-                    || (startKeyOneofCase == RowRange.StartKeyOneofCase.StartKeyOpen &&
-                        StartKeyIsAlreadyRead(rowRange.StartKeyOpen))
-                    || startKeyOneofCase == RowRange.StartKeyOneofCase.None)
+                foreach (RowRange rowRange in originalRows.RowRanges)
                 {
-                    newRange = newRange.Clone();
-                    newRange.StartKeyOpen = LastFoundKey.Value;
+                    RowRange.EndKeyOneofCase endKeyOneofCase = rowRange.EndKeyCase;
+                    if (endKeyOneofCase == RowRange.EndKeyOneofCase.EndKeyClosed &&
+                        EndKeyIsAlreadyRead(rowRange.EndKeyClosed)
+                        || endKeyOneofCase == RowRange.EndKeyOneofCase.EndKeyOpen &&
+                        EndKeyIsAlreadyRead(rowRange.EndKeyOpen))
+                    {
+                        continue;
+                    }
+
+                    RowRange.StartKeyOneofCase startKeyOneofCase = rowRange.StartKeyCase;
+                    RowRange newRange = rowRange;
+                    if (startKeyOneofCase == RowRange.StartKeyOneofCase.StartKeyClosed &&
+                        StartKeyIsAlreadyRead(rowRange.StartKeyClosed)
+                        || (startKeyOneofCase == RowRange.StartKeyOneofCase.StartKeyOpen &&
+                            StartKeyIsAlreadyRead(rowRange.StartKeyOpen))
+                        || startKeyOneofCase == RowRange.StartKeyOneofCase.None)
+                    {
+                        newRange = newRange.Clone();
+                        newRange.StartKeyOpen = LastFoundKey.Value;
+                    }
+
+                    newRowSet.RowRanges.Add(newRange);
                 }
-                newRowSet.RowRanges.Add(newRange);
+            }
+            else
+            {
+                newRowSet = RowSet.FromRowRanges(RowRange.Open(LastFoundKey, null));
             }
 
             return newRowSet;


### PR DESCRIPTION
Currently in the scenario of an exception during full table read (or with `RowsLimit` only) smart retry logic will throw an exception `Object reference not set to an instance of an object.` at this [point](https://github.com/googleapis/google-cloud-dotnet/blob/master/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableReadRowsRequestManager.cs#L99) since `originalRows` will be `null`.