### PR TITLE
Extension for reading monitored resource data from host builder context.

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/DiagnosticsWebHostTests.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/DiagnosticsWebHostTests.cs
@@ -22,8 +22,10 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -96,6 +98,43 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
                 await TestErrorReporting(testId, client);
             }
         }
+
+#if NETCOREAPP2_0
+        [Fact]
+        public async Task UseGoogleDiagnostics_ConfiguresComponentsFromHostBuilderContext()
+        {
+            var testId = IdGenerator.FromDateTime();
+            var startTime = DateTime.UtcNow;
+            var configurationData = new Dictionary<string, string>
+            {
+                { "project_id", TestEnvironment.GetTestProjectId() },
+                { "module_id", EntryData.Service },
+                { "version_id", EntryData.Version }
+            };
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(configurationData)
+                .Build();
+
+            var webHostBuilder = new WebHostBuilder()
+                .UseConfiguration(configuration)
+                .ConfigureServices(services => services.AddMvcCore())
+                .Configure(app => app.UseMvcWithDefaultRoute())
+                .UseGoogleDiagnostics(
+                    ctx => ctx.Configuration["project_id"],
+                    ctx => ctx.Configuration["module_id"],
+                    ctx => ctx.Configuration["version_id"]
+                );
+
+            using (var server = new TestServer(webHostBuilder))
+            using (var client = server.CreateClient())
+            {
+                await TestTrace(testId, startTime, client);
+                await TestLogging(testId, startTime, client);
+                await TestErrorReporting(testId, client);
+            }
+        }
+#endif
 
         private static async Task TestLogging(string testId, DateTime startTime, HttpClient client)
         {

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/GoogleDiagnosticsWebHostBuilderExtensions.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/GoogleDiagnosticsWebHostBuilderExtensions.cs
@@ -16,6 +16,7 @@ using Google.Api;
 using Google.Cloud.Diagnostics.Common;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using System;
 
 namespace Google.Cloud.Diagnostics.AspNetCore
 {
@@ -25,7 +26,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
     public static class GoogleDiagnosticsWebHostBuilderExtensions
     {
         /// <summary>
-        /// Configures Google Diagostics services for Logging, Tracing and Error Reporting middleware.
+        /// Configures Google Diagnostics services for Logging, Tracing and Error Reporting middleware.
         /// </summary>
         /// <param name="builder">The <see cref="IWebHostBuilder"/> instance.</param>
         /// <param name="projectId">
@@ -44,26 +45,64 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         public static IWebHostBuilder UseGoogleDiagnostics(this IWebHostBuilder builder, string projectId = null, string serviceName = null, string serviceVersion = null)
             => UseGoogleDiagnostics(builder, projectId, serviceName, serviceVersion, monitoredResource: null);
 
+#if NETSTANDARD2_0
+        // On .NET Standard 2.0 or higher the IWebHostBuilder.ConfigureServices has a new overload that takes both
+        // an IServiceCollection and a WebHostBuilderContext. We can use the context for retrieving information from the
+        // host builder at startup time, like reading configuration.
+
+        /// <summary>
+        /// Configures Google Diagnostics services for Logging, Tracing and Error Reporting middleware.
+        /// </summary>
+        /// <param name="builder">The <see cref="IWebHostBuilder"/> instance.</param>
+        /// <param name="projectIdGetter">
+        /// A function that takes a <see cref="WebHostBuilderContext"/> and retrieves the Google Cloud Platform project ID.
+        /// If unspecified and running on GAE/GCE/GKE the project ID will be detected from the platform.
+        /// </param>
+        /// <param name="serviceNameGetter">
+        /// A function that takes a <see cref="WebHostBuilderContext"/> and retrieves the identifier of the service used for exception logging, such as the name of the executable or job.
+        /// If unspecified and running on GAE the service name will be detected from the platform.
+        /// </param>
+        /// <param name="serviceVersionGetter">
+        /// A function that takes a <see cref="WebHostBuilderContext"/> and retrieves the version of the service or the source code used for exception logging.
+        /// If unspecified and running on GAE the service version will be detected from the platform.
+        /// </param>
+        /// <returns>The <see cref="IWebHostBuilder"/> instance.</returns>
+        public static IWebHostBuilder UseGoogleDiagnostics(this IWebHostBuilder builder, Func<WebHostBuilderContext, string> projectIdGetter = null, Func<WebHostBuilderContext, string> serviceNameGetter = null, Func<WebHostBuilderContext, string> serviceVersionGetter = null)
+        {
+            builder.ConfigureServices((context, services) =>
+            {
+                ConfigureGoogleDiagnosticsServices(services, projectIdGetter?.Invoke(context), serviceNameGetter?.Invoke(context), serviceVersionGetter?.Invoke(context), null);
+            });
+
+            return builder;
+        }
+#endif
+
         // Overload which allows passing in a MonitoredResource instance
         // Internal for testing
         internal static IWebHostBuilder UseGoogleDiagnostics(this IWebHostBuilder builder, string projectId = null, string serviceName = null, string serviceVersion = null, MonitoredResource monitoredResource = null)
         {
             builder.ConfigureServices(services =>
             {
-                projectId = Project.GetAndCheckProjectId(projectId, monitoredResource);
-
-                services.AddLogEntryLabelProvider<TraceIdLogEntryLabelProvider>();
-                services.AddSingleton<IStartupFilter>(new GoogleDiagnosticsStartupFilter(projectId, monitoredResource));
-                services.AddGoogleTrace(options => options.ProjectId = projectId);
-                services.AddGoogleExceptionLogging(options =>
-                {
-                    options.ProjectId = projectId;
-                    options.ServiceName = Project.GetAndCheckServiceName(serviceName, monitoredResource);
-                    options.Version = Project.GetAndCheckServiceVersion(serviceVersion, monitoredResource);
-                });
+                ConfigureGoogleDiagnosticsServices(services, projectId, serviceName, serviceVersion, monitoredResource);
             });
 
             return builder;
+        }
+
+        private static void ConfigureGoogleDiagnosticsServices(IServiceCollection services, string projectId, string serviceName, string serviceVersion, MonitoredResource monitoredResource)
+        {
+            projectId = Project.GetAndCheckProjectId(projectId, monitoredResource);
+
+            services.AddLogEntryLabelProvider<TraceIdLogEntryLabelProvider>();
+            services.AddSingleton<IStartupFilter>(new GoogleDiagnosticsStartupFilter(projectId, monitoredResource));
+            services.AddGoogleTrace(options => options.ProjectId = projectId);
+            services.AddGoogleExceptionLogging(options =>
+            {
+                options.ProjectId = projectId;
+                options.ServiceName = Project.GetAndCheckServiceName(serviceName, monitoredResource);
+                options.Version = Project.GetAndCheckServiceVersion(serviceVersion, monitoredResource);
+            });
         }
     }
 }


### PR DESCRIPTION
Resolves issue #2435.

Added an extension for `IWebHostBuilder` that allows the project ID, service name, and service version information to come from the `WebHostBuilderContext` at registration time rather than having to be passed in directly. This allows the data to be stored in configuration or in other locations.

The `WebHostBuilderContext` overload for the `ConfigureServices` method [was introduced in ASP.NET Core 2.0.0](https://github.com/aspnet/Hosting/commit/2b07e88a581ef2ad1cccd6a68170cf5aba77c6e7) so it's only available for the `netstandard2.0` version of the `Google.Cloud.Diagnostics.AspNetCore` library. The corresponding integration test is only run when targeting `netcoreapp2.0`.