### PR TITLE
PubSub: Avoid unobserved InvalidOperationException in AsyncSingleRecvQueue

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberClient.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberClient.cs
@@ -659,7 +659,8 @@ namespace Google.Cloud.PubSub.V1
                 }
                 if (tcs != null)
                 {
-                    // Don't run in lock, as it may execute continuations synchonously.
+                    // Don't run in lock, as it may execute continuations synchronously.
+                    // Use TrySetResult as this can be called multiple times on the same tcs instance
                     tcs.TrySetResult(0);
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-cloud-dotnet/issues/2763.

This fixes unobserved exception which happened when `SetResult` was called multiple times.

~~Comment in code mentioned that problem was that continuations of `TaskCompletionSource` can run synchonously so i changed just that (i may be missing some details why it won't work). Also it is generally [recommended](https://github.com/davidfowl/AspNetCoreDiagnosticScenarios/blob/master/AsyncGuidance.md#always-create-taskcompletionsourcet-with-taskcreationoptionsruncontinuationsasynchronously) to use `TaskCreationOptions.RunContinuationsAsynchronously`.~~ - this does not build

Another approach it to use [TrySetResult](https://docs.microsoft.com/en-us/dotnet/api/system.threading.tasks.taskcompletionsource-1.trysetresult?view=netcore-1.0) with current approach.