### PR TITLE
Having the RateLimiter work properly when everything needs to be traced and there are many parallel requests.

### DIFF
--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Trace/RateLimiterTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Trace/RateLimiterTest.cs
@@ -69,7 +69,7 @@ namespace Google.Cloud.Diagnostics.Common.Tests
             int canTraceCounter = 0;
             DateTime start = DateTime.UtcNow;
             DateTime end = start.AddSeconds(5.5);
-            // Create 10 threads to run for a little over two seconds.
+            // Create 10 threads to run for a little over five seconds.
             var threads = Enumerable.Range(0, 10)
                 .Select(_ => new Thread(() =>
                 {
@@ -100,13 +100,14 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         [Fact]
         public void CanTrace_Always_StressTest()
         {
+
             // Create a rate limiter that allows 1_000_000 QPS, which effectively means can trace always.
             var rateLimiter = new RateLimiter(1_000_000, StopwatchTimer.Create());
             int canTraceCounter = 0;
             int canTraceQuestions = 0;
             DateTime start = DateTime.UtcNow;
             DateTime end = start.AddSeconds(5.5);
-            // Create 10 threads to run for a little over two seconds.
+            // Create 10 threads to run for a little over five seconds.
             var threads = Enumerable.Range(0, 10)
                 .Select(_ => new Thread(() =>
                 {
@@ -130,6 +131,57 @@ namespace Google.Cloud.Diagnostics.Common.Tests
 
             // Since everything is to be traced, we should have as many traces as we attempted.
             Assert.Equal(canTraceQuestions, canTraceCounter);
+        }
+
+        [Fact]
+        public void CanTrace_1000Qps_StressTest()
+        {
+            // Mocking the stopwatch.
+            long[] elapsedMilliseconds = new long[1953];
+            FillElapsedMilliseconds(0, 300, 1); // 300 requests on mill 1.
+            FillElapsedMilliseconds(300, 800, 2); // 500 requests on mill 2.
+            FillElapsedMilliseconds(800, 802, 3); // 2 requests on mill 3.
+            FillElapsedMilliseconds(802, 1802, 4); // 1000 requests on mill 4.
+            FillElapsedMilliseconds(1802, 1952, 6); // No requests on mill 5 and 150 requests on mill 6.
+            FillElapsedMilliseconds(1952, 1953, 7); // 1 request in mill 7
+            // We should have 6 traces since we need to trace one for every millisecond in which we received traces.
+
+            void FillElapsedMilliseconds(int from, int to, long value)
+            {
+                for (int i = from; i < to; i++)
+                {
+                    elapsedMilliseconds[i] = value;
+                }
+            }
+
+            // Create a rate limiter that allows 1_000 QPS, which effectively means we should have one trace per millisecond.
+            // Mock the stopwatch to simulate the calls per millisecond as defined above.
+            var rateLimiter = TraceUtils.GetRateLimiter(1_000, elapsedMilliseconds);
+            int canTraceQuestions = 0;
+            int canTraceCounter = 0;
+            // Create 10 threads to run while we haven't reached the 1953 requests.
+            var threads = Enumerable.Range(0, 10)
+                .Select(_ => new Thread(() =>
+                {
+                    while (Interlocked.Increment(ref canTraceQuestions) <= 1953)
+                    {
+                        // Avoid completely tight-looping, so that we can actually start enough threads.
+                        // (Note that Thread.Yield isn't available on .NET Core.)
+                        Thread.Sleep(1);
+                        if (rateLimiter.CanTrace())
+                        {
+                            Interlocked.Increment(ref canTraceCounter);
+                        }
+                    }
+                }))
+                .ToList();
+
+            // Start the threads and wait for them all to finish
+            threads.ForEach(t => t.Start());
+            threads.ForEach(t => t.Join());
+
+            // We should have one trace per every millisecond that we attempted to trace.
+            Assert.Equal(6, canTraceCounter);
         }
     }
 }

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/RateLimiter.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/RateLimiter.cs
@@ -14,7 +14,6 @@
 
 using Google.Api.Gax;
 using System;
-using System.Threading;
 
 namespace Google.Cloud.Diagnostics.Common
 {
@@ -75,10 +74,15 @@ namespace Google.Cloud.Diagnostics.Common
         /// <returns>True if tracing is allowed.</returns>
         public bool CanTrace()
         {
+            if(_fixedDelayMillis == 0)
+            {
+                return true;
+            }
+
             lock (_lastCallMutex)
             {
                 var nowMillis = _timer.GetElapsedMilliseconds();
-                if(nowMillis - _lastCallMillis >= _fixedDelayMillis)
+                if (nowMillis - _lastCallMillis >= _fixedDelayMillis)
                 {
                     _lastCallMillis = nowMillis;
                     return true;


### PR DESCRIPTION
Fixes #2834 .

The problem is that to determined wheter we needed to trace or not we were relying too much on no other requests coming in at the same time, and this won't work when we either need to trace almost everything and have a lot of parallel requests.

The new test wasn't passing before the fix.