### PR TITLE
Perform case-insensitive checking on image labels

### DIFF
--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Snippets/ImageAnnotatorClientSnippets.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Snippets/ImageAnnotatorClientSnippets.cs
@@ -207,9 +207,9 @@ namespace Google.Cloud.Vision.V1.Snippets
 
             // Not exhaustive, but let's check certain basic labels.
             var descriptions = labels.Select(l => l.Description).ToList();
-            Assert.Contains("flower", descriptions);
-            Assert.Contains("plant", descriptions);
-            Assert.Contains("vase", descriptions);
+            Assert.Contains("flower", descriptions, StringComparer.OrdinalIgnoreCase);
+            Assert.Contains("plant", descriptions, StringComparer.OrdinalIgnoreCase);
+            Assert.Contains("vase", descriptions, StringComparer.OrdinalIgnoreCase);
         }
 
         // See-also: DetectLabels(*, *, *, *)


### PR DESCRIPTION
While we could just update to use Plant, Flower etc, it's simpler to be a bit looser with the comparison.