### PR TITLE
Support custom value type serialization, even for documents

### DIFF
--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/SerializationTestData.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/SerializationTestData.cs
@@ -150,6 +150,10 @@ namespace Google.Cloud.Firestore.Tests
             { new CustomPlayer { Name = "Amanda", Score = 15 },
                 new Value { MapValue = new MapValue { Fields = { { "PlayerName", new Value { StringValue = "Amanda" } }, { "PlayerScore", new Value { IntegerValue = 15L } } } } } },
 
+            // Attributed value type serialized and deserialized by CustomValueTypeConverter
+            { new CustomValueType("xyz", 10),
+                new Value { MapValue = new MapValue { Fields = { { "Name", new Value { StringValue = "xyz" } }, { "Value", new Value { IntegerValue = 10L } } } } } },
+
             // Nullable type handling
             { new NullableContainer { NullableValue = null },
                 new Value { MapValue = new MapValue { Fields = { { "NullableValue", new Value { NullValue = wkt::NullValue.NullValue } } } } } },
@@ -383,6 +387,38 @@ namespace Google.Cloud.Firestore.Tests
                 {
                     ["PlayerName"] = value.Name,
                     ["PlayerScore"] = value.Score
+                };
+        }
+
+        [FirestoreData(ConverterType = typeof(CustomValueTypeConverter))]
+        internal struct CustomValueType
+        {
+            public string Name { get; }
+            public int Value { get; }
+
+            public CustomValueType(string name, int value)
+            {
+                Name = name;
+                Value = value;
+            }
+        }
+
+        internal class CustomValueTypeConverter : IFirestoreConverter<CustomValueType>
+        {
+            public CustomValueType FromFirestore(object value)
+            {
+                var dictionary = (IDictionary<string, object>)value;
+                return new CustomValueType(
+                    (string)dictionary["Name"],
+                    (int)(long)dictionary["Value"]
+                );
+            }
+
+            public object ToFirestore(CustomValueType value) =>
+                new Dictionary<string, object>
+                {
+                    ["Name"] = value.Name,
+                    ["Value"] = value.Value
                 };
         }
     }

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/ValueSerializerTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/ValueSerializerTest.cs
@@ -18,7 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Dynamic;
 using Xunit;
-
+using static Google.Cloud.Firestore.Tests.SerializationTestData;
 using wkt = Google.Protobuf.WellKnownTypes;
 
 namespace Google.Cloud.Firestore.Tests
@@ -166,7 +166,6 @@ namespace Google.Cloud.Firestore.Tests
             var badArray = new[] { new int[10] };
             Assert.Throws<ArgumentException>(() => ValueSerializer.Serialize(badArray));
         }
-        
 
         [FirestoreData]
         private class SentinelModel

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/DocumentSnapshot.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/DocumentSnapshot.cs
@@ -92,11 +92,11 @@ namespace Google.Cloud.Firestore
         /// </summary>
         /// <typeparam name="T">The type to deserialize the document data as.</typeparam>
         /// <returns>The deserialized data, or null if this object represents a missing document.</returns>
-        public T ConvertTo<T>() where T : class
+        public T ConvertTo<T>()
         {
             if (!Exists)
             {
-                return null;
+                return default;
             }
             return (T) ValueDeserializer.DeserializeMap(Database, Document.Fields, typeof(T));
         }

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/FirestoreDataAttribute.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/FirestoreDataAttribute.cs
@@ -19,7 +19,7 @@ namespace Google.Cloud.Firestore
     /// <summary>
     /// Attribute indicating that a type is intended to be used with Firestore.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class)]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Delegate | AttributeTargets.Interface)]
     public sealed class FirestoreDataAttribute : Attribute
     {
         /// <summary>


### PR DESCRIPTION
- Removes the restriction on FirestoreDataAttribute
- Removes the restriction on DocumentSnapshot.ConvertTo
- Tests that it actually works

Fixes #2843.
