### PR TITLE
Make LogPerformanceEntries protected

### DIFF
--- a/apis/Google.Cloud.EntityFrameworkCore.Spanner/Google.Cloud.EntityFrameworkCore.Spanner/Diagnostics/SpannerLogBridge.cs
+++ b/apis/Google.Cloud.EntityFrameworkCore.Spanner/Google.Cloud.EntityFrameworkCore.Spanner/Diagnostics/SpannerLogBridge.cs
@@ -50,7 +50,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <summary>
         /// This is internal functionality and not intended for public use.
         /// </summary>
-        public override void LogPerformanceEntries(IEnumerable<string> entries)
+        protected override void LogPerformanceEntries(IEnumerable<string> entries)
         {
             string message = $"Performance entries{Environment.NewLine}{string.Join(Environment.NewLine, entries)}";
             _efLogger.Logger.Log(Microsoft.Extensions.Logging.LogLevel.Information,

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.CommonTesting/TestLogger.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.CommonTesting/TestLogger.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.Spanner.Data.CommonTesting
         protected override void LogImpl(V1.Internal.Logging.LogLevel level, string message, Exception exception) =>
             WriteLine(exception == null ? $"{level}: {message}" : $"{level}: {message}, Exception: {exception}");
 
-        public override void LogPerformanceEntries(IEnumerable<string> entries)
+        protected override void LogPerformanceEntries(IEnumerable<string> entries)
         {
             WriteLine("Performance:");
             foreach (var entry in entries)

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SessionPoolTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SessionPoolTests.cs
@@ -242,7 +242,7 @@ namespace Google.Cloud.Spanner.V1.Tests
                 LogLevel = LogLevel.Debug;
             }
 
-            public override void LogPerformanceEntries(IEnumerable<string> entries)
+            protected override void LogPerformanceEntries(IEnumerable<string> entries)
             {
                 // No-op
             }

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Internal/Logging/DefaultLogger.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Internal/Logging/DefaultLogger.cs
@@ -27,7 +27,7 @@ namespace Google.Cloud.Spanner.V1.Internal.Logging
             WriteLine(exception == null ? $"{level}: {message}" : $"{level}: {message}, Exception: {exception}");
 
         /// <inheritdoc />
-        public override void LogPerformanceEntries(IEnumerable<string> entries)
+        protected override void LogPerformanceEntries(IEnumerable<string> entries)
         {
             string separator = Environment.NewLine + "  ";
             WriteLine($"Performance:{separator}{string.Join(separator, entries)}");

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Internal/Logging/Logger.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Internal/Logging/Logger.cs
@@ -90,7 +90,7 @@ namespace Google.Cloud.Spanner.V1.Internal.Logging
         /// <summary>
         /// This is an internal method and is not intended to be used by external code.
         /// </summary>
-        public abstract void LogPerformanceEntries(IEnumerable<string> entries);
+        protected abstract void LogPerformanceEntries(IEnumerable<string> entries);
 
         /// <summary>
         /// This is an internal method and is not intended to be used by external code.


### PR DESCRIPTION
This is effectively part of the implementation, not something to be called from elsewhere.

(I made sure I fixed the EF Core implementation at the same time :)