### PR TITLE
Remove a FIXME by simplifying the code

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerConnectionTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerConnectionTests.cs
@@ -1,0 +1,36 @@
+﻿// Copyright 2018 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.IO;
+using Xunit;
+
+namespace Google.Cloud.Spanner.Data.Tests
+{
+    public class SpannerConnectionTests
+    {
+        [Fact]
+        public void OpenWithNoDatabase_InvalidCredentials()
+        {
+            var builder = new SpannerConnectionStringBuilder
+            {
+                DataSource = "projects/project_id/instances/instance_id",
+                CredentialFile = "this_will_not_exist.json"
+            };
+            using (var connection = new SpannerConnection(builder))
+            {
+                Assert.Throws<FileNotFoundException>(() => connection.Open());
+            }
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnection.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnection.cs
@@ -511,7 +511,7 @@ namespace Google.Cloud.Spanner.Data
         }
 
         /// <summary>
-        /// Opens the connection (which includes acquiring a SessionPool, unless there's no database)
+        /// Opens the connection, which involves acquiring a SessionPool,
         /// and potentially enlists the connection in the current transaction.
         /// </summary>
         /// <param name="transactionEnlister">Enlistment delegate; may be null.</param>
@@ -523,14 +523,6 @@ namespace Google.Cloud.Spanner.Data
             return ExecuteHelper.WithErrorTranslationAndProfiling(
                 async () =>
                 {
-                    // FIXME: Prevent opening instead? It's an annoyingly inconsistent state (with no _sessionPool).
-                    // Although we don't actually need a database to get a session pool...
-                    if (string.IsNullOrEmpty(_connectionStringBuilder.SpannerDatabase))
-                    {
-                        _state = ConnectionState.Open;
-                        return;
-                    }
-
                     ConnectionState previousState;
                     lock (_sync)
                     {


### PR DESCRIPTION
Open() makes sure we have a SessionPool, but that's all. It doesn't
need to allocate a session, therefore it doesn't matter whether or
not we have a database. We can validate quite a lot of things
without that. Admittedly if the project or instance is invalid, we
won't spot that at this point, but that's not so bad. It means we
have more consistency: an open connection always has a session pool.