### PR TITLE
Update the Cloud KMS documentation to link to the main site

### DIFF
--- a/apis/Google.Cloud.Kms.V1/docs/index.md
+++ b/apis/Google.Cloud.Kms.V1/docs/index.md
@@ -19,3 +19,6 @@
 This example lists all the key rings in the "global" location for a specific project.
 
 {{sample:KeyManagementServiceClient.ListGlobalKeyRings}}
+
+For further information and examples, see the [main Cloud KMS
+documentation](https://cloud.google.com/kms/docs/reference/libraries#client-libraries-install-csharp).


### PR DESCRIPTION
This avoids duplicating a lot of samples within our page.

cc @bdhess