### PR TITLE
Update V4 URL signing to use lower-case query parameter names

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/UrlSignerTest.V4SignerTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/UrlSignerTest.V4SignerTest.cs
@@ -45,9 +45,9 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
             public async Task GetTest() => await _fixture.FinishDelayTest(GetTestName());
             private void GetTest_InitDelayTest() => GetTest_Common(_fixture, Signer);
 
-            [Fact(Skip = "Bucket content listing not supported in V4 right now")]
+            [Fact]
             public async Task GetBucketTest() => await _fixture.FinishDelayTest(GetTestName());
-            //private void GetBucketTest_InitDelayTest() => GetBucketTest_Common(_fixture, Signer);
+            private void GetBucketTest_InitDelayTest() => GetBucketTest_Common(_fixture, Signer);
 
             [Fact]
             public async Task GetObjectWithSpacesTest() => await _fixture.FinishDelayTest(GetTestName());

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/UrlSignerTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/UrlSignerTest.cs
@@ -116,6 +116,7 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
                     // Verify that the URL works initially.
                     var response = await fixture.HttpClient.GetAsync(url);
                     var result = await response.Content.ReadAsStringAsync();
+                    Assert.True(response.IsSuccessStatusCode, result.ToString());
                     var document = XDocument.Parse(result);
                     var ns = document.Root.GetDefaultNamespace();
                     var keys = document.Root.Elements(ns + "Contents").Select(contents => contents.Element(ns + "Key").Value).ToList();

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/UrlSignerTest.V4SignerTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/UrlSignerTest.V4SignerTest.cs
@@ -45,11 +45,11 @@ namespace Google.Cloud.Storage.V1.Tests
                 var uriString = signer.Sign(bucket, obj, expiry, HttpMethod.Get);
                 var parameters = ExtractQueryParameters(uriString);
 
-                Assert.Equal("GOOG4-RSA-SHA256", parameters["X-Goog-Algorithm"]);
-                Assert.Equal("test-account%40spec-test-ruby-samples.iam.gserviceaccount.com%2F20181119%2Fauto%2Fgcs%2Fgoog4_request", parameters["X-Goog-Credential"]);
-                Assert.Equal("20181119T055654Z", parameters["X-Goog-Date"]);
-                Assert.Equal("3600", parameters["X-Goog-Expires"]);
-                Assert.Equal("host", parameters["X-Goog-SignedHeaders"]);
+                Assert.Equal("GOOG4-RSA-SHA256", parameters["x-goog-algorithm"]);
+                Assert.Equal("test-account%40spec-test-ruby-samples.iam.gserviceaccount.com%2F20181119%2Fauto%2Fgcs%2Fgoog4_request", parameters["x-goog-credential"]);
+                Assert.Equal("20181119T055654Z", parameters["x-goog-date"]);
+                Assert.Equal("3600", parameters["x-goog-expires"]);
+                Assert.Equal("host", parameters["x-goog-signedheaders"]);
                 
                 // No check for the exact signature.
             }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/UrlSigner.V4Signer.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/UrlSigner.V4Signer.cs
@@ -127,11 +127,11 @@ namespace Google.Cloud.Storage.V1
 
                     queryParameters = new List<string>
                     {
-                        "X-Goog-Algorithm=GOOG4-RSA-SHA256",
-                        $"X-Goog-Credential={credential}",
-                        $"X-Goog-Date={timestamp}",
-                        $"X-Goog-Expires={expirySeconds}",
-                        $"X-Goog-SignedHeaders={signedHeaders}"
+                        "x-goog-algorithm=GOOG4-RSA-SHA256",
+                        $"x-goog-credential={credential}",
+                        $"x-goog-date={timestamp}",
+                        $"x-goog-expires={expirySeconds}",
+                        $"x-goog-signedheaders={signedHeaders}"
                     };
                     if (isResumableUpload)
                     {


### PR DESCRIPTION
Along with service changes, this means we can now test listing bucket contents using V4.
The change in UrlSignerTest.cs just makes it easier to diagnose what's wrong if it *does* fail.