### PR TITLE
Separate out the retry of streaming results from extracting values

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/AsyncStreamAdapter.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/AsyncStreamAdapter.cs
@@ -1,0 +1,39 @@
+﻿// Copyright 2019 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Grpc.Core;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Cloud.Spanner.V1.Tests
+{
+    // TODO: Move this to GAX?
+    /// <summary>
+    /// Adapter to wrap an IAsyncEnumerator{T} into the gRPC IAsyncStreamReader{T} type.
+    /// </summary>
+    internal sealed class AsyncStreamAdapter<T> : IAsyncStreamReader<T>
+    {
+        private readonly IAsyncEnumerator<T> _enumerator;
+
+        internal AsyncStreamAdapter(IAsyncEnumerator<T> enumerator)
+        {
+            _enumerator = enumerator;
+        }
+
+        public T Current => _enumerator.Current;
+        public void Dispose() => _enumerator.Dispose();
+        public Task<bool> MoveNext(CancellationToken cancellationToken) => _enumerator.MoveNext(cancellationToken);
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/ReliableStreamReaderTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/ReliableStreamReaderTests.cs
@@ -12,159 +12,80 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
+using Google.Cloud.Spanner.V1.Internal.Logging;
+using Google.Protobuf.WellKnownTypes;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
-using Google.Api.Gax.Grpc;
-using Google.Protobuf;
-using Google.Protobuf.WellKnownTypes;
-using Grpc.Core;
 using Xunit;
-using static Google.Cloud.Spanner.V1.SpannerClient;
-using static Google.Cloud.Spanner.V1.SpannerClientImpl;
 
 namespace Google.Cloud.Spanner.V1.Tests
 {
     public class ReliableStreamReaderTests
     {
         [Fact]
-        public async Task Simple()
+        public async Task SimpleStringValues()
         {
-            var result1 = CreateResultSet("token1", "a", "b", "c");
-            var result2 = CreateResultSet("token2", "x", "y", "z");
-            var result3 = CreateResultSet("token3", "0", "1", "2");
-            var metadata = CreateSingleStringFieldMetadata();
-
-            var client = new FakeSpannerClient(metadata, new[] { result1, result2, result3 });
-            var reader = CreateReader(client);
-
-            Assert.True(await reader.HasDataAsync(default));
-            Assert.Equal(metadata, await reader.GetMetadataAsync(default));
-            var expected = new[] { "a", "b", "c", "x", "y", "z", "0", "1", "2" };
-            var actual = (await FetchAllValuesAsync(reader)).Select(v => v.StringValue).ToArray();
-            Assert.Equal(expected, actual);
+            var results = new[]
+            {
+                CreateResultSet("a", "b", "c"),
+                CreateResultSet("d", "e"),
+                CreateResultSet("f", "g", "h")
+            };
+            var reader = CreateReader(results); // Populates results[0].Metadata too
+            await AssertValues(reader, "a", "b", "c", "d", "e", "f", "g", "h");
+            Assert.Equal(results[0].Metadata, await reader.GetMetadataAsync(default));
         }
 
         [Fact]
-        public async Task ResumeAfterFailure()
+        public async Task StringMerging()
         {
-            var result1 = CreateResultSet("token1", "a", "b", "c");
-            var result2 = CreateResultSet("token2", "x", "y", "z");
-            var result3 = CreateResultSet("token3", "0", "1", "2");
-            var metadata = CreateSingleStringFieldMetadata();
-
-            var filter = CreateOneTimeExceptionFilter(prs => prs.ResumeToken.ToStringUtf8() == "token2", new RpcException(new Status(StatusCode.DeadlineExceeded, "Deadline exceeded")));
-            var client = new FakeSpannerClient(metadata, new[] { result1, result2, result3 }, filter);
-            var reader = CreateReader(client);
-
-            var expected = new[] { "a", "b", "c", "x", "y", "z", "0", "1", "2" };
-            var actual = (await FetchAllValuesAsync(reader)).Select(v => v.StringValue).ToArray();
-            Assert.Equal(expected, actual);
-        }
-
-        private Func<PartialResultSet, PartialResultSet> CreateOneTimeExceptionFilter(Func<PartialResultSet, bool> predicate, RpcException exception)
-        {
-            bool thrown = false;
-            return prs =>
+            var results = new[]
             {
-                if (thrown || !predicate(prs))
-                {
-                    return prs;
-                }
-                thrown = true;
-                throw exception;
+                CreateResultSet("a", "x"),
+                CreateResultSet("y", "c")
             };
+            results[0].ChunkedValue = true;
+            var reader = CreateReader(results);
+            await AssertValues(reader, "a", "xy", "c");
         }
 
-        private static async Task<List<Value>> FetchAllValuesAsync(ReliableStreamReader reader)
+        private static async Task AssertValues(ReliableStreamReader reader, params string[] expectedValues)
         {
-            var ret = new List<Value>();
-            Value nextValue;
-            while ((nextValue = await reader.NextAsync(default)) != null)
+            var actual = new List<string>();
+            Value value;
+            while ((value = await reader.NextAsync(default)) != null)
             {
-                ret.Add(nextValue);
+                Assert.Equal(Value.KindOneofCase.StringValue, value.KindCase);
+                actual.Add(value.StringValue);
             }
-            return ret;
+            Assert.Equal(expectedValues, actual.ToArray());
         }
 
-        private static ReliableStreamReader CreateReader(SpannerClient client) =>
-            new ReliableStreamReader(client, new ExecuteSqlRequest(), new Session(), 60);
+        private static PartialResultSet CreateResultSet(params string[] textValues) =>
+            CreateResultSet(textValues.Select(text => Value.ForString(text)));
 
-        private static PartialResultSet CreateResultSet(string resumeToken, params string[] textValues) =>
-            CreateResultSet(resumeToken, textValues.Select(text => Value.ForString(text)));
+        private static PartialResultSet CreateResultSet(IEnumerable<Value> values) => new PartialResultSet { Values = { values } };
 
-        private static PartialResultSet CreateResultSet(string resumeToken, IEnumerable<Value> values) =>
-            new PartialResultSet
-            {
-                Values = { values },
-                ResumeToken = resumeToken == null ? ByteString.Empty : ByteString.CopyFromUtf8(resumeToken)
-            };
+        private static ReliableStreamReader CreateReader(PartialResultSet[] results, ResultSetMetadata metadata = null)
+        {
+            results[0].Metadata = metadata ?? CreateSingleStringFieldMetadata();
+            return new ReliableStreamReader(new AsyncStreamAdapter<PartialResultSet>(results.ToAsyncEnumerable().GetEnumerator()), Logger.DefaultLogger);
+        }
 
         private static ResultSetMetadata CreateSingleStringFieldMetadata() =>
-            new ResultSetMetadata
-            {
-                RowType = new StructType
-                {
-                    Fields =
-                    {
+           new ResultSetMetadata
+           {
+               RowType = new StructType
+               {
+                   Fields =
+                   {
                         new StructType.Types.Field
                         {
                             Name = "text", Type = new V1.Type { Code = TypeCode.String }
                         }
-                    }
-                }
-            };
-
-        private class FakeSpannerClient : SpannerClient
-        {
-            private readonly IEnumerable<PartialResultSet> _results;
-            private readonly ResultSetMetadata _metadata;
-            private readonly Func<PartialResultSet, PartialResultSet> _filter;
-
-            public FakeSpannerClient(ResultSetMetadata metadata, IEnumerable<PartialResultSet> results, Func<PartialResultSet, PartialResultSet> filter = null)
-            {
-                Settings = SpannerSettings.GetDefault();
-                _results = results;
-                _metadata = metadata;
-                // Default to an identity filter
-                _filter = filter ?? (x => x);
-            }
-
-            public override ExecuteStreamingSqlStream ExecuteStreamingSql(ExecuteSqlRequest request, CallSettings callSettings = null)
-            {
-                List<PartialResultSet> callResults =
-                    // If a resume token is presented, that means we need to skip all responses up to *and including* that one - so skip while we haven't seen it, then skip an extra one.
-                    (request.ResumeToken.IsEmpty ? _results : _results.SkipWhile(r => r.ResumeToken != request.ResumeToken).Skip(1))
-                    .Select(r => r.Clone())
-                    .ToList();
-                callResults.First().Metadata = _metadata;
-                var asyncResults = new StreamAdapter<PartialResultSet>(callResults.Select(_filter).ToAsyncEnumerable().GetEnumerator());
-
-                var call = new AsyncServerStreamingCall<PartialResultSet>(
-                    asyncResults, Task.FromResult(new Metadata()), () => new Status(), () => new Metadata(), () => { });
-                return new ExecuteStreamingSqlStreamImpl(call);
-            }
-        }
-
-        // TODO: Move this to GAX?
-        /// <summary>
-        /// Adapter to wrap an IAsyncEnumerator{T} into the gRPC IAsyncStreamReader{T} type.
-        /// </summary>
-        private class StreamAdapter<T> : IAsyncStreamReader<T>
-        {
-            private readonly IAsyncEnumerator<T> _enumerator;
-
-            internal StreamAdapter(IAsyncEnumerator<T> enumerator)
-            {
-                _enumerator = enumerator;
-            }
-
-            public T Current => _enumerator.Current;
-            public void Dispose() => _enumerator.Dispose();
-            public Task<bool> MoveNext(CancellationToken cancellationToken) => _enumerator.MoveNext(cancellationToken);
-        }
+                   }
+               }
+           };
     }
 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SqlResultStreamTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SqlResultStreamTests.cs
@@ -1,0 +1,246 @@
+﻿// Copyright 2019 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using Google.Api.Gax.Grpc;
+using Google.Cloud.ClientTesting;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+using Grpc.Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using static Google.Cloud.Spanner.V1.SpannerClientImpl;
+
+namespace Google.Cloud.Spanner.V1.Tests
+{
+    public class SqlResultStreamTests
+    {
+        private const StatusCode RetriableStatusCode = StatusCode.Unavailable;
+        private const StatusCode NonRetriableStatusCode = StatusCode.PermissionDenied;
+
+        private static readonly CallSettings s_simpleCallSettings = CallSettings.FromCallTiming(CallTiming.FromTimeout(TimeSpan.FromSeconds(1)));
+        private static readonly BackoffSettings s_backoffSettings = new BackoffSettings(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(15), 2.0);
+
+        [Fact]
+        public async Task SimpleSuccess()
+        {
+            var results = CreateResultSets("token1", "token2", "token3");
+
+            var client = new FakeSpannerClient(results);
+            var stream = CreateStream(client);
+
+            await AssertResultsAsync(stream, results);
+            Assert.Equal(1, client.Calls);
+        }
+
+        [Fact]
+        public async Task ResumeAfterFailure()
+        {
+            var results = CreateResultSets("token1", "token2", "token3");
+
+            var filter = CreateExceptionFilter("token2", RetriableStatusCode);
+            var client = new FakeSpannerClient(results, filter);
+            var stream = CreateStream(client);
+
+            await AssertResultsAsync(stream, results);
+            Assert.Equal(2, client.Calls);
+        }
+
+        [Fact]
+        public async Task ResumeWithBuffering()
+        {
+            var results = CreateResultSets("token1", "token2", "", "", "token3");
+
+            var filter = CreateExceptionFilter("token3", RetriableStatusCode);
+            var client = new FakeSpannerClient(results, filter);
+            var stream = CreateStream(client);
+
+            await AssertResultsAsync(stream, results);
+            Assert.Equal(2, client.Calls);
+        }
+
+        [Fact]
+        public async Task MultipleErrors_WithSuccessBetween()
+        {
+            var results = CreateResultSets("token1", "token2", "token3", "token4");
+
+            var filter1 = CreateExceptionFilter("token2", RetriableStatusCode);
+            var filter2 = CreateExceptionFilter("token3", RetriableStatusCode);
+
+            // Note: if we do this a lot, we might want a way of specifying multiple filters easily.
+            var client = new FakeSpannerClient(results, prs => filter2(filter1(prs)));
+            var stream = CreateStream(client);
+
+            await AssertResultsAsync(stream, results);
+            Assert.Equal(3, client.Calls);
+        }
+
+        [Fact]
+        public async Task MultipleErrors_ForSameResumeToken()
+        {
+            var results = CreateResultSets("token1", "token2", "token3", "token4");
+            var client = new FakeSpannerClient(results, CreateExceptionFilter("token2", RetriableStatusCode, 2));
+            var stream = CreateStream(client);
+
+            // We expect calls of:
+            // - Start: no token, MoveNext(yes), MoveNext(throw)
+            // - Start: token1, MoveNext(throw)
+            // - No further calls, due to second failure
+            // Only the result with token1 is returned
+            await AssertResultsThenExceptionAsync(stream, results, 1);
+            Assert.Equal(2, client.Calls);
+        }
+
+        [Fact]
+        public async Task BufferOverflow_NoErrors()
+        {
+            // No resume tokens, so we buffer for a while, then we're forced to return the results anyway.
+            var results = CreateResultSets("", "", "", "");
+            var client = new FakeSpannerClient(results);
+            var stream = CreateStream(client, maxBufferSize: 3);
+            await AssertResultsAsync(stream, results);
+            Assert.Equal(1, client.Calls);
+        }
+
+        [Fact]
+        public async Task BufferOverflow_ErrorBeforeFlushing()
+        {
+            // No resume tokens, so we buffer for a while, then we're forced to return the results anyway.
+            // We encounter a server error before we get the resume token, so we have to abandon the stream.
+            var results = CreateResultSets("", "", "", "", "token1", "token2");
+            var client = new FakeSpannerClient(results, CreateExceptionFilter("token1", RetriableStatusCode));
+            var stream = CreateStream(client, maxBufferSize: 3);
+            await AssertResultsThenExceptionAsync(stream, results, 4);
+            Assert.Equal(1, client.Calls);
+        }
+
+        [Fact]
+        public async Task BufferOverflow_ErrorAfterFlushing()
+        {
+            // No resume tokens, so we buffer for a while... but then we flush when we see the first resume token,
+            // at which point it's okay for the server to fail, as we can resume safely.
+            var results = CreateResultSets("", "", "", "", "token1", "token2");
+            var client = new FakeSpannerClient(results, CreateExceptionFilter("token2", RetriableStatusCode));
+            var stream = CreateStream(client, maxBufferSize: 3);
+            await AssertResultsAsync(stream, results);
+            Assert.Equal(2, client.Calls);
+        }
+
+        [Fact]
+        public async Task NonRetriableException()
+        {
+            var results = CreateResultSets("token1", "token2", "token3", "token4");
+            var client = new FakeSpannerClient(results, CreateExceptionFilter("token2", NonRetriableStatusCode));
+            var stream = CreateStream(client);
+
+            await AssertResultsThenExceptionAsync(stream, results, 1);
+            Assert.Equal(1, client.Calls);
+        }
+
+        private async Task AssertResultsAsync(SqlResultStream stream, IEnumerable<PartialResultSet> expectedResults)
+        {
+            var ret = new List<PartialResultSet>();
+            while (await stream.MoveNext(default))
+            {
+                ret.Add(stream.Current);
+            }
+            Assert.Equal(expectedResults.ToList(), ret);
+        }
+
+        private async Task AssertResultsThenExceptionAsync(SqlResultStream stream, List<PartialResultSet> allResults, int expectedSuccesses)
+        {
+            for (int i = 0; i < expectedSuccesses; i++)
+            {
+                Assert.True(await stream.MoveNext(default));
+                Assert.Equal(allResults[i], stream.Current);
+            }
+            await Assert.ThrowsAsync<RpcException>(() => stream.MoveNext(default));
+        }
+
+        private Func<PartialResultSet, PartialResultSet> CreateExceptionFilter(string resumeToken, StatusCode statusCode, int timesToThrow = 1) =>
+            CreateExceptionFilter(resumeToken, new RpcException(new Status(statusCode, "Bang")), timesToThrow);
+
+        private Func<PartialResultSet, PartialResultSet> CreateExceptionFilter(string resumeToken, RpcException exception, int timesToThrow = 1)
+        {
+            ByteString resumeTokenByteString = ByteString.CopyFromUtf8(resumeToken);
+            return prs =>
+            {
+                if (prs.ResumeToken != resumeTokenByteString || timesToThrow == 0)
+                {
+                    return prs;
+                }
+                timesToThrow--;
+                throw exception;
+            };
+        }
+
+        private static SqlResultStream CreateStream(SpannerClient client, int maxBufferSize = 10) =>
+            new SqlResultStream(client, new ExecuteSqlRequest(), new Session(), s_simpleCallSettings, maxBufferSize,
+                s_backoffSettings, RetrySettings.NoJitter);
+
+        private static List<PartialResultSet> CreateResultSets(params string[] resumeTokens) =>
+            resumeTokens
+                .Select((resumeToken, index) => new PartialResultSet
+                {
+                    ResumeToken = ByteString.CopyFromUtf8(resumeToken),
+                    // Each result set is unique (within this call) so that they don't accidentally compare equal.
+                    Values = { Value.ForNumber(index) }
+                })
+                .ToList();
+
+        // Note: a more realistic client would populate the metadata on the first response of each stream, but
+        // SqlResultStream doesn't use the metadata anyway, so it's just simpler to just return the result sets as they are.
+        private sealed class FakeSpannerClient : SpannerClient
+        {
+            private IEnumerable<PartialResultSet> _results;
+            public int Calls { get; private set; }
+            private readonly Func<PartialResultSet, PartialResultSet> _filter;
+
+            public FakeSpannerClient(IEnumerable<PartialResultSet> results, Func<PartialResultSet, PartialResultSet> filter = null)
+            {
+                Settings = SpannerSettings.GetDefault().Clone();
+                Settings.Scheduler = new NoOpScheduler();
+                _results = results;
+                // Default to an identity filter
+                _filter = filter ?? (x => x);
+            }
+
+            public override ExecuteStreamingSqlStream ExecuteStreamingSql(ExecuteSqlRequest request, CallSettings callSettings = null)
+            {
+                FileLogger.Log($"Called with token {request.ResumeToken.ToStringUtf8()}");
+                Calls++;
+                IEnumerable<PartialResultSet> callResults = request.ResumeToken.IsEmpty
+                    ? _results
+                    // If a resume token is presented, that means we need to skip all responses up to *and including* that one - so skip while we haven't seen it, then skip an extra one.
+                    : _results.SkipWhile(r => r.ResumeToken != request.ResumeToken).Skip(1);
+                callResults = callResults.Select(_filter);
+                var asyncResults = new AsyncStreamAdapter<PartialResultSet>(callResults.ToAsyncEnumerable().GetEnumerator());
+
+                var call = new AsyncServerStreamingCall<PartialResultSet>(asyncResults,
+                    // These arguments are all for aspects of gRPC streaming we don't care about.
+                    Task.FromResult(new Metadata()), () => new Status(), () => new Metadata(), () => { });
+                return new ExecuteStreamingSqlStreamImpl(call);
+            }
+        }
+
+        private sealed class NoOpScheduler : IScheduler
+        {
+            public Task Delay(TimeSpan delay, CancellationToken cancellationToken) => Task.FromResult(0);
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/PooledSession.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/PooledSession.cs
@@ -238,7 +238,14 @@ namespace Google.Cloud.Spanner.V1
             {
                 request.Transaction = new TransactionSelector { Id = TransactionId };
             }
-            return new ReliableStreamReader(Client, request, _session, timeoutSeconds);
+            request.SessionAsSessionName = SessionName;
+
+            // Not using CreateSettings as we don't have a cancellation token.
+            var settings = Client.Settings.ExecuteStreamingSqlSettings.WithExpiration(
+                Client.Settings.ConvertTimeoutToExpiration(timeoutSeconds));
+
+            SqlResultStream stream = new SqlResultStream(Client, request, _session, settings);
+            return new ReliableStreamReader(stream, Client.Settings.Logger);
         }
 
         /// <summary>

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SqlResultStream.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SqlResultStream.cs
@@ -1,0 +1,287 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using Google.Api.Gax.Grpc;
+using Google.Cloud.Spanner.V1.Internal;
+using Google.Rpc;
+using Grpc.Core;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using static Google.Api.Gax.Grpc.RetrySettings;
+
+namespace Google.Cloud.Spanner.V1
+{
+    /// <summary>
+    /// Implements buffering, retry and resume for the results of executing streaming SQL calls.
+    /// </summary>
+    internal sealed class SqlResultStream : IAsyncEnumerator<PartialResultSet>
+    {
+        /// <summary>
+        /// The default maximum buffer size. Currently this isn't user-tweakable; we don't expect to see more than this many
+        /// responses without a resume token anyway.
+        /// </summary>
+        private const int DefaultMaxBufferSize = 512;
+        // TODO: Validate that these make sense!
+        private static readonly BackoffSettings s_defaultBackoffSettings = new BackoffSettings(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(15), 2.0);
+
+        private readonly LinkedList<PartialResultSet> _buffer;
+        private readonly SpannerClient _client;
+        private readonly ExecuteSqlRequest _request;
+        private readonly Session _session;
+        private readonly CallSettings _callSettings;
+        private readonly BackoffSettings _backoffSettings;
+        private readonly IJitter _backoffJitter;
+        private readonly int _maxBufferSize;
+
+        /// <summary>
+        /// Indicates whether the underlying stream has completed. We may still be draining results from the buffer.
+        /// </summary>
+        private bool _finished;
+        private bool _safeToRetry = true;
+
+        private AsyncServerStreamingCall<PartialResultSet> _grpcCall;
+
+        /// <summary>
+        /// Constructor for normal 
+        /// </summary>
+        internal SqlResultStream(SpannerClient client, ExecuteSqlRequest request, Session session, CallSettings callSettings)
+            : this(client, request, session, callSettings, DefaultMaxBufferSize, s_defaultBackoffSettings, RetrySettings.RandomJitter)
+        {
+        }
+
+        /// <summary>
+        /// Constructor with complete control, for testing purposes.
+        /// </summary>
+        internal SqlResultStream(
+            SpannerClient client,
+            ExecuteSqlRequest request,
+            Session session,
+            CallSettings callSettings,
+            int maxBufferSize,
+            BackoffSettings backoffSettings,
+            IJitter backoffJitter)
+        {
+            _buffer = new LinkedList<PartialResultSet>();
+            _client = GaxPreconditions.CheckNotNull(client, nameof(client));
+            _request = GaxPreconditions.CheckNotNull(request, nameof(request));
+            _session = GaxPreconditions.CheckNotNull(session, nameof(session));
+            _callSettings = GaxPreconditions.CheckNotNull(callSettings, nameof(callSettings));
+            _maxBufferSize = GaxPreconditions.CheckArgumentRange(maxBufferSize, nameof(maxBufferSize), 1, 10_000);
+            _backoffSettings = GaxPreconditions.CheckNotNull(backoffSettings, nameof(backoffSettings));
+            _backoffJitter = GaxPreconditions.CheckNotNull(backoffJitter, nameof(backoffJitter));
+        }
+
+        public PartialResultSet Current { get; private set; }
+
+        public void Dispose()
+        {
+            _grpcCall?.Dispose();
+            _grpcCall = null;
+            _finished = true;
+            _buffer.Clear();
+        }
+
+        public async Task<bool> MoveNext(CancellationToken cancellationToken)
+        {
+            var value = await ComputeNextAsync(cancellationToken).ConfigureAwait(false);
+            Current = value;
+            return value != null;
+        }
+
+        // See https://github.com/googleapis/google-cloud-java/blob/master/google-cloud-clients/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerImpl.java#L2674
+        private async Task<PartialResultSet> ComputeNextAsync(CancellationToken cancellationToken)
+        {
+            // The retry state is local to the method as we're not trying to handle callers retrying.
+            RetryState retryState = new RetryState(_client.Settings.Scheduler ?? SystemScheduler.Instance, _backoffSettings, _backoffJitter);
+
+            while (true)
+            {
+                // TODO: This shouldn't be required. We should be able to rely on the MoveNext call.
+                cancellationToken.ThrowIfCancellationRequested();
+
+                // If we've successfully read to the end of the stream and emptied the buffer, we've read all the responses.
+                if (_finished && _buffer.Count == 0)
+                {
+                    return null;
+                }
+
+                // Buffer contains items up to a resume token or has reached capacity: flush.
+                if (_buffer.Count > 0 && (_finished || !_safeToRetry || !_buffer.Last.Value.ResumeToken.IsEmpty))
+                {
+                    var firstResult = _buffer.First.Value;
+                    _buffer.RemoveFirst();
+                    return firstResult;
+                }
+
+                try
+                {
+                    if (_grpcCall == null)
+                    {
+                        _grpcCall = _client.ExecuteStreamingSql(_request, _callSettings).GrpcCall;
+                        // TODO: How do we use the cancellation token?
+                        await _grpcCall.ResponseHeadersAsync.WithSessionExpiryChecking(_session).ConfigureAwait(false);
+                    }
+                    bool hasNext = await _grpcCall.ResponseStream
+                        .MoveNext(cancellationToken)
+                        .WithSessionExpiryChecking(_session)
+                        .ConfigureAwait(false);
+                    retryState.Reset();
+
+                    if (hasNext)
+                    {
+                        var next = _grpcCall.ResponseStream.Current;
+                        var hasResumeToken = !next.ResumeToken.IsEmpty;
+
+                        if (hasResumeToken)
+                        {
+                            _request.ResumeToken = next.ResumeToken;
+                            _safeToRetry = true;
+                        }
+                        // If the buffer is empty and this result has a resume token or we cannot resume safely
+                        // anyway, we can yield it immediately rather than placing it in the buffer to be
+                        // returned on the next iteration.
+                        if ((hasResumeToken || !_safeToRetry) && _buffer.Count == 0)
+                        {
+                            return next;
+                        }
+                        _buffer.AddLast(next);
+                        if (_buffer.Count > _maxBufferSize && !hasResumeToken)
+                        {
+                            // We need to flush without a restart token.  Errors encountered until we see
+                            // such a token will fail the read.
+                            _safeToRetry = false;
+                        }
+                    }
+                    else
+                    {
+                        _finished = true;
+                        // Let the next iteration of the loop return 0 or buffered data.
+                    }
+                }
+                catch (RpcException e) when (_safeToRetry && retryState.CanRetry(e))
+                {
+                    _client.Settings.Logger.Warn($"Exception when reading from result stream. Retrying.", e);
+                    await retryState.RecordErrorAndWaitAsync(e, cancellationToken).ConfigureAwait(false);
+
+                    // Clear anything we've received since the previous response that contained a resume token
+                    _buffer.Clear();
+                    _grpcCall.Dispose();
+                    _grpcCall = null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Keeps track of whether exceptions should be retried or not, along with any delay between retries.
+        /// We may want to make this a top-level class at some point.
+        /// </summary>
+        internal class RetryState
+        {
+            internal static readonly string RetryInfoKey = (RetryInfo.Descriptor.FullName + "-bin").ToLowerInvariant();
+            private const int DefaultMaxConsecutiveErrors = 1;
+
+            private readonly IScheduler _scheduler;
+            private readonly BackoffSettings _backoffSettings;
+            private readonly IJitter _backoffJitter;
+            private readonly int _maxConsecutiveErrors;
+            private TimeSpan _nextDelay;
+            private int _consecutiveErrors;
+
+            internal RetryState(IScheduler scheduler, BackoffSettings backoffSettings, IJitter backoffJitter)
+                : this(scheduler, backoffSettings, backoffJitter, DefaultMaxConsecutiveErrors)
+            {
+            }
+
+            internal RetryState(IScheduler scheduler, BackoffSettings backoffSettings, IJitter backoffJitter, int maxConsecutiveErrors)
+            {
+                _scheduler = scheduler;
+                _backoffSettings = backoffSettings;
+                _backoffJitter = backoffJitter;
+                _maxConsecutiveErrors = maxConsecutiveErrors;
+                Reset();
+            }
+
+            internal RetryState Clone() =>
+                new RetryState(_scheduler, _backoffSettings, _backoffJitter);
+
+            /// <summary>
+            /// Indicates whether the given exception can be retried in the current state.
+            /// This does not change the state.
+            /// </summary>
+            internal bool CanRetry(RpcException exception)
+            {
+                if (_consecutiveErrors >= _maxConsecutiveErrors)
+                {
+                    return false;
+                }
+
+                switch (exception.StatusCode)
+                {
+                    // TODO: Work out what the Java retriable cases look like in .NET.
+                    // It matches on messages "HTTP/2 error code: INTERNAL_ERROR", "Connection closed with unknown cause", "Received unexpected EOS on DATA frame from server".
+                    // I'd rather not use the message text if possible.
+                    case StatusCode.Internal:
+                    // TODO: Check that this is valid. The Java code doesn't allow it, but it seems reasonable for a large
+                    // result set to require multiple calls to fetch all the data.
+                    case StatusCode.DeadlineExceeded:
+                    case StatusCode.Unavailable:
+                        return true;
+                    case StatusCode.ResourceExhausted:
+                        return (GetRetryDelay(exception) ?? TimeSpan.Zero) > TimeSpan.Zero;
+                    default:
+                        return false;
+                }
+            }
+
+            /// <summary>
+            /// Updates the state on the basis of the given exception, delaying for as long as is necessary
+            /// between retries.
+            /// </summary>
+            internal async Task RecordErrorAndWaitAsync(RpcException exception, CancellationToken cancellationToken)
+            {
+                _consecutiveErrors++;
+                TimeSpan thisDelay = GetRetryDelay(exception) ?? _nextDelay;
+                await _scheduler.Delay(_backoffJitter.GetDelay(thisDelay), cancellationToken).ConfigureAwait(false);
+                _nextDelay = _backoffSettings.NextDelay(_nextDelay);
+            }
+
+            /// <summary>
+            /// Resets the state, in terms of delays and error counts. This should
+            /// be called after each successful call.
+            /// </summary>
+            internal void Reset()
+            {
+                _consecutiveErrors = 0;
+                _nextDelay = _backoffSettings.Delay;
+            }
+
+            private TimeSpan? GetRetryDelay(RpcException e)
+            {
+                foreach (var entry in e.Trailers)
+                {
+                    if (entry.Key == RetryInfoKey)
+                    {
+                        // TODO: Handle invalid values silently, rather than throwing?
+                        RetryInfo retryInfo = RetryInfo.Parser.ParseFrom(entry.ValueBytes);
+                        return retryInfo.RetryDelay.ToTimeSpan();
+                    }
+                }
+                return null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit is not for submission - we need (at least) a bunch of
tests, many of which would have been hard to write before.

AutoResumingResultStream may not be the right name - other ideas
welcome.