### PR TITLE
Use "maximum 32-bit seconds Unix time" as "infinite" expiry

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/UrlSignerTest.V2SignerTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/UrlSignerTest.V2SignerTest.cs
@@ -57,11 +57,14 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
             private void GetWithCustomerSuppliedEncryptionKeysTest_InitDelayTest() => GetWithCustomerSuppliedEncryptionKeysTest_Common(_fixture, Signer);
 
             [Fact]
-            public async Task GetNoExpirationTest()
+            public async Task GetNoExpirationSpecifiedTest()
             {
 #pragma warning disable CS0618 // Type or member is obsolete
                 var url = Signer.Sign(_fixture.ReadBucket, _fixture.SmallObject, expiration: null);
 #pragma warning restore CS0618 // Type or member is obsolete
+
+                // We use int.MaxValue seconds, i.e. the January 3rd 2038, as a value "as close to infinite as we can represent"
+                Assert.Contains("Expires=2147483647", url);
 
                 // Verify that the URL works.
                 var response = await _fixture.HttpClient.GetAsync(url);

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/UrlSigner.ISigner.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/UrlSigner.ISigner.cs
@@ -32,7 +32,7 @@ namespace Google.Cloud.Storage.V1
             string Sign(
                 string bucket,
                 string objectName,
-                DateTimeOffset? expiration,
+                DateTimeOffset expiration,
                 HttpMethod requestMethod,
                 Dictionary<string, IEnumerable<string>> requestHeaders,
                 Dictionary<string, IEnumerable<string>> contentHeaders,
@@ -42,7 +42,7 @@ namespace Google.Cloud.Storage.V1
             Task<string> SignAsync(
                 string bucket,
                 string objectName,
-                DateTimeOffset? expiration,
+                DateTimeOffset expiration,
                 HttpMethod requestMethod,
                 Dictionary<string, IEnumerable<string>> requestHeaders,
                 Dictionary<string, IEnumerable<string>> contentHeaders,

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/UrlSigner.V2Signer.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/UrlSigner.V2Signer.cs
@@ -32,7 +32,7 @@ namespace Google.Cloud.Storage.V1
             public string Sign(
                 string bucket,
                 string objectName,
-                DateTimeOffset? expiration,
+                DateTimeOffset expiration,
                 HttpMethod requestMethod,
                 Dictionary<string, IEnumerable<string>> requestHeaders,
                 Dictionary<string, IEnumerable<string>> contentHeaders,
@@ -47,7 +47,7 @@ namespace Google.Cloud.Storage.V1
             public async Task<string> SignAsync(
                 string bucket,
                 string objectName,
-                DateTimeOffset? expiration,
+                DateTimeOffset expiration,
                 HttpMethod requestMethod,
                 Dictionary<string, IEnumerable<string>> requestHeaders,
                 Dictionary<string, IEnumerable<string>> contentHeaders,
@@ -73,7 +73,7 @@ namespace Google.Cloud.Storage.V1
                 internal SigningState(
                     string bucket,
                     string objectName,
-                    DateTimeOffset? expiration,
+                    DateTimeOffset expiration,
                     HttpMethod requestMethod,
                     Dictionary<string, IEnumerable<string>> requestHeaders,
                     Dictionary<string, IEnumerable<string>> contentHeaders,
@@ -92,7 +92,7 @@ namespace Google.Cloud.Storage.V1
                         requestMethod = HttpMethod.Post;
                     }
 
-                    string expiryUnixSeconds = ((int?)((expiration - UnixEpoch)?.TotalSeconds))?.ToString(CultureInfo.InvariantCulture);
+                    string expiryUnixSeconds = ((int) (expiration - UnixEpoch).TotalSeconds).ToString(CultureInfo.InvariantCulture);
                     resourcePath = $"/{bucket}";
                     if (objectName != null)
                     {

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/UrlSigner.V4Signer.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/UrlSigner.V4Signer.cs
@@ -36,7 +36,7 @@ namespace Google.Cloud.Storage.V1
             public string Sign(
                 string bucket,
                 string objectName,
-                DateTimeOffset? expiration,
+                DateTimeOffset expiration,
                 HttpMethod requestMethod,
                 Dictionary<string, IEnumerable<string>> requestHeaders,
                 Dictionary<string, IEnumerable<string>> contentHeaders,
@@ -53,7 +53,7 @@ namespace Google.Cloud.Storage.V1
             public async Task<string> SignAsync(
                 string bucket,
                 string objectName,
-                DateTimeOffset? expiration,
+                DateTimeOffset expiration,
                 HttpMethod requestMethod,
                 Dictionary<string, IEnumerable<string>> requestHeaders,
                 Dictionary<string, IEnumerable<string>> contentHeaders,
@@ -81,7 +81,7 @@ namespace Google.Cloud.Storage.V1
                 internal SigningState(
                     string bucket,
                     string objectName,
-                    DateTimeOffset? expiration,
+                    DateTimeOffset expiration,
                     HttpMethod requestMethod,
                     Dictionary<string, IEnumerable<string>> requestHeaders,
                     Dictionary<string, IEnumerable<string>> contentHeaders,
@@ -104,8 +104,9 @@ namespace Google.Cloud.Storage.V1
                     var now = clock.GetCurrentDateTimeUtc();
                     var timestamp = now.ToString("yyyyMMdd'T'HHmmss'Z'", CultureInfo.InvariantCulture);
                     var datestamp = now.ToString("yyyyMMdd", CultureInfo.InvariantCulture);
-                    // FIXME: Default expiry?
-                    string expirySeconds = ((int?)(expiration - now)?.TotalSeconds)?.ToString(CultureInfo.InvariantCulture) ?? "3600";
+                    // TODO: Validate again maximum expirary duration
+                    int expirySeconds = (int) (expiration - now).TotalSeconds;
+                    string expiryText = expirySeconds.ToString(CultureInfo.InvariantCulture);
 
                     string clientEmail = blobSigner.Id;
                     string credentialScope = $"{datestamp}/auto/gcs/goog4_request";


### PR DESCRIPTION
Signed URLs without an expiry time are not intended to work - the
expiry time is intended to be a required query parameter. This
change comes as close to being backward-compatible as is feasible.

cc @frankyn