### PR TITLE
Updates to Spanner documentation

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/SpannerConnectionSnippets.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/SpannerConnectionSnippets.cs
@@ -20,6 +20,7 @@ using System.Threading.Tasks;
 using Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling;
 using Xunit;
 using Google.Cloud.Spanner.Data.CommonTesting;
+using Google.Cloud.Spanner.V1;
 
 #if !NETCOREAPP1_0
 using System.Transactions;
@@ -258,7 +259,7 @@ namespace Google.Cloud.Spanner.Data.Snippets
                     // Include the primary key and update columns.
                     SpannerCommand updateCmd = connection.CreateUpdateCommand("TestTable");
                     updateCmd.Parameters.Add("Key", SpannerDbType.String, keys[0]);
-                    updateCmd.Parameters.Add("Int64Value", SpannerDbType.Int64, 0L);            
+                    updateCmd.Parameters.Add("Int64Value", SpannerDbType.Int64, 0L);
                     await updateCmd.ExecuteNonQueryAsync();
 
                     // Delete row for keys[1]
@@ -320,6 +321,34 @@ namespace Google.Cloud.Spanner.Data.Snippets
                         }
                     }
                 });
+            // End sample
+        }
+
+        [Fact]
+        public void CustomSessionPoolManager()
+        {
+            string connectionString = _fixture.ConnectionString;
+
+            // Sample: CustomSessionPoolManager
+            SessionPoolOptions options = new SessionPoolOptions
+            {
+                MinimumPooledSessions = 100,
+                MaximumActiveSessions = 250
+            };
+            SessionPoolManager manager = SessionPoolManager.Create(options);
+
+            // Note: a single SpannerConnectionStringBuilder instance can be reused whenever you
+            // need to build a connection
+            SpannerConnectionStringBuilder builder = new SpannerConnectionStringBuilder(connectionString)
+            {
+                SessionPoolManager = manager
+            };
+
+            // (Elsewhere in your code...)
+            using (SpannerConnection connection = new SpannerConnection(builder))
+            {
+                // Use the connection
+            }
             // End sample
         }
 

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnectionStringBuilder.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnectionStringBuilder.cs
@@ -328,7 +328,7 @@ namespace Google.Cloud.Spanner.Data
         /// Data Source=projects/{project}/instances/{instance}/databases/{database};[Host={hostname};][Port={portnumber}].
         /// Must not be null.</param>
         /// <param name="credentials">The credential to use for the connection. May be null.</param>
-        /// <param name="sessionPoolManager">The session pool manager to use.</param>
+        /// <param name="sessionPoolManager">The session pool manager to use. Must not be null.</param>
         public SpannerConnectionStringBuilder(string connectionString, ChannelCredentials credentials, SessionPoolManager sessionPoolManager)
         {
             ConnectionString = GaxPreconditions.CheckNotNull(connectionString, nameof(connectionString));

--- a/apis/Google.Cloud.Spanner.Data/docs/configuration.md
+++ b/apis/Google.Cloud.Spanner.Data/docs/configuration.md
@@ -1,0 +1,187 @@
+# Configuration
+
+Many applications will only ever need to configure Spanner in terms
+of the database to connect via the connection string. (The database
+name consists of a project ID, instance ID and database ID.)
+
+Beyond that, configuration is largely for the sake of diagnostics
+and performance tuning. There are two main sources for configuration:
+
+- The connection string provided to `SpannerConnection`. Options
+  here are also exposed as properties on
+  `SpannerConnectionStringBuilder`
+- The session pool options, as exposed via
+  `Google.Cloud.Spanner.V1.SessionPoolOptions`.
+
+The connection string options are [specified in this
+document](connection_string.md). The remaining options relate to the
+session pool, which handles acquiring, refreshing and evicting
+sessions. Spanner sessions are relatively expensive (in terms of
+time) to create, so it's important that they are handled
+appropriately.
+
+## Session pool options explained
+
+`SessionPoolOptions` exposes the following properties:
+
+**MaximumActiveSessions**
+
+Default value: 100
+
+The maximum number of sessions that can be active per database. An
+active session is one that has been acquired but not yet released
+back to the pool. Broadly speaking, this is equivalent to the number
+of concurrent Spanner-based operations your application will be able
+to perform.
+
+Applications may wish to change this setting if they require high
+levels of concurrency.
+
+**MinimumPooledSessions**
+
+Default value: 10
+
+The minimum number of sessions to maintain in the pool of available
+sessions, on a per-database basis. If the number of pooled sessions
+falls below this number, more sessions are added automatically,
+unless that would require more than the configured maximum active
+session count. (Setting the minimum pool size to a larger value than
+the maximum active session count has no purpose; the size will still
+be bounded by the maximum active session count.)
+
+Applications may wish to change this setting if they are likely to
+encounter sudden bursts of requests, and don't wish to have to wait
+for sessions to be created.
+
+**WriteSessionsFraction**
+
+Default value: 0.2
+
+The session pool maintains sessions in two states:
+
+- Without a transaction
+- With a read/write transaction
+
+The value of this setting determines how many sessions to keep in
+each state. For example, with the default value of 0.2, roughly 20%
+of sessions will be pooled with a read/write transaction.
+
+When a session is acquired, if there is not one already available
+with the requested transaction options, a transaction can be
+requested. Using a session which was previously associated with a
+read/write transaction for operations which don't use that
+transaction does not affect the behavior; it just wastes the small
+amount of time spent creating the transaction to start with.
+
+Increasing this value will increase the average time taken to release a
+session back to the pool, as more read/write transactions will be
+acquired as part of that operation. However, acquiring sessions with
+read/write transactions from the pool will then be faster.
+
+Applications that are aware of their usage patterns ahead of time
+may wish to change this setting to reduce latency. This is
+particularly true for applications which only perform read-only
+operations (in which case this value should be set to 0) or only
+perform operations using read/write transactions (in which case this
+value should be set to 1.0).
+
+**IdleSessionRefreshDelay**
+
+Default value: 15 minutes
+
+After this amount of time, a session which has been idle is
+refreshed automatically.
+
+Sessions that are unused for long periods of time can be invalidated
+by the server. The session pool periodically checks whether pooled
+sessions need refreshing. When a session needs refreshing, the pool
+just executes a simple query using that session. Sessions are
+additionally checked for refresh when they are released back to the
+pool. Jitter is applied to the session refresh to avoid large
+numbers of sessions all being refreshed at exactly the same time.
+
+Applications rarely need to change this setting.
+
+**PoolEvictionDelay**
+
+Default value: 7 days
+
+Processes that run for extended periods may refresh sessions many
+times, and the server will generally permit this indefinitely.
+However, that puts a strain on server-side resource management. This
+setting controls the time after which sessions are evicted. Like
+refresh settings, jitter is applied so that sessions are not evicted
+all at once.
+
+Applications rarely need to change this setting.
+
+**WaitOnResourcesExhausted**
+
+Default value: Block
+
+This enum value controls the behavior when an application requests a
+new session despite having already acquired the maximum number of
+active sessions.
+
+The default value (`Block`) will block the pending
+session acquisition operation until a session is available. This
+allows an application to continue to function correctly, but with
+reduced responsiveness.
+
+The value of `Fail` will cause the pending session acquisition to
+throw an exception. This is useful for spotting resource leaks, and
+some applications may prefer a swift failure over a delayed response
+when the application is heavily loaded.
+
+**Timeout**
+
+Default value: 60
+
+The total time in seconds allowed for a network call to the Cloud
+Spanner server, including retries. This setting is applied to calls
+to create, refresh and delete sessions, as well as beginning
+transactions.
+
+Applications rarely need to change this setting
+
+**MaximumConcurrentSessionCreates**
+
+Default value: 10
+
+Spanner has limits on the number of sessions that can be created
+concurrently without affecting performance. The session pool uses
+this setting to throttle the number of concurrent session creation
+operations, across all databases.
+
+Applications rarely need to change this setting.
+
+## Modifying the default SessionPoolOptions from ADO.NET
+
+When using the ADO.NET implementation (Google.Cloud.Spanner.Data), a
+`SessionPoolManager` is used to create `SessionPool` instances based
+on the connection string. (Different endpoints would require
+different pools, for example.) Each `SessionPoolManager` has a set
+of `SessionPoolOptions` that it uses whenever it creates a new
+`SessionPool`. It's easy to modify the options used by
+the default `SessionPoolManager`. For example, to change the minimum
+number of sessions in each session pool:
+
+```csharp
+SessionPoolManager.Default.SessionOptions.MinimumPooledSessions = 100;
+```
+
+Any changes to the options should be made before the first Spanner
+operation is executed. Changes to the options used by a
+`SessionPool` after it has become active *may* still take effect,
+but that varies by option and may change over time as an
+implementation detail.
+
+## Using a non-default SessionPoolManager
+
+An alternative to modifying the options used by the default
+`SessionPoolManager` is to create a new manager object with a new
+set of options. The `SessionPoolManager` can then be set in
+`SpannerConnectionStringBuilder` which is then used to build a
+`SpannerConnection`. For example:
+
+{{sample:SpannerConnection.CustomSessionPoolManager}}

--- a/apis/Google.Cloud.Spanner.Data/docs/connection_string.md
+++ b/apis/Google.Cloud.Spanner.Data/docs/connection_string.md
@@ -1,4 +1,4 @@
-# Connection string options
+Connection string options
 
 Spanner connection strings support the following options:
 
@@ -65,3 +65,52 @@ v1.0.
 Example:
 
 - UseClrDefaultForNull=true
+
+# Timeout
+
+The default timeout used for `SpannerCommand.CommandTimeout`,
+`SpannerTransaction.CommitTimeout`, and other Spanner network
+operations. Defaults to 60 seconds.
+
+Example:
+
+- Timeout=30
+
+# AllowImmediateTimeouts
+
+When set to False, a timeout of 0 means an indefinite timeout.
+When set to True, a timeout of 0 means an immediate timeout.
+Defaults to False.
+
+Example:
+
+- AllowImmediateTimeouts=true
+
+# MaximumGrpcChannels
+
+The maximum number of gRPC channels to use per connection using the
+same settings. Defaults to 4. This setting rarely needs to be
+modified.
+
+Example:
+
+- MaximumGrpcChannels=8
+
+# MaxConcurrentStreamsLowWatermark
+
+The maximum number of concurrent streams per gRPC channel before
+using a new channel. Defaults to 20. This setting rarely needs to be
+modified.
+
+Example:
+
+- MaxConcurrentStreamsLowWatermark=30
+
+# Host and Port
+
+These control the Spanner service to connect to. These are primarily
+available for testing purposes.
+
+Examples:
+
+- Host=alternative-spanner.googleapis.com; Port=1443

--- a/apis/Google.Cloud.Spanner.Data/docs/migration-to-2.md
+++ b/apis/Google.Cloud.Spanner.Data/docs/migration-to-2.md
@@ -1,0 +1,105 @@
+# Migration to Google.Cloud.Spanner.Data 2.0
+
+Google.Cloud.Spanner.Data version 2.0 includes a number of breaking
+changes compared with version 1.0. We expect that most users will
+not be affected by these changes, particularly when default settings
+are used. For users who are affected, this document should help you
+to migrate your application to the 2.0 version of the libraries.
+
+If you have any problems with the breaking changes and they're not
+covered in this document, please [file an
+issue](https://github.com/googleapis/google-cloud-dotnet/issues/new)
+so we can help you further.
+
+## Configuration changes
+
+- `SpannerOptions` has been removed completely. See the [configuration
+  guide](configuration.md) for more details, but for migration
+  purposes:
+  - `KeepAliveInterval` is replaced by `SessionPoolOptions.IdleSessionRefreshDelay`
+  - `MaximumPooledSessions` has no direct equivalent in 2.0; once a session
+  is part of the pool, it will be refreshed as necessary until it is evicted.
+  - `MaximumActiveSessions` is now only present in `SessionPoolOptions`
+  - `MaximumGrpcChannels` is specified in the connection string
+  - `LogLevel` is controlled on a per-logger basis; this property on
+    `SpannerOptions` was equivalent to changing
+    `Logger.DefaultLogger.LogLevel`.
+  - `PoolEvictionDelay` is now only present in `SessionPoolOptions`
+  - `ResourcesExhaustedBehavior` has moved to `SessionPoolOptions`
+  - `Timeout` is specified in the connection string
+  - `MaximumConcurrentSessionCreates` is now only present in
+    `SessionPoolOptions`
+- `ClientPool` has been removed in 2.0. Its functionality has largely
+  been replaced by `SessionPoolManager`. It is expected that the
+  default session pool manager will be appropriate for most use cases,
+  but you can associate a `SessionPoolManager` with the
+  `SpannerConnectionStringBuilder` used to build a connection for more
+  advanced situations.
+- `ResourcesExhaustedBehavior` has moved to Google.Cloud.Spanner.V1,
+  as it is now configured in `SessionPoolOptions`.
+- Loggers are configured on a `SessionPoolManager` basis
+
+## Breaking changes in connection, command and transaction types
+
+- The `SpannerCommandTextBuilder(string)` constructor has been removed.
+  The equivalent functionality is available via the static
+  `SpannerCommandTextBuilder.FromCommandText` method.
+- `SpannerTransaction.CommitAsync` returns a `Task<DateTime>` rather
+  than a `Task<DateTime?>`. The server will always return a commit
+  timestamp, so the task's result would never have been null in 1.0
+  anyway. Client code should be able to use the resulting
+  `Task<DateTime>` more easily in most cases.
+- `SpannerConnection` and `SpannerConnectionStringBuilder` no longer
+  expose `GetCredentials` method. There is no direct equivalent in 2.0;
+  please file an issue if you rely on this functionality.
+- `SpannerConnection.ClearPooledResourcesAsync` is replaced by
+  `SpannerConnection.ShutdownSessionPoolAsync`. After this is called,
+  no further sessions can be created with the associated session pool.
+  If you need to control sessions in a more fine-grained way (for
+  example, shutting down one session pool but then creating new
+  sessions) you can associate a new `SessionPoolManager` instance with the
+  `SpannerConnectionStringBuilder` used to build a connection. See
+  the [configuration guide](configuration.md) for an example of this.
+- `SpannerTransaction.CommitAsync` now accepts a cancellation token.
+  This defaults to `CancellationToken.None`, so existing source code
+  should still compile, but this is a binary-incompatible change.
+
+## Miscellaneous breaking changes
+
+- `SpannerDbType.StructOf` has been replaced by
+  `SpannerDbType.ForStruct`, using the new `SpannerStruct` type.
+
+## Breaking changes in Google.Cloud.Spanner.V1
+
+Users of the ADO.NET implementation in Google.Cloud.Spanner.Data
+will rarely need to directly refer to the types in
+Google.Cloud.Spanner.V1, but some low-level users may wish to do so.
+
+The previous `Google.Cloud.Spanner.V1.SessionPool` class has been
+replaced by a completely new implementation, with a new API and some
+changes to the corresponding `SessionPoolOptions` class. The new
+`SessionPool` manages transactions as well as sessions, so the
+`TransactionPool` class from 1.0 has been removed. `PooledSession`
+instances are acquired from the session pool (and must be released
+appropriately). These are automatically refreshed (and eventually
+evicted) by the session pool.
+
+## Changes in Google.Cloud.Spanner.V1.Internal
+
+The Google.Cloud.Spanner.V1 package exposes some types in the
+Google.Cloud.Spanner.V1.Internal namespace, for use by
+Google.Cloud.Spanner.Data. These types were not intended for
+use by third-party code, so this document does not go into detail
+around the changes in this namespace.
+
+## Execution-time behavior changes
+
+- Null values are returned as `DBNull.Value` by default rather
+  than the CLR default value for the type. Array and struct elements
+  use a null value where feasible, but throw `InvalidCastException`
+  when requested to be converted to a non-nullable value type. The
+  1.0 behavior can be requested using the `UseClrDefaultForNull`
+  [connection string option](connection_string.md).
+- `Hashtable` is no longer used as a default type for
+  struct values. It can still be specified explicitly.
+  The new default is `Dictionary<string, object>`.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPoolOptions.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPoolOptions.cs
@@ -24,6 +24,7 @@ namespace Google.Cloud.Spanner.V1
     public sealed class SessionPoolOptions
     {
         // Note: if any of these defaults are changed, update the XML documentation comments on the properties accordingly.
+        // Also adjust docs/configuration.md
         private int _maximumActiveSessions = 100;
         private int _minimumPooledSessions = 10;
         private TimeSpan _idleSessionRefreshDelay = TimeSpan.FromMinutes(15);


### PR DESCRIPTION
- A guide to migrating to 2.0 with all the breaking changes I'm aware of
- Updates to the connection string documentation
- A guide to configuration, including details of session pool options

The way you use a custom SessionPoolManager is really awkward, but I
don't know what would be better right now. We should definitely
revisit it.