### PR TITLE
Fix CopyObject by using Done instead of RewriteToken to detect completion

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.CopyObject.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.CopyObject.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.Storage.V1
         {
             var request = CreateCopyObjectRequest(sourceBucket, sourceObjectName, destinationBucket, destinationObjectName, options);
             var response = request.Execute();
-            while (response.RewriteToken != null)
+            while (response.Done != true)
             {
                 request.RewriteToken = response.RewriteToken;
                 response = request.Execute();


### PR DESCRIPTION
It looks like the server recently changed from not returning a
rewrite token at all to returning an empty one. Using Done is a
better check, and prevents duplicate requests.

Fixes #2710. We should consider whether we want to backport this and release a 2.2.1 package as well.