### PR TITLE
Retry BatchGetDocuments RPC within GetDocumentSnapshotsAsync

### DIFF
--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/FirestoreClientPartial.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/FirestoreClientPartial.cs
@@ -17,6 +17,26 @@ using System;
 
 namespace Google.Cloud.Firestore.V1
 {
+    // Partial classes to expose FirestoreSettings
+    public partial class FirestoreClient
+    {
+        /// <summary>
+        /// Returns the effective <see cref="CallSettings"/> used for each API call.
+        /// This can be used to create a modified instance of <see cref="CallSettings"/> to pass
+        /// for a single API request.
+        /// </summary>
+        public virtual FirestoreSettings Settings { get; protected set; }
+    }
+
+    public partial class FirestoreClientImpl
+    {
+        partial void OnConstruction(Firestore.FirestoreClient grpcClient, FirestoreSettings effectiveSettings, ClientHelper clientHelper)
+        {
+            Settings = effectiveSettings;
+        }
+    }
+
+    // Partial class to set up resource-based routing.
     public partial class FirestoreClientImpl
     {
         /// <summary>

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/FakeFirestoreClient.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/FakeFirestoreClient.cs
@@ -13,13 +13,14 @@
 // limitations under the License.
 
 using Google.Cloud.Firestore.V1;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Google.Cloud.Firestore.Tests
 {
     internal class FakeFirestoreClient : FirestoreClient
     {
+        internal FakeFirestoreClient()
+        {
+            Settings = FirestoreSettings.GetDefault();
+        }
     }
 }

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/TransactionTestingClient.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/TransactionTestingClient.cs
@@ -59,6 +59,7 @@ namespace Google.Cloud.Firestore.Tests
         /// </summary>
         public TransactionTestingClient(int failures, Exception exception)
         {
+            Settings = FirestoreSettings.GetDefault();
             _failures = failures;
             _exception = exception;
         }

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/RetryHelper.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/RetryHelper.cs
@@ -1,0 +1,67 @@
+﻿// Copyright 2019, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using Google.Api.Gax.Grpc;
+using Grpc.Core;
+using System;
+using System.Threading.Tasks;
+
+namespace Google.Cloud.Firestore
+{
+    /// <summary>
+    /// Provides retry functionality similar to that provided by GAX.
+    /// (This code is almost entirely copied from GAX. The GAX code doesn't quite work
+    /// for our use case.)
+    /// </summary>
+    internal static class RetryHelper
+    {
+        internal static async Task<TResponse> Retry<TRequest, TResponse>(
+            Func<TRequest, CallSettings, Task<TResponse>> fn,
+            TRequest request, CallSettings callSettings, IClock clock, IScheduler scheduler)
+        {
+            RetrySettings retrySettings = callSettings.Timing?.Retry;
+            if (retrySettings == null)
+            {
+                return await fn(request, callSettings).ConfigureAwait(false);
+            }
+            DateTime? overallDeadline = retrySettings.TotalExpiration.CalculateDeadline(clock);
+            TimeSpan retryDelay = retrySettings.RetryBackoff.Delay;
+            TimeSpan callTimeout = retrySettings.TimeoutBackoff.Delay;
+            while (true)
+            {
+                DateTime attemptDeadline = clock.GetCurrentDateTimeUtc() + callTimeout;
+                // Note: this handles a null total deadline due to "<" returning false if overallDeadline is null.
+                DateTime combinedDeadline = overallDeadline < attemptDeadline ? overallDeadline.Value : attemptDeadline;
+                CallSettings attemptCallSettings = callSettings.WithCallTiming(CallTiming.FromDeadline(combinedDeadline));
+                try
+                {
+                    return await fn(request, attemptCallSettings).ConfigureAwait(false);
+                }
+                catch (RpcException e) when (retrySettings.RetryFilter(e))
+                {
+                    TimeSpan actualDelay = retrySettings.DelayJitter.GetDelay(retryDelay);
+                    DateTime expectedRetryTime = clock.GetCurrentDateTimeUtc() + actualDelay;
+                    if (expectedRetryTime > overallDeadline)
+                    {
+                        throw;
+                    }
+                    await scheduler.Delay(actualDelay, callSettings.CancellationToken.GetValueOrDefault()).ConfigureAwait(false);
+                    retryDelay = retrySettings.RetryBackoff.NextDelay(retryDelay);
+                    callTimeout = retrySettings.TimeoutBackoff.NextDelay(callTimeout);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This effectively treats the streaming API as if it were a unary API. We may be able to remove some of the redundancy between this and GAX in the future.
We *only* apply this to GetDocumentSnapshotsAsync - when streaming query results, we can't retry transparently as the caller can see some results before the failure.

The use of FirestoreClient.Settings doesn't play nicely with mocking. It would be nice to be able to say "You can call Settings as often as you like, but make sure no other unexpected calls are made" but I haven't been able to achieve that. It's not a big problem though.

Fixes #2760