### PR TITLE
Fix snippets

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/SpannerConnectionSnippets.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/SpannerConnectionSnippets.cs
@@ -352,8 +352,12 @@ namespace Google.Cloud.Spanner.Data.Snippets
             // End sample
         }
 
-        [Fact]
+
+        // Deliberately not a Fact! We don't want to run this, otherwise the default session pool will be
+        // shut down after the test...
+#pragma warning disable xUnit1013 // Public method should be marked as test
         public async Task ShutdownSessionPoolAsync()
+#pragma warning restore xUnit1013 // Public method should be marked as test
         {
             string connectionString = _fixture.ConnectionString;
 


### PR DESCRIPTION
We don't want to shut the default session pool down before other
tests run, so the example of that needs to not be a test. (It's
still useful to have in code to check that it compiles etc.)