### PR TITLE
Guarantee a commit timestamp

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/TransactionTableFixture.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/TransactionTableFixture.cs
@@ -80,7 +80,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                         command.Transaction = tx;
                         command.ExecuteNonQuery();
                         tx.Commit(out var timestamp);
-                        TimestampBeforeEntries = timestamp.Value;
+                        TimestampBeforeEntries = timestamp;
                     }
                 });
 

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/TransactionTestBase.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/TransactionTestBase.cs
@@ -68,7 +68,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                         valueParameter.Value = IdGenerator.FromGuid();
                         command.ExecuteNonQuery();
                         tx.Commit(out var timestamp);
-                        oldest = new HistoryEntry((string)valueParameter.Value, timestamp.Value);
+                        oldest = new HistoryEntry((string)valueParameter.Value, timestamp);
                     }
                 });
 
@@ -98,7 +98,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                         valueParameter.Value = IdGenerator.FromGuid();
                         command.ExecuteNonQuery();
                         tx.Commit(out var timestamp);
-                        newest = new HistoryEntry((string)valueParameter.Value, timestamp.Value);
+                        newest = new HistoryEntry((string)valueParameter.Value, timestamp);
                     }
                 });
 


### PR DESCRIPTION
This is a breaking API change, but one which will make customer code simpler.

Note: I've assigned this to both of you to help consider whether this breaking change is a good idea or not. It's more likely to impact customers than our other breaking changes, but if we're going to do it, now's the time *to* do it.