### PR TITLE
Fix EF Core Spanner implementation

### DIFF
--- a/apis/Google.Cloud.EntityFrameworkCore.Spanner/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerRelationalConnection.cs
+++ b/apis/Google.Cloud.EntityFrameworkCore.Spanner/Google.Cloud.EntityFrameworkCore.Spanner/Storage/Internal/SpannerRelationalConnection.cs
@@ -52,12 +52,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             return new SpannerRelationalConnection(Dependencies.With(optionsBuilder.Options));
         }
 
+        // TODO: Integrate Spanner logging with EF logging
+
         /// <inheritdoc />
-        protected override DbConnection CreateDbConnection()
-            => new SpannerConnection(ConnectionString)
-            {
-                //This will route all contextual logs through the EF logger to give a consistent logging experience.
-                Logger = new SpannerLogBridge<DbLoggerCategory.Database.Connection>(Dependencies.ConnectionLogger)
-            };
+        protected override DbConnection CreateDbConnection() => new SpannerConnection(ConnectionString);
     }
 }

--- a/apis/Google.Cloud.EntityFrameworkCore.Spanner/Google.Cloud.EntityFrameworkCore.Spanner/Update/Internal/SpannerModificationCommandBatch.cs
+++ b/apis/Google.Cloud.EntityFrameworkCore.Spanner/Google.Cloud.EntityFrameworkCore.Spanner/Update/Internal/SpannerModificationCommandBatch.cs
@@ -109,7 +109,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                     throw new NotSupportedException(
                         $"Modification type {modificationCommand.EntityState} is not supported.");
             }
-            spannerConnection.Logger = new SpannerLogBridge<DbLoggerCategory.Database.Command>(_logger);
+            // TODO: Integrate with Spanner logging
             cmd.Transaction = transaction;
             foreach (var columnModification in modificationCommand.ColumnModifications)
                 cmd.Parameters.Add(


### PR DESCRIPTION
We can no longer set the logger on a SpannerConnection. If we come
back to the EF Core provider for Spanner, we'll need to re-evaluate
how we integrate with logging. (We can add more logging integration
points into the Spanner library later, but we're trimming them for
now.)