### PR TITLE
Create pubsub channels with correct unique-per-channel id

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/PublisherClient.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/PublisherClient.cs
@@ -197,17 +197,16 @@ namespace Google.Cloud.PubSub.V1
             var endpoint = clientCreationSettings?.ServiceEndpoint ?? PublisherServiceApiClient.DefaultEndpoint;
             var clients = new PublisherServiceApiClient[clientCount];
             var shutdowns = new Func<Task>[clientCount];
-            // Set channel send/recv message size to unlimited. It defaults to ~4Mb which causes failures.
-            var channelOptions = new[]
-            {
-                new ChannelOption(ChannelOptions.MaxSendMessageLength, -1),
-                new ChannelOption(ChannelOptions.MaxReceiveMessageLength, -1),
-
-                // Use a random arg to prevent sub-channel re-use in gRPC, so each channel uses its own connection.
-                new ChannelOption("sub-channel-separator", Guid.NewGuid().ToString())
-            };
             for (int i = 0; i < clientCount; i++)
             {
+                var channelOptions = new[]
+                {
+                    // Set channel send/recv message size to unlimited. It defaults to ~4Mb which causes failures.
+                    new ChannelOption(ChannelOptions.MaxSendMessageLength, -1),
+                    new ChannelOption(ChannelOptions.MaxReceiveMessageLength, -1),
+                    // Use a random arg to prevent sub-channel re-use in gRPC, so each channel uses its own connection.
+                    new ChannelOption("sub-channel-separator", Guid.NewGuid().ToString())
+                };
                 var channel = new Channel(endpoint.Host, endpoint.Port, channelCredentials, channelOptions);
                 clients[i] = PublisherServiceApiClient.Create(channel, clientCreationSettings?.PublisherServiceApiSettings);
                 shutdowns[i] = channel.ShutdownAsync;

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberClient.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberClient.cs
@@ -244,17 +244,16 @@ namespace Google.Cloud.PubSub.V1
             var endpoint = clientCreationSettings?.ServiceEndpoint ?? SubscriberServiceApiClient.DefaultEndpoint;
             var clients = new SubscriberServiceApiClient[clientCount];
             var shutdowns = new Func<Task>[clientCount];
-            // Set channel send/recv message size to unlimited. It defaults to ~4Mb which causes failures.
-            var channelOptions = new[]
-            {
-                new ChannelOption(ChannelOptions.MaxSendMessageLength, -1),
-                new ChannelOption(ChannelOptions.MaxReceiveMessageLength, -1),
-
-                // Use a random arg to prevent sub-channel re-use in gRPC, so each channel uses its own connection.
-                new ChannelOption("sub-channel-separator", Guid.NewGuid().ToString())
-            };
             for (int i = 0; i < clientCount; i++)
             {
+                var channelOptions = new[]
+                {
+                    // Set channel send/recv message size to unlimited. It defaults to ~4Mb which causes failures.
+                    new ChannelOption(ChannelOptions.MaxSendMessageLength, -1),
+                    new ChannelOption(ChannelOptions.MaxReceiveMessageLength, -1),
+                    // Use a random arg to prevent sub-channel re-use in gRPC, so each channel uses its own connection.
+                    new ChannelOption("sub-channel-separator", Guid.NewGuid().ToString())
+                };
                 var channel = new Channel(endpoint.Host, endpoint.Port, channelCredentials, channelOptions);
                 clients[i] = SubscriberServiceApiClient.Create(channel, clientCreationSettings?.SubscriberServiceApiSettings);
                 shutdowns[i] = channel.ShutdownAsync;


### PR DESCRIPTION
This bug only becomes apparent with gRPC >=1.15.0 when the sub-channel sharing code changed.