### PR TITLE
Use Done in CopyObjectAsync too

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.CopyObject.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.CopyObject.cs
@@ -52,7 +52,7 @@ namespace Google.Cloud.Storage.V1
         {
             var request = CreateCopyObjectRequest(sourceBucket, sourceObjectName, destinationBucket, destinationObjectName, options);
             var response = await request.ExecuteAsync(cancellationToken).ConfigureAwait(false);
-            while (response.RewriteToken != null)
+            while (response.Done != true)
             {
                 request.RewriteToken = response.RewriteToken;
                 response = await request.ExecuteAsync(cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Fixes #2710 (again)

Although this commit comes after the change in version number, the 2.2.1 release was *not* created - we caught this in time.