### PR TITLE
Regenerate Spanner API

### DIFF
--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/SpannerInstanceAdminGrpc.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/SpannerInstanceAdminGrpc.cs
@@ -3,7 +3,7 @@
 //     source: google/spanner/admin/instance/v1/spanner_instance_admin.proto
 // </auto-generated>
 // Original file comments:
-// Copyright 2018 Google LLC.
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 //
 #pragma warning disable 1591
 #region Designer generated code

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.Snippets/SpannerClientSnippets.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.Snippets/SpannerClientSnippets.g.cs
@@ -431,41 +431,6 @@ namespace Google.Cloud.Spanner.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ExecuteBatchDmlAsync</summary>
-        public async Task ExecuteBatchDmlAsync_RequestObject()
-        {
-            // Snippet: ExecuteBatchDmlAsync(ExecuteBatchDmlRequest,CallSettings)
-            // Additional: ExecuteBatchDmlAsync(ExecuteBatchDmlRequest,CancellationToken)
-            // Create client
-            SpannerClient spannerClient = await SpannerClient.CreateAsync();
-            // Initialize request argument(s)
-            ExecuteBatchDmlRequest request = new ExecuteBatchDmlRequest
-            {
-                SessionAsSessionName = new SessionName("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]"),
-                Statements = { },
-            };
-            // Make the request
-            ExecuteBatchDmlResponse response = await spannerClient.ExecuteBatchDmlAsync(request);
-            // End snippet
-        }
-
-        /// <summary>Snippet for ExecuteBatchDml</summary>
-        public void ExecuteBatchDml_RequestObject()
-        {
-            // Snippet: ExecuteBatchDml(ExecuteBatchDmlRequest,CallSettings)
-            // Create client
-            SpannerClient spannerClient = SpannerClient.Create();
-            // Initialize request argument(s)
-            ExecuteBatchDmlRequest request = new ExecuteBatchDmlRequest
-            {
-                SessionAsSessionName = new SessionName("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]"),
-                Statements = { },
-            };
-            // Make the request
-            ExecuteBatchDmlResponse response = spannerClient.ExecuteBatchDml(request);
-            // End snippet
-        }
-
         /// <summary>Snippet for ExecuteStreamingSql</summary>
         public async Task ExecuteStreamingSql()
         {
@@ -489,6 +454,45 @@ namespace Google.Cloud.Spanner.V1.Snippets
                 // Do something with streamed response
             }
             // The response stream has completed
+            // End snippet
+        }
+
+        /// <summary>Snippet for ExecuteBatchDmlAsync</summary>
+        public async Task ExecuteBatchDmlAsync_RequestObject()
+        {
+            // Snippet: ExecuteBatchDmlAsync(ExecuteBatchDmlRequest,CallSettings)
+            // Additional: ExecuteBatchDmlAsync(ExecuteBatchDmlRequest,CancellationToken)
+            // Create client
+            SpannerClient spannerClient = await SpannerClient.CreateAsync();
+            // Initialize request argument(s)
+            ExecuteBatchDmlRequest request = new ExecuteBatchDmlRequest
+            {
+                SessionAsSessionName = new SessionName("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]"),
+                Transaction = new TransactionSelector(),
+                Statements = { },
+                Seqno = 0L,
+            };
+            // Make the request
+            ExecuteBatchDmlResponse response = await spannerClient.ExecuteBatchDmlAsync(request);
+            // End snippet
+        }
+
+        /// <summary>Snippet for ExecuteBatchDml</summary>
+        public void ExecuteBatchDml_RequestObject()
+        {
+            // Snippet: ExecuteBatchDml(ExecuteBatchDmlRequest,CallSettings)
+            // Create client
+            SpannerClient spannerClient = SpannerClient.Create();
+            // Initialize request argument(s)
+            ExecuteBatchDmlRequest request = new ExecuteBatchDmlRequest
+            {
+                SessionAsSessionName = new SessionName("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]"),
+                Transaction = new TransactionSelector(),
+                Statements = { },
+                Seqno = 0L,
+            };
+            // Make the request
+            ExecuteBatchDmlResponse response = spannerClient.ExecuteBatchDml(request);
             // End snippet
         }
 

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.Tests/SpannerClientTest.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.Tests/SpannerClientTest.g.cs
@@ -308,7 +308,9 @@ namespace Google.Cloud.Spanner.V1.Tests
             ExecuteBatchDmlRequest request = new ExecuteBatchDmlRequest
             {
                 SessionAsSessionName = new SessionName("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]"),
+                Transaction = new TransactionSelector(),
                 Statements = { },
+                Seqno = 109325920L,
             };
             ExecuteBatchDmlResponse expectedResponse = new ExecuteBatchDmlResponse();
             mockGrpcClient.Setup(x => x.ExecuteBatchDml(request, It.IsAny<CallOptions>()))
@@ -326,7 +328,9 @@ namespace Google.Cloud.Spanner.V1.Tests
             ExecuteBatchDmlRequest request = new ExecuteBatchDmlRequest
             {
                 SessionAsSessionName = new SessionName("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]"),
+                Transaction = new TransactionSelector(),
                 Statements = { },
+                Seqno = 109325920L,
             };
             ExecuteBatchDmlResponse expectedResponse = new ExecuteBatchDmlResponse();
             mockGrpcClient.Setup(x => x.ExecuteBatchDmlAsync(request, It.IsAny<CallOptions>()))

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SpannerClient.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SpannerClient.cs
@@ -55,8 +55,8 @@ namespace Google.Cloud.Spanner.V1
             ListSessionsSettings = existing.ListSessionsSettings;
             DeleteSessionSettings = existing.DeleteSessionSettings;
             ExecuteSqlSettings = existing.ExecuteSqlSettings;
-            ExecuteBatchDmlSettings = existing.ExecuteBatchDmlSettings;
             ExecuteStreamingSqlSettings = existing.ExecuteStreamingSqlSettings;
+            ExecuteBatchDmlSettings = existing.ExecuteBatchDmlSettings;
             ReadSettings = existing.ReadSettings;
             StreamingReadSettings = existing.StreamingReadSettings;
             BeginTransactionSettings = existing.BeginTransactionSettings;
@@ -377,6 +377,15 @@ namespace Google.Cloud.Spanner.V1
             )));
 
         /// <summary>
+        /// <see cref="gaxgrpc::CallSettings"/> for calls to <c>SpannerClient.ExecuteStreamingSql</c>.
+        /// </summary>
+        /// <remarks>
+        /// Default RPC expiration is 1200000 milliseconds.
+        /// </remarks>
+        public gaxgrpc::CallSettings ExecuteStreamingSqlSettings { get; set; } = gaxgrpc::CallSettings.FromCallTiming(
+            gaxgrpc::CallTiming.FromTimeout(sys::TimeSpan.FromMilliseconds(1200000)));
+
+        /// <summary>
         /// <see cref="gaxgrpc::CallSettings"/> for synchronous and asynchronous calls to
         /// <c>SpannerClient.ExecuteBatchDml</c> and <c>SpannerClient.ExecuteBatchDmlAsync</c>.
         /// </summary>
@@ -405,15 +414,6 @@ namespace Google.Cloud.Spanner.V1
                 totalExpiration: gax::Expiration.FromTimeout(sys::TimeSpan.FromMilliseconds(600000)),
                 retryFilter: IdempotentRetryFilter
             )));
-
-        /// <summary>
-        /// <see cref="gaxgrpc::CallSettings"/> for calls to <c>SpannerClient.ExecuteStreamingSql</c>.
-        /// </summary>
-        /// <remarks>
-        /// Default RPC expiration is 1200000 milliseconds.
-        /// </remarks>
-        public gaxgrpc::CallSettings ExecuteStreamingSqlSettings { get; set; } = gaxgrpc::CallSettings.FromCallTiming(
-            gaxgrpc::CallTiming.FromTimeout(sys::TimeSpan.FromMilliseconds(1200000)));
 
         /// <summary>
         /// <see cref="gaxgrpc::CallSettings"/> for synchronous and asynchronous calls to
@@ -627,13 +627,11 @@ namespace Google.Cloud.Spanner.V1
         /// The default Spanner scopes are:
         /// <list type="bullet">
         /// <item><description>"https://www.googleapis.com/auth/cloud-platform"</description></item>
-        /// <item><description>"https://www.googleapis.com/auth/spanner.admin"</description></item>
         /// <item><description>"https://www.googleapis.com/auth/spanner.data"</description></item>
         /// </list>
         /// </remarks>
         public static scg::IReadOnlyList<string> DefaultScopes { get; } = new sco::ReadOnlyCollection<string>(new string[] {
             "https://www.googleapis.com/auth/cloud-platform",
-            "https://www.googleapis.com/auth/spanner.admin",
             "https://www.googleapis.com/auth/spanner.data",
         });
 
@@ -1225,7 +1223,9 @@ namespace Google.Cloud.Spanner.V1
         }
 
         /// <summary>
-        /// Ends a session, releasing server resources associated with it.
+        /// Ends a session, releasing server resources associated with it. This will
+        /// asynchronously trigger cancellation of any operations that are running with
+        /// this session.
         /// </summary>
         /// <param name="name">
         /// Required. The name of the session to delete.
@@ -1246,7 +1246,9 @@ namespace Google.Cloud.Spanner.V1
                 callSettings);
 
         /// <summary>
-        /// Ends a session, releasing server resources associated with it.
+        /// Ends a session, releasing server resources associated with it. This will
+        /// asynchronously trigger cancellation of any operations that are running with
+        /// this session.
         /// </summary>
         /// <param name="name">
         /// Required. The name of the session to delete.
@@ -1264,7 +1266,9 @@ namespace Google.Cloud.Spanner.V1
                 gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        /// Ends a session, releasing server resources associated with it.
+        /// Ends a session, releasing server resources associated with it. This will
+        /// asynchronously trigger cancellation of any operations that are running with
+        /// this session.
         /// </summary>
         /// <param name="name">
         /// Required. The name of the session to delete.
@@ -1282,7 +1286,9 @@ namespace Google.Cloud.Spanner.V1
                 callSettings);
 
         /// <summary>
-        /// Ends a session, releasing server resources associated with it.
+        /// Ends a session, releasing server resources associated with it. This will
+        /// asynchronously trigger cancellation of any operations that are running with
+        /// this session.
         /// </summary>
         /// <param name="request">
         /// The request object containing all of the parameters for the API call.
@@ -1301,7 +1307,9 @@ namespace Google.Cloud.Spanner.V1
         }
 
         /// <summary>
-        /// Ends a session, releasing server resources associated with it.
+        /// Ends a session, releasing server resources associated with it. This will
+        /// asynchronously trigger cancellation of any operations that are running with
+        /// this session.
         /// </summary>
         /// <param name="request">
         /// The request object containing all of the parameters for the API call.
@@ -1319,7 +1327,9 @@ namespace Google.Cloud.Spanner.V1
                 gaxgrpc::CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
-        /// Ends a session, releasing server resources associated with it.
+        /// Ends a session, releasing server resources associated with it. This will
+        /// asynchronously trigger cancellation of any operations that are running with
+        /// this session.
         /// </summary>
         /// <param name="request">
         /// The request object containing all of the parameters for the API call.
@@ -1342,10 +1352,12 @@ namespace Google.Cloud.Spanner.V1
         ///
         /// Operations inside read-write transactions might return `ABORTED`. If
         /// this occurs, the application should restart the transaction from
-        /// the beginning. See [Transaction][google.spanner.v1.Transaction] for more details.
+        /// the beginning. See [Transaction][google.spanner.v1.Transaction] for more
+        /// details.
         ///
         /// Larger result sets can be fetched in streaming fashion by calling
-        /// [ExecuteStreamingSql][google.spanner.v1.Spanner.ExecuteStreamingSql] instead.
+        /// [ExecuteStreamingSql][google.spanner.v1.Spanner.ExecuteStreamingSql]
+        /// instead.
         /// </summary>
         /// <param name="request">
         /// The request object containing all of the parameters for the API call.
@@ -1371,10 +1383,12 @@ namespace Google.Cloud.Spanner.V1
         ///
         /// Operations inside read-write transactions might return `ABORTED`. If
         /// this occurs, the application should restart the transaction from
-        /// the beginning. See [Transaction][google.spanner.v1.Transaction] for more details.
+        /// the beginning. See [Transaction][google.spanner.v1.Transaction] for more
+        /// details.
         ///
         /// Larger result sets can be fetched in streaming fashion by calling
-        /// [ExecuteStreamingSql][google.spanner.v1.Spanner.ExecuteStreamingSql] instead.
+        /// [ExecuteStreamingSql][google.spanner.v1.Spanner.ExecuteStreamingSql]
+        /// instead.
         /// </summary>
         /// <param name="request">
         /// The request object containing all of the parameters for the API call.
@@ -1399,10 +1413,12 @@ namespace Google.Cloud.Spanner.V1
         ///
         /// Operations inside read-write transactions might return `ABORTED`. If
         /// this occurs, the application should restart the transaction from
-        /// the beginning. See [Transaction][google.spanner.v1.Transaction] for more details.
+        /// the beginning. See [Transaction][google.spanner.v1.Transaction] for more
+        /// details.
         ///
         /// Larger result sets can be fetched in streaming fashion by calling
-        /// [ExecuteStreamingSql][google.spanner.v1.Spanner.ExecuteStreamingSql] instead.
+        /// [ExecuteStreamingSql][google.spanner.v1.Spanner.ExecuteStreamingSql]
+        /// instead.
         /// </summary>
         /// <param name="request">
         /// The request object containing all of the parameters for the API call.
@@ -1418,6 +1434,36 @@ namespace Google.Cloud.Spanner.V1
             gaxgrpc::CallSettings callSettings = null)
         {
             throw new sys::NotImplementedException();
+        }
+
+        /// <summary>
+        /// Like [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql], except returns the
+        /// result set as a stream. Unlike
+        /// [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql], there is no limit on
+        /// the size of the returned result set. However, no individual row in the
+        /// result set can exceed 100 MiB, and no column value can exceed 10 MiB.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The server stream.
+        /// </returns>
+        public virtual ExecuteStreamingSqlStream ExecuteStreamingSql(
+            ExecuteSqlRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            throw new sys::NotImplementedException();
+        }
+
+        /// <summary>
+        /// Server streaming methods for <c>ExecuteStreamingSql</c>.
+        /// </summary>
+        public abstract partial class ExecuteStreamingSqlStream : gaxgrpc::ServerStreamingBase<PartialResultSet>
+        {
         }
 
         /// <summary>
@@ -1531,46 +1577,17 @@ namespace Google.Cloud.Spanner.V1
         }
 
         /// <summary>
-        /// Like [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql], except returns the result
-        /// set as a stream. Unlike [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql], there
-        /// is no limit on the size of the returned result set. However, no
-        /// individual row in the result set can exceed 100 MiB, and no
-        /// column value can exceed 10 MiB.
-        /// </summary>
-        /// <param name="request">
-        /// The request object containing all of the parameters for the API call.
-        /// </param>
-        /// <param name="callSettings">
-        /// If not null, applies overrides to this RPC call.
-        /// </param>
-        /// <returns>
-        /// The server stream.
-        /// </returns>
-        public virtual ExecuteStreamingSqlStream ExecuteStreamingSql(
-            ExecuteSqlRequest request,
-            gaxgrpc::CallSettings callSettings = null)
-        {
-            throw new sys::NotImplementedException();
-        }
-
-        /// <summary>
-        /// Server streaming methods for <c>ExecuteStreamingSql</c>.
-        /// </summary>
-        public abstract partial class ExecuteStreamingSqlStream : gaxgrpc::ServerStreamingBase<PartialResultSet>
-        {
-        }
-
-        /// <summary>
         /// Reads rows from the database using key lookups and scans, as a
         /// simple key/value style alternative to
-        /// [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql].  This method cannot be used to
-        /// return a result set larger than 10 MiB; if the read matches more
+        /// [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql].  This method cannot be
+        /// used to return a result set larger than 10 MiB; if the read matches more
         /// data than that, the read fails with a `FAILED_PRECONDITION`
         /// error.
         ///
         /// Reads inside read-write transactions might return `ABORTED`. If
         /// this occurs, the application should restart the transaction from
-        /// the beginning. See [Transaction][google.spanner.v1.Transaction] for more details.
+        /// the beginning. See [Transaction][google.spanner.v1.Transaction] for more
+        /// details.
         ///
         /// Larger result sets can be yielded in streaming fashion by calling
         /// [StreamingRead][google.spanner.v1.Spanner.StreamingRead] instead.
@@ -1594,14 +1611,15 @@ namespace Google.Cloud.Spanner.V1
         /// <summary>
         /// Reads rows from the database using key lookups and scans, as a
         /// simple key/value style alternative to
-        /// [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql].  This method cannot be used to
-        /// return a result set larger than 10 MiB; if the read matches more
+        /// [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql].  This method cannot be
+        /// used to return a result set larger than 10 MiB; if the read matches more
         /// data than that, the read fails with a `FAILED_PRECONDITION`
         /// error.
         ///
         /// Reads inside read-write transactions might return `ABORTED`. If
         /// this occurs, the application should restart the transaction from
-        /// the beginning. See [Transaction][google.spanner.v1.Transaction] for more details.
+        /// the beginning. See [Transaction][google.spanner.v1.Transaction] for more
+        /// details.
         ///
         /// Larger result sets can be yielded in streaming fashion by calling
         /// [StreamingRead][google.spanner.v1.Spanner.StreamingRead] instead.
@@ -1624,14 +1642,15 @@ namespace Google.Cloud.Spanner.V1
         /// <summary>
         /// Reads rows from the database using key lookups and scans, as a
         /// simple key/value style alternative to
-        /// [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql].  This method cannot be used to
-        /// return a result set larger than 10 MiB; if the read matches more
+        /// [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql].  This method cannot be
+        /// used to return a result set larger than 10 MiB; if the read matches more
         /// data than that, the read fails with a `FAILED_PRECONDITION`
         /// error.
         ///
         /// Reads inside read-write transactions might return `ABORTED`. If
         /// this occurs, the application should restart the transaction from
-        /// the beginning. See [Transaction][google.spanner.v1.Transaction] for more details.
+        /// the beginning. See [Transaction][google.spanner.v1.Transaction] for more
+        /// details.
         ///
         /// Larger result sets can be yielded in streaming fashion by calling
         /// [StreamingRead][google.spanner.v1.Spanner.StreamingRead] instead.
@@ -1653,9 +1672,9 @@ namespace Google.Cloud.Spanner.V1
         }
 
         /// <summary>
-        /// Like [Read][google.spanner.v1.Spanner.Read], except returns the result set as a
-        /// stream. Unlike [Read][google.spanner.v1.Spanner.Read], there is no limit on the
-        /// size of the returned result set. However, no individual row in
+        /// Like [Read][google.spanner.v1.Spanner.Read], except returns the result set
+        /// as a stream. Unlike [Read][google.spanner.v1.Spanner.Read], there is no
+        /// limit on the size of the returned result set. However, no individual row in
         /// the result set can exceed 100 MiB, and no column value can exceed
         /// 10 MiB.
         /// </summary>
@@ -1684,7 +1703,8 @@ namespace Google.Cloud.Spanner.V1
 
         /// <summary>
         /// Begins a new transaction. This step can often be skipped:
-        /// [Read][google.spanner.v1.Spanner.Read], [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql] and
+        /// [Read][google.spanner.v1.Spanner.Read],
+        /// [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql] and
         /// [Commit][google.spanner.v1.Spanner.Commit] can begin a new transaction as a
         /// side-effect.
         /// </summary>
@@ -1713,7 +1733,8 @@ namespace Google.Cloud.Spanner.V1
 
         /// <summary>
         /// Begins a new transaction. This step can often be skipped:
-        /// [Read][google.spanner.v1.Spanner.Read], [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql] and
+        /// [Read][google.spanner.v1.Spanner.Read],
+        /// [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql] and
         /// [Commit][google.spanner.v1.Spanner.Commit] can begin a new transaction as a
         /// side-effect.
         /// </summary>
@@ -1739,7 +1760,8 @@ namespace Google.Cloud.Spanner.V1
 
         /// <summary>
         /// Begins a new transaction. This step can often be skipped:
-        /// [Read][google.spanner.v1.Spanner.Read], [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql] and
+        /// [Read][google.spanner.v1.Spanner.Read],
+        /// [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql] and
         /// [Commit][google.spanner.v1.Spanner.Commit] can begin a new transaction as a
         /// side-effect.
         /// </summary>
@@ -1768,7 +1790,8 @@ namespace Google.Cloud.Spanner.V1
 
         /// <summary>
         /// Begins a new transaction. This step can often be skipped:
-        /// [Read][google.spanner.v1.Spanner.Read], [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql] and
+        /// [Read][google.spanner.v1.Spanner.Read],
+        /// [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql] and
         /// [Commit][google.spanner.v1.Spanner.Commit] can begin a new transaction as a
         /// side-effect.
         /// </summary>
@@ -1790,7 +1813,8 @@ namespace Google.Cloud.Spanner.V1
 
         /// <summary>
         /// Begins a new transaction. This step can often be skipped:
-        /// [Read][google.spanner.v1.Spanner.Read], [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql] and
+        /// [Read][google.spanner.v1.Spanner.Read],
+        /// [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql] and
         /// [Commit][google.spanner.v1.Spanner.Commit] can begin a new transaction as a
         /// side-effect.
         /// </summary>
@@ -1811,7 +1835,8 @@ namespace Google.Cloud.Spanner.V1
 
         /// <summary>
         /// Begins a new transaction. This step can often be skipped:
-        /// [Read][google.spanner.v1.Spanner.Read], [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql] and
+        /// [Read][google.spanner.v1.Spanner.Read],
+        /// [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql] and
         /// [Commit][google.spanner.v1.Spanner.Commit] can begin a new transaction as a
         /// side-effect.
         /// </summary>
@@ -2169,8 +2194,9 @@ namespace Google.Cloud.Spanner.V1
         /// <summary>
         /// Rolls back a transaction, releasing any locks it holds. It is a good
         /// idea to call this for any transaction that includes one or more
-        /// [Read][google.spanner.v1.Spanner.Read] or [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql] requests and
-        /// ultimately decides not to commit.
+        /// [Read][google.spanner.v1.Spanner.Read] or
+        /// [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql] requests and ultimately
+        /// decides not to commit.
         ///
         /// `Rollback` returns `OK` if it successfully aborts the transaction, the
         /// transaction was already aborted, or the transaction is not
@@ -2202,8 +2228,9 @@ namespace Google.Cloud.Spanner.V1
         /// <summary>
         /// Rolls back a transaction, releasing any locks it holds. It is a good
         /// idea to call this for any transaction that includes one or more
-        /// [Read][google.spanner.v1.Spanner.Read] or [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql] requests and
-        /// ultimately decides not to commit.
+        /// [Read][google.spanner.v1.Spanner.Read] or
+        /// [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql] requests and ultimately
+        /// decides not to commit.
         ///
         /// `Rollback` returns `OK` if it successfully aborts the transaction, the
         /// transaction was already aborted, or the transaction is not
@@ -2232,8 +2259,9 @@ namespace Google.Cloud.Spanner.V1
         /// <summary>
         /// Rolls back a transaction, releasing any locks it holds. It is a good
         /// idea to call this for any transaction that includes one or more
-        /// [Read][google.spanner.v1.Spanner.Read] or [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql] requests and
-        /// ultimately decides not to commit.
+        /// [Read][google.spanner.v1.Spanner.Read] or
+        /// [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql] requests and ultimately
+        /// decides not to commit.
         ///
         /// `Rollback` returns `OK` if it successfully aborts the transaction, the
         /// transaction was already aborted, or the transaction is not
@@ -2262,8 +2290,9 @@ namespace Google.Cloud.Spanner.V1
         /// <summary>
         /// Rolls back a transaction, releasing any locks it holds. It is a good
         /// idea to call this for any transaction that includes one or more
-        /// [Read][google.spanner.v1.Spanner.Read] or [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql] requests and
-        /// ultimately decides not to commit.
+        /// [Read][google.spanner.v1.Spanner.Read] or
+        /// [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql] requests and ultimately
+        /// decides not to commit.
         ///
         /// `Rollback` returns `OK` if it successfully aborts the transaction, the
         /// transaction was already aborted, or the transaction is not
@@ -2288,8 +2317,9 @@ namespace Google.Cloud.Spanner.V1
         /// <summary>
         /// Rolls back a transaction, releasing any locks it holds. It is a good
         /// idea to call this for any transaction that includes one or more
-        /// [Read][google.spanner.v1.Spanner.Read] or [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql] requests and
-        /// ultimately decides not to commit.
+        /// [Read][google.spanner.v1.Spanner.Read] or
+        /// [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql] requests and ultimately
+        /// decides not to commit.
         ///
         /// `Rollback` returns `OK` if it successfully aborts the transaction, the
         /// transaction was already aborted, or the transaction is not
@@ -2313,8 +2343,9 @@ namespace Google.Cloud.Spanner.V1
         /// <summary>
         /// Rolls back a transaction, releasing any locks it holds. It is a good
         /// idea to call this for any transaction that includes one or more
-        /// [Read][google.spanner.v1.Spanner.Read] or [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql] requests and
-        /// ultimately decides not to commit.
+        /// [Read][google.spanner.v1.Spanner.Read] or
+        /// [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql] requests and ultimately
+        /// decides not to commit.
         ///
         /// `Rollback` returns `OK` if it successfully aborts the transaction, the
         /// transaction was already aborted, or the transaction is not
@@ -2336,10 +2367,11 @@ namespace Google.Cloud.Spanner.V1
         /// <summary>
         /// Creates a set of partition tokens that can be used to execute a query
         /// operation in parallel.  Each of the returned partition tokens can be used
-        /// by [ExecuteStreamingSql][google.spanner.v1.Spanner.ExecuteStreamingSql] to specify a subset
-        /// of the query result to read.  The same session and read-only transaction
-        /// must be used by the PartitionQueryRequest used to create the
-        /// partition tokens and the ExecuteSqlRequests that use the partition tokens.
+        /// by [ExecuteStreamingSql][google.spanner.v1.Spanner.ExecuteStreamingSql] to
+        /// specify a subset of the query result to read.  The same session and
+        /// read-only transaction must be used by the PartitionQueryRequest used to
+        /// create the partition tokens and the ExecuteSqlRequests that use the
+        /// partition tokens.
         ///
         /// Partition tokens become invalid when the session used to create them
         /// is deleted, is idle for too long, begins a new transaction, or becomes too
@@ -2365,10 +2397,11 @@ namespace Google.Cloud.Spanner.V1
         /// <summary>
         /// Creates a set of partition tokens that can be used to execute a query
         /// operation in parallel.  Each of the returned partition tokens can be used
-        /// by [ExecuteStreamingSql][google.spanner.v1.Spanner.ExecuteStreamingSql] to specify a subset
-        /// of the query result to read.  The same session and read-only transaction
-        /// must be used by the PartitionQueryRequest used to create the
-        /// partition tokens and the ExecuteSqlRequests that use the partition tokens.
+        /// by [ExecuteStreamingSql][google.spanner.v1.Spanner.ExecuteStreamingSql] to
+        /// specify a subset of the query result to read.  The same session and
+        /// read-only transaction must be used by the PartitionQueryRequest used to
+        /// create the partition tokens and the ExecuteSqlRequests that use the
+        /// partition tokens.
         ///
         /// Partition tokens become invalid when the session used to create them
         /// is deleted, is idle for too long, begins a new transaction, or becomes too
@@ -2393,10 +2426,11 @@ namespace Google.Cloud.Spanner.V1
         /// <summary>
         /// Creates a set of partition tokens that can be used to execute a query
         /// operation in parallel.  Each of the returned partition tokens can be used
-        /// by [ExecuteStreamingSql][google.spanner.v1.Spanner.ExecuteStreamingSql] to specify a subset
-        /// of the query result to read.  The same session and read-only transaction
-        /// must be used by the PartitionQueryRequest used to create the
-        /// partition tokens and the ExecuteSqlRequests that use the partition tokens.
+        /// by [ExecuteStreamingSql][google.spanner.v1.Spanner.ExecuteStreamingSql] to
+        /// specify a subset of the query result to read.  The same session and
+        /// read-only transaction must be used by the PartitionQueryRequest used to
+        /// create the partition tokens and the ExecuteSqlRequests that use the
+        /// partition tokens.
         ///
         /// Partition tokens become invalid when the session used to create them
         /// is deleted, is idle for too long, begins a new transaction, or becomes too
@@ -2422,12 +2456,13 @@ namespace Google.Cloud.Spanner.V1
         /// <summary>
         /// Creates a set of partition tokens that can be used to execute a read
         /// operation in parallel.  Each of the returned partition tokens can be used
-        /// by [StreamingRead][google.spanner.v1.Spanner.StreamingRead] to specify a subset of the read
-        /// result to read.  The same session and read-only transaction must be used by
-        /// the PartitionReadRequest used to create the partition tokens and the
-        /// ReadRequests that use the partition tokens.  There are no ordering
-        /// guarantees on rows returned among the returned partition tokens, or even
-        /// within each individual StreamingRead call issued with a partition_token.
+        /// by [StreamingRead][google.spanner.v1.Spanner.StreamingRead] to specify a
+        /// subset of the read result to read.  The same session and read-only
+        /// transaction must be used by the PartitionReadRequest used to create the
+        /// partition tokens and the ReadRequests that use the partition tokens.  There
+        /// are no ordering guarantees on rows returned among the returned partition
+        /// tokens, or even within each individual StreamingRead call issued with a
+        /// partition_token.
         ///
         /// Partition tokens become invalid when the session used to create them
         /// is deleted, is idle for too long, begins a new transaction, or becomes too
@@ -2453,12 +2488,13 @@ namespace Google.Cloud.Spanner.V1
         /// <summary>
         /// Creates a set of partition tokens that can be used to execute a read
         /// operation in parallel.  Each of the returned partition tokens can be used
-        /// by [StreamingRead][google.spanner.v1.Spanner.StreamingRead] to specify a subset of the read
-        /// result to read.  The same session and read-only transaction must be used by
-        /// the PartitionReadRequest used to create the partition tokens and the
-        /// ReadRequests that use the partition tokens.  There are no ordering
-        /// guarantees on rows returned among the returned partition tokens, or even
-        /// within each individual StreamingRead call issued with a partition_token.
+        /// by [StreamingRead][google.spanner.v1.Spanner.StreamingRead] to specify a
+        /// subset of the read result to read.  The same session and read-only
+        /// transaction must be used by the PartitionReadRequest used to create the
+        /// partition tokens and the ReadRequests that use the partition tokens.  There
+        /// are no ordering guarantees on rows returned among the returned partition
+        /// tokens, or even within each individual StreamingRead call issued with a
+        /// partition_token.
         ///
         /// Partition tokens become invalid when the session used to create them
         /// is deleted, is idle for too long, begins a new transaction, or becomes too
@@ -2483,12 +2519,13 @@ namespace Google.Cloud.Spanner.V1
         /// <summary>
         /// Creates a set of partition tokens that can be used to execute a read
         /// operation in parallel.  Each of the returned partition tokens can be used
-        /// by [StreamingRead][google.spanner.v1.Spanner.StreamingRead] to specify a subset of the read
-        /// result to read.  The same session and read-only transaction must be used by
-        /// the PartitionReadRequest used to create the partition tokens and the
-        /// ReadRequests that use the partition tokens.  There are no ordering
-        /// guarantees on rows returned among the returned partition tokens, or even
-        /// within each individual StreamingRead call issued with a partition_token.
+        /// by [StreamingRead][google.spanner.v1.Spanner.StreamingRead] to specify a
+        /// subset of the read result to read.  The same session and read-only
+        /// transaction must be used by the PartitionReadRequest used to create the
+        /// partition tokens and the ReadRequests that use the partition tokens.  There
+        /// are no ordering guarantees on rows returned among the returned partition
+        /// tokens, or even within each individual StreamingRead call issued with a
+        /// partition_token.
         ///
         /// Partition tokens become invalid when the session used to create them
         /// is deleted, is idle for too long, begins a new transaction, or becomes too
@@ -2523,8 +2560,8 @@ namespace Google.Cloud.Spanner.V1
         private readonly gaxgrpc::ApiCall<ListSessionsRequest, ListSessionsResponse> _callListSessions;
         private readonly gaxgrpc::ApiCall<DeleteSessionRequest, pbwkt::Empty> _callDeleteSession;
         private readonly gaxgrpc::ApiCall<ExecuteSqlRequest, ResultSet> _callExecuteSql;
-        private readonly gaxgrpc::ApiCall<ExecuteBatchDmlRequest, ExecuteBatchDmlResponse> _callExecuteBatchDml;
         private readonly gaxgrpc::ApiServerStreamingCall<ExecuteSqlRequest, PartialResultSet> _callExecuteStreamingSql;
+        private readonly gaxgrpc::ApiCall<ExecuteBatchDmlRequest, ExecuteBatchDmlResponse> _callExecuteBatchDml;
         private readonly gaxgrpc::ApiCall<ReadRequest, ResultSet> _callRead;
         private readonly gaxgrpc::ApiServerStreamingCall<ReadRequest, PartialResultSet> _callStreamingRead;
         private readonly gaxgrpc::ApiCall<BeginTransactionRequest, Transaction> _callBeginTransaction;
@@ -2553,10 +2590,10 @@ namespace Google.Cloud.Spanner.V1
                 GrpcClient.DeleteSessionAsync, GrpcClient.DeleteSession, effectiveSettings.DeleteSessionSettings);
             _callExecuteSql = clientHelper.BuildApiCall<ExecuteSqlRequest, ResultSet>(
                 GrpcClient.ExecuteSqlAsync, GrpcClient.ExecuteSql, effectiveSettings.ExecuteSqlSettings);
-            _callExecuteBatchDml = clientHelper.BuildApiCall<ExecuteBatchDmlRequest, ExecuteBatchDmlResponse>(
-                GrpcClient.ExecuteBatchDmlAsync, GrpcClient.ExecuteBatchDml, effectiveSettings.ExecuteBatchDmlSettings);
             _callExecuteStreamingSql = clientHelper.BuildApiCall<ExecuteSqlRequest, PartialResultSet>(
                 GrpcClient.ExecuteStreamingSql, effectiveSettings.ExecuteStreamingSqlSettings);
+            _callExecuteBatchDml = clientHelper.BuildApiCall<ExecuteBatchDmlRequest, ExecuteBatchDmlResponse>(
+                GrpcClient.ExecuteBatchDmlAsync, GrpcClient.ExecuteBatchDml, effectiveSettings.ExecuteBatchDmlSettings);
             _callRead = clientHelper.BuildApiCall<ReadRequest, ResultSet>(
                 GrpcClient.ReadAsync, GrpcClient.Read, effectiveSettings.ReadSettings);
             _callStreamingRead = clientHelper.BuildApiCall<ReadRequest, PartialResultSet>(
@@ -2581,10 +2618,10 @@ namespace Google.Cloud.Spanner.V1
             Modify_DeleteSessionApiCall(ref _callDeleteSession);
             Modify_ApiCall(ref _callExecuteSql);
             Modify_ExecuteSqlApiCall(ref _callExecuteSql);
-            Modify_ApiCall(ref _callExecuteBatchDml);
-            Modify_ExecuteBatchDmlApiCall(ref _callExecuteBatchDml);
             Modify_ApiCall(ref _callExecuteStreamingSql);
             Modify_ExecuteStreamingSqlApiCall(ref _callExecuteStreamingSql);
+            Modify_ApiCall(ref _callExecuteBatchDml);
+            Modify_ExecuteBatchDmlApiCall(ref _callExecuteBatchDml);
             Modify_ApiCall(ref _callRead);
             Modify_ReadApiCall(ref _callRead);
             Modify_ApiCall(ref _callStreamingRead);
@@ -2620,8 +2657,8 @@ namespace Google.Cloud.Spanner.V1
         partial void Modify_ListSessionsApiCall(ref gaxgrpc::ApiCall<ListSessionsRequest, ListSessionsResponse> call);
         partial void Modify_DeleteSessionApiCall(ref gaxgrpc::ApiCall<DeleteSessionRequest, pbwkt::Empty> call);
         partial void Modify_ExecuteSqlApiCall(ref gaxgrpc::ApiCall<ExecuteSqlRequest, ResultSet> call);
-        partial void Modify_ExecuteBatchDmlApiCall(ref gaxgrpc::ApiCall<ExecuteBatchDmlRequest, ExecuteBatchDmlResponse> call);
         partial void Modify_ExecuteStreamingSqlApiCall(ref gaxgrpc::ApiServerStreamingCall<ExecuteSqlRequest, PartialResultSet> call);
+        partial void Modify_ExecuteBatchDmlApiCall(ref gaxgrpc::ApiCall<ExecuteBatchDmlRequest, ExecuteBatchDmlResponse> call);
         partial void Modify_ReadApiCall(ref gaxgrpc::ApiCall<ReadRequest, ResultSet> call);
         partial void Modify_StreamingReadApiCall(ref gaxgrpc::ApiServerStreamingCall<ReadRequest, PartialResultSet> call);
         partial void Modify_BeginTransactionApiCall(ref gaxgrpc::ApiCall<BeginTransactionRequest, Transaction> call);
@@ -2813,7 +2850,9 @@ namespace Google.Cloud.Spanner.V1
         }
 
         /// <summary>
-        /// Ends a session, releasing server resources associated with it.
+        /// Ends a session, releasing server resources associated with it. This will
+        /// asynchronously trigger cancellation of any operations that are running with
+        /// this session.
         /// </summary>
         /// <param name="request">
         /// The request object containing all of the parameters for the API call.
@@ -2833,7 +2872,9 @@ namespace Google.Cloud.Spanner.V1
         }
 
         /// <summary>
-        /// Ends a session, releasing server resources associated with it.
+        /// Ends a session, releasing server resources associated with it. This will
+        /// asynchronously trigger cancellation of any operations that are running with
+        /// this session.
         /// </summary>
         /// <param name="request">
         /// The request object containing all of the parameters for the API call.
@@ -2857,10 +2898,12 @@ namespace Google.Cloud.Spanner.V1
         ///
         /// Operations inside read-write transactions might return `ABORTED`. If
         /// this occurs, the application should restart the transaction from
-        /// the beginning. See [Transaction][google.spanner.v1.Transaction] for more details.
+        /// the beginning. See [Transaction][google.spanner.v1.Transaction] for more
+        /// details.
         ///
         /// Larger result sets can be fetched in streaming fashion by calling
-        /// [ExecuteStreamingSql][google.spanner.v1.Spanner.ExecuteStreamingSql] instead.
+        /// [ExecuteStreamingSql][google.spanner.v1.Spanner.ExecuteStreamingSql]
+        /// instead.
         /// </summary>
         /// <param name="request">
         /// The request object containing all of the parameters for the API call.
@@ -2887,10 +2930,12 @@ namespace Google.Cloud.Spanner.V1
         ///
         /// Operations inside read-write transactions might return `ABORTED`. If
         /// this occurs, the application should restart the transaction from
-        /// the beginning. See [Transaction][google.spanner.v1.Transaction] for more details.
+        /// the beginning. See [Transaction][google.spanner.v1.Transaction] for more
+        /// details.
         ///
         /// Larger result sets can be fetched in streaming fashion by calling
-        /// [ExecuteStreamingSql][google.spanner.v1.Spanner.ExecuteStreamingSql] instead.
+        /// [ExecuteStreamingSql][google.spanner.v1.Spanner.ExecuteStreamingSql]
+        /// instead.
         /// </summary>
         /// <param name="request">
         /// The request object containing all of the parameters for the API call.
@@ -2907,6 +2952,48 @@ namespace Google.Cloud.Spanner.V1
         {
             Modify_ExecuteSqlRequest(ref request, ref callSettings);
             return _callExecuteSql.Sync(request, callSettings);
+        }
+
+        /// <summary>
+        /// Like [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql], except returns the
+        /// result set as a stream. Unlike
+        /// [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql], there is no limit on
+        /// the size of the returned result set. However, no individual row in the
+        /// result set can exceed 100 MiB, and no column value can exceed 10 MiB.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The server stream.
+        /// </returns>
+        public override ExecuteStreamingSqlStream ExecuteStreamingSql(
+            ExecuteSqlRequest request,
+            gaxgrpc::CallSettings callSettings = null)
+        {
+            Modify_ExecuteSqlRequest(ref request, ref callSettings);
+            return new ExecuteStreamingSqlStreamImpl(_callExecuteStreamingSql.Call(request, callSettings));
+        }
+
+        internal sealed partial class ExecuteStreamingSqlStreamImpl : ExecuteStreamingSqlStream
+        {
+            /// <summary>
+            /// Construct the server-streaming method for <c>ExecuteStreamingSql</c>.
+            /// </summary>
+            /// <param name="call">The underlying gRPC server-streaming call.</param>
+            internal ExecuteStreamingSqlStreamImpl(grpccore::AsyncServerStreamingCall<PartialResultSet> call)
+            {
+                GrpcCall = call;
+            }
+
+            /// <inheritdoc/>
+            public override grpccore::AsyncServerStreamingCall<PartialResultSet> GrpcCall { get; }
+
+            /// <inheritdoc/>
+            public override scg::IAsyncEnumerator<PartialResultSet> ResponseStream => GrpcCall.ResponseStream;
         }
 
         /// <summary>
@@ -2986,58 +3073,17 @@ namespace Google.Cloud.Spanner.V1
         }
 
         /// <summary>
-        /// Like [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql], except returns the result
-        /// set as a stream. Unlike [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql], there
-        /// is no limit on the size of the returned result set. However, no
-        /// individual row in the result set can exceed 100 MiB, and no
-        /// column value can exceed 10 MiB.
-        /// </summary>
-        /// <param name="request">
-        /// The request object containing all of the parameters for the API call.
-        /// </param>
-        /// <param name="callSettings">
-        /// If not null, applies overrides to this RPC call.
-        /// </param>
-        /// <returns>
-        /// The server stream.
-        /// </returns>
-        public override ExecuteStreamingSqlStream ExecuteStreamingSql(
-            ExecuteSqlRequest request,
-            gaxgrpc::CallSettings callSettings = null)
-        {
-            Modify_ExecuteSqlRequest(ref request, ref callSettings);
-            return new ExecuteStreamingSqlStreamImpl(_callExecuteStreamingSql.Call(request, callSettings));
-        }
-
-        internal sealed partial class ExecuteStreamingSqlStreamImpl : ExecuteStreamingSqlStream
-        {
-            /// <summary>
-            /// Construct the server-streaming method for <c>ExecuteStreamingSql</c>.
-            /// </summary>
-            /// <param name="call">The underlying gRPC server-streaming call.</param>
-            internal ExecuteStreamingSqlStreamImpl(grpccore::AsyncServerStreamingCall<PartialResultSet> call)
-            {
-                GrpcCall = call;
-            }
-
-            /// <inheritdoc/>
-            public override grpccore::AsyncServerStreamingCall<PartialResultSet> GrpcCall { get; }
-
-            /// <inheritdoc/>
-            public override scg::IAsyncEnumerator<PartialResultSet> ResponseStream => GrpcCall.ResponseStream;
-        }
-
-        /// <summary>
         /// Reads rows from the database using key lookups and scans, as a
         /// simple key/value style alternative to
-        /// [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql].  This method cannot be used to
-        /// return a result set larger than 10 MiB; if the read matches more
+        /// [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql].  This method cannot be
+        /// used to return a result set larger than 10 MiB; if the read matches more
         /// data than that, the read fails with a `FAILED_PRECONDITION`
         /// error.
         ///
         /// Reads inside read-write transactions might return `ABORTED`. If
         /// this occurs, the application should restart the transaction from
-        /// the beginning. See [Transaction][google.spanner.v1.Transaction] for more details.
+        /// the beginning. See [Transaction][google.spanner.v1.Transaction] for more
+        /// details.
         ///
         /// Larger result sets can be yielded in streaming fashion by calling
         /// [StreamingRead][google.spanner.v1.Spanner.StreamingRead] instead.
@@ -3062,14 +3108,15 @@ namespace Google.Cloud.Spanner.V1
         /// <summary>
         /// Reads rows from the database using key lookups and scans, as a
         /// simple key/value style alternative to
-        /// [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql].  This method cannot be used to
-        /// return a result set larger than 10 MiB; if the read matches more
+        /// [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql].  This method cannot be
+        /// used to return a result set larger than 10 MiB; if the read matches more
         /// data than that, the read fails with a `FAILED_PRECONDITION`
         /// error.
         ///
         /// Reads inside read-write transactions might return `ABORTED`. If
         /// this occurs, the application should restart the transaction from
-        /// the beginning. See [Transaction][google.spanner.v1.Transaction] for more details.
+        /// the beginning. See [Transaction][google.spanner.v1.Transaction] for more
+        /// details.
         ///
         /// Larger result sets can be yielded in streaming fashion by calling
         /// [StreamingRead][google.spanner.v1.Spanner.StreamingRead] instead.
@@ -3092,9 +3139,9 @@ namespace Google.Cloud.Spanner.V1
         }
 
         /// <summary>
-        /// Like [Read][google.spanner.v1.Spanner.Read], except returns the result set as a
-        /// stream. Unlike [Read][google.spanner.v1.Spanner.Read], there is no limit on the
-        /// size of the returned result set. However, no individual row in
+        /// Like [Read][google.spanner.v1.Spanner.Read], except returns the result set
+        /// as a stream. Unlike [Read][google.spanner.v1.Spanner.Read], there is no
+        /// limit on the size of the returned result set. However, no individual row in
         /// the result set can exceed 100 MiB, and no column value can exceed
         /// 10 MiB.
         /// </summary>
@@ -3135,7 +3182,8 @@ namespace Google.Cloud.Spanner.V1
 
         /// <summary>
         /// Begins a new transaction. This step can often be skipped:
-        /// [Read][google.spanner.v1.Spanner.Read], [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql] and
+        /// [Read][google.spanner.v1.Spanner.Read],
+        /// [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql] and
         /// [Commit][google.spanner.v1.Spanner.Commit] can begin a new transaction as a
         /// side-effect.
         /// </summary>
@@ -3158,7 +3206,8 @@ namespace Google.Cloud.Spanner.V1
 
         /// <summary>
         /// Begins a new transaction. This step can often be skipped:
-        /// [Read][google.spanner.v1.Spanner.Read], [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql] and
+        /// [Read][google.spanner.v1.Spanner.Read],
+        /// [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql] and
         /// [Commit][google.spanner.v1.Spanner.Commit] can begin a new transaction as a
         /// side-effect.
         /// </summary>
@@ -3236,8 +3285,9 @@ namespace Google.Cloud.Spanner.V1
         /// <summary>
         /// Rolls back a transaction, releasing any locks it holds. It is a good
         /// idea to call this for any transaction that includes one or more
-        /// [Read][google.spanner.v1.Spanner.Read] or [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql] requests and
-        /// ultimately decides not to commit.
+        /// [Read][google.spanner.v1.Spanner.Read] or
+        /// [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql] requests and ultimately
+        /// decides not to commit.
         ///
         /// `Rollback` returns `OK` if it successfully aborts the transaction, the
         /// transaction was already aborted, or the transaction is not
@@ -3263,8 +3313,9 @@ namespace Google.Cloud.Spanner.V1
         /// <summary>
         /// Rolls back a transaction, releasing any locks it holds. It is a good
         /// idea to call this for any transaction that includes one or more
-        /// [Read][google.spanner.v1.Spanner.Read] or [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql] requests and
-        /// ultimately decides not to commit.
+        /// [Read][google.spanner.v1.Spanner.Read] or
+        /// [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql] requests and ultimately
+        /// decides not to commit.
         ///
         /// `Rollback` returns `OK` if it successfully aborts the transaction, the
         /// transaction was already aborted, or the transaction is not
@@ -3287,10 +3338,11 @@ namespace Google.Cloud.Spanner.V1
         /// <summary>
         /// Creates a set of partition tokens that can be used to execute a query
         /// operation in parallel.  Each of the returned partition tokens can be used
-        /// by [ExecuteStreamingSql][google.spanner.v1.Spanner.ExecuteStreamingSql] to specify a subset
-        /// of the query result to read.  The same session and read-only transaction
-        /// must be used by the PartitionQueryRequest used to create the
-        /// partition tokens and the ExecuteSqlRequests that use the partition tokens.
+        /// by [ExecuteStreamingSql][google.spanner.v1.Spanner.ExecuteStreamingSql] to
+        /// specify a subset of the query result to read.  The same session and
+        /// read-only transaction must be used by the PartitionQueryRequest used to
+        /// create the partition tokens and the ExecuteSqlRequests that use the
+        /// partition tokens.
         ///
         /// Partition tokens become invalid when the session used to create them
         /// is deleted, is idle for too long, begins a new transaction, or becomes too
@@ -3317,10 +3369,11 @@ namespace Google.Cloud.Spanner.V1
         /// <summary>
         /// Creates a set of partition tokens that can be used to execute a query
         /// operation in parallel.  Each of the returned partition tokens can be used
-        /// by [ExecuteStreamingSql][google.spanner.v1.Spanner.ExecuteStreamingSql] to specify a subset
-        /// of the query result to read.  The same session and read-only transaction
-        /// must be used by the PartitionQueryRequest used to create the
-        /// partition tokens and the ExecuteSqlRequests that use the partition tokens.
+        /// by [ExecuteStreamingSql][google.spanner.v1.Spanner.ExecuteStreamingSql] to
+        /// specify a subset of the query result to read.  The same session and
+        /// read-only transaction must be used by the PartitionQueryRequest used to
+        /// create the partition tokens and the ExecuteSqlRequests that use the
+        /// partition tokens.
         ///
         /// Partition tokens become invalid when the session used to create them
         /// is deleted, is idle for too long, begins a new transaction, or becomes too
@@ -3347,12 +3400,13 @@ namespace Google.Cloud.Spanner.V1
         /// <summary>
         /// Creates a set of partition tokens that can be used to execute a read
         /// operation in parallel.  Each of the returned partition tokens can be used
-        /// by [StreamingRead][google.spanner.v1.Spanner.StreamingRead] to specify a subset of the read
-        /// result to read.  The same session and read-only transaction must be used by
-        /// the PartitionReadRequest used to create the partition tokens and the
-        /// ReadRequests that use the partition tokens.  There are no ordering
-        /// guarantees on rows returned among the returned partition tokens, or even
-        /// within each individual StreamingRead call issued with a partition_token.
+        /// by [StreamingRead][google.spanner.v1.Spanner.StreamingRead] to specify a
+        /// subset of the read result to read.  The same session and read-only
+        /// transaction must be used by the PartitionReadRequest used to create the
+        /// partition tokens and the ReadRequests that use the partition tokens.  There
+        /// are no ordering guarantees on rows returned among the returned partition
+        /// tokens, or even within each individual StreamingRead call issued with a
+        /// partition_token.
         ///
         /// Partition tokens become invalid when the session used to create them
         /// is deleted, is idle for too long, begins a new transaction, or becomes too
@@ -3379,12 +3433,13 @@ namespace Google.Cloud.Spanner.V1
         /// <summary>
         /// Creates a set of partition tokens that can be used to execute a read
         /// operation in parallel.  Each of the returned partition tokens can be used
-        /// by [StreamingRead][google.spanner.v1.Spanner.StreamingRead] to specify a subset of the read
-        /// result to read.  The same session and read-only transaction must be used by
-        /// the PartitionReadRequest used to create the partition tokens and the
-        /// ReadRequests that use the partition tokens.  There are no ordering
-        /// guarantees on rows returned among the returned partition tokens, or even
-        /// within each individual StreamingRead call issued with a partition_token.
+        /// by [StreamingRead][google.spanner.v1.Spanner.StreamingRead] to specify a
+        /// subset of the read result to read.  The same session and read-only
+        /// transaction must be used by the PartitionReadRequest used to create the
+        /// partition tokens and the ReadRequests that use the partition tokens.  There
+        /// are no ordering guarantees on rows returned among the returned partition
+        /// tokens, or even within each individual StreamingRead call issued with a
+        /// partition_token.
         ///
         /// Partition tokens become invalid when the session used to create them
         /// is deleted, is idle for too long, begins a new transaction, or becomes too

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SpannerGrpc.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SpannerGrpc.cs
@@ -217,7 +217,9 @@ namespace Google.Cloud.Spanner.V1 {
       }
 
       /// <summary>
-      /// Ends a session, releasing server resources associated with it.
+      /// Ends a session, releasing server resources associated with it. This will
+      /// asynchronously trigger cancellation of any operations that are running with
+      /// this session.
       /// </summary>
       /// <param name="request">The request received from the client.</param>
       /// <param name="context">The context of the server-side call handler being invoked.</param>
@@ -671,7 +673,9 @@ namespace Google.Cloud.Spanner.V1 {
         return CallInvoker.AsyncUnaryCall(__Method_ListSessions, null, options, request);
       }
       /// <summary>
-      /// Ends a session, releasing server resources associated with it.
+      /// Ends a session, releasing server resources associated with it. This will
+      /// asynchronously trigger cancellation of any operations that are running with
+      /// this session.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
@@ -683,7 +687,9 @@ namespace Google.Cloud.Spanner.V1 {
         return DeleteSession(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
       /// <summary>
-      /// Ends a session, releasing server resources associated with it.
+      /// Ends a session, releasing server resources associated with it. This will
+      /// asynchronously trigger cancellation of any operations that are running with
+      /// this session.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="options">The options for the call.</param>
@@ -693,7 +699,9 @@ namespace Google.Cloud.Spanner.V1 {
         return CallInvoker.BlockingUnaryCall(__Method_DeleteSession, null, options, request);
       }
       /// <summary>
-      /// Ends a session, releasing server resources associated with it.
+      /// Ends a session, releasing server resources associated with it. This will
+      /// asynchronously trigger cancellation of any operations that are running with
+      /// this session.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
@@ -705,7 +713,9 @@ namespace Google.Cloud.Spanner.V1 {
         return DeleteSessionAsync(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
       /// <summary>
-      /// Ends a session, releasing server resources associated with it.
+      /// Ends a session, releasing server resources associated with it. This will
+      /// asynchronously trigger cancellation of any operations that are running with
+      /// this session.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="options">The options for the call.</param>


### PR DESCRIPTION
Comments (and ordering) only - and one scope removal.
Will rerun tests now, just to check that the scope removal isn't a problem. (If we use the same credentials for non-admin and admin operations, that could require more work.)