### PR TITLE
Handle non-public parameterless constructors in Firestore deserialization

### DIFF
--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/FirestoreDataAttributedTypeTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/FirestoreDataAttributedTypeTest.cs
@@ -60,6 +60,14 @@ namespace Google.Cloud.Firestore.Tests
             [FirestoreProperty] public int this[string index] => 0;
         }
 
+        [FirestoreData]
+        private class NoParameterlessConstructor
+        {
+            [FirestoreProperty] public int Foo { get; set; }
+
+            public NoParameterlessConstructor(int foo) => Foo = foo;
+        }
+
         public static TheoryData<BclType, string> InvalidTypes = new TheoryData<BclType, string>
         {
             { typeof(NotAttributed), nameof(FirestoreDataAttribute) },
@@ -68,7 +76,8 @@ namespace Google.Cloud.Firestore.Tests
             { typeof(DuplicateWritableProperties), "Foo" },
             { typeof(StaticReadableProperty), "static" },
             { typeof(StaticWritableProperty), "static" },
-            { typeof(Indexer), "indexer" }
+            { typeof(Indexer), "indexer" },
+            { typeof(NoParameterlessConstructor), "constructor" }
         };
 
         [Theory, MemberData(nameof(InvalidTypes))]

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/ValueDeserializerTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/ValueDeserializerTest.cs
@@ -229,6 +229,19 @@ namespace Google.Cloud.Firestore.Tests
             Assert.Equal("y", deserialized.PublicAccessToPrivateProperty);
         }
 
+        [Fact]
+        public void DeserializePrivateConstructor()
+        {
+            var original = PrivateConstructor.Create("test", 15);
+            var value = ValueSerializer.Serialize(original);
+            Assert.Equal("test", value.MapValue.Fields["Name"].StringValue);
+            Assert.Equal(15L, value.MapValue.Fields["Value"].IntegerValue);
+
+            var deserialized = (PrivateConstructor) DeserializeDefault(value, typeof(PrivateConstructor));
+            Assert.Equal("test", deserialized.Name);
+            Assert.Equal(15, deserialized.Value);
+        }
+        
         private string DeserializeAndReturnWarnings<T>(object valueToSerialize)
         {
             var value = ValueSerializer.Serialize(valueToSerialize);
@@ -256,5 +269,22 @@ namespace Google.Cloud.Firestore.Tests
         /// An interface that we can't deserialize to, because Dictionary{,} doesn't implement it.
         /// </summary>
         public interface IUnsupportedDictionary : IDictionary<string, string> { }
+
+        [FirestoreData]
+        private class PrivateConstructor
+        {
+            [FirestoreProperty]
+            public string Name { get; private set; }
+
+            [FirestoreProperty]
+            public int Value { get; private set; }
+
+            private PrivateConstructor()
+            {
+            }
+
+            public static PrivateConstructor Create(string name, int value) =>
+                new PrivateConstructor { Name = name, Value = value };
+        }
     }
 }

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/ValueDeserializer.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/ValueDeserializer.cs
@@ -182,7 +182,7 @@ namespace Google.Cloud.Firestore
             if (IsFirestoreAttributedType(targetType))
             {
                 var attributedType = FirestoreDataAttributedType.ForType(targetType);
-                var ret = Activator.CreateInstance(targetType);
+                var ret = attributedType.CreateInstance();
 
                 foreach (var pair in values)
                 {


### PR DESCRIPTION
Fixes #2639