### PR TITLE
Fix docs around logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,7 @@ The following libraries are available at a [beta](#versioning) quality level:
 * [Google Cloud Firestore](https://cloud.google.com/firestore/): two packages are available, both beta:
   * [Google.Cloud.Firestore](http://googleapis.github.io/google-cloud-dotnet/docs/Google.Cloud.Firestore/): High-level client library for Google Cloud Firestore (recommended)
   * [Google.Cloud.Firestore.V1](http://googleapis.github.io/google-cloud-dotnet/docs/Google.Cloud.Firestore.V1/): Low-level access to Firestore API
-* [Google Stackdriver Logging](https://cloud.google.com/logging/)
-  * Integration with NLog is provided via [Google.Cloud.Logging.NLog](http://googleapis.github.io/google-cloud-dotnet/docs/Google.Cloud.Logging.NLog/) (beta)
+* [Google.Cloud.Logging.NLog](http://googleapis.github.io/google-cloud-dotnet/docs/Google.Cloud.Logging.NLog/) - Google Stackdriver Logging integration with NLog (beta)
 * [Google OS Login](https://cloud.google.com/compute/docs/instances/managing-instance-access) - [API docs](http://googleapis.github.io/google-cloud-dotnet/docs/Google.Cloud.OsLogin.V1/) (beta)
 * [Google Cloud Memorystore for Redis](https://cloud.google.com/memorystore/) - [API docs](http://googleapis.github.io/google-cloud-dotnet/docs/Google.Cloud.Redis.V1/) (beta)
   * The [V1Beta1 API package](http://googleapis.github.io/google-cloud-dotnet/docs/Google.Cloud.Redis.V1Beta1/) is also available (beta)

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -58,8 +58,7 @@ Beta:
 - Google Cloud Firestore:
   - [Google.Cloud.Firestore](Google.Cloud.Firestore/index.html): High-level client library for Google Cloud Firestore (recommended)
   - [Google.Cloud.Firestore.V1](Google.Cloud.Firestore.V1/index.html): Low-level access to Firestore API
-- [Google.Cloud.Logging.V2](Google.Cloud.Logging.V2/index.html)
-  - Additionally, a [separate NLog integration package is available](Google.Cloud.Logging.NLog/index.html)
+- [Google.Cloud.Logging.NLog](Google.Cloud.Logging.NLog/index.html) - Stackdriver Logging integration with NLog
 - [Google.Cloud.OsLogin.V1](Google.Cloud.OsLogin.V1/index.html)
 - [Google.Cloud.Redis.V1](Google.Cloud.Redis.V1/index.html)
 - [Google.Cloud.Redis.V1Beta1](Google.Cloud.Redis.V1Beta1/index.html)


### PR DESCRIPTION
Currently it gives the impression that Logging is only available in beta. That's only the NLog integration.