### PR TITLE
Use Translate method instead of List method, to avoid URI construction limits

### DIFF
--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.IntegrationTests/AdvancedTranslationClientTest.cs
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.IntegrationTests/AdvancedTranslationClientTest.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Linq;
 using Xunit;
 
 namespace Google.Cloud.Translation.V2.IntegrationTests
@@ -19,6 +20,8 @@ namespace Google.Cloud.Translation.V2.IntegrationTests
     public class AdvancedTranslationClientTest
     {
         private static readonly string LargeText = TranslationClientTest.LoadResource("independence.txt");
+        private const int ApiLimit = 100 * 1024;
+        private static readonly string VeryLargeText = string.Join("\n", Enumerable.Repeat(LargeText, ApiLimit / LargeText.Length));
 
         [Fact]
         public void DetectLanguage_LargeText()
@@ -33,6 +36,14 @@ namespace Google.Cloud.Translation.V2.IntegrationTests
         {
             var client = AdvancedTranslationClient.Create();
             var translation = client.TranslateText(LargeText, LanguageCodes.French);
+            Assert.Contains("au cours d", translation.TranslatedText);
+        }
+
+        [Fact]
+        public void Translate_VeryLargeText()
+        {
+            var client = AdvancedTranslationClient.Create();
+            var translation = client.TranslateText(VeryLargeText, LanguageCodes.French);
             Assert.Contains("au cours d", translation.TranslatedText);
         }
 

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.IntegrationTests/TranslationClientTest.cs
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.IntegrationTests/TranslationClientTest.cs
@@ -14,6 +14,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using Xunit;
 
@@ -22,6 +23,8 @@ namespace Google.Cloud.Translation.V2.IntegrationTests
     public class TranslationClientTest
     {
         private static readonly string LargeText = LoadResource("independence.txt");
+        private const int ApiLimit = 100 * 1024;
+        private static readonly string VeryLargeText = string.Join("\n", Enumerable.Repeat(LargeText, ApiLimit / LargeText.Length));
 
         [Fact]
         public void DetectLanguage_LargeText()
@@ -38,6 +41,18 @@ namespace Google.Cloud.Translation.V2.IntegrationTests
             var translation = client.TranslateText(LargeText, LanguageCodes.French);
             Assert.Contains("au cours d", translation.TranslatedText);
             Assert.Equal(LargeText, translation.OriginalText);
+            Assert.Equal(LanguageCodes.French, translation.TargetLanguage);
+            Assert.Equal(LanguageCodes.English, translation.DetectedSourceLanguage);
+            Assert.Null(translation.SpecifiedSourceLanguage);
+        }
+
+        [Fact]
+        public void Translate_VeryLargeText()
+        {
+            var client = TranslationClient.Create();
+            var translation = client.TranslateText(VeryLargeText, LanguageCodes.French);
+            Assert.Contains("au cours d", translation.TranslatedText);
+            Assert.Equal(VeryLargeText, translation.OriginalText);
             Assert.Equal(LanguageCodes.French, translation.TargetLanguage);
             Assert.Equal(LanguageCodes.English, translation.DetectedSourceLanguage);
             Assert.Null(translation.SpecifiedSourceLanguage);

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.Tests/AdvancedTranslationClientImplTest.cs
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.Tests/AdvancedTranslationClientImplTest.cs
@@ -86,8 +86,13 @@ namespace Google.Cloud.Translation.V2.Tests
             var service = new FakeTranslateService();
             var client = new AdvancedTranslationClientImpl(service);
             var inputs = new string[] { "a", "b" };
-            var request = service.Translations.List(new Repeatable<string>(inputs), "en");
-            request.Format = FormatEnum.Text;
+            var body = new TranslateTextRequest
+            {
+                Q = inputs,
+                Format = "text",
+                Target = "en"
+            };
+            var request = service.Translations.Translate(body);
             var response = new TranslationsListResponse
             {
                 // Content is irrelevant; we shouldn't get that far

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.Tests/AssemblyInfo.cs
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.Tests/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Runtime.CompilerServices;
+using Xunit;
+
+// Because of the Stackdriver limits on reading and writing entries.
+// This reduces the chances of exceeding the limits.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.Tests/TranslationClientImplTest.cs
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.Tests/TranslationClientImplTest.cs
@@ -86,8 +86,13 @@ namespace Google.Cloud.Translation.V2.Tests
             var service = new FakeTranslateService();
             var client = new TranslationClientImpl(service);
             var inputs = new string[] { "a", "b" };
-            var request = service.Translations.List(new Repeatable<string>(inputs), "en");
-            request.Format = FormatEnum.Text;
+            var body = new TranslateTextRequest
+            {
+                Q = inputs,
+                Format = "text",
+                Target = "en"
+            };
+            var request = service.Translations.Translate(body);
             var response = new TranslationsListResponse
             {
                 // Content is irrelevant; we shouldn't get that far

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/AdvancedTranslationClientImpl.cs
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/AdvancedTranslationClientImpl.cs
@@ -41,6 +41,10 @@ namespace Google.Cloud.Translation.V2
     /// </remarks>
     public sealed class AdvancedTranslationClientImpl : AdvancedTranslationClient
     {
+        // The Translate method doesn't use the format enum. While we could switch on it, it's simpler to hard-code the values it expects.
+        private const string HtmlFormat = "html";
+        private const string TextFormat = "text";
+
         private static readonly object _applicationNameLock = new object();
         private static string _applicationName = UserAgentHelper.GetDefaultUserAgent(typeof(AdvancedTranslationClient));
         private static Action<HttpRequestMessage> _versionHeaderAction = UserAgentHelper.CreateRequestModifier(typeof(AdvancedTranslationClient));
@@ -94,8 +98,9 @@ namespace Google.Cloud.Translation.V2
         {
             var items = ConvertToListAndCheckNoNullElements(textItems, nameof(textItems));
             GaxPreconditions.CheckNotNull(targetLanguage, nameof(targetLanguage));
-            var request = Service.Translations.List(new Repeatable<string>(items), targetLanguage);
-            ModifyRequest(request, sourceLanguage, FormatEnum.Text, model);
+            var translateRequest = new TranslateTextRequest { Q = items, Target = targetLanguage };
+            var request = Service.Translations.Translate(translateRequest);
+            ModifyRequest(request, translateRequest, sourceLanguage, TextFormat, model);
             return UnpackTranslationResponse(items, sourceLanguage, targetLanguage, request.Execute());
         }
 
@@ -104,8 +109,9 @@ namespace Google.Cloud.Translation.V2
         {
             var items = ConvertToListAndCheckNoNullElements(htmlItems, nameof(htmlItems));
             GaxPreconditions.CheckNotNull(targetLanguage, nameof(targetLanguage));
-            var request = Service.Translations.List(new Repeatable<string>(items), targetLanguage);
-            ModifyRequest(request, sourceLanguage, FormatEnum.Html, model);
+            var translateRequest = new TranslateTextRequest { Q = items, Target = targetLanguage };
+            var request = Service.Translations.Translate(translateRequest);
+            ModifyRequest(request, translateRequest, sourceLanguage, HtmlFormat, model);
             return UnpackTranslationResponse(items, sourceLanguage, targetLanguage, request.Execute());
         }
 
@@ -134,8 +140,9 @@ namespace Google.Cloud.Translation.V2
         {
             var items = ConvertToListAndCheckNoNullElements(textItems, nameof(textItems));
             GaxPreconditions.CheckNotNull(targetLanguage, nameof(targetLanguage));
-            var request = Service.Translations.List(new Repeatable<string>(items), targetLanguage);
-            ModifyRequest(request, sourceLanguage, FormatEnum.Text, model);
+            var translateRequest = new TranslateTextRequest { Q = items, Target = targetLanguage };
+            var request = Service.Translations.Translate(translateRequest);
+            ModifyRequest(request, translateRequest, sourceLanguage, TextFormat, model);
             var response = await request.ExecuteAsync(cancellationToken).ConfigureAwait(false);
             return UnpackTranslationResponse(items, sourceLanguage, targetLanguage, response);
         }
@@ -146,8 +153,9 @@ namespace Google.Cloud.Translation.V2
         {
             var items = ConvertToListAndCheckNoNullElements(htmlItems, nameof(htmlItems));
             GaxPreconditions.CheckNotNull(targetLanguage, nameof(targetLanguage));
-            var request = Service.Translations.List(new Repeatable<string>(items), targetLanguage);
-            ModifyRequest(request, sourceLanguage, FormatEnum.Html, model);
+            var translateRequest = new TranslateTextRequest { Q = items, Target = targetLanguage };
+            var request = Service.Translations.Translate(translateRequest);
+            ModifyRequest(request, translateRequest, sourceLanguage, HtmlFormat, model);
             var response = await request.ExecuteAsync(cancellationToken).ConfigureAwait(false);
             return UnpackTranslationResponse(items, sourceLanguage, targetLanguage, response);
         }
@@ -208,12 +216,12 @@ namespace Google.Cloud.Translation.V2
                 .ToList();
         }
 
-        private void ModifyRequest(ListRequest request, string sourceLanguage, FormatEnum format, string model)
+        private void ModifyRequest(TranslateRequest request, TranslateTextRequest body, string sourceLanguage, string format, string model)
         {
             request.ModifyRequest += _versionHeaderAction;
-            request.Source = sourceLanguage;
-            request.Format = format;
-            request.Model = GetEffectiveModelName(model);
+            body.Source = sourceLanguage;
+            body.Format = format;
+            body.Model = GetEffectiveModelName(model);
         }
 
         private string GetEffectiveModelName(string model)


### PR DESCRIPTION
Fixes #2957 as far as we can.

I won't merge this yet, but would appreciate the review. I need to check:

- Whether this limit increase is actually useful to the customer who raised #2957
- Whether the Translate API team is okay with it