### PR TITLE
Fix BigQueryRow TimestampConverter rounding issue

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryRowTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryRowTest.cs
@@ -49,7 +49,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
                     new TableCell { V = "AQI=" }, // 1, 2
                     new TableCell { V = "2.5" },
                     new TableCell { V = "text" },
-                    new TableCell { V = "1477566580.5" }, // 2016-10-27T11:09:40.500Z
+                    new TableCell { V = "95617584000.059" }, // 5000-01-01T00:00:00.059Z
                     new TableCell { V = "2017-08-09" },
                     new TableCell { V = "2017-08-09T12:34:56.123" },
                     new TableCell { V = "12:34:56.123" },
@@ -63,7 +63,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
             Assert.Equal(new byte[] { 1, 2 }, (byte[])row["bytes"]);
             Assert.Equal(2.5d, (double)row["float"]);
             Assert.Equal("text", (string)row["string"]);
-            Assert.Equal(new DateTime(2016, 10, 27, 11, 9, 40, 500, DateTimeKind.Utc), (DateTime)row["timestamp"]);
+            Assert.Equal(new DateTime(5000, 1, 1, 0, 0, 0, 59, DateTimeKind.Utc), (DateTime)row["timestamp"]);
             Assert.Equal(new DateTime(2017, 8, 9, 0, 0, 0, DateTimeKind.Utc), (DateTime)row["date"]);
             Assert.Equal(new DateTime(2017, 8, 9, 12, 34, 56, 123, DateTimeKind.Utc), (DateTime)row["dateTime"]);
             Assert.Equal(new TimeSpan(0, 12, 34, 56, 123), (TimeSpan)row["time"]);

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryRow.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryRow.cs
@@ -60,13 +60,14 @@ namespace Google.Cloud.BigQuery.V2
 
         private static readonly Func<string, string> StringConverter = v => v;
         private static readonly Func<string, long> Int64Converter = v => long.Parse(v, CultureInfo.InvariantCulture);
+        private static readonly Func<string, decimal> DecimalConverter = v => decimal.Parse(v, CultureInfo.InvariantCulture);
         private static readonly Func<string, double> DoubleConverter = v => double.Parse(v, CultureInfo.InvariantCulture);
         // AddSeconds rounds to the nearest millisecond, for some reason.
         // Instead, we work out the number of ticks and add that.
         private static readonly Func<string, DateTime> TimestampConverter = v =>
         {
-            double seconds = DoubleConverter(v);
-            long microseconds = (long) (seconds * 1e6);
+            decimal seconds = DecimalConverter(v);
+            long microseconds = (long)(seconds * 1000000M);
             long ticks = microseconds * 10;
             return new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddTicks(ticks);
         };


### PR DESCRIPTION
Fixed rounding errors in TimestampConverter from double to DateTime for dates in the far future and updated scalar test with a value that fails for double and passes for decimal