### PR TITLE
Log exceptions in a separate field of the JSON structure

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLogger.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLogger.cs
@@ -120,6 +120,10 @@ namespace Google.Cloud.Diagnostics.AspNetCore
                 var jsonStruct = new Struct();
                 jsonStruct.Fields.Add("message", Value.ForString(message));
                 jsonStruct.Fields.Add("log_name", Value.ForString(_logName));
+                if (exception != null)
+                {
+                    jsonStruct.Fields.Add("exception", Value.ForString(exception.ToString()));
+                }
 
                 if (eventId.Id != 0 || eventId.Name != null)
                 {


### PR DESCRIPTION
Fixes #2967

Future possible work (to be done when requested):

- Allow this to be disabled (e.g. if you're using Error Reporting and this is essentially slow duplicate work)
- Expose the type name as a separate field for filtering etc
- Or have an Action<Exception, Struct> to perform the formatting in a completely flexible way

cc @iantalarico who knows more about this - a quick glance would be useful. (In particular, if there's a reason we *don't* currently do this, I'd love to know!)