### PR TITLE
Add recent GAX dependencies for Diagnostics

### DIFF
--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
@@ -23,6 +23,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
+    <PackageReference Include="Google.Api.Gax" Version="2.6.0" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="2.6.0" />
     <PackageReference Include="Google.Cloud.Logging.V2" Version="2.1.0" />
     <PackageReference Include="Google.Cloud.Trace.V1" Version="1.0.0" />
     <PackageReference Include="Grpc.Core" Version="1.18.0" PrivateAssets="None" />

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -257,6 +257,9 @@
     "description": "Google Stackdriver Instrumentation Libraries Common Components.",
     "tags": [ "Error", "Reporting", "Stackdriver", "ExceptionLogger", "Trace", "Diagnostics" ],
     "dependencies": {
+      // Explicitly add dependencies for GAX so we have recent versions
+      "Google.Api.Gax": "default",
+      "Google.Api.Gax.Grpc": "default",
       "Google.Cloud.Logging.V2": "2.1.0",
       "Google.Cloud.Trace.V1": "1.0.0",
       "Grpc.Core": "default"


### PR DESCRIPTION
The GAX libraries have improved in terms of platform and monitored
resource detection, but the logging/trace packages haven't been
updated for a while. This forces a more recent version.