### PR TITLE
Use Grpc.Gcp 1.1.1 for Spanner and Bigtable

### DIFF
--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="Google.Api.Gax.Grpc.Gcp" Version="2.6.0-beta02" />
     <ProjectReference Include="..\..\Google.Cloud.Bigtable.Common.V2\Google.Cloud.Bigtable.Common.V2\Google.Cloud.Bigtable.Common.V2.csproj" />
     <PackageReference Include="Grpc.Core" Version="1.16.0" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Gcp" Version="1.1.1" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.csproj
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.csproj
@@ -27,7 +27,7 @@
     <ProjectReference Include="..\..\Google.Cloud.Spanner.Admin.Instance.V1\Google.Cloud.Spanner.Admin.Instance.V1\Google.Cloud.Spanner.Admin.Instance.V1.csproj" />
     <ProjectReference Include="..\..\Google.Cloud.Spanner.V1\Google.Cloud.Spanner.V1\Google.Cloud.Spanner.V1.csproj" />
     <PackageReference Include="Grpc.Core" Version="1.16.0" PrivateAssets="None" />
-    <PackageReference Include="Grpc.Gcp" Version="1.1.0" />
+    <PackageReference Include="Grpc.Gcp" Version="1.1.1" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -105,7 +105,8 @@
       "Google.Api.Gax.Grpc": "2.6.0-beta02",
       "Google.Api.Gax.Grpc.Gcp": "2.6.0-beta02",
       "Google.Cloud.Bigtable.Common.V2": "project",
-      "Grpc.Core": "1.16.0"
+      "Grpc.Core": "1.16.0",
+      "Grpc.Gcp": "1.1.1"
     },
     "testDependencies": {
       "Google.Api.Gax.Grpc.Testing": "2.6.0-beta02",
@@ -627,7 +628,7 @@
       "Google.Cloud.Spanner.Admin.Database.V1": "project",
       "Google.Cloud.Spanner.Admin.Instance.V1": "project",
       "Grpc.Core": "1.16.0",
-      "Grpc.Gcp": "1.1.0"
+      "Grpc.Gcp": "1.1.1"
     },
     "testDependencies": {
       "CoreCompat.EnterpriseLibrary.TransientFaultHandling": "6.0.1304-r3",


### PR DESCRIPTION
Fixes #2675

Eventually we'll be able to just use the GAX reference from Bigtable, but there isn't a release with the new dependency yet