### PR TITLE
[Diagnostics] Stopping the timer before performing the final manual Flush.

### DIFF
--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/TimedBufferingConsumer.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/TimedBufferingConsumer.cs
@@ -13,11 +13,10 @@
 // limitations under the License.
 
 using Google.Api.Gax;
-using System.Collections.Generic;
 using System;
-using System.Threading.Tasks;
+using System.Collections.Generic;
 using System.Threading;
-using Grpc.Core;
+using System.Threading.Tasks;
 
 namespace Google.Cloud.Diagnostics.Common
 {
@@ -68,8 +67,8 @@ namespace Google.Cloud.Diagnostics.Common
         /// <inheritdoc />
         public override void Dispose()
         {
-            Flush();
             _timer.Dispose();
+            Flush();
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
This might help with #2791.
Anyways, the right thing to do is to stop the timer as first thing when disposing.