### PR TITLE
Update error handling in Firestore Watch

### DIFF
--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/WatchStateTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/WatchStateTest.cs
@@ -1,0 +1,52 @@
+﻿// Copyright 2019, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Firestore.V1;
+using Grpc.Core;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Cloud.Firestore.Tests
+{
+    /// <summary>
+    /// Most tests for WatchState are via proto conformance tests. This class is used for tests
+    /// which aren't currently in that set.
+    /// </summary>
+    public class WatchStateTest
+    {
+        [Fact]
+        public async Task TargetRemoved()
+        {
+            var db = FirestoreDb.Create("project", "database", new FakeFirestoreClient());
+            var query = db.Collection("col");
+
+            var state = new WatchState(query, (snapshot, token) => throw new Exception("Unexpected callback"));
+            string message = "MESSAGE_TO_FIND";
+            var response = new ListenResponse
+            {
+                TargetChange = new TargetChange
+                {
+                    TargetChangeType = TargetChange.Types.TargetChangeType.Remove,
+                    TargetIds = { WatchStream.WatchTargetId },
+                    Cause = new Rpc.Status { Code = (int) Rpc.Code.ResourceExhausted, Message = message }
+                }
+            };
+            var exception = await Assert.ThrowsAsync<RpcException>(() => state.HandleResponseAsync(response, default));
+
+            Assert.Equal(StatusCode.ResourceExhausted, exception.StatusCode);
+            Assert.Contains(message, exception.Message);
+        }
+    }
+}

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/WatchStreamTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/WatchStreamTest.cs
@@ -108,7 +108,7 @@ namespace Google.Cloud.Firestore.Tests
             sequence.ProvideResponse(WatchResponseResult.StreamHealthy, token1);
             sequence.ProvideResponse(WatchResponseResult.StreamHealthy, token2);
             sequence.RpcException(new RpcException(new Status(StatusCode.DeadlineExceeded, "This exception is transient")));
-            // The server throw a retriable exception. Reinitialize.
+            // The server threw a retriable exception. Reinitialize.
             sequence.ExpectConnect(token2, StreamInitializationCause.RpcError);
             sequence.ProvideResponse(WatchResponseResult.Continue);
             sequence.WaitForCancellation();

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/WatchStream.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/WatchStream.cs
@@ -28,6 +28,7 @@ namespace Google.Cloud.Firestore
     {
         private static readonly HashSet<StatusCode> s_transientErrorStatusCodes = new HashSet<StatusCode>
         {
+            StatusCode.Aborted,
             StatusCode.Cancelled,
             StatusCode.Unknown,
             StatusCode.DeadlineExceeded,


### PR DESCRIPTION
- Retry on Aborted
- Use RpcException when the server removes a target (we don't want to retry)

Fixes #2776
Fixes #2721