### PR TITLE
Prevent logging null log entry labels

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Logging/LabelProviders/UserLogEntryLabelProviderTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Logging/LabelProviders/UserLogEntryLabelProviderTest.cs
@@ -57,31 +57,6 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Tests
         }
 
         [Fact]
-        public void AddsUserNameLabelWithEmptyUserName()
-        {
-            // Arrange
-            var mockHttpContext = new Mock<HttpContext>();
-            mockHttpContext.Setup(x => x.User.Identity.IsAuthenticated).Returns(true);
-
-            var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
-            mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(mockHttpContext.Object);
-
-            var instance = new UserLogEntryLabelProvider(mockHttpContextAccessor.Object);
-            var labels = new Dictionary<string, string>();
-
-            // Act
-            instance.Invoke(labels);
-
-            // Assert
-            var expected = new Dictionary<string, string>
-            {
-                { "user_authenticated", true.ToString() },
-                { "user_name", null }
-            };
-            Assert.Equal(expected, labels);
-        }
-
-        [Fact]
         public void AddsUserNameLabelWithUserName()
         {
             // Arrange

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLogger.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLogger.cs
@@ -194,7 +194,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
                 Severity = logLevel.ToLogSeverity(),
                 Timestamp = Timestamp.FromDateTime(_clock.GetCurrentDateTimeUtc()),
                 JsonPayload = jsonStruct,
-                Labels = { labels },
+                Labels = { labels.Where(kvp => !string.IsNullOrEmpty(kvp.Value)).ToDictionary(kvp => kvp.Key, kvp => kvp.Value) },
                 Trace = GetTraceName() ?? "",
             };
 

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/LabelProviders/EnvironmentNameLogEntryLabelProvider.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/LabelProviders/EnvironmentNameLogEntryLabelProvider.cs
@@ -38,7 +38,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         /// <inheritdoc/>
         public void Invoke(Dictionary<string, string> labels)
         {
-            labels["aspnetcore_environment"] = _hostingEnvironment.EnvironmentName;
+            labels["aspnetcore_environment"] = _hostingEnvironment.EnvironmentName ?? "N/A";
         }
     }
 }

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/LabelProviders/UserLogEntryLabelProvider.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/LabelProviders/UserLogEntryLabelProvider.cs
@@ -38,9 +38,10 @@ namespace Google.Cloud.Diagnostics.AspNetCore
             if (httpContext.User?.Identity != null)
             {
                 labels["user_authenticated"] = httpContext.User.Identity.IsAuthenticated.ToString();
-                if (httpContext.User.Identity.IsAuthenticated)
+                var userName = GetUserName(httpContext.User.Identity);
+                if (httpContext.User.Identity.IsAuthenticated && !string.IsNullOrEmpty(userName))
                 {
-                    labels["user_name"] = GetUserName(httpContext.User.Identity);
+                    labels["user_name"] = userName;
                 }
             }
         }


### PR DESCRIPTION
A log entry which contains a label with an empty value results in an `ArgumentException` when serializing it to a protobuf message. This can result in pretty ugly bugs, for example: https://github.com/aspnet/AspNetCore/issues/3460. 

This PR prevents adding en empty user name in `UserLogEntryLabelProvider` and an empty environment name in `EnvironmentNameLogEntryLabelProvider` as well as removing any `null` or empty labels in custom log entry label providers.