### PR TITLE
Release Google.Cloud.BigQuery.V2 version 1.3.0-beta08

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.3.0-beta07</Version>
+    <Version>1.3.0-beta08</Version>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.3</TargetFrameworks>
     <LangVersion>latest</LangVersion>
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Rest" Version="2.5.0" />
-    <PackageReference Include="Google.Apis.Bigquery.v2" Version="1.37.0.1468" />
+    <PackageReference Include="Google.Apis.Bigquery.v2" Version="1.38.0.1484" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -49,12 +49,12 @@
     "id": "Google.Cloud.BigQuery.V2",
     "productName": "Google BigQuery",
     "productUrl": "https://cloud.google.com/bigquery/",
-    "version": "1.3.0-beta07",
+    "version": "1.3.0-beta08",
     "type": "rest",
     "description": "Recommended Google client library to access the BigQuery API. It wraps the Google.Apis.Bigquery.v2 client library, making common operations simpler in client code. BigQuery is a data platform for customers to create, manage, share and query data.",
     "dependencies": {
       "Google.Api.Gax.Rest": "2.5.0",
-      "Google.Apis.Bigquery.v2": "1.37.0.1468"
+      "Google.Apis.Bigquery.v2": "1.38.0.1484"
     },
     "testDependencies": {
       "Google.Cloud.Storage.V1": "project"


### PR DESCRIPTION
Fixes #2845 

(Or rather, the release includes the fix to #2845.)