### PR TITLE
Stop generating the Vision.V1P{1,2} APIs

### DIFF
--- a/generateapis.sh
+++ b/generateapis.sh
@@ -190,6 +190,4 @@ generate_api Google.Cloud.Trace.V1 google/devtools/cloudtrace/v1 cloudtrace_v1.y
 generate_api Google.Cloud.Trace.V2 google/devtools/cloudtrace/v2 cloudtrace_v2.yaml
 generate_api Google.Cloud.VideoIntelligence.V1 google/cloud/videointelligence/v1 videointelligence_v1.yaml
 generate_api Google.Cloud.Vision.V1 google/cloud/vision/v1 vision_v1.yaml
-generate_api Google.Cloud.Vision.V1P1Beta1 google/cloud/vision/v1p1beta1 vision_v1p1beta1.yaml
-generate_api Google.Cloud.Vision.V1P2Beta1 google/cloud/vision/v1p2beta1 vision_v1p2beta1.yaml
 


### PR DESCRIPTION
This should have been in the previous PR, of course...