### PR TITLE
Another attempt to fix flakiness

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SessionPoolTests.TargetedSessionPoolTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SessionPoolTests.TargetedSessionPoolTests.cs
@@ -347,7 +347,7 @@ namespace Google.Cloud.Spanner.V1.Tests
                 });
             }
 
-            [Fact(Timeout = TestTimeoutMilliseconds, Skip = "Another flaky test - needs looking into")]
+            [Fact(Timeout = TestTimeoutMilliseconds)]
             public async Task MaintainPool_EvictsSessions()
             {
                 var pool = CreatePool(true);
@@ -414,7 +414,7 @@ namespace Google.Cloud.Spanner.V1.Tests
                 });
             }
 
-            [Fact(Timeout = TestTimeoutMilliseconds, Skip = "Flaky in CI; needs further investigation")]
+            [Fact(Timeout = TestTimeoutMilliseconds)]
             public async Task WaitForPoolAsync_CancelOneOfTwo()
             {
                 var pool = CreatePool(false);

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SessionPoolTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SessionPoolTests.cs
@@ -53,7 +53,7 @@ namespace Google.Cloud.Spanner.V1.Tests
             logger.AssertNoWarningsOrErrors();
         }
 
-        [Fact(Timeout = TestTimeoutMilliseconds, Skip = "Flaky in CI; needs further investigation")]
+        [Fact(Timeout = TestTimeoutMilliseconds)]
         public async Task ScheduledMaintenanceEvictsSessions()
         {
             var client = new SessionTestingSpannerClient();
@@ -192,7 +192,7 @@ namespace Google.Cloud.Spanner.V1.Tests
             await client.Scheduler.RunAndPause(TimeSpan.FromMinutes(2));
         }
 
-        [Fact(Timeout = TestTimeoutMilliseconds, Skip = "Flaky in CI; needs further investigation")]
+        [Fact(Timeout = TestTimeoutMilliseconds)]
         public async Task MaintenanceTaskCompletesWhenPoolIsGarbageCollected()
         {
             var client = new SessionTestingSpannerClient();


### PR DESCRIPTION
This feels slightly "magical" but is based on interesting
diagnostics. I suspect that we had tasks scheduled on threads that
are blocked by the FakeScheduler thread, and don't wait quite long
enough for the TPL work stealing to kick in.
