### PR TITLE
(Not for submission) Potential Datastore emulator configuration

### DIFF
--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/ClientBuilder.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/ClientBuilder.cs
@@ -1,0 +1,247 @@
+﻿// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Note: this will be in GAX, with the right copyright notice.
+
+using Google.Apis.Auth.OAuth2;
+using Grpc.Auth;
+using Grpc.Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Api.Gax.Grpc
+{
+    /// <summary>
+    /// Base class for API-specific builders.
+    /// </summary>
+    /// <typeparam name="TClient">The type of client created by this builder.</typeparam>
+    public abstract class ClientBuilder<TClient>
+    {
+        /// <summary>
+        /// The endpoint to connect to, or null to use the default endpoint.
+        /// </summary>
+        public ServiceEndpoint Endpoint { get; set; }
+
+        /// <summary>
+        /// The scopes to use, or null to use the default scopes.
+        /// </summary>
+        public IEnumerable<string> Scopes { get; set; }
+
+        /// <summary>
+        /// The channel credentials to use, or null if credentials are being provided in a different way.
+        /// </summary>
+        public ChannelCredentials ChannelCredentials { get; set; }
+
+        /// <summary>
+        /// The path to the credentials file to use, or null if credentials are being provided in a different way.
+        /// </summary>
+        public string CredentialsPath { get; set; }
+
+        /// <summary>
+        /// The credentials to use as a JSON string, or null if credentials are being provided in a different way.
+        /// </summary>
+        public string JsonCredentials { get; set; }
+
+        /// <summary>
+        /// The token access method to use, or null if credentials are being provided in a different way.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// To use a GoogleCredential for credentials, set this property using a method group conversion, e.g.
+        /// <c>TokenAccessMethod = credential.GetAccessTokenForRequestAsync</c>
+        /// </para>
+        /// </remarks>
+        public Func<string, CancellationToken, Task<string>> TokenAccessMethod { get; set; }
+
+        /// <summary>
+        /// The call invoker to use, or null to create the call invoker from other properties when the client is built.
+        /// </summary>
+        public CallInvoker CallInvoker { get; set; }
+
+        /// <summary>
+        /// Creates a new instance with no settings.
+        /// </summary>
+        protected ClientBuilder()
+        {
+        }
+        
+        /// <summary>
+        /// Validates that the builder is in a consistent state for building. For example, it's invalid to call
+        /// <see cref="Build"/> on an instance which has both JSON credentials and a credentials path specified.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">The builder is in an invalid state.</exception>
+        protected virtual void Validate()
+        {
+            // If there's a call invoker, we shouldn't have any credentials-related information or an endpoint.
+            ValidateOptionExcludesOthers("CallInvoker cannot be specified with credentials settings or an endpoint", CallInvoker,
+                ChannelCredentials, CredentialsPath, JsonCredentials, Scopes, Endpoint, TokenAccessMethod);
+
+            ValidateAtMostOneNotNull("Only one source of credentials can be specified",
+                ChannelCredentials, CredentialsPath, JsonCredentials, TokenAccessMethod);
+
+            ValidateOptionExcludesOthers("Scopes are not relevant when a token access method or channel credentials are supplied", Scopes,
+                TokenAccessMethod, ChannelCredentials);            
+        }
+
+        /// <summary>
+        /// Validates that at most one of the given values is not null.
+        /// </summary>
+        /// <param name="message">The message if the condition is violated.</param>
+        /// <param name="values">The values to check for nullity.</param>
+        /// <exception cref="InvalidOperationException">More than one value is null.</exception>
+        protected void ValidateAtMostOneNotNull(string message, params object[] values)
+        {
+            int notNull = values.Count(v => v == null);
+            GaxPreconditions.CheckState(notNull < 2, message);
+        }
+
+        /// <summary>
+        /// Validates that if <paramref name="controlling"/> is not null, then every value in <paramref name="values"/> is null.
+        /// </summary>
+        /// <param name="message">The message if the condition is violated.</param>
+        /// <param name="controlling">The value controlling whether or not any other value can be non-null.</param>
+        /// <param name="values">The values checked for non-nullity if <paramref name="controlling"/> is non-null.</param>
+        protected void ValidateOptionExcludesOthers(string message, object controlling, params object[] values)
+        {
+            GaxPreconditions.CheckState(controlling == null || !values.Contains(null), message);
+        }
+
+        /// <summary>
+        /// Creates a call invoker synchronously. Override this method in a concrete builder type if more
+        /// call invoker mechanisms are supported.
+        /// </summary>
+        protected virtual CallInvoker CreateCallInvoker()
+        {
+            if (CallInvoker != null)
+            {
+                return CallInvoker;
+            }
+            var endpoint = Endpoint ?? GetDefaultEndpoint();
+            var credentials = GetChannelCredentials();
+            Channel channel = new Channel(endpoint.Host, endpoint.Port, GetChannelCredentials());
+            return new DefaultCallInvoker(channel);
+        }
+
+        /// <summary>
+        /// Creates a call invoker asynchronously. Override this method in a concrete builder type if more
+        /// call invoker mechanisms are supported.
+        /// </summary>
+        protected virtual async Task<CallInvoker> CreateCallInvokerAsync(CancellationToken cancellationToken)
+        {
+            if (CallInvoker != null)
+            {
+                return CallInvoker;
+            }
+            var endpoint = Endpoint ?? GetDefaultEndpoint();
+            var credentials = await GetChannelCredentialsAsync(cancellationToken).ConfigureAwait(false);
+            Channel channel = new Channel(endpoint.Host, endpoint.Port, credentials);
+            return new DefaultCallInvoker(channel);
+        }
+
+        /// <summary>
+        /// Obtains channel credentials synchronously. Override this method in a concrete builder type if more
+        /// credential mechanisms are supported.
+        /// </summary>
+        protected virtual ChannelCredentials GetChannelCredentials()
+        {
+            if (ChannelCredentials != null)
+            {
+                return ChannelCredentials;
+            }
+            GoogleCredential unscoped;
+            if (CredentialsPath != null)
+            {
+                unscoped = GoogleCredential.FromFile(CredentialsPath);
+            }
+            else if (JsonCredentials != null)
+            {
+                unscoped = GoogleCredential.FromJson(JsonCredentials);
+            }
+            else
+            {
+                unscoped = GoogleCredential.GetApplicationDefault();
+            }
+            return unscoped.CreateScoped(Scopes?.ToList() ?? GetDefaultScopes()).ToChannelCredentials();
+        }
+
+        /// <summary>
+        /// Obtains channel credentials asynchronously. Override this method in a concrete builder type if more
+        /// credential mechanisms are supported.
+        /// </summary>
+        protected async virtual Task<ChannelCredentials> GetChannelCredentialsAsync(CancellationToken cancellationToken)
+        {
+            if (ChannelCredentials != null)
+            {
+                return ChannelCredentials;
+            }
+            GoogleCredential unscoped;
+            if (CredentialsPath != null)
+            {
+                // TODO: Use an async overload when one is available
+                unscoped = GoogleCredential.FromFile(CredentialsPath);
+            }
+            else if (JsonCredentials != null)
+            {
+                unscoped = GoogleCredential.FromJson(JsonCredentials);
+            }
+            else
+            {
+                // TODO: Use cancellationToken when an overload accepting one is available
+                unscoped = await GoogleCredential.GetApplicationDefaultAsync().ConfigureAwait(false);
+            }
+            return unscoped.CreateScoped(Scopes?.ToList() ?? GetDefaultScopes()).ToChannelCredentials();
+        }
+
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
+        protected abstract IReadOnlyList<string> GetDefaultScopes();
+
+        /// <summary>
+        /// Returns the endpoint for this builder type, used if no endpoint is otherwise specified.
+        /// </summary>
+        protected abstract ServiceEndpoint GetDefaultEndpoint();
+
+        /// <summary>
+        /// Builds the resulting client.
+        /// </summary>
+        public TClient Build()
+        {
+            Validate();
+            return BuildImpl();
+        }
+
+        /// <summary>
+        /// Builds the resulting client asynchronously.
+        /// </summary>
+        public Task<TClient> BuildAsync(CancellationToken cancellationToken = default)
+        {
+            Validate();
+            return BuildImplAsync(cancellationToken);
+        }
+
+        /// <summary>
+        /// Builds the resulting client. Validation will already have been performed by the time this is called.
+        /// </summary>
+        protected abstract TClient BuildImpl();
+
+        /// <summary>
+        /// Builds the resulting client asynchronously. Validation will already have been performed by the time this is called.
+        /// </summary>
+        protected abstract Task<TClient> BuildImplAsync(CancellationToken cancellationToken);
+    }
+}

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/ClientBuilder.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/ClientBuilder.cs
@@ -39,7 +39,7 @@ namespace Google.Api.Gax.Grpc
         /// <summary>
         /// The scopes to use, or null to use the default scopes.
         /// </summary>
-        public IEnumerable<string> Scopes { get; set; }
+        public IReadOnlyList<string> Scopes { get; set; }
 
         /// <summary>
         /// The channel credentials to use, or null if credentials are being provided in a different way.
@@ -61,14 +61,14 @@ namespace Google.Api.Gax.Grpc
         /// </summary>
         /// <remarks>
         /// <para>
-        /// To use a GoogleCredential for credentials, set this property using a method group conversion, e.g.
-        /// <c>TokenAccessMethod = credential.GetAccessTokenForRequestAsync</c>
+        /// To use a GoogleCredential for credentials, call this method using a method group conversion, e.g.
+        /// <c>builder = builder.WithTokenAccessMethod(credential.GetAccessTokenForRequestAsync);</c>
         /// </para>
         /// </remarks>
         public Func<string, CancellationToken, Task<string>> TokenAccessMethod { get; set; }
 
         /// <summary>
-        /// The call invoker to use, or null to create the call invoker from other properties when the client is built.
+        /// The call invoker to use, or null to create the call invoker when the client is built.
         /// </summary>
         public CallInvoker CallInvoker { get; set; }
 
@@ -175,7 +175,7 @@ namespace Google.Api.Gax.Grpc
             {
                 unscoped = GoogleCredential.GetApplicationDefault();
             }
-            return unscoped.CreateScoped(Scopes?.ToList() ?? GetDefaultScopes()).ToChannelCredentials();
+            return unscoped.CreateScoped(Scopes ?? GetDefaultScopes()).ToChannelCredentials();
         }
 
         /// <summary>
@@ -203,7 +203,7 @@ namespace Google.Api.Gax.Grpc
                 // TODO: Use cancellationToken when an overload accepting one is available
                 unscoped = await GoogleCredential.GetApplicationDefaultAsync().ConfigureAwait(false);
             }
-            return unscoped.CreateScoped(Scopes?.ToList() ?? GetDefaultScopes()).ToChannelCredentials();
+            return unscoped.CreateScoped(Scopes ?? GetDefaultScopes()).ToChannelCredentials();
         }
 
         /// <summary>
@@ -219,7 +219,7 @@ namespace Google.Api.Gax.Grpc
         /// <summary>
         /// Builds the resulting client.
         /// </summary>
-        public TClient Build()
+        public virtual TClient Build()
         {
             Validate();
             return BuildImpl();
@@ -228,7 +228,7 @@ namespace Google.Api.Gax.Grpc
         /// <summary>
         /// Builds the resulting client asynchronously.
         /// </summary>
-        public Task<TClient> BuildAsync(CancellationToken cancellationToken = default)
+        public virtual Task<TClient> BuildAsync(CancellationToken cancellationToken = default)
         {
             Validate();
             return BuildImplAsync(cancellationToken);

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreClientBuilder.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreClientBuilder.cs
@@ -1,0 +1,57 @@
+﻿// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax.Grpc;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Cloud.Datastore.V1
+{
+    // Note: this file would be generated.
+
+    public partial class DatastoreClient
+    {
+        /// <summary>
+        /// Creates a new <see cref="DatastoreClientBuilder"/> instance. This method is primarily present for discoverability.
+        /// </summary>
+        /// <returns>A new <see cref="DatastoreClientBuilder"/> instance.</returns>
+        public DatastoreClientBuilder CreateBuilder() => new DatastoreClientBuilder();
+
+    }
+
+    /// <summary>
+    /// Builder class for <see cref="DatastoreClient"/> to provide simple configuration of credentials, endpoint etc.
+    /// </summary>
+    public sealed partial class DatastoreClientBuilder : ClientBuilder<DatastoreClient>
+    {
+        /// <summary>
+        /// The settings to use for RPCs, or null for the default settings.
+        /// </summary>
+        public DatastoreSettings Settings { get; set; }
+
+        /// <inheritdoc />
+        protected override DatastoreClient BuildImpl() => DatastoreClient.Create(CreateCallInvoker(), Settings);
+
+        /// <inheritdoc />
+        protected override async Task<DatastoreClient> BuildImplAsync(CancellationToken cancellationToken = default) =>
+            DatastoreClient.Create(await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false), Settings);
+
+        /// <inheritdoc />
+        protected override ServiceEndpoint GetDefaultEndpoint() => DatastoreClient.DefaultEndpoint;
+
+        /// <inheritdoc />
+        protected override IReadOnlyList<string> GetDefaultScopes() => DatastoreClient.DefaultScopes;
+    }
+}

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreClientBuilder.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreClientBuilder.cs
@@ -53,5 +53,8 @@ namespace Google.Cloud.Datastore.V1
 
         /// <inheritdoc />
         protected override IReadOnlyList<string> GetDefaultScopes() => DatastoreClient.DefaultScopes;
+
+        // Provide validation access for DatastoreDbBuilder.
+        internal void ValidateInternal() => Validate();
     }
 }

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreDb.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreDb.cs
@@ -54,7 +54,7 @@ namespace Google.Cloud.Datastore.V1
     /// to construct instances; alternatively, you can construct a <see cref="DatastoreClient"/> directly.
     /// </para>
     /// </remarks>
-    public abstract class DatastoreDb
+    public abstract partial class DatastoreDb
     {
         /// <summary>
         /// The <see cref="DatastoreClient"/> used for all remote operations.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreDbBuilder.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreDbBuilder.cs
@@ -1,0 +1,247 @@
+﻿// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using Google.Api.Gax.Grpc;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Cloud.Datastore.V1
+{
+    // Note: this file would be generated.
+
+    public partial class DatastoreDb
+    {
+        /// <summary>
+        /// Creates a new <see cref="DatastoreDbBuilder"/> instance. This method is primarily present for discoverability.
+        /// </summary>
+        /// <returns>A new <see cref="DatastoreDbBuilder"/> instance.</returns>
+        public DatastoreDbBuilder CreateBuilder() => new DatastoreDbBuilder();
+
+    }
+
+    /// <summary>
+    /// Builder class for <see cref="DatastoreClient"/> to provide simple configuration of credentials, endpoint etc.
+    /// </summary>
+    public sealed partial class DatastoreDbBuilder : ClientBuilder<DatastoreDb>
+    {
+        /// <summary>
+        /// The settings to use for RPCs, or null for the default settings.
+        /// </summary>
+        public DatastoreSettings Settings { get; set; }
+
+        private EmulatorDetection _emulatorDetection;
+        /// <summary>
+        /// Specifies how the builder responds to the presence of emulator environment variables as described
+        /// by https://cloud.google.com/datastore/docs/tools/datastore-emulator.
+        /// </summary>
+        /// <remarks>
+        /// This property defaults to <see cref="EmulatorDetection.None"/>, meaning that environment variables are
+        /// ignored.
+        /// </remarks>
+        public EmulatorDetection EmulatorDetection
+        {
+            get => _emulatorDetection;
+            set => _emulatorDetection = GaxPreconditions.CheckEnumValue(value, nameof(value));
+        }
+
+        /// <summary>
+        /// The project ID, or null if this has not yet been configured. Note that a project ID must be configured
+        /// (or detected via an emulator environment variable) before building the <see cref="DatastoreDb"/>.
+        /// </summary>
+        public string ProjectId { get; set; }
+
+        /// <summary>
+        /// Common code for handling the emulator configuration.
+        /// </summary>
+        private ConfiguredBuilder PrepareBuilder()
+        {
+            var clientBuilder = new DatastoreClientBuilder
+            {
+                Endpoint = Endpoint,
+                CallInvoker = CallInvoker,
+                ChannelCredentials = ChannelCredentials,
+                CredentialsPath = CredentialsPath,
+                JsonCredentials = JsonCredentials,
+                Scopes = Scopes,
+                Settings = Settings,
+                TokenAccessMethod = TokenAccessMethod
+            };
+            string projectId = ProjectId;
+
+            if (EmulatorDetection != EmulatorDetection.None)
+            {
+                var emulatorConfig = EmulatorConfiguration.FromEnvironment();
+                switch (EmulatorDetection)
+                {
+                    case EmulatorDetection.ProductionOnlyThrowOnEmulatorEnvironment:
+                        GaxPreconditions.CheckState(
+                            emulatorConfig.ProjectId == null && emulatorConfig.Endpoint == null,
+                            "Emulator environment variables are set, contrary to use of {0}.{1}",
+                            nameof(EmulatorDetection), nameof(EmulatorDetection.ProductionOnlyThrowOnEmulatorEnvironment));
+                        break;
+                    case EmulatorDetection.EmulatorOnly:
+                        GaxPreconditions.CheckState(
+                            emulatorConfig.Endpoint != null,
+                            "Expected {0} environment variable to be set", EmulatorConfiguration.EmulatorHostVariable);
+                        ApplyEmulatorConfiguration();
+                        break;
+                    case EmulatorDetection.ProductionOrEmulator:
+                        if (emulatorConfig.Endpoint != null)
+                        {
+                            ApplyEmulatorConfiguration();
+                        }
+                        else
+                        {
+                            GaxPreconditions.CheckState(emulatorConfig.ProjectId == null, "{0} should not be set when {1} is not", EmulatorConfiguration.EmulatorProjectVariable, EmulatorConfiguration.EmulatorProjectVariable);
+                        }
+                        break;
+                }
+
+                void ApplyEmulatorConfiguration()
+                {
+                    // TODO: Do we want to require this? Or should a configured emulator override any credentials?
+                    GaxPreconditions.CheckState(clientBuilder.Endpoint == null, "{0} should not be set when connecting to an emulator", nameof(clientBuilder.Endpoint));
+                    GaxPreconditions.CheckState(clientBuilder.CallInvoker == null, "{0} should not be set when connecting to an emulator", nameof(clientBuilder.CallInvoker));
+                    GaxPreconditions.CheckState(clientBuilder.ChannelCredentials == null, "{0} should not be set when connecting to an emulator", nameof(clientBuilder.ChannelCredentials));
+                    GaxPreconditions.CheckState(clientBuilder.CredentialsPath == null, "{0} should not be set when connecting to an emulator", nameof(clientBuilder.CredentialsPath));
+                    GaxPreconditions.CheckState(clientBuilder.JsonCredentials == null, "{0} should not be set when connecting to an emulator", nameof(clientBuilder.JsonCredentials));
+                    GaxPreconditions.CheckState(clientBuilder.Scopes == null, "{0} should not be set when connecting to an emulator", nameof(clientBuilder.Scopes));
+                    GaxPreconditions.CheckState(clientBuilder.TokenAccessMethod == null, "{0} should not be set when connecting to an emulator", nameof(clientBuilder.TokenAccessMethod));
+                    clientBuilder.Endpoint = emulatorConfig.Endpoint;
+                    clientBuilder.ChannelCredentials = Grpc.Core.ChannelCredentials.Insecure;
+                    projectId = projectId ?? emulatorConfig.ProjectId;
+                }
+            }
+            GaxPreconditions.CheckState(!string.IsNullOrEmpty(projectId), "The project ID must be configured");
+            return new ConfiguredBuilder(projectId, NamespaceId, clientBuilder);
+        }
+
+        /// <summary>
+        /// The namespace ID, or null to use the default.
+        /// </summary>
+        public string NamespaceId { get; set; }
+
+        /// <inheritdoc />
+        public override DatastoreDb Build() =>
+            PrepareBuilder().Build();
+
+        /// <inheritdoc />
+        public override Task<DatastoreDb> BuildAsync(CancellationToken cancellationToken = default) =>
+            PrepareBuilder().BuildAsync(cancellationToken);
+
+        /// <inheritdoc />
+        protected override DatastoreDb BuildImpl() =>
+            throw new InvalidOperationException("Never called: Build is overridden");
+
+        /// <inheritdoc />
+        protected override Task<DatastoreDb> BuildImplAsync(CancellationToken cancellationToken) =>
+            throw new InvalidOperationException("Never called: BuildAsync is overridden");
+
+        /// <inheritdoc />
+        protected override ServiceEndpoint GetDefaultEndpoint() => DatastoreClient.DefaultEndpoint;
+
+        /// <inheritdoc />
+        protected override IReadOnlyList<string> GetDefaultScopes() => DatastoreClient.DefaultScopes;
+
+        private DatastoreClient CreateClient() => DatastoreClient.Create(CreateCallInvoker(), Settings);
+
+        private async Task<DatastoreClient> CreateClientAsync(CancellationToken cancellationToken) =>
+            DatastoreClient.Create(await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false), Settings);
+
+        private class EmulatorConfiguration
+        {
+            internal const string EmulatorHostVariable = "DATASTORE_EMULATOR_HOST";
+            internal const string EmulatorProjectVariable = "DATASTORE_PROJECT_ID";
+            internal ServiceEndpoint Endpoint { get; }
+            internal string ProjectId { get; }
+
+            private EmulatorConfiguration(ServiceEndpoint endpoint, string projectId)
+            {
+                Endpoint = endpoint;
+                ProjectId = projectId;
+            }
+
+            internal static EmulatorConfiguration FromEnvironment()
+            {
+                // Treat present-but-empty environment variables as if they were absent.
+                string hostAndPort = Environment.GetEnvironmentVariable(EmulatorHostVariable)?.Trim();
+                string projectId = Environment.GetEnvironmentVariable(EmulatorProjectVariable)?.Trim();
+                if (hostAndPort == "")
+                {
+                    hostAndPort= null;
+                }
+                if (projectId == "")
+                {
+                    projectId = null;
+                }
+                var endpoint = string.IsNullOrEmpty(hostAndPort) ? null : ParseEndpoint(hostAndPort);
+                return new EmulatorConfiguration(endpoint, projectId);
+            }
+
+            // TODO: Move this to ServiceEndpoint, and add lots of tests.
+            private static ServiceEndpoint ParseEndpoint(string text)
+            {
+                GaxPreconditions.CheckNotNullOrEmpty(text, nameof(text));
+                int colonIndex = text.IndexOf(':');
+                if (colonIndex == -1)
+                {
+                    // Default to 443 as the port
+                    return new ServiceEndpoint(text, 443);
+                }
+                else
+                {
+                    string host = text.Substring(0, colonIndex).Trim();
+                    string portText = text.Substring(colonIndex + 1).Trim();
+                    GaxPreconditions.CheckArgument(host != "", nameof(text), "Host portion is empty");
+                    GaxPreconditions.CheckArgument(portText != "", nameof(text), "Port portion is empty");
+                    if (!int.TryParse(portText, NumberStyles.None, CultureInfo.InvariantCulture, out var port))
+                    {
+                        throw new ArgumentException($"Port portion '{portText}' could not be parsed as an integer", nameof(text));
+                    }
+                    return new ServiceEndpoint(host, port);
+                }
+            }
+        }
+
+        private class ConfiguredBuilder
+        {
+            private string _projectId;
+            private string _namespaceId;
+            private DatastoreClientBuilder _clientBuilder;
+
+            internal ConfiguredBuilder(string projectId, string namespaceId, DatastoreClientBuilder clientBuilder)
+            {
+                _projectId = projectId;
+                _namespaceId = namespaceId;
+                _clientBuilder = clientBuilder;
+            }
+
+            internal DatastoreDb Build()
+            {
+                var client = _clientBuilder.Build();
+                return DatastoreDb.Create(_projectId, _namespaceId, client);
+            }
+
+            internal async Task<DatastoreDb> BuildAsync(CancellationToken cancellationToken)
+            {
+                var client = await _clientBuilder.BuildAsync(cancellationToken).ConfigureAwait(false);
+                return DatastoreDb.Create(_projectId, _namespaceId, client);
+            }
+        }
+    }
+}

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/EmulatorBehavior.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/EmulatorBehavior.cs
@@ -1,0 +1,50 @@
+﻿// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Google.Cloud.Datastore.V1
+{
+    /// <summary>
+    /// Specifies how the use of the Datastore emulator is detected via environment variables,
+    /// when used by <see cref="DatastoreDbBuilder"/>.
+    /// </summary>
+    public enum EmulatorDetection
+    {
+        /// <summary>
+        /// Ignore environment variables entirely.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Always connect to the production servers, but throw an exception if
+        /// environment variables exist that would suggest the emulator is expected.
+        /// </summary>
+        ProductionOnlyThrowOnEmulatorEnvironment = 1,
+
+        /// <summary>
+        /// Always connect to the emulator, throwing an exception if the environment
+        /// variables are not configured.
+        /// </summary>
+        EmulatorOnly = 2,
+
+        /// <summary>
+        /// Connect to the emulator if suitable environment variables are present,
+        /// or production otherwise. This is a convenient option, but risks damage to
+        /// production databases or running up unexpected bills if tests are accidentally
+        /// run in production due to environment variables being absent unexpectedly.
+        /// (Using separate projects for production and testing is a best practice for
+        /// preventing the first issue, but may be unrealistic for small or hobby projects.)
+        /// </summary>
+        ProductionOrEmulator = 3
+    }
+}


### PR DESCRIPTION
This builds on #2769, but with a DatastoreDbBuilder. Sample:

```csharp
var db = new DatastoreDbBuilder
{
    ProjectId = "my-project",
    EmulatorBehavior = EmulatorBehavior.ProductionOrEmulator
}.Build();
```

We probably want to review the whole interaction between the base class and subclasses in terms of validation, but that's relatively straightforward.

(We might also want a `DatastoreDbBuilder` constructor accepting a project ID.)