### PR TITLE
Enable clustering at table creation time

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/CreateTableOptionsTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/CreateTableOptionsTest.cs
@@ -33,6 +33,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
                 TimePartitioning = TimePartition.CreateDailyPartitioning(TimeSpan.FromDays(10)),
                 ExternalDataConfiguration = new ExternalDataConfiguration(),
                 EncryptionConfiguration = new EncryptionConfiguration { KmsKeyName = "projects/1/locations/us/keyRings/1/cryptoKeys/1" },
+                Clustering = new Clustering { Fields = new[] { "x", "y", "z" } }
             };
             Table table = new Table();
             InsertRequest request = new InsertRequest(new BigqueryService(), table, "project", "dataset");
@@ -44,6 +45,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
             Assert.Equal(10 * 24 * 60 * 60 * 1000L, table.TimePartitioning.ExpirationMs);
             Assert.Same(options.ExternalDataConfiguration, table.ExternalDataConfiguration);
             Assert.Equal("projects/1/locations/us/keyRings/1/cryptoKeys/1", table.EncryptionConfiguration.KmsKeyName);
+            Assert.Same(options.Clustering, table.Clustering);
         }
 
         [Fact]

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/CreateTableOptions.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/CreateTableOptions.cs
@@ -63,6 +63,11 @@ namespace Google.Cloud.BigQuery.V2
         /// </summary>
         public EncryptionConfiguration EncryptionConfiguration { get; set; }
 
+        /// <summary>
+        /// The clustering to apply to the created table, if any.
+        /// </summary>
+        public Clustering Clustering { get; set; }
+
         internal void ModifyRequest(Table table, InsertRequest request)
         {
             if (Description != null)
@@ -98,6 +103,10 @@ namespace Google.Cloud.BigQuery.V2
             if (EncryptionConfiguration != null)
             {
                 table.EncryptionConfiguration = EncryptionConfiguration;
+            }
+            if (Clustering != null)
+            {
+                table.Clustering = Clustering;
             }
         }
     }


### PR DESCRIPTION
Note that although clustering can currently only be specified for
partitioned tables, that may be relaxed - so the client doesn't
attempt to validate it.

Fixes #2823.