### PR TITLE
[Diagnostics.Tracing] Supporting the System.Net.Http.IHttpClientFactory way of creating HttpClient instances for tracing outgoing requests.

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests.csproj
@@ -45,5 +45,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http">
+      <Version>2.1.1</Version>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/Google.Cloud.Diagnostics.AspNetCore.Snippets.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/Google.Cloud.Diagnostics.AspNetCore.Snippets.csproj
@@ -47,5 +47,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http">
+      <Version>2.1.1</Version>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/docs/index.md
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/docs/index.md
@@ -85,6 +85,21 @@ can in inject the `IManagedTracer` into the action method using the `[FromServic
 
 {{sample:Trace.UseTracerRunIn}}
 
-## Trace Outgoing HTTP Requests
+## Trace Outgoing HTTP Requests (all platforms)
 
 {{sample:Trace.TraceOutgoing}}
+
+## Trace Outgoing HTTP Requests (recommended for ASP.NET Core 2.0 upwards)
+
+The [recommended way of creating HttpClient](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/http-requests?view=aspnetcore-2.1) in ASP.NET Core 2.0 and upwards is to use the 
+`System.Net.Http.IHttpClientFactory` defined in the Microsoft.Extensions.Http package.
+The following example demonstrates how to register and use an HttpClient using Google Trace so that it traces
+outgoing requests.
+
+### Configuration
+
+{{sample:Trace.ConfigureHttpClient}}
+
+### Usage
+
+{{sample:Trace.TraceOutgoingClientFactory}}

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Trace/TraceHeaderPropagatingHandlerTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Trace/TraceHeaderPropagatingHandlerTest.cs
@@ -14,7 +14,6 @@
 
 using Moq;
 using System;
-using System.Diagnostics;
 using System.Linq;
 using System.Net.Http;
 using System.Threading;
@@ -36,6 +35,15 @@ namespace Google.Cloud.Diagnostics.Common.Tests
             mockTracer.Setup(t => t.GetCurrentTraceId()).Returns(traceId);
             mockTracer.Setup(t => t.GetCurrentSpanId()).Returns(spanId);
             return mockTracer;
+        }
+
+        [Fact]
+        public void InnerHandler_Set()
+        {
+            var mockTracer = new Mock<IManagedTracer>();
+            var traceHandler = new TraceHeaderPropagatingHandler(() => mockTracer.Object);
+
+            Assert.NotNull(traceHandler.InnerHandler);
         }
 
         [Fact]

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Trace/UnchainedTraceHeaderPropagatingHandlerTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Trace/UnchainedTraceHeaderPropagatingHandlerTest.cs
@@ -1,0 +1,31 @@
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Moq;
+using Xunit;
+
+namespace Google.Cloud.Diagnostics.Common.Tests.Trace
+{
+    public class UnchainedTraceHeaderPropagatingHandlerTest
+    {
+        [Fact]
+        public void InnerHandler_Unset()
+        {
+            var mockTracer = new Mock<IManagedTracer>();
+            var traceHandler = new UnchainedTraceHeaderPropagatingHandler(() => mockTracer.Object);
+
+            Assert.Null(traceHandler.InnerHandler);
+        }
+    }
+}

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/UnchainedTraceHeaderPropagatingHandler.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/UnchainedTraceHeaderPropagatingHandler.cs
@@ -1,0 +1,80 @@
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Cloud.Diagnostics.Common
+{
+    /// <summary>
+    /// Class for tracing outgoing HTTP requests and propagating the trace header.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Ensures the trace header is propagated in the headers for outgoing HTTP requests and 
+    /// traces the total time of the outgoing HTTP request. This is only done if tracing is initialized
+    /// and tracing is enabled for the request current request.
+    /// </para>
+    /// <para>
+    /// Explicitly leaves unset the InnerHandler property so that this Handler can be used with the
+    /// System.Net.Http.IHttpClientFactory defined in Microsoft.Extensions.Http.
+    /// </para>
+    /// </remarks>
+    public class UnchainedTraceHeaderPropagatingHandler : DelegatingHandler
+    {
+        private readonly Func<IManagedTracer> _managedTracerFactory;
+
+        /// <summary>
+        /// Constructs a new instance using the given delegate to obtain the "current" tracer
+        /// on each request.
+        /// </summary>
+        /// <param name="managedTracerFactory">A delegate used to obtain the "current" tracer
+        /// for each request. The delegate should therefore be thread-safe.</param>
+        public UnchainedTraceHeaderPropagatingHandler(Func<IManagedTracer> managedTracerFactory)
+        {
+            _managedTracerFactory = GaxPreconditions.CheckNotNull(managedTracerFactory, nameof(managedTracerFactory));
+        }
+
+        /// <summary>
+        /// Sends the given request. If tracing is initialized and enabled the outgoing request is
+        /// traced and the trace header is added to the request.
+        /// </summary>
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var tracer = _managedTracerFactory();
+            if (tracer.GetCurrentTraceId() == null)
+            {
+                return base.SendAsync(request, cancellationToken);
+            }
+
+            var traceHeader = TraceHeaderContext.Create(
+                tracer.GetCurrentTraceId(), tracer.GetCurrentSpanId() ?? 0, true);
+            request.Headers.Add(TraceHeaderContext.TraceHeader, traceHeader.ToString());
+
+            return tracer.RunInSpanAsync(
+                async () =>
+                {
+                    tracer.AnnotateSpan(TraceLabels.FromHttpRequestMessage(request));
+                    var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                    tracer.AnnotateSpan(TraceLabels.FromHttpResponseMessage(response));
+                    return response;
+                },
+                request.RequestUri.ToString());
+        }
+    }
+}


### PR DESCRIPTION
On a closer look this way of [initiating HTTP requests](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/http-requests) is not only for Asp.Net Core 2.1, but is supported for .Net Standard 2.0 upwards.

Addresses #2629.