### PR TITLE
Add the ASP.NET trace identifier to trace labels

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Trace/LabelsTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Trace/LabelsTest.cs
@@ -45,7 +45,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Tests
             Assert.Equal("123", labels[LabelsCommon.HttpRequestSize]);
             Assert.Equal("google.com", labels[LabelsCommon.HttpHost]);
             Assert.Equal("PUT", labels[LabelsCommon.HttpMethod]);
-            Assert.Equal("trace-id", labels[LabelsCommon.CoreTraceId]);
+            Assert.Equal("trace-id", labels[Labels.CoreTraceId]);
         }
 
         [Fact]

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Trace/LabelsTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Trace/LabelsTest.cs
@@ -41,10 +41,11 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Tests
             request.Method = "PUT";
 
             var labels = Labels.FromDefaultHttpRequest(request);
-            Assert.Equal(3, labels.Count);
+            Assert.Equal(4, labels.Count);
             Assert.Equal("123", labels[LabelsCommon.HttpRequestSize]);
             Assert.Equal("google.com", labels[LabelsCommon.HttpHost]);
             Assert.Equal("PUT", labels[LabelsCommon.HttpMethod]);
+            Assert.NotEmpty(labels["aspnetcore/trace_identifier"]);
         }
 
         [Fact]

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Trace/LabelsTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Trace/LabelsTest.cs
@@ -35,7 +35,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Tests
         [Fact]
         public void FromDefaultHttpRequest()
         {
-            var request = new DefaultHttpRequest(new DefaultHttpContext());
+            var request = new DefaultHttpRequest(new DefaultHttpContext { TraceIdentifier = "trace-id" });
             request.ContentLength = 123;
             request.Host = new HostString("google.com");
             request.Method = "PUT";
@@ -45,7 +45,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Tests
             Assert.Equal("123", labels[LabelsCommon.HttpRequestSize]);
             Assert.Equal("google.com", labels[LabelsCommon.HttpHost]);
             Assert.Equal("PUT", labels[LabelsCommon.HttpMethod]);
-            Assert.NotEmpty(labels["aspnetcore/trace_identifier"]);
+            Assert.Equal("trace-id", labels[LabelsCommon.CoreTraceId]);
         }
 
         [Fact]

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/Labels.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/Labels.cs
@@ -47,13 +47,19 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         internal static Dictionary<string, string> FromDefaultHttpRequest(DefaultHttpRequest request)
         {
             GaxPreconditions.CheckNotNull(request, nameof(request));
-            return new Dictionary<string, string>
+            var labels = new Dictionary<string, string>
             {
                 { LabelsCommon.HttpRequestSize, request.ContentLength.ToString() },
                 { LabelsCommon.HttpHost, request.Host.ToString() },
-                { LabelsCommon.HttpMethod, request.Method },
-                { "aspnetcore/trace_identifier", request.HttpContext.TraceIdentifier }
+                { LabelsCommon.HttpMethod, request.Method }
             };
+
+            if (!string.IsNullOrEmpty(request.HttpContext.TraceIdentifier))
+            {
+                labels[LabelsCommon.CoreTraceId] = request.HttpContext.TraceIdentifier;
+            }
+
+            return labels;
         }
 
         internal static Dictionary<string, string> FromDefaultHttpResponse(DefaultHttpResponse response)

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/Labels.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/Labels.cs
@@ -27,6 +27,9 @@ namespace Google.Cloud.Diagnostics.AspNetCore
     /// </summary>
     internal static class Labels
     {
+        ///<summary>The label to denote the ASP.NET Core request trace identifier.</summary> 
+        public const string CoreTraceId = "/aspnetcore/trace_identifier";
+
         /// <summary>
         /// Gets a map with the label for the agent which contains the agent's name and version.
         /// </summary>
@@ -56,7 +59,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
 
             if (!string.IsNullOrEmpty(request.HttpContext.TraceIdentifier))
             {
-                labels[LabelsCommon.CoreTraceId] = request.HttpContext.TraceIdentifier;
+                labels[CoreTraceId] = request.HttpContext.TraceIdentifier;
             }
 
             return labels;

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/Labels.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/Labels.cs
@@ -51,7 +51,8 @@ namespace Google.Cloud.Diagnostics.AspNetCore
             {
                 { LabelsCommon.HttpRequestSize, request.ContentLength.ToString() },
                 { LabelsCommon.HttpHost, request.Host.ToString() },
-                { LabelsCommon.HttpMethod, request.Method }
+                { LabelsCommon.HttpMethod, request.Method },
+                { "aspnetcore/trace_identifier", request.HttpContext.TraceIdentifier }
             };
         }
 

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/TraceLabels.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/TraceLabels.cs
@@ -44,9 +44,6 @@ namespace Google.Cloud.Diagnostics.Common
         ///<summary>The label to denote an agent.</summary> 
         public const string Agent = "/agent";
 
-        ///<summary>The label to denote the ASP.NET Core request trace identifier.</summary> 
-        public const string CoreTraceId = "/aspnetcore/trace_identifier";
-
         /// <summary>
         /// Creates a a map of labels to represent a <see cref="StackTrace"/> for a span.
         /// </summary>

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/TraceLabels.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/TraceLabels.cs
@@ -44,6 +44,9 @@ namespace Google.Cloud.Diagnostics.Common
         ///<summary>The label to denote an agent.</summary> 
         public const string Agent = "/agent";
 
+        ///<summary>The label to denote the ASP.NET Core request trace identifier.</summary> 
+        public const string CoreTraceId = "/aspnetcore/trace_identifier";
+
         /// <summary>
         /// Creates a a map of labels to represent a <see cref="StackTrace"/> for a span.
         /// </summary>


### PR DESCRIPTION
Adding the trace identifier enables correlating traces with HTTP requests more easily.