### PR TITLE
A simple tool to show the release status of our packages

### DIFF
--- a/tools/Google.Cloud.Tools.Common/ApiMetadata.cs
+++ b/tools/Google.Cloud.Tools.Common/ApiMetadata.cs
@@ -15,12 +15,15 @@
 using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace Google.Cloud.Tools.Common
 {
     public class ApiMetadata
     {
+        private static readonly Regex PrereleaseApiPattern = new Regex(@"^V[1-9]\d*[^\d]+.*$");
+
         private static readonly Regex ReleaseVersion = new Regex(@"^[1-9]\d*\.\d+\.\d+$");
 
         public string Version { get; set; }
@@ -47,6 +50,21 @@ namespace Google.Cloud.Tools.Common
         public List<string> MetaApis { get; set; } // TODO: enum?
 
         public bool IsReleaseVersion => ReleaseVersion.IsMatch(Version);
+
+        // TODO: Optimize to do this lazily if it's ever an issue
+        public bool CanHaveGaRelease
+        {
+            get
+            {
+                string[] parts = Id.Split('.');
+                // Three possibilities:
+                // - GA API, e.g. Google.Cloud.Spanner.V1
+                // - Prerelease API, e.g. Google.Cloud.Spanner.V1Beta1 or Google.Cloud.Spanner.V1P1Beta1
+                // - Non-API, e.g. Google.Cloud.Spanner.Data
+                // We can create GA packages for the first and the last.
+                return !PrereleaseApiPattern.IsMatch(parts.Last());
+            }
+        }
 
         public static List<ApiMetadata> LoadApis()
         {

--- a/tools/Google.Cloud.Tools.ShowReleaseStatus/Google.Cloud.Tools.ShowReleaseStatus.csproj
+++ b/tools/Google.Cloud.Tools.ShowReleaseStatus/Google.Cloud.Tools.ShowReleaseStatus.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="LibGit2Sharp" Version="0.25.0" />
+    <ProjectReference Include="..\Google.Cloud.Tools.Common\Google.Cloud.Tools.Common.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tools/Google.Cloud.Tools.ShowReleaseStatus/PackageRelease.cs
+++ b/tools/Google.Cloud.Tools.ShowReleaseStatus/PackageRelease.cs
@@ -1,0 +1,39 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Google.Cloud.Tools.ShowReleaseStatus
+{
+    public sealed class PackageRelease
+    {
+        public string Id { get; }
+        public string Version { get; }
+        public DateTimeOffset Timestamp { get; }
+        public bool IsGa => !Version.Contains("-") && !Version.StartsWith("0");
+
+        public PackageRelease(string id, string version, DateTimeOffset timestamp)
+        {
+            Id = id;
+            Version = version;
+            Timestamp = timestamp;
+        }
+
+        public override string ToString()
+        {
+            int ageInDays = (int)(DateTime.UtcNow - Timestamp).TotalDays;
+            return $"{Version} on {Timestamp:yyyy-MM-dd} ({ageInDays} days ago)";
+        }
+    }
+}

--- a/tools/Google.Cloud.Tools.ShowReleaseStatus/Program.cs
+++ b/tools/Google.Cloud.Tools.ShowReleaseStatus/Program.cs
@@ -1,0 +1,110 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Tools.Common;
+using LibGit2Sharp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Google.Cloud.Tools.ShowReleaseStatus
+{
+    /// <summary>
+    /// Tool to show the release status of each package in the API catalog.
+    /// Note that this is based on git tags for efficiency: please make sure you have the latest tags before running.
+    /// </summary>
+    class Program
+    {
+        private static readonly TimeSpan AttentionAge = TimeSpan.FromDays(28);
+
+        static void Main(string[] args)
+        {
+            bool attentionOnly = args.Contains("--attention");
+
+            var root = DirectoryLayout.DetermineRootDirectory();
+            var apis = ApiMetadata.LoadApis();
+
+            using (var repo = new Repository(root))
+            {
+                var diff = repo.Diff;
+                var tags = repo.Tags;
+                var shaToTimestamp = repo.Commits.ToDictionary(commit => commit.Sha, commit => commit.Committer.When);
+
+                foreach (var api in apis)
+                {
+                    DisplayApi(attentionOnly, api, tags, shaToTimestamp);
+                }
+            }
+        }
+
+        private static void DisplayApi(bool attentionOnly, ApiMetadata api, TagCollection tags, Dictionary<string, DateTimeOffset> shaToTimestamp)
+        {
+            string tagPrefix = $"{api.Id}-";
+            var releases = tags
+                .Where(tag => tag.FriendlyName.StartsWith(tagPrefix))
+                .Where(tag => shaToTimestamp.ContainsKey(tag.Target.Sha))
+                .Select(tag => new PackageRelease(api.Id, tag.FriendlyName.Substring(tagPrefix.Length), shaToTimestamp[tag.Target.Sha]))
+                .OrderByDescending(release => release.Timestamp)
+                .ToList();
+            var lastGa = releases.FirstOrDefault(release => release.IsGa);
+            var lastPrerelease = releases.FirstOrDefault(release => !release.IsGa);
+
+            if (attentionOnly && !NeedsAttention(api, lastPrerelease, lastGa))
+            {
+                return;
+            }
+
+            Console.WriteLine(api.Id);
+            if (lastGa is null && lastPrerelease is null)
+            {
+                Console.WriteLine("No releases");
+            }
+            else
+            {
+                // Only display a prerelease if it's more recent than the last GA
+                if (lastPrerelease != null && (lastGa is null || lastPrerelease.Timestamp > lastGa.Timestamp))
+                {
+                    Console.WriteLine($"Last prerelease: {lastPrerelease}");
+                }
+                if (lastGa != null)
+                {
+                    Console.WriteLine($"Last GA: {lastGa}");
+                }
+            }
+            Console.WriteLine();
+        }
+
+        /// <summary>
+        /// A release needs attention if it's a package that *can* go GA (so not an API beta),
+        /// and its last prerelease was after its last GA (or there is no GA)
+        /// but that prerelease is at least 28 days old... and the API itself is GA.
+        /// </summary>
+        private static bool NeedsAttention(ApiMetadata api, PackageRelease prerelease, PackageRelease ga)
+        {
+            if (!api.CanHaveGaRelease)
+            {
+                return false;
+            }
+            if (prerelease == null)
+            {
+                return false;
+            }
+            if (ga != null && prerelease.Timestamp < ga.Timestamp)
+            {
+                return false;
+            }
+            return prerelease.Timestamp + AttentionAge < DateTimeOffset.UtcNow;
+        }
+    }
+}

--- a/tools/Google.Cloud.Tools.sln
+++ b/tools/Google.Cloud.Tools.sln
@@ -38,6 +38,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Tools.ProcessB
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Tools.GeneratePublicApi", "Google.Cloud.Tools.GeneratePublicApi\Google.Cloud.Tools.GeneratePublicApi.csproj", "{6C268EFF-E10A-458E-8CDB-060F5381238A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Tools.ShowReleaseStatus", "Google.Cloud.Tools.ShowReleaseStatus\Google.Cloud.Tools.ShowReleaseStatus.csproj", "{1EAFDF69-BBF8-450F-8B73-BAED481378F3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -264,6 +266,18 @@ Global
 		{6C268EFF-E10A-458E-8CDB-060F5381238A}.Release|x64.Build.0 = Release|Any CPU
 		{6C268EFF-E10A-458E-8CDB-060F5381238A}.Release|x86.ActiveCfg = Release|Any CPU
 		{6C268EFF-E10A-458E-8CDB-060F5381238A}.Release|x86.Build.0 = Release|Any CPU
+		{1EAFDF69-BBF8-450F-8B73-BAED481378F3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1EAFDF69-BBF8-450F-8B73-BAED481378F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1EAFDF69-BBF8-450F-8B73-BAED481378F3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1EAFDF69-BBF8-450F-8B73-BAED481378F3}.Debug|x64.Build.0 = Debug|Any CPU
+		{1EAFDF69-BBF8-450F-8B73-BAED481378F3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1EAFDF69-BBF8-450F-8B73-BAED481378F3}.Debug|x86.Build.0 = Debug|Any CPU
+		{1EAFDF69-BBF8-450F-8B73-BAED481378F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1EAFDF69-BBF8-450F-8B73-BAED481378F3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1EAFDF69-BBF8-450F-8B73-BAED481378F3}.Release|x64.ActiveCfg = Release|Any CPU
+		{1EAFDF69-BBF8-450F-8B73-BAED481378F3}.Release|x64.Build.0 = Release|Any CPU
+		{1EAFDF69-BBF8-450F-8B73-BAED481378F3}.Release|x86.ActiveCfg = Release|Any CPU
+		{1EAFDF69-BBF8-450F-8B73-BAED481378F3}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This helps to highlight packages that we should consider moving to GA.

We can make it more subtle later on, of course.