### PR TITLE
Provide nullable row counts

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/QueryTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/QueryTest.cs
@@ -622,6 +622,27 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             Assert.Empty(job.GetQueryResults());
         }
 
+        [Fact]
+        public void DmlQuery()
+        {
+            var client = BigQueryClient.Create(_fixture.ProjectId);
+            var dataset = client.GetDataset(_fixture.DatasetId);
+            var table = dataset.GetTable(_fixture.HighScoreTableId);
+
+            var parameters = new[]
+            {
+                new BigQueryParameter("player", BigQueryDbType.String, "karen"),
+                new BigQueryParameter("gameStarted", BigQueryDbType.Timestamp, new DateTime(2005, 1, 1, 0, 0, 0, DateTimeKind.Utc)),
+                new BigQueryParameter("score", BigQueryDbType.Int64, 300)
+            };
+            var results = client.ExecuteQuery(
+                $"INSERT INTO {table} (player, gameStarted, score) VALUES (@player, @gameStarted, @score)",
+                parameters)
+                .ThrowOnAnyError();
+            Assert.Null(results.SafeTotalRows);
+            Assert.Equal(1, results.NumDmlAffectedRows);
+        }
+
         private class TitleComparer : IEqualityComparer<BigQueryRow>
         {
             public bool Equals(BigQueryRow x, BigQueryRow y) => (string)x["title"] == (string)y["title"];

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryResults.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryResults.cs
@@ -15,6 +15,7 @@
 using Google.Api.Gax;
 using Google.Apis.Bigquery.v2.Data;
 using Google.Apis.Requests;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -50,7 +51,24 @@ namespace Google.Cloud.BigQuery.V2
         /// <summary>
         /// The total number of rows in the results.
         /// </summary>
+        /// <remarks>
+        /// In certain cases, the query results do not provide a row count. In these cases, accessing this property
+        /// will throw an <see cref="InvalidOperationException"/>. The <see cref="SafeTotalRows"/> property provides
+        /// a way of accessing the same value, but with a nullable value which will be null if the query results do not
+        /// provide a row count.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">The query results do not provide a row count.</exception>
         public ulong TotalRows => _response.TotalRows.Value;
+
+        /// <summary>
+        /// The total number of rows in the results, or <c>null</c> if the query results do not provide a row count.
+        /// </summary>
+        public ulong? SafeTotalRows => _response.TotalRows;
+
+        /// <summary>
+        /// The total number of rows affected by a DML statement, or <c>null</c> for non-DML results.
+        /// </summary>
+        public long? NumDmlAffectedRows => _response.NumDmlAffectedRows;
 
         /// <summary>
         /// Returns an asynchronous sequence of rows from this set of results.


### PR DESCRIPTION
I'm open to alternative names instead of `SafeTotalRows` - or indeed alternative approaches.

I won't merge this PR until I've performed further investigation of #2764, but feedback is still welcomed.