### PR TITLE
Implement field mask option when fetching document snapshots in bulk

### DIFF
--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/FieldMaskFetchingTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/FieldMaskFetchingTest.cs
@@ -1,0 +1,60 @@
+﻿// Copyright 2018, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Firestore.IntegrationTests.Models;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Cloud.Firestore.IntegrationTests
+{
+    [Collection(nameof(FirestoreFixture))]
+    public class FieldMaskFetchingTest
+    {
+        private readonly FirestoreFixture _fixture;
+        public FieldMaskFetchingTest(FirestoreFixture fixture) => _fixture = fixture;
+
+        [Fact]
+        public async Task FirestoreDbGetAllDocumentsAsync_WithFieldMask()
+        {
+            var docs = await _fixture.HighScoreCollection.ListDocumentsAsync().ToList();
+            var fieldMask = new FieldMask("Name", "Score");
+            var snapshots = await _fixture.FirestoreDb.GetAllSnapshotsAsync(docs, fieldMask);
+            var models = snapshots.Select(s => s.ConvertTo<HighScore>()).ToList();
+            Assert.All(models, AssertMasked);
+        }
+
+        [Fact]
+        public async Task TransactionGetAllDocumentsAsync_WithFieldMask()
+        {
+            var docs = await _fixture.HighScoreCollection.ListDocumentsAsync().ToList();
+            var fieldMask = new FieldMask("Name", "Score");
+            await _fixture.FirestoreDb.RunTransactionAsync(async t =>
+            {
+                var snapshots = await t.GetAllSnapshotsAsync(docs, fieldMask);
+                var models = snapshots.Select(s => s.ConvertTo<HighScore>()).ToList();
+                Assert.All(models, AssertMasked);
+            });
+        }
+
+        private static void AssertMasked(HighScore model)
+        {
+            // We fetched name and score, so those should always be non-default values.
+            Assert.NotNull(model.Name);
+            Assert.NotEqual(0, model.Score);
+            // We didn't fetch the level, so that should always be 0.
+            Assert.Equal(0, model.Level);
+        }
+    }
+}

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/ComparisonTester.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/ComparisonTester.cs
@@ -22,8 +22,10 @@ namespace Google.Cloud.Firestore.Tests
         internal static void AssertComparison<T>(T smaller, T larger, IComparer<T> comparer = null)
         {
             comparer = comparer ?? Comparer<T>.Default;
-            Assert.InRange(comparer.Compare(smaller, larger), int.MinValue, -1);
-            Assert.InRange(comparer.Compare(larger, smaller), 1, int.MaxValue);
+            Assert.True(comparer.Compare(smaller, larger) < 0,
+                $"Compare({smaller}, {larger}) should be < 0");
+            Assert.True(comparer.Compare(larger, smaller) > 0,
+                $"Compare({larger}, {smaller}) should be > 0.");
             Assert.Equal(0, comparer.Compare(smaller, smaller));
             Assert.Equal(0, comparer.Compare(larger, larger));
         }

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/FieldMaskTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/FieldMaskTest.cs
@@ -1,0 +1,52 @@
+﻿// Copyright 2018, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.ClientTesting;
+using Google.Cloud.Firestore.V1Beta1;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Google.Cloud.Firestore.Tests
+{
+    public class FieldMaskTest
+    {
+        [Fact]
+        public void Equality()
+        {
+            EqualityTester.AssertEqual(new FieldMask("a", "b"),
+                new[] { new FieldMask("a", "b", "b"), new FieldMask(new FieldPath("a"), new FieldPath("b")) },
+                new[] { new FieldMask("a"), new FieldMask("a", "c"), new FieldMask("a", "b", "c") });
+        }
+
+        [Fact]
+        public void InvalidConstruction()
+        {
+            Assert.Throws<ArgumentNullException>(() => new FieldMask((FieldPath[]) null));
+            Assert.Throws<ArgumentNullException>(() => new FieldMask((string[]) null));
+            Assert.Throws<ArgumentException>(() => new FieldMask((string) null));
+            Assert.Throws<ArgumentException>(() => new FieldMask(""));
+            Assert.Throws<ArgumentException>(() => new FieldMask("a~b"));
+            Assert.Throws<ArgumentException>(() => new FieldMask((FieldPath) null));
+        }
+
+        [Fact]
+        public void ToProto()
+        {
+            var mask = new FieldMask("b", @"a.c\d", "a");
+            Assert.Equal(new DocumentMask { FieldPaths = { "a", @"a.`c\\d`", "b" } }, mask.ToProto());
+        }
+    }
+}

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/FieldPathTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/FieldPathTest.cs
@@ -108,5 +108,29 @@ namespace Google.Cloud.Firestore.Tests
             var fp2 = FieldPath.FromDotSeparatedString(path2);
             Assert.Equal(expected, fp1.IsPrefixOf(fp2));
         }
+
+        [Fact]
+        public void Ordering()
+        {
+            var paths = new[]
+            {
+                FieldPath.Empty,
+                new FieldPath("a"),
+                new FieldPath("a", "b"),
+                new FieldPath("a", "b", "b"),
+                new FieldPath("a", "b", "ba"),
+                new FieldPath("a", "b", "c"),
+                new FieldPath("b", "a"),
+            };
+
+            for (int i = 0; i < paths.Length; i++)
+            {
+                for (int j = i + 1; j < paths.Length; j++)
+                {
+                    // This will also compare field paths with themselves
+                    ComparisonTester.AssertComparison(paths[i], paths[j]);
+                }
+            }
+        }
     }
 }

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/DocumentReference.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/DocumentReference.cs
@@ -195,7 +195,7 @@ namespace Google.Cloud.Firestore
         /// <returns>A snapshot of the document. The snapshot may represent a missing document.</returns>
         internal async Task<DocumentSnapshot> GetSnapshotAsync(ByteString transactionId, CancellationToken cancellationToken)
         {
-            var multiple = await Database.GetDocumentSnapshotsAsync(new[] { this }, transactionId, cancellationToken).ConfigureAwait(false);
+            var multiple = await Database.GetDocumentSnapshotsAsync(new[] { this }, transactionId, fieldMask: null, cancellationToken).ConfigureAwait(false);
             return multiple.Single();
         }
 

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/FieldMask.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/FieldMask.cs
@@ -1,0 +1,86 @@
+﻿// Copyright 2018, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using Google.Api.Gax;
+using Google.Cloud.Firestore.V1Beta1;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Google.Cloud.Firestore
+{
+    /// <summary>
+    /// An immutable set of field paths, used to limit the data returned by calls to
+    /// <see cref="FirestoreDb.GetAllSnapshotsAsync(IEnumerable{DocumentReference}, System.Threading.CancellationToken)"/>
+    /// and similar calls.
+    /// </summary>
+    public sealed class FieldMask : IEquatable<FieldMask>
+    {
+        // We store the paths in order for the sake of testability: we can predict the protobuf form easily, and this
+        // provides setwise behavior too.
+        private readonly SortedSet<FieldPath> _fieldPaths;
+
+        private FieldMask(IEnumerable<FieldPath> paths)
+        {
+            _fieldPaths = new SortedSet<FieldPath>(paths);
+        }
+
+        /// <summary>
+        /// Creates a mask from the given paths. Each path is treated as a dot-separated sequence of field names.
+        /// </summary>
+        /// <param name="paths">The paths, as dot-separated strings. This must not be null, and it must not contain any null or empty elements.</param>
+        public FieldMask(params string[] paths) : this(ConvertPaths(paths))
+        {
+        }
+
+        static IEnumerable<FieldPath> ConvertPaths(string[] paths)
+        {
+            GaxPreconditions.CheckNotNull(paths, nameof(paths));
+            return paths.Select(path =>
+            {
+                GaxPreconditions.CheckArgument(!string.IsNullOrEmpty(path), nameof(paths), "Path array must not contain any null or empty elements");
+                return FieldPath.FromDotSeparatedString(path);
+            });
+        }
+
+        /// <summary>
+        /// Creates a mask from the given paths.
+        /// </summary>
+        /// <param name="paths">The segments of the path. This must not be null, and it must not contain any null elements.</param>
+        public FieldMask(params FieldPath[] paths) : this(CheckPaths(paths))
+        {
+        }
+
+        static IEnumerable<FieldPath> CheckPaths(FieldPath[] paths)
+        {
+            GaxPreconditions.CheckNotNull(paths, nameof(paths));
+            GaxPreconditions.CheckArgument(!paths.Contains(null), nameof(paths), "Path array must not contain any null elements");
+            return paths;
+        }
+
+        internal DocumentMask ToProto() => new DocumentMask { FieldPaths = { _fieldPaths.Select(p => p.EncodedPath) } };
+
+        // Note: even though this is order-sensitive (which is odd for set behavior), that's fine as we use a sorted set.
+        /// <inheritdoc />
+        public override int GetHashCode() => EqualityHelpers.GetEnumerableHashCode(_fieldPaths);
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as FieldMask);
+
+        /// <inheritdoc />
+        public bool Equals(FieldMask other) =>
+            other != null &&
+            _fieldPaths.Count == other._fieldPaths.Count && // Surprisingly, it looks like this optimization isn't in SortedSet<T>
+            _fieldPaths.SetEquals(other._fieldPaths);
+    }
+}

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Transaction.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Transaction.cs
@@ -91,11 +91,28 @@ namespace Google.Cloud.Firestore
         /// <param name="documentReferences">The document references to fetch. Must not be null, or contain null references.</param>
         /// <param name="cancellationToken">A cancellation token to monitor for the asynchronous operation.</param>
         /// <returns>The document snapshots, in the same order as <paramref name="documentReferences"/>.</returns>
-        public Task<IList<DocumentSnapshot>> GetAllSnapshotsAsync(IEnumerable<DocumentReference> documentReferences, CancellationToken cancellationToken = default)
+        public Task<IList<DocumentSnapshot>> GetAllSnapshotsAsync(IEnumerable<DocumentReference> documentReferences, CancellationToken cancellationToken = default) =>
+            GetAllSnapshotsAsync(documentReferences, fieldMask: null, cancellationToken);
+
+        /// <summary>
+        /// Fetch snapshots of all the documents specified by <paramref name="documentReferences"/>, with respect to this transaction,
+        /// potentially limiting the fields returned.
+        /// This method cannot be called after any write operations have been created.
+        /// </summary>
+        /// <remarks>
+        /// Any documents which are missing are represented in the returned list by a <see cref="DocumentSnapshot"/>
+        /// with <see cref="DocumentSnapshot.Exists"/> value of <c>false</c>.
+        /// </remarks>
+        /// <param name="documentReferences">The document references to fetch. Must not be null, or contain null references.</param>
+        /// <param name="fieldMask">The field mask to use to restrict which fields are retrieved. May be null, in which
+        /// case no field mask is applied, and the complete documents are retrieved.</param>
+        /// <param name="cancellationToken">A cancellation token to monitor for the asynchronous operation.</param>
+        /// <returns>The document snapshots, in the same order as <paramref name="documentReferences"/>.</returns>
+        public Task<IList<DocumentSnapshot>> GetAllSnapshotsAsync(IEnumerable<DocumentReference> documentReferences, FieldMask fieldMask, CancellationToken cancellationToken = default)
         {
             GaxPreconditions.CheckState(_writes.IsEmpty, "Firestore transactions require all reads to be executed before all writes.");
             CancellationToken effectiveToken = GetEffectiveCancellationToken(cancellationToken);
-            return Database.GetAllSnapshotsAsync(documentReferences, TransactionId, effectiveToken);
+            return Database.GetAllSnapshotsAsync(documentReferences, TransactionId, fieldMask, effectiveToken);
         }
 
         /// <summary>

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Utilities/EqualityHelpers.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Utilities/EqualityHelpers.cs
@@ -73,6 +73,26 @@ namespace Google.Cloud.Firestore
             }
         }
 
+        /// <summary>
+        /// Computes an ordering-sensitive hash code for a sequence.
+        /// </summary>
+        internal static int GetEnumerableHashCode<T>(IEnumerable<T> sequence) where T : IEquatable<T>
+        {
+            if (sequence == null)
+            {
+                return 0;
+            }
+            unchecked
+            {
+                int hash = HashInitialValue;
+                foreach (var item in sequence)
+                {
+                    hash = (hash << 5) + hash + item.GetHashCode();
+                }
+                return hash;
+            }
+        }
+
         // Hash code convenience methods using DJB2 constants.
         // Alternatives would be generic methods that call GetHashCode directly.
         // Only necessary overloads are present; more can be added.


### PR DESCRIPTION
Fixes #2048 (for batchGet anyway; I don't expect we'll do this for get, where there's significantly less impact).