### PR TITLE
NOTE: I removed the [Where T: class] , and changed to return default(T)

### DIFF
--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/DocumentSnapshot.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/DocumentSnapshot.cs
@@ -92,11 +92,11 @@ namespace Google.Cloud.Firestore
         /// </summary>
         /// <typeparam name="T">The type to deserialize the document data as.</typeparam>
         /// <returns>The deserialized data, or null if this object represents a missing document.</returns>
-        public T ConvertTo<T>() where T : class
+        public T ConvertTo<T>() 
         {
             if (!Exists)
             {
-                return null;
+                return default(T);
             }
             return (T) ValueDeserializer.DeserializeMap(Database, Document.Fields, typeof(T));
         }


### PR DESCRIPTION
==> you only need the T: class constraint, becuase you wanted to return null.
==> but your valueserializer works any T, so there is no need for this constraint.

Default(T) will return null if T is class.

=======================================
It is causing downstream issues, with calling this function (within generic methods that do not have this constraint) ==> 3rd party libraries, which have generic methods, will not allow you to call your method (since it does not have the constraint)  ==>I created bug:  https://github.com/googleapis/google-cloud-dotnet/issues/2843