### PR TITLE
Remove unnecessary logging attributes

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/CopyObjectTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/CopyObjectTest.cs
@@ -23,7 +23,6 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
     using static TestHelpers;
 
     [Collection(nameof(StorageFixture))]
-    [FileLoggerBeforeAfterTest]
     public class CopyObjectTest
     {
         private readonly StorageFixture _fixture;

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/DeleteBucketTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/DeleteBucketTest.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using Google.Apis.Storage.v1.Data;
-using Google.Cloud.ClientTesting;
 using System.Net;
 using System.Threading.Tasks;
 using Xunit;
@@ -23,7 +22,6 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
     using static TestHelpers;
 
     [Collection(nameof(StorageFixture))]
-    [FileLoggerBeforeAfterTest]
     public class DeleteBucketTest
     {
         // Only overloads accepting Bucket are tested, but the overloads accepting string go

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/DeleteObjectTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/DeleteObjectTest.cs
@@ -24,7 +24,6 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
     using static TestHelpers;
 
     [Collection(nameof(StorageFixture))]
-    [FileLoggerBeforeAfterTest]
     public class DeleteObjectTest
     {
         private readonly StorageFixture _fixture;

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/DownloadObjectTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/DownloadObjectTest.cs
@@ -15,7 +15,6 @@
 using Google.Apis.Download;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
-using Google.Cloud.ClientTesting;
 using System;
 using System.IO;
 using System.Linq;
@@ -31,7 +30,6 @@ using Object = Google.Apis.Storage.v1.Data.Object;
 namespace Google.Cloud.Storage.V1.IntegrationTests
 {
     [Collection(nameof(StorageFixture))]
-    [FileLoggerBeforeAfterTest]
     public class DownloadObjectTest
     {
         private readonly StorageFixture _fixture;

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/EncryptionTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/EncryptionTest.cs
@@ -26,7 +26,6 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
     /// see <see cref="KmsTest"/>.
     /// </summary>
     [Collection(nameof(StorageFixture))]
-    [FileLoggerBeforeAfterTest]
     public class EncryptionTest
     {
         private readonly StorageFixture _fixture;

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/GetObjectTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/GetObjectTest.cs
@@ -12,14 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Google.Cloud.ClientTesting;
 using System.Linq;
 using Xunit;
 
 namespace Google.Cloud.Storage.V1.IntegrationTests
 {
     [Collection(nameof(StorageFixture))]
-    [FileLoggerBeforeAfterTest]
     public class GetObjectTest
     {
         private readonly StorageFixture _fixture;

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/KmsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/KmsTest.cs
@@ -28,7 +28,6 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
     /// Tests for customer-managed encryption keys (CMEK) that use Cloud KMS.
     /// </summary>
     [Collection(nameof(StorageFixture))]
-    [FileLoggerBeforeAfterTest]
     public class KmsTest
     {
         // Name of a US-based keyring, which is expected to be in the test project, in "locations/us"

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/ListBucketsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/ListBucketsTest.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using Google.Apis.Storage.v1.Data;
-using Google.Cloud.ClientTesting;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -24,7 +23,6 @@ using Xunit;
 namespace Google.Cloud.Storage.V1.IntegrationTests
 {
     [Collection(nameof(StorageFixture))]
-    [FileLoggerBeforeAfterTest]
     public class ListBucketsTest
     {
         private readonly StorageFixture _fixture;

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/ListObjectsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/ListObjectsTest.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Google.Cloud.ClientTesting;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -24,7 +23,6 @@ using Object = Google.Apis.Storage.v1.Data.Object;
 namespace Google.Cloud.Storage.V1.IntegrationTests
 {
     [Collection(nameof(StorageFixture))]
-    [FileLoggerBeforeAfterTest]
     public class ListObjectsTest
     {
         private readonly StorageFixture _fixture;

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/NotificationsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/NotificationsTest.cs
@@ -12,24 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Xunit;
 using Google.Apis.Storage.v1.Data;
+using Google.Cloud.ClientTesting;
 using Google.Cloud.PubSub.V1;
 using System;
+using System.IO;
 using System.Linq;
 using System.Text;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-
+using Xunit;
 using Object = Google.Apis.Storage.v1.Data.Object;
-using Google.Cloud.Iam.V1;
-using Google.Cloud.ClientTesting;
 
 namespace Google.Cloud.Storage.V1.IntegrationTests
 {
     [Collection(nameof(StorageFixture))]
-    [FileLoggerBeforeAfterTest]
     public class NotificationsTest
     {
         private readonly StorageFixture _fixture;

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/PatchBucketTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/PatchBucketTest.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using Google.Apis.Storage.v1.Data;
-using Google.Cloud.ClientTesting;
 using System;
 using Xunit;
 using static Google.Apis.Storage.v1.Data.Bucket;
@@ -21,7 +20,6 @@ using static Google.Apis.Storage.v1.Data.Bucket;
 namespace Google.Cloud.Storage.V1.IntegrationTests
 {
     [Collection(nameof(StorageFixture))]
-    [FileLoggerBeforeAfterTest]
     public class PatchBucketTest
     {
         private readonly StorageFixture _fixture;

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/PatchObjectTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/PatchObjectTest.cs
@@ -21,7 +21,6 @@ using Object = Google.Apis.Storage.v1.Data.Object;
 namespace Google.Cloud.Storage.V1.IntegrationTests
 {
     [Collection(nameof(StorageFixture))]
-    [FileLoggerBeforeAfterTest]
     public class PatchObjectTest
     {
         private readonly StorageFixture _fixture;

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/RequesterPaysTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/RequesterPaysTest.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Google.Cloud.ClientTesting;
-using System;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -26,7 +24,6 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
     // https://github.com/xunit/samples.xunit/tree/master/DynamicSkipExample
 
     [Collection(nameof(StorageFixture))]
-    [FileLoggerBeforeAfterTest]
     public class RequesterPaysTest
     {
         private readonly StorageFixture _fixture;

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/RetentionPolicyTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/RetentionPolicyTest.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using Google.Apis.Storage.v1.Data;
-using Google.Cloud.ClientTesting;
 using System;
 using System.IO;
 using System.Text;
@@ -24,7 +23,6 @@ using Object = Google.Apis.Storage.v1.Data.Object;
 namespace Google.Cloud.Storage.V1.IntegrationTests
 {
     [Collection(nameof(StorageFixture))]
-    [FileLoggerBeforeAfterTest]
     public class RetentionPolicyTest
     {
         private readonly StorageFixture _fixture;

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/StorageClassTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/StorageClassTest.cs
@@ -20,7 +20,6 @@ using Object = Google.Apis.Storage.v1.Data.Object;
 namespace Google.Cloud.Storage.V1.IntegrationTests
 {
     [Collection(nameof(StorageFixture))]
-    [FileLoggerBeforeAfterTest]
     public class StorageClassTest
     {
         private readonly StorageFixture _fixture;

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/UnauthenticatedAccessTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/UnauthenticatedAccessTest.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Google.Cloud.ClientTesting;
 using System.IO;
 using System.Linq;
 using Xunit;
@@ -20,7 +19,6 @@ using Xunit;
 namespace Google.Cloud.Storage.V1.IntegrationTests
 {
     [Collection(nameof(StorageFixture))]
-    [FileLoggerBeforeAfterTest]
     public class UnauthenticatedAccessTest
     {
         // See https://cloud.google.com/storage/docs/public-datasets/landsat

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/UpdateObjectTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/UpdateObjectTest.cs
@@ -19,9 +19,7 @@ using Xunit;
 
 namespace Google.Cloud.Storage.V1.IntegrationTests
 {
-
     [Collection(nameof(StorageFixture))]
-    [FileLoggerBeforeAfterTest]
     public class UpdateObjectTest
     {
         private readonly StorageFixture _fixture;

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/UploadObjectTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/UploadObjectTest.cs
@@ -30,7 +30,6 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
     using static TestHelpers;
 
     [Collection(nameof(StorageFixture))]
-    [FileLoggerBeforeAfterTest]
     public class UploadObjectTest
     {
         private readonly StorageFixture _fixture;

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/UrlSignerTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/UrlSignerTest.cs
@@ -31,7 +31,6 @@ using Xunit;
 namespace Google.Cloud.Storage.V1.IntegrationTests
 {
     [Collection(nameof(StorageFixture))]
-    [FileLoggerBeforeAfterTest]
     public class UrlSignerTest
     {
         private static readonly TimeSpan _duration = TimeSpan.FromSeconds(5);


### PR DESCRIPTION
The fixture has the attribute, so we don't need it on any test that uses the fixture.