### PR TITLE
Add a lot of tracking test names for Spanner integration tests

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/BindingTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/BindingTests.cs
@@ -44,8 +44,36 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             SpannerDbType.ArrayOf(SpannerDbType.Float64),
             SpannerDbType.ArrayOf(SpannerDbType.Date),
             SpannerDbType.ArrayOf(SpannerDbType.Bytes),
-        };        
+        };
 
+        // [START spanner_test_query_bind_bool_null]
+        // [END spanner_test_query_bind_bool_null]
+        // [START spanner_test_query_bind_int64_null]
+        // [END spanner_test_query_bind_int64_null]
+        // [START spanner_test_query_bind_float64_null]
+        // [END spanner_test_query_bind_float64_null]
+        // [START spanner_test_query_bind_string_null]
+        // [END spanner_test_query_bind_string_null]
+        // [START spanner_test_query_bind_bytes_null]
+        // [END spanner_test_query_bind_bytes_null]
+        // [START spanner_test_query_bind_timestamp_null]
+        // [END spanner_test_query_bind_timestamp_null]
+        // [START spanner_test_query_bind_date_null]
+        // [END spanner_test_query_bind_date_null]
+        // [START spanner_test_query_bind_bool_array_null]
+        // [END spanner_test_query_bind_bool_array_null]
+        // [START spanner_test_query_bind_int64_array_null]
+        // [END spanner_test_query_bind_int64_array_null]
+        // [START spanner_test_query_bind_float64_array_null]
+        // [END spanner_test_query_bind_float64_array_null]
+        // [START spanner_test_query_bind_string_array_null]
+        // [END spanner_test_query_bind_string_array_null]
+        // [START spanner_test_query_bind_bytes_array_null]
+        // [END spanner_test_query_bind_bytes_array_null]
+        // [START spanner_test_query_bind_timestamp_array_null]
+        // [END spanner_test_query_bind_timestamp_array_null]
+        // [START spanner_test_query_bind_date_array_null]
+        // [END spanner_test_query_bind_date_array_null]
         [Theory]
         [MemberData(nameof(BindNullData))]
         public async Task BindNull(SpannerDbType parameterType)
@@ -111,24 +139,33 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             }
         }
 
+        // [START spanner_test_query_bind_bool]
         [Fact]
         public Task BindBoolean() => TestBindNonNull(SpannerDbType.Bool, true, r => r.GetBoolean(0));
+        // [END spanner_test_query_bind_bool]
 
+        // [START spanner_test_query_bind_bool_array]
         [Fact]
         public Task BindBooleanArray() => TestBindNonNull(
             SpannerDbType.ArrayOf(SpannerDbType.Bool),
             new bool?[] {true, null, false});
+        // [END spanner_test_query_bind_bool_array]
 
+        // [START spanner_test_query_bind_bool_array_empty]
         [Fact]
         public Task BindBooleanEmptyArray() => TestBindNonNull(
             SpannerDbType.ArrayOf(SpannerDbType.Bool),
             new bool[] { });
+        // [END spanner_test_query_bind_bool_array_empty]
 
+        // [START spanner_test_query_bind_bytes]
         [Fact]
         public Task BindByteArray() => TestBindNonNull(
             SpannerDbType.Bytes,
             new byte[] {1, 2, 3});
+        // [END spanner_test_query_bind_bytes]
 
+        // [START spanner_test_query_bind_bytes_array]
         [Fact]
         public Task BindByteArrayList() => TestBindNonNull(
             SpannerDbType.ArrayOf(SpannerDbType.Bytes),
@@ -137,80 +174,113 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 new byte[] { 4, 5, 6 },
                 null
             });
+        // [END spanner_test_query_bind_bytes_array]
 
+        // [START spanner_test_query_bind_bytes_array_empty]
         [Fact]
         public Task BindEmptyByteArrayList() => TestBindNonNull(
             SpannerDbType.ArrayOf(SpannerDbType.Bytes),
             new List<byte[]>());
+        // [END spanner_test_query_bind_bytes_array_empty]
 
+        // [START spanner_test_query_bind_date]
         [Fact]
         public Task BindDate() => TestBindNonNull(
             SpannerDbType.Date,
             new DateTime(2017, 5, 26));
+        // [END spanner_test_query_bind_date]
 
+        // [START spanner_test_query_bind_date_array]
         [Fact]
         public Task BindDateArray() => TestBindNonNull(
             SpannerDbType.ArrayOf(SpannerDbType.Date),
             new DateTime?[] {new DateTime(2017, 5, 26), null, new DateTime(2017, 5, 9)});
+        // [END spanner_test_query_bind_date_array]
 
+        // [START spanner_test_query_bind_date_array_empty]
         [Fact]
         public Task BindDateEmptyArray() => TestBindNonNull(
             SpannerDbType.ArrayOf(SpannerDbType.Date),
             new DateTime?[] { });
+        // [END spanner_test_query_bind_date_array_empty]
 
+        // [START spanner_test_query_bind_float64]
         [Fact]
         public Task BindFloat64() => TestBindNonNull(SpannerDbType.Float64, 1.0, r => r.GetDouble(0));
+        // [END spanner_test_query_bind_float64]
 
+        // [START spanner_test_query_bind_float64_array]
         [Fact]
         public Task BindFloat64Array() => TestBindNonNull(
             SpannerDbType.ArrayOf(SpannerDbType.Float64),
             new double?[] {0.0, null, 1.0});
+        // [END spanner_test_query_bind_float64_array]
 
+        // [START spanner_test_query_bind_float64_array_empty]
         [Fact]
         public Task BindFloat64EmptyArray() => TestBindNonNull(
             SpannerDbType.ArrayOf(SpannerDbType.Float64),
             new double[] { });
+        // [END spanner_test_query_bind_float64_array_empty]
 
+        // [START spanner_test_query_bind_int64]
         [Fact]
         public Task BindInt64() => TestBindNonNull(SpannerDbType.Int64, 1, r => r.GetInt64(0));
+        // [END spanner_test_query_bind_int64]
 
+        // [START spanner_test_query_bind_int64_array]
         [Fact]
         public Task BindInt64Array() => TestBindNonNull(
             SpannerDbType.ArrayOf(SpannerDbType.Int64),
             new long?[] {1, null, 0});
+        // [END spanner_test_query_bind_int64_array]
 
+        // [START spanner_test_query_bind_int64_array_empty]
         [Fact]
         public Task BindInt64EmptyArray() => TestBindNonNull(
             SpannerDbType.ArrayOf(SpannerDbType.Int64),
             new long[] { });
+        // [END spanner_test_query_bind_int64_array_empty]
 
+        // [START spanner_test_query_bind_string]
         [Fact]
         public Task BindString() => TestBindNonNull(SpannerDbType.String, "abc", r => r.GetString(0));
+        // [END spanner_test_query_bind_string]
 
+        // [START spanner_test_query_bind_string_array]
         [Fact]
         public Task BindStringArray() => TestBindNonNull(
             SpannerDbType.ArrayOf(SpannerDbType.String),
             new[] {"abc", null, "123"});
+        // [END spanner_test_query_bind_string_array]
 
+        // [START spanner_test_query_bind_string_array_empty]
         [Fact]
         public Task BindStringEmptyArray() => TestBindNonNull(
             SpannerDbType.ArrayOf(SpannerDbType.String),
             new string[] { });
+        // [END spanner_test_query_bind_string_array_empty]
 
+        // [START spanner_test_query_bind_timestamp]
         [Fact]
         public Task BindTimestamp() => TestBindNonNull(
             SpannerDbType.Timestamp,
             new DateTime(2017, 5, 26, 15, 0, 0));
+        // [END spanner_test_query_bind_timestamp]
 
+        // [START spanner_test_query_bind_timestamp_array]
         [Fact]
         public Task BindTimestampArray() => TestBindNonNull(
             SpannerDbType.ArrayOf(SpannerDbType.Timestamp),
             new DateTime?[]
                 {new DateTime(2017, 5, 26, 3, 15, 0), null, new DateTime(2017, 5, 9, 12, 30, 0)});
+        // [END spanner_test_query_bind_timestamp_array]
 
+        // [START spanner_test_query_bind_timestamp_array_empty]
         [Fact]
         public Task BindTimestampEmptyArray() => TestBindNonNull(
             SpannerDbType.ArrayOf(SpannerDbType.Timestamp),
             new DateTime?[] { });
+        // [END spanner_test_query_bind_timestamp_array_empty]
     }
 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/ChunkingTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/ChunkingTests.cs
@@ -88,6 +88,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             return writeCommand.ExecuteNonQueryAsync();
         }
 
+        // [START spanner_test_query_chunked_data]
         [Fact]
         public async Task TestChunking()
         {
@@ -150,5 +151,6 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
 
             Assert.Equal(rowsToWrite, rowsRead);
         }
+        // [END spanner_test_query_chunked_data]
     }
 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/ReadTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/ReadTests.cs
@@ -43,6 +43,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             }
         }
 
+        // [START spanner_test_read_invalid_column_name]
         [Fact]
         public async Task BadColumnName()
         {
@@ -57,7 +58,9 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 }
             }
         }
+        // [END spanner_test_read_invalid_column_name]
 
+        // [START spanner_test_read_invalid_db_name]
         [Fact]
         public async Task BadDbName()
         {
@@ -77,7 +80,9 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             // later in the log.
             await SessionPoolHelpers.ShutdownPoolAsync(connectionString);
         }
+        // [END spanner_test_read_invalid_db_name]
 
+        // [START spanner_test_read_invalid_table_name]
         [Fact]
         public async Task BadTableName()
         {
@@ -92,7 +97,9 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 }
             }
         }
+        // [END spanner_test_read_invalid_table_name]
 
+        // [START spanner_test_cancel_read_fails]
         [Fact]
         public async Task CancelRead()
         {
@@ -110,7 +117,9 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 }
             }
         }
+        // [END spanner_test_cancel_read_fails]
 
+        // [START spanner_test_query_empty_array_struct]
         [Fact]
         public async Task EmptyStructArray()
         {
@@ -118,14 +127,18 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             var result = await ExecuteAsync<IList>(sqlQuery);
             Assert.Equal(0, result.Count);
         }
+        // [END spanner_test_query_empty_array_struct]
 
+        // [START spanner_test_query_nan]
         [Fact]
         public async Task NaN()
         {
             double result = await ExecuteAsync<double>("SELECT IEEE_DIVIDE(0, 0)");
             Assert.True(double.IsNaN(result));
         }
+        // [END spanner_test_query_nan]
 
+        // [START spanner_test_query_array_posinf_neginf_nan]
         [Fact]
         public async Task NaNArray()
         {
@@ -137,14 +150,18 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             Assert.True(double.IsNegativeInfinity(result[1]));
             Assert.True(double.IsNaN(result[2]));
         }
+        // [END spanner_test_query_array_posinf_neginf_nan]
 
+        // [START spanner_test_query_neg_infinity]
         [Fact]
         public async Task NegativeInf()
         {
             double result = await ExecuteAsync<double>("SELECT IEEE_DIVIDE(-1, 0)");
             Assert.True(double.IsNegativeInfinity(result));
         }
+        // [END spanner_test_query_neg_infinity]
 
+        // [START spanner_test_single_key_read]
         [Fact]
         public async Task PointRead()
         {
@@ -161,6 +178,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 }
             }
         }
+        // [END spanner_test_single_key_read]
 
         [Fact]
         public async Task ReadAllowsNewApis()
@@ -179,6 +197,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             }
         }
 
+        // [START spanner_test_single_key_dne_read]
         [Fact]
         public async Task PointReadEmpty()
         {
@@ -191,14 +210,18 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 }
             }
         }
+        // [END spanner_test_single_key_dne_read]
 
+        // [START spanner_test_query_pos_infinity]
         [Fact]
         public async Task PositiveInf()
         {
             double result = await ExecuteAsync<double>("SELECT IEEE_DIVIDE(1, 0)");
             Assert.True(double.IsPositiveInfinity(result));
         }
+        // [END spanner_test_query_pos_infinity]
 
+        // [START spanner_test_query_invalid]
         [Fact]
         public async Task QueryTypo()
         {
@@ -213,6 +236,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 }
             }
         }
+        // [END spanner_test_query_invalid]
 
         // [START spanner_test_empty_read]
         [Fact]
@@ -279,12 +303,14 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             }
         }
 
+        // [START spanner_test_query_select_one]
         [Fact]
         public async Task SelectOne()
         {
             long result = await ExecuteAsync<long>("SELECT 1");
             Assert.Equal(1, result);
         }
+        // [END spanner_test_query_select_one]
 
         [Fact]
         public async Task StructArray_AsDictionaryArray()
@@ -302,6 +328,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             Assert.Equal(2L, result[1]["C2"]);
         }
 
+        // [START spanner_test_query_array_struct]
         [Fact]
         public async Task StructArray_AsSpannerStructArray()
         {
@@ -319,6 +346,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             AssertStructField("C1", SpannerDbType.String, "b", struct2[0]);
             AssertStructField("C2", SpannerDbType.Int64, 2L, struct2[1]);
         }
+        // [END spanner_test_query_array_struct]
 
         [Fact]
         public async Task StructArray_DuplicateAndEmptyFieldNames()
@@ -397,6 +425,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             }
         }
 
+        // [START spanner_test_deadline_exceeded_fails]
         [Fact]
         public async Task TimeoutFromOptions()
         {
@@ -414,5 +443,6 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 SpannerAssert.IsTimeout(e);
             }
         }
+        // [END spanner_test_deadline_exceeded_fails]
     }
 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/TransactionTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/TransactionTests.cs
@@ -112,6 +112,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             }
         }
 
+        // [START spanner_test_transaction_retry_on_aborted]
         [Fact]
         public async Task AbortedThrownCorrectly()
         {
@@ -182,7 +183,9 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 }
             }
         }
+        // [END spanner_test_transaction_retry_on_aborted]
 
+        // [START spanner_test_transaction_query_increment]
         [Fact]
         public async Task MultiWrite()
         {
@@ -216,6 +219,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 connections[i].Dispose();
             }
         }
+        // [END spanner_test_transaction_query_increment]
 
         [Fact]
         public void MultiTableWrite()
@@ -278,6 +282,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             }
         }
 
+        // [START spanner_test_read_exact]
         [Fact]
         public async Task ReadExact()
         {
@@ -303,7 +308,9 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 }
             }
         }
+        // [END spanner_test_read_exact]
 
+        // [START spanner_test_exact_read_concurrent_updates]
         [Fact]
         public async Task ReadExactSingle()
         {
@@ -320,7 +327,11 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 }
             }
         }
+        // [END spanner_test_exact_read_concurrent_updates]
 
+        // [START spanner_test_read_min_single_use]
+        // [END spanner_test_read_min_single_use]
+        // [START spanner_test_read_min]
         [Fact]
         public async Task ReadMin()
         {
@@ -342,7 +353,9 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 }
             }
         }
+        // [END spanner_test_read_min]
 
+        // [START spanner_test_read_exact_staleness]
         [Fact]
         public async Task ReadStaleExact()
         {
@@ -364,7 +377,9 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 }
             }
         }
+        // [END spanner_test_read_exact_staleness]
 
+        // [START spanner_test_read_exact_staleness_concurrent_updates]
         [Fact]
         public async Task ReadStaleExactSingle()
         {
@@ -379,7 +394,11 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 }
             }
         }
+        // [END spanner_test_read_exact_staleness_concurrent_updates]
 
+        // [START spanner_test_read_max_staleness_single_use]
+        // [END spanner_test_read_max_staleness_single_use]
+        // [START spanner_test_read_max_staleness]
         [Fact]
         public async Task ReadStaleMax()
         {
@@ -402,7 +421,9 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 }
             }
         }
+        // [END spanner_test_read_max_staleness]
 
+        // [START spanner_test_strong_read]
         [Fact]
         public async Task ReadStrong()
         {
@@ -425,7 +446,9 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 }
             }
         }
+        // [END spanner_test_strong_read]
 
+        // [START spanner_test_strong_read_concurrent_updates]
         [Fact]
         public async Task ReadStrongSingle()
         {
@@ -442,5 +465,6 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 }
             }
         }
+        // [END spanner_test_strong_read_concurrent_updates]
     }
 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/WriteTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/WriteTests.cs
@@ -70,6 +70,30 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             }
         }
 
+        // [START spanner_test_write_read_bool]
+        // [END spanner_test_write_read_bool]
+        // [START spanner_test_write_read_int64]
+        // [END spanner_test_write_read_int64]
+        // [START spanner_test_write_read_float64]
+        // [END spanner_test_write_read_float64]
+        // [START spanner_test_write_read_string]
+        // [END spanner_test_write_read_string]
+        // [START spanner_test_write_read_timestamp]
+        // [END spanner_test_write_read_timestamp]
+        // [START spanner_test_write_read_date]
+        // [END spanner_test_write_read_date]
+        // [START spanner_test_write_read_bool_array]
+        // [END spanner_test_write_read_bool_array]
+        // [START spanner_test_write_read_int64_array]
+        // [END spanner_test_write_read_int64_array]
+        // [START spanner_test_write_read_float64_array]
+        // [END spanner_test_write_read_float64_array]
+        // [START spanner_test_write_read_string_array]
+        // [END spanner_test_write_read_string_array]
+        // [START spanner_test_write_read_timestamp_array]
+        // [END spanner_test_write_read_timestamp_array]
+        // [START spanner_test_write_read_date_array]
+        // [END spanner_test_write_read_date_array]
         [Fact]
         public async Task WriteValues()
         {
@@ -126,6 +150,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             });
         }
 
+        // [START spanner_test_write_invalid_column_name]
         [Fact]
         public async Task BadColumnName()
         {
@@ -139,7 +164,9 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 Assert.False(e.IsTransientSpannerFault());
             }
         }
+        // [END spanner_test_write_invalid_column_name]
 
+        // [START spanner_test_write_incorrect_type]
         [Fact]
         public async Task BadColumnType()
         {
@@ -153,7 +180,9 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 Assert.False(e.IsTransientSpannerFault());
             }
         }
+        // [END spanner_test_write_incorrect_type]
 
+        // [START spanner_test_write_invalid_table_name]
         [Fact]
         public async Task BadTableName()
         {
@@ -167,7 +196,20 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 Assert.False(e.IsTransientSpannerFault());
             }
         }
+        // [END spanner_test_write_invalid_table_name]
 
+        // [START spanner_test_write_read_empty_bool_array]
+        // [END spanner_test_write_read_empty_bool_array]
+        // [START spanner_test_write_read_empty_int64_array]
+        // [END spanner_test_write_read_empty_int64_array]
+        // [START spanner_test_write_read_empty_float64_array]
+        // [END spanner_test_write_read_empty_float64_array]
+        // [START spanner_test_write_read_empty_string_array]
+        // [END spanner_test_write_read_empty_string_array]
+        // [START spanner_test_write_read_empty_timestamp_array]
+        // [END spanner_test_write_read_empty_timestamp_array]
+        // [START spanner_test_write_read_empty_date_array]
+        // [END spanner_test_write_read_empty_date_array]
         [Fact]
         public async Task WriteEmpties()
         {
@@ -217,6 +259,30 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             await WithLastRowAsync(reader => Assert.True(double.IsNegativeInfinity(reader.GetFieldValue<double>("Float64Value"))));
         }
 
+        // [START spanner_test_write_read_null_bool]
+        // [END spanner_test_write_read_null_bool]
+        // [START spanner_test_write_read_null_int64]
+        // [END spanner_test_write_read_null_int64]
+        // [START spanner_test_write_read_null_float64]
+        // [END spanner_test_write_read_null_float64]
+        // [START spanner_test_write_read_null_string]
+        // [END spanner_test_write_read_null_string]
+        // [START spanner_test_write_read_null_timestamp]
+        // [END spanner_test_write_read_null_timestamp]
+        // [START spanner_test_write_read_null_date]
+        // [END spanner_test_write_read_null_date]
+        // [START spanner_test_write_read_null_bool_array]
+        // [END spanner_test_write_read_null_bool_array]
+        // [START spanner_test_write_read_null_int64_array]
+        // [END spanner_test_write_read_null_int64_array]
+        // [START spanner_test_write_read_null_float64_array]
+        // [END spanner_test_write_read_null_float64_array]
+        // [START spanner_test_write_read_null_string_array]
+        // [END spanner_test_write_read_null_string_array]
+        // [START spanner_test_write_read_null_timestamp_array]
+        // [END spanner_test_write_read_null_timestamp_array]
+        // [START spanner_test_write_read_null_date_array]
+        // [END spanner_test_write_read_null_date_array]
         [Fact]
         public async Task WriteNulls()
         {
@@ -226,6 +292,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 { "Int64Value", SpannerDbType.Int64, null },
                 { "Float64Value", SpannerDbType.Float64, null },
                 { "StringValue", SpannerDbType.String, null },
+                { "BytesValue", SpannerDbType.Bytes, null },
                 { "TimestampValue", SpannerDbType.Timestamp, null },
                 { "DateValue", SpannerDbType.Date, null },
                 { "BoolArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Bool), null },
@@ -244,6 +311,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 Assert.True(reader.IsDBNull(reader.GetOrdinal("Int64Value")));
                 Assert.True(reader.IsDBNull(reader.GetOrdinal("Float64Value")));
                 Assert.True(reader.IsDBNull(reader.GetOrdinal("StringValue")));
+                Assert.True(reader.IsDBNull(reader.GetOrdinal("BytesValue")));
                 Assert.True(reader.IsDBNull(reader.GetOrdinal("TimestampValue")));
                 Assert.True(reader.IsDBNull(reader.GetOrdinal("DateValue")));
                 Assert.True(reader.IsDBNull(reader.GetOrdinal("BoolArrayValue")));
@@ -256,6 +324,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             });
         }
 
+        // [START spanner_test_write_read_random_bytes]
         [Fact]
         public async Task WriteRandomBytes()
         {
@@ -297,6 +366,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 Assert.Equal(0, recordedValues.Count);
             }
         }
+        // [END spanner_test_write_read_random_bytes]
 
         [Fact]
         public async Task CommandTimeout()


### PR DESCRIPTION
Also adds a test for writing then reading a null bytes field, which we'd missed before.