### PR TITLE
Fix Firestore timestamp comparisons

### DIFF
--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/TimestampTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/TimestampTest.cs
@@ -49,6 +49,7 @@ namespace Google.Cloud.Firestore.Tests
             AssertComparisonAndReverse(t1, t2, 0);
             AssertComparisonAndReverse(t1, t3, -1);
             AssertComparisonAndReverse(t1, t4, -1);
+            AssertComparisonAndReverse(t3, t4, -1);
 
             void AssertComparisonAndReverse(Timestamp x, Timestamp y, int expectedSign)
             {

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Timestamp.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Timestamp.cs
@@ -151,7 +151,7 @@ namespace Google.Cloud.Firestore
         {
             // Note: assumes normalized form.
             int secondsComparison = _seconds.CompareTo(other._seconds);
-            return secondsComparison != 0 ? secondsComparison : _nanoseconds.CompareTo(_nanoseconds);
+            return secondsComparison != 0 ? secondsComparison : _nanoseconds.CompareTo(other._nanoseconds);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
A typo in nanosecond comparisons effectively made a timestamp equal to any other timestamp with the same "seconds" value (when using CompareTo).

Supercedes #2839.