### PR TITLE
Provide a logger to SpannerSettings, and use it.

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SessionPoolManagerTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SessionPoolManagerTests.cs
@@ -21,7 +21,7 @@ using Xunit;
 
 namespace Google.Cloud.Spanner.Data.Tests
 {
-    using ClientFactory = Func<SpannerClientCreationOptions, Task<SpannerClient>>;
+    using ClientFactory = Func<SpannerClientCreationOptions, Logger, Task<SpannerClient>>;
 
     public class SessionPoolManagerTests
     {
@@ -32,7 +32,7 @@ namespace Google.Cloud.Spanner.Data.Tests
         public async Task EqualOptions_SameSessionPool()
         {
             int factoryCalls = 0;
-            ClientFactory factory = options =>
+            ClientFactory factory = (options, logger) =>
             {
                 factoryCalls++;
                 return Task.FromResult<SpannerClient>(new FailingSpannerClient());
@@ -53,7 +53,7 @@ namespace Google.Cloud.Spanner.Data.Tests
         public async Task DifferentOptions_DifferentSessionPools()
         {
             int factoryCalls = 0;
-            ClientFactory factory = options =>
+            ClientFactory factory = (options, logger) =>
             {
                 factoryCalls++;
                 return Task.FromResult<SpannerClient>(new FailingSpannerClient());
@@ -91,7 +91,7 @@ namespace Google.Cloud.Spanner.Data.Tests
         private class FailingSpannerClient : SpannerClient
         {
             // A simple non-counting factory.
-            internal static ClientFactory Factory { get; } = _ => Task.FromResult<SpannerClient>(new FailingSpannerClient());
+            internal static ClientFactory Factory { get; } = (options, logger) => Task.FromResult<SpannerClient>(new FailingSpannerClient());
 
             public FailingSpannerClient()
             {

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/PooledSessionTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/PooledSessionTests.cs
@@ -302,7 +302,7 @@ namespace Google.Cloud.Spanner.V1.Tests
 
             internal FakeSessionPool()
             {
-                Mock = SpannerClientHelpers.CreateMockClient();
+                Mock = SpannerClientHelpers.CreateMockClient(Logger);
                 Options = new SessionPoolOptions
                 {
                     SessionEvictionJitter = RetrySettings.NoJitter,

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SessionPoolTests.DetachedSessionPoolTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SessionPoolTests.DetachedSessionPoolTests.cs
@@ -28,8 +28,8 @@ namespace Google.Cloud.Spanner.V1.Tests
             public void ReleaseDetachedSession_NoDelete()
             {
                 var logger = new InMemoryLogger();
-                var mock = SpannerClientHelpers.CreateMockClient();
-                var pool = new SessionPool(mock.Object, new SessionPoolOptions(), logger);
+                var mock = SpannerClientHelpers.CreateMockClient(logger);
+                var pool = new SessionPool(mock.Object, new SessionPoolOptions());
                 var session = pool.RecreateSession(s_sampleSessionName, s_sampleTransactionId, ModeOneofCase.ReadOnly);
 
                 // No calls to DeleteSession
@@ -41,13 +41,13 @@ namespace Google.Cloud.Spanner.V1.Tests
             public void ReleaseDetachedSession_Delete()
             {
                 var logger = new InMemoryLogger();
-                var mock = SpannerClientHelpers.CreateMockClient();
+                var mock = SpannerClientHelpers.CreateMockClient(logger);
                 // We will force the session to be deleted, so check it happens in the mock.
                 mock.Setup(client => client.DeleteSessionAsync(new DeleteSessionRequest { SessionName = s_sampleSessionName }, null))
                     .Returns(Task.FromResult(0))
                     .Verifiable();
 
-                var pool = new SessionPool(mock.Object, new SessionPoolOptions(), logger);
+                var pool = new SessionPool(mock.Object, new SessionPoolOptions());
                 var session = pool.RecreateSession(s_sampleSessionName, s_sampleTransactionId, ModeOneofCase.ReadOnly);
 
                 // Logically, the deletion happens asynchronously. However, everything completes synchronously so we don't need

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SessionPoolTests.SessionTestingSpannerClient.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SessionPoolTests.SessionTestingSpannerClient.cs
@@ -59,6 +59,7 @@ namespace Google.Cloud.Spanner.V1.Tests
                 Settings = SpannerSettings.GetDefault();
                 Settings.Scheduler = Scheduler;
                 Settings.Clock = Clock;
+                Settings.Logger = Logger;
             }
 
             public override async Task<Transaction> BeginTransactionAsync(BeginTransactionRequest request, CallSettings callSettings = null)

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SessionPoolTests.TargetedSessionPoolTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SessionPoolTests.TargetedSessionPoolTests.cs
@@ -68,7 +68,7 @@ namespace Google.Cloud.Spanner.V1.Tests
                      WaitOnResourcesExhausted = ResourcesExhaustedBehavior.Block,
                      WriteSessionsFraction = 0.2
                 };
-                var parent = new SessionPool(client, options, client.Logger);
+                var parent = new SessionPool(client, options);
                 return new TargetedSessionPool(parent, s_databaseName, acquireSessionsImmediately);
             }
 

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SessionPoolTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SessionPoolTests.cs
@@ -42,8 +42,8 @@ namespace Google.Cloud.Spanner.V1.Tests
         public void RecreateSession()
         {
             var logger = new InMemoryLogger();
-            var mock = SpannerClientHelpers.CreateMockClient();
-            var pool = new SessionPool(mock.Object, new SessionPoolOptions(), logger);
+            var mock = SpannerClientHelpers.CreateMockClient(logger);
+            var pool = new SessionPool(mock.Object, new SessionPoolOptions());
 
             var mode = ModeOneofCase.ReadOnly;
             var session = pool.RecreateSession(s_sampleSessionName, s_sampleTransactionId, mode);
@@ -68,7 +68,7 @@ namespace Google.Cloud.Spanner.V1.Tests
                 MaximumConcurrentSessionCreates = 20,
                 WriteSessionsFraction = 0
             };
-            var sessionPool = new SessionPool(client, options, client.Logger);
+            var sessionPool = new SessionPool(client, options);
             var acquisitionTask = sessionPool.AcquireSessionAsync(s_sampleDatabaseName, new TransactionOptions(), default);
 
             await client.Scheduler.RunAsync(TimeSpan.FromMinutes(1));
@@ -103,7 +103,7 @@ namespace Google.Cloud.Spanner.V1.Tests
                 MaximumConcurrentSessionCreates = 20,
                 WriteSessionsFraction = 0
             };
-            var sessionPool = new SessionPool(client, options, client.Logger);
+            var sessionPool = new SessionPool(client, options);
             var acquisitionTask = sessionPool.AcquireSessionAsync(s_sampleDatabaseName, new TransactionOptions(), default);
 
             // After a minute, we should have a session. Release it immediately for simplicity.
@@ -143,7 +143,7 @@ namespace Google.Cloud.Spanner.V1.Tests
                 MaximumConcurrentSessionCreates = 20,
                 WriteSessionsFraction = 0
             };
-            var sessionPool = new SessionPool(client, options, client.Logger);
+            var sessionPool = new SessionPool(client, options);
 
             // Ask when the pool is ready, which shouldn't take a minute.
             var poolReadyTask = sessionPool.WhenPoolReady(s_sampleDatabaseName, default);
@@ -160,7 +160,7 @@ namespace Google.Cloud.Spanner.V1.Tests
         {
             var client = new SessionTestingSpannerClient();
             var options = new SessionPoolOptions();
-            var sessionPool = new SessionPool(client, options, client.Logger);
+            var sessionPool = new SessionPool(client, options);
             // We haven't used the database in this session pool, so there are no statistics for it.
             Assert.Null(sessionPool.GetStatisticsSnapshot(s_sampleDatabaseName));
         }
@@ -173,7 +173,7 @@ namespace Google.Cloud.Spanner.V1.Tests
             {
                 MinimumPooledSessions = 10,
             };
-            var sessionPool = new SessionPool(client, options, client.Logger);
+            var sessionPool = new SessionPool(client, options);
             var acquisitionTask1 = sessionPool.AcquireSessionAsync(s_sampleDatabaseName, new TransactionOptions(), default);
             var acquisitionTask2 = sessionPool.AcquireSessionAsync(s_sampleDatabaseName2, new TransactionOptions(), default);
             var stats = sessionPool.GetStatisticsSnapshot();
@@ -201,7 +201,7 @@ namespace Google.Cloud.Spanner.V1.Tests
                 MinimumPooledSessions = 10,
                 MaintenanceLoopDelay = TimeSpan.FromMinutes(1)
             };
-            var sessionPool = new SessionPool(client, options, client.Logger);
+            var sessionPool = new SessionPool(client, options);
             var waitingTask = sessionPool.WhenPoolReady(s_sampleDatabaseName);
             await client.Scheduler.RunAsync(TimeSpan.FromMinutes(5.5));
             await waitingTask;

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SpannerClientHelpers.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SpannerClientHelpers.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Google.Api.Gax.Testing;
+using Google.Cloud.Spanner.V1.Internal.Logging;
 using Moq;
 
 namespace Google.Cloud.Spanner.V1.Tests
@@ -26,11 +27,12 @@ namespace Google.Cloud.Spanner.V1.Tests
         /// Creates a mock SpannerClient configured with settings that include a fake clock
         /// and a fake scheduler.
         /// </summary>
-        internal static Mock<SpannerClient> CreateMockClient(MockBehavior behavior = MockBehavior.Strict)
+        internal static Mock<SpannerClient> CreateMockClient(Logger logger, MockBehavior behavior = MockBehavior.Strict)
         {
             var settings = SpannerSettings.GetDefault();
             settings.Clock = new FakeClock();
             settings.Scheduler = new FakeScheduler();
+            settings.Logger = logger;
             var mock = new Mock<SpannerClient>(behavior);
             mock.SetupProperty(client => client.Settings, settings);
             return mock;

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnection.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnection.cs
@@ -92,15 +92,10 @@ namespace Google.Cloud.Spanner.Data
         [Category("Data")]
         public string SpannerInstance => Builder.SpannerInstance;
 
-        private Logger _logger = Logger.DefaultLogger;
         /// <summary>
-        /// This property is intended for internal use only.
+        /// The logger used by this connection. This is never null.
         /// </summary>
-        public Logger Logger
-        {
-            get => _logger;
-            set => _logger = GaxPreconditions.CheckNotNull(value, nameof(value));
-        }
+        internal Logger Logger => Builder.SessionPoolManager.Logger;
 
         /// <inheritdoc />
         public override ConnectionState State

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/VolatileResourceManager.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/VolatileResourceManager.cs
@@ -37,7 +37,7 @@ namespace Google.Cloud.Spanner.Data
             _transactionId = transactionId;
         }
 
-        private Logger Logger => _spannerConnection?.Logger ?? Logger.DefaultLogger;
+        private Logger Logger => _spannerConnection.Logger;
 
         public void Dispose()
         {

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Internal/Logging/Logger.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Internal/Logging/Logger.cs
@@ -23,9 +23,6 @@ using System.Threading.Tasks;
 
 namespace Google.Cloud.Spanner.V1.Internal.Logging
 {
-    // TODO: Clearer separation between default implementation and interface.
-    // (Use the EF provider and default logger to drive the design.)
-
     /// <summary>
     /// This is an internal class and is not intended to be used by external code.
     /// </summary>

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/PooledSession.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/PooledSession.cs
@@ -16,10 +16,8 @@ using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
 using Google.Cloud.Spanner.V1.Internal;
 using Google.Protobuf;
-using Grpc.Core;
 using System;
 using System.Runtime.CompilerServices;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using static Google.Cloud.Spanner.V1.TransactionOptions;
@@ -234,7 +232,6 @@ namespace Google.Cloud.Spanner.V1
                 request.Transaction = new TransactionSelector { Id = TransactionId };
             }
             var reader = Client.GetSqlStreamReader(request, _session, timeoutSeconds);
-            reader.Logger = _pool.Logger;
             return reader;
         }
 

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/ReliableStreamReader.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/ReliableStreamReader.cs
@@ -64,12 +64,7 @@ namespace Google.Cloud.Spanner.V1
             _request.SessionAsSessionName = _session.SessionName;
         }
 
-        // TODO: Take this in the constructor instead? Or maybe put it in SpannerClientSettings?
-
-        /// <summary>
-        /// This property is intended for internal use only.
-        /// </summary>
-        public Logger Logger { get; set; } = Logger.DefaultLogger;
+        private Logger Logger => _spannerClient.Settings.Logger;
 
         /// <summary>
         /// Indicates whether the reader is closed or not.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPool.ISessionPool.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPool.ISessionPool.cs
@@ -25,7 +25,6 @@ namespace Google.Cloud.Spanner.V1
         /// </summary>
         internal interface ISessionPool
         {
-            Logger Logger { get; }
             SpannerClient Client { get; }
             IClock Clock { get; }
             void Release(PooledSession session, bool deleteSession);

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPool.SessionPoolBase.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPool.SessionPoolBase.cs
@@ -26,7 +26,6 @@ namespace Google.Cloud.Spanner.V1
         internal abstract class SessionPoolBase : ISessionPool
         {
             public SpannerClient Client => Parent._client;
-            public Logger Logger => Parent._logger;
             public IClock Clock => Parent._clock;
             public SessionPoolOptions Options => Parent.Options;
             protected SessionPool Parent { get; }

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPool.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPool.cs
@@ -56,14 +56,13 @@ namespace Google.Cloud.Spanner.V1
         /// </summary>
         /// <param name="client">The client to use for this session pool. Must not be null.</param>
         /// <param name="options">The options for this session pool. Must not be null.</param>
-        /// <param name="logger">The logger to use. May be null, in which case the default logger is used.</param>
-        public SessionPool(SpannerClient client, SessionPoolOptions options, Logger logger)
+        public SessionPool(SpannerClient client, SessionPoolOptions options)
         {
             _client = GaxPreconditions.CheckNotNull(client, nameof(client));
             _clock = _client.Settings.Clock ?? SystemClock.Instance;
             _scheduler = _client.Settings.Scheduler ?? SystemScheduler.Instance;
             Options = GaxPreconditions.CheckNotNull(options, nameof(options));
-            _logger = logger ?? Logger.DefaultLogger;
+            _logger = client.Settings.Logger; // Just to avoid fetching it all the time
             _detachedSessionPool = new DetachedSessionPool(this);
             _sessionAcquisitionSemaphore = new SemaphoreSlim(Options.MaximumConcurrentSessionCreates);
             if (Options.MaintenanceLoopDelay != TimeSpan.Zero)

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SpannerClient.Streaming.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SpannerClient.Streaming.cs
@@ -15,6 +15,7 @@
 using System;
 using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
+using Google.Cloud.Spanner.V1.Internal.Logging;
 using Grpc.Core;
 
 namespace Google.Cloud.Spanner.V1
@@ -62,6 +63,18 @@ namespace Google.Cloud.Spanner.V1
         {
             ExecuteSqlStreamSettings = existing.ExecuteSqlStreamSettings;
             AllowImmediateTimeouts = existing.AllowImmediateTimeouts;
+            Logger = existing.Logger;
+        }
+
+        private Logger _logger = Logger.DefaultLogger;
+
+        /// <summary>
+        /// The logger to use for operations involving this client. This property is never null.
+        /// </summary>
+        public Logger Logger
+        {
+            get => _logger;
+            set => _logger = GaxPreconditions.CheckNotNull(value, nameof(value));
         }
 
         /// <summary>


### PR DESCRIPTION
(API documentation messages still need rewriting.) The sole "entry
point" for configuring a logger when using ADO.NET is now the
SessionPoolManager.