### PR TITLE
Two cherry-picks for 2.2.1

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/NotificationsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/NotificationsTest.cs
@@ -45,7 +45,7 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
             {
                 projectId = projectId.Substring(orgSeparatorIndex + 1);
             }
-            Assert.Equal($"{projectId}@gs-project-accounts.iam.gserviceaccount.com", email);
+            Assert.EndsWith("@gs-project-accounts.iam.gserviceaccount.com", email);
         }
 
         /// <summary>


### PR DESCRIPTION
- The service account email address format has changed slightly over time, so the test needed to change
- The URL signer *production* code has changed since 2.2.0; this is a fix (which I'll highlight in the release notes)