### PR TITLE
Fix refresh sessions test

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/V1/SessionPoolTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/V1/SessionPoolTests.cs
@@ -54,7 +54,7 @@ namespace Google.Cloud.Spanner.V1.IntegrationTests
                 var expectedRefreshTime = DateTime.UtcNow + options.IdleSessionRefreshDelay;
                 // Acquire all the sessions, which should all have a required refresh time within our upper bound
                 var initialSessions = await AcquireSessionsAsync(pool);
-                Assert.All(initialSessions, s => Assert.True(s.RefreshTimeForTest < expectedRefreshTime));
+                Assert.All(initialSessions, s => Assert.True(s.RefreshTimeForTest <= expectedRefreshTime));
 
                 // Wait for everything to idle out
                 await Task.Delay(options.IdleSessionRefreshDelay + TimeSpan.FromSeconds(1));


### PR DESCRIPTION
If WaitForPoolAsync returns at exactly the instant when the final
session is created, the refresh time will be exactly "now + refresh
period". We shouldn't need the clock to tick between those intervals.

I believe all the other conditions are okay.