### PR TITLE
Make URL signing methods accepting DateTimeOffset? obsolete

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/UrlSignerTest.V2SignerTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/UrlSignerTest.V2SignerTest.cs
@@ -59,7 +59,9 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
             [Fact]
             public async Task GetNoExpirationTest()
             {
+#pragma warning disable CS0618 // Type or member is obsolete
                 var url = Signer.Sign(_fixture.ReadBucket, _fixture.SmallObject, expiration: null);
+#pragma warning restore CS0618 // Type or member is obsolete
 
                 // Verify that the URL works.
                 var response = await _fixture.HttpClient.GetAsync(url);

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/UrlSignerTest.V4SignerTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/UrlSignerTest.V4SignerTest.cs
@@ -58,17 +58,6 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
             private void GetWithCustomerSuppliedEncryptionKeysTest_InitDelayTest() => GetWithCustomerSuppliedEncryptionKeysTest_Common(_fixture, Signer);
 
             [Fact]
-            public async Task GetNoExpirationTest()
-            {
-                var url = Signer.Sign(_fixture.ReadBucket, _fixture.SmallObject, expiration: null);
-
-                // Verify that the URL works.
-                var response = await _fixture.HttpClient.GetAsync(url);
-                var result = await response.Content.ReadAsByteArrayAsync();
-                AssertContentEqual(_fixture.SmallContent, result);
-            }
-
-            [Fact]
             public async Task GetWithCustomHeadersTest() => await _fixture.FinishDelayTest(GetTestName());
             private void GetWithCustomHeadersTest_InitDelayTest() => GetWithCustomHeadersTest_Common(_fixture, Signer);
 

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/UrlSignerTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/UrlSignerTest.cs
@@ -74,6 +74,7 @@ namespace Google.Cloud.Storage.V1.Tests
             Assert.Throws<ArgumentNullException>(() => signer.Sign(null, "objectName", DateTimeOffset.UtcNow, HttpMethod.Get, emptyHeaders, emptyHeaders));
             Assert.Throws<ArgumentException>(() => signer.Sign("BUCKETNAME", "objectName", DateTimeOffset.UtcNow, HttpMethod.Get, emptyHeaders, emptyHeaders));
 
+#pragma warning disable CS0618 // Type or member is obsolete
             // Make sure exceptions are not thrown for things which may be null or uppercase.
             signer.Sign("bucketname", null, TimeSpan.FromDays(1), null);
             signer.Sign("bucketname", null, null, null, null, null);
@@ -82,6 +83,7 @@ namespace Google.Cloud.Storage.V1.Tests
             signer.SignAsync("bucketname", null, TimeSpan.FromDays(1), request: null).Wait();
             signer.SignAsync("bucketname", null, null, null, null, null).Wait();
             signer.SignAsync("bucketname", "OBJECTNAME", null, null, null, null).Wait();
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         private class FakeBlobSigner : UrlSigner.IBlobSigner


### PR DESCRIPTION
In the future, non-expiring signed URLs will not be supported. In a future PR, we'll probably turn "infinite expiry" into "expires in 2038" as a workaround for this.

Bonus for @frankyn: I was wrong about this *defaulting* to no expiry. At least users are having to explicitly pass null at the moment. Any code passing a non-null value (with a non-null compile-time type) will start using the non-obsolete overload automatically.