### PR TITLE
Enforce expiration limitations on V4 URL signing

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/UrlSignerTest.V4SignerTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/UrlSignerTest.V4SignerTest.cs
@@ -83,6 +83,40 @@ namespace Google.Cloud.Storage.V1.Tests
                 .Select(test => new object[] { test })
                 .ToList();
 
+            [Fact]
+            public void ExpiryValidation_Negative()
+            {
+                var signer = UrlSigner
+                    .FromServiceAccountCredential(s_testCredential)
+                    .WithSigningVersion(SigningVersion.V4)
+                    .WithClock(new FakeClock());
+
+                Assert.Throws<ArgumentOutOfRangeException>(() => signer.Sign("bucket", "object", TimeSpan.FromSeconds(-1), HttpMethod.Get));
+            }
+
+            [Fact]
+            public void ExpiryValidation_Exactly1Week()
+            {
+                var signer = UrlSigner
+                    .FromServiceAccountCredential(s_testCredential)
+                    .WithSigningVersion(SigningVersion.V4)
+                    .WithClock(new FakeClock());
+
+                // Just testing that no exception is thrown.
+                signer.Sign("bucket", "object", TimeSpan.FromDays(7), HttpMethod.Get);
+            }
+
+            [Fact]
+            public void ExpiryValidation_Beyond1Week()
+            {
+                var signer = UrlSigner
+                    .FromServiceAccountCredential(s_testCredential)
+                    .WithSigningVersion(SigningVersion.V4)
+                    .WithClock(new FakeClock());
+
+                Assert.Throws<ArgumentOutOfRangeException>(() => signer.Sign("bucket", "object", TimeSpan.FromDays(7) + TimeSpan.FromSeconds(1), HttpMethod.Get));
+            }
+
             [Theory, MemberData(nameof(JsonTestData))]
             public void JsonSourceTest(JsonTest test)
             {


### PR DESCRIPTION
I'm asking for confirmation that a limit of "7 days" is inclusive, but it'll be simple to change afterwards if necessary.