### PR TITLE
Change targets for diagnostics libraries

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.ClientApp/Google.Cloud.Diagnostics.AspNet.ClientApp.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.ClientApp/Google.Cloud.Diagnostics.AspNet.ClientApp.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/Google.Cloud.Diagnostics.AspNet.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/Google.Cloud.Diagnostics.AspNet.IntegrationTests.csproj
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">net452</TargetFrameworks>
+    <TargetFrameworks>net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Snippets/Google.Cloud.Diagnostics.AspNet.Snippets.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Snippets/Google.Cloud.Diagnostics.AspNet.Snippets.csproj
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">net452</TargetFrameworks>
+    <TargetFrameworks>net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/Google.Cloud.Diagnostics.AspNet.Tests.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/Google.Cloud.Diagnostics.AspNet.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">net452</TargetFrameworks>
+    <TargetFrameworks>net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.csproj
@@ -2,8 +2,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Version>3.0.0-beta11</Version>
-    <TargetFrameworks>net45</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">net45</TargetFrameworks>
+    <TargetFrameworks>net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>
@@ -25,9 +25,9 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <ProjectReference Include="..\..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.csproj" />
     <PackageReference Include="Grpc.Core" Version="1.18.0" PrivateAssets="None" />
-    <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.2.3" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.3" />
-    <PackageReference Include="Microsoft.AspNet.WebPages" Version="3.2.3" />
+    <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.2.7" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.7" />
+    <PackageReference Include="Microsoft.AspNet.WebPages" Version="3.2.7" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/DiagnosticsWebHostTests.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/DiagnosticsWebHostTests.cs
@@ -99,7 +99,6 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
             }
         }
 
-#if NETCOREAPP2_1
         [Fact]
         public async Task UseGoogleDiagnostics_ConfiguresComponentsFromHostBuilderContext()
         {
@@ -134,7 +133,6 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
                 await TestErrorReporting(testId, client);
             }
         }
-#endif
 
         private static async Task TestLogging(string testId, DateTime startTime, HttpClient client)
         {

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests.csproj
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;netcoreapp2.1;net46</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>
@@ -12,8 +12,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <DebugSymbols>true</DebugSymbols>
-    <DebugType Condition="'$(TargetFramework)' == 'netcoreapp1.0'">pdbonly</DebugType>
-    <DebugType Condition="'$(TargetFramework)' == 'net46'">pdbonly</DebugType>
+    <DebugType Condition="'$(TargetFramework)' == 'net461'">pdbonly</DebugType>
     <DebugType Condition="'$(TargetFramework)' == 'netcoreapp2.1'">portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
@@ -31,22 +30,10 @@
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="1.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="1.0.2" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="1.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="1.0.2" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http">
-      <Version>2.1.1</Version>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Trace/TraceTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Trace/TraceTest.cs
@@ -98,9 +98,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
 
         [Theory]
         [InlineData(nameof(TraceController.TraceOutgoing))]
-#if NETCOREAPP2_1
         [InlineData(nameof(TraceController.TraceOutgoingClientFactory))]
-#endif
         public async Task Trace_OutGoing(string methodName)
         {
             var uri = $"/Trace/{methodName}/{_testId}";
@@ -462,13 +460,11 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
                 options.Options = traceOptions;
             });
 
-#if NETCOREAPP2_1
             services.AddHttpClient("google", c =>
                 {
                     c.BaseAddress = new Uri("https://google.com/");
                 })
                 .AddOutgoingGoogleTraceHandler();
-#endif
 
             services.AddMvc();
         }
@@ -553,7 +549,6 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
             return message;
         }
 
-#if NETCOREAPP2_1
         public async Task<string> TraceOutgoingClientFactory(string id, [FromServices] IManagedTracer tracer, [FromServices] IHttpClientFactory httpClientFactory)
         {
             string message = EntryData.GetMessage(nameof(TraceOutgoingClientFactory), id);
@@ -564,7 +559,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
             }
             return message;
         }
-#endif
+
         public async Task<string> TraceOutgoing(string id, [FromServices] IManagedTracer tracer, [FromServices] TraceHeaderPropagatingHandler propagatingHandler)
         {
             string message = EntryData.GetMessage(nameof(TraceOutgoing), id);

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/Google.Cloud.Diagnostics.AspNetCore.Snippets.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/Google.Cloud.Diagnostics.AspNetCore.Snippets.csproj
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;netcoreapp2.1;net46</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>
@@ -12,10 +12,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <DebugSymbols>true</DebugSymbols>
-    <Optimize Condition="'$(TargetFramework)' == 'netcoreapp1.0'">false</Optimize>
-    <Optimize Condition="'$(TargetFramework)' == 'net46'">false</Optimize>
-    <DebugType Condition="'$(TargetFramework)' == 'netcoreapp1.0'">pdbonly</DebugType>
-    <DebugType Condition="'$(TargetFramework)' == 'net46'">pdbonly</DebugType>
+    <Optimize Condition="'$(TargetFramework)' == 'net461'">false</Optimize>
+    <DebugType Condition="'$(TargetFramework)' == 'net461'">pdbonly</DebugType>
     <DebugType Condition="'$(TargetFramework)' == 'netcoreapp2.1'">portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
@@ -33,17 +31,7 @@
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="1.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="1.0.2" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="1.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="1.0.2" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.0" />

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/LoggingSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/LoggingSnippets.cs
@@ -137,7 +137,6 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
 
         private IWebHostBuilder GetSimpleHostBuilder()
         {
-#if NETCOREAPP2_1
             string projectId = TestEnvironment.GetTestProjectId();
             // Sample: RegisterGoogleLogger2
             return new WebHostBuilder()
@@ -148,14 +147,10 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
                 })
                 .UseStartup<Startup>();
             // End sample
-#else
-            return new WebHostBuilder().UseStartup<LoggingTestApplication>();
-#endif
         }
 
         private IWebHostBuilder GetExceptionPropagatingHostBuilder()
         {
-#if NETCOREAPP2_1
             string projectId = LoggingTestApplicationPropagateExceptions.ProjectId;
             // Sample: RegisterGoogleLoggerPropagateExceptions2
             return new WebHostBuilder()
@@ -173,14 +168,10 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
                 })
                 .UseStartup<Startup>();
             // End sample
-#else
-            return new WebHostBuilder().UseStartup<LoggingTestApplicationPropagateExceptions>();
-#endif
         }
 
         private IWebHostBuilder GetUrlWriterHostBuilder()
         {
-#if NETCOREAPP2_0
             string projectId = TestEnvironment.GetTestProjectId();
 
             // Sample: RegisterGoogleLoggerWriteUrl2
@@ -196,9 +187,6 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
                 })
                 .UseStartup<Startup>();
             // End sample
-#else
-            return new WebHostBuilder().UseStartup<LoggingTestApplicationWriteUrl>();
-#endif
         }
     }
 

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/TraceSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/TraceSnippets.cs
@@ -128,7 +128,6 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
             Assert.False(response.Headers.Contains(TraceHeaderContext.TraceHeader));
         }
 
-#if NETCOREAPP2_1
         [Fact]
         public async Task Traces_OutgoingClientFactory()
         {
@@ -148,7 +147,6 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
                 Assert.False(response.Headers.Contains(TraceHeaderContext.TraceHeader));
             }
         }
-#endif
 
         public void Dispose()
         {
@@ -197,7 +195,6 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
         // End sample
     }
 
-#if NETCOREAPP2_1
     internal class TraceClientFactoryTestApplication
     {
         private static readonly string ProjectId = TestEnvironment.GetTestProjectId();
@@ -239,7 +236,6 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
         }
         // End sample
     }
-#endif
 
     /// <summary>
     /// A controller for the <see cref="TraceTestApplication"/> used to trace operations.
@@ -299,7 +295,6 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
         }
         // End sample
 
-#if NETCOREAPP2_1
         // Sample: TraceOutgoingClientFactory
         /// <summary>
         /// Use the <see cref="IHttpClientFactory"/> to create an HttpClient that will guarantee
@@ -314,7 +309,6 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
             return await httpClient.GetAsync("https://weather.com/");
         }
         // End sample
-#endif
     }
 
     // Sample: TraceMVCConstructor

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Google.Cloud.Diagnostics.AspNetCore.Tests.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Google.Cloud.Diagnostics.AspNetCore.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;netcoreapp2.1;net46</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>
@@ -25,23 +25,10 @@
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="1.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="1.0.2" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="1.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="1.0.2" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
-    <Reference Include="System.Web" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.csproj
@@ -2,8 +2,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Version>3.0.0-beta11</Version>
-    <TargetFrameworks>netstandard2.0;netstandard1.5;net46</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0;netstandard1.5</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>
@@ -30,18 +30,11 @@
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' OR  '$(TargetFramework)' == 'net46' ">
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="1.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="1.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="1.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.0.2" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.2" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.3" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.2" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/GoogleDiagnosticsWebHostBuilderExtensions.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/GoogleDiagnosticsWebHostBuilderExtensions.cs
@@ -46,7 +46,6 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         public static IWebHostBuilder UseGoogleDiagnostics(this IWebHostBuilder builder, string projectId = null, string serviceName = null, string serviceVersion = null)
             => UseGoogleDiagnostics(builder, projectId, serviceName, serviceVersion, monitoredResource: null);
 
-#if NETSTANDARD2_0
         // On .NET Standard 2.0 or higher the IWebHostBuilder.ConfigureServices has a new overload that takes both
         // an IServiceCollection and a WebHostBuilderContext. We can use the context for retrieving information from the
         // host builder at startup time, like reading configuration.
@@ -84,7 +83,6 @@ namespace Google.Cloud.Diagnostics.AspNetCore
 
             return builder;
         }
-#endif
 
         // Overload which allows passing in a MonitoredResource instance
         // Internal for testing

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/CloudTraceExtension.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/CloudTraceExtension.cs
@@ -123,12 +123,10 @@ namespace Google.Cloud.Diagnostics.AspNetCore
 
             services.AddSingleton(ManagedTracer.CreateDelegatingTracer(ContextTracerManager.GetCurrentTracer));
 
-#if NETSTANDARD2_0
             // On .Net Standard 2.0 or higher, we can use the System.Net.Http.IHttpClientFactory defined in Microsoft.Extensions.Http,
             // for which we need a DelagatingHandler with no InnerHandler set. This is the recommended way.
             // It should be registered as follows.
             services.AddTransient(sp => new UnchainedTraceHeaderPropagatingHandler(ContextTracerManager.GetCurrentTracer));
-#endif
             // This is to be used for explicitly creating an HttpClient instance. Valid for all platforms.
             services.AddSingleton(new TraceHeaderPropagatingHandler(ContextTracerManager.GetCurrentTracer));
 

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Google.Cloud.Diagnostics.Common.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Google.Cloud.Diagnostics.Common.IntegrationTests.csproj
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp1.0;net452</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.1;netcoreapp1.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Google.Cloud.Diagnostics.Common.Tests.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Google.Cloud.Diagnostics.Common.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp1.0;net452</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.1;netcoreapp1.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
@@ -2,8 +2,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Version>3.0.0-beta11</Version>
-    <TargetFrameworks>netstandard2.0;netstandard1.5;net45</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0;netstandard1.5</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>
@@ -32,18 +32,9 @@
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="1.0.2" />
-    <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Http">
-      <Version>2.1.1</Version>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />
     <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
-    <Reference Include="System.Web" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/ContextTracerManager.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/ContextTracerManager.cs
@@ -21,27 +21,12 @@ namespace Google.Cloud.Diagnostics.Common
     /// </summary>
     public static class ContextTracerManager
     {
-#if NET45
-        private static readonly string _callContextName = System.Guid.NewGuid().ToString("N");
-        private static IManagedTracer CurrentTracer
-        {
-            get
-            {
-                return System.Runtime.Remoting.Messaging.CallContext.LogicalGetData(_callContextName) as IManagedTracer;
-            }
-            set
-            {
-                System.Runtime.Remoting.Messaging.CallContext.LogicalSetData(_callContextName, value);
-            }
-        }
-#else
         private static readonly AsyncLocal<IManagedTracer> _currentTracer = new AsyncLocal<IManagedTracer>();
         private static IManagedTracer CurrentTracer
         {
             get { return _currentTracer.Value; }
             set { _currentTracer.Value = value; }
         }
-#endif
 
         /// <summary>
         /// Sets the current <see cref="IManagedTracer"/>.  This is called for each new trace context.

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/HttpClientBuilderExtensions.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/HttpClientBuilderExtensions.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NETSTANDARD2_0
-
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Google.Cloud.Diagnostics.Common
@@ -32,5 +30,3 @@ namespace Google.Cloud.Diagnostics.Common
             clientBuilder.AddHttpMessageHandler<UnchainedTraceHeaderPropagatingHandler>();
     }
 }
-
-#endif

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/SimpleManagedTracer.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/SimpleManagedTracer.cs
@@ -326,21 +326,6 @@ namespace Google.Cloud.Diagnostics.Common
         /// will never be removed in the context of that async block/thread. Do not rely on the stack contents to know the state
         /// of things on other threads. It may contain previously closed spans.
         /// </summary>
-#if NET45
-        private readonly string _callContextName = Guid.NewGuid().ToString("N");
-        private ImmutableStack<Span> TraceStack
-        {
-            get
-            {
-                var ret = System.Runtime.Remoting.Messaging.CallContext.LogicalGetData(_callContextName) as ImmutableStack<Span>;
-                return ret ?? ImmutableStack<Span>.Empty;
-            }
-            set
-            {
-                System.Runtime.Remoting.Messaging.CallContext.LogicalSetData(_callContextName, value);
-            }
-        }
-#else
         private readonly AsyncLocal<ImmutableStack<Span>> _traceStack = new AsyncLocal<ImmutableStack<Span>>();
         private ImmutableStack<Span> TraceStack
         {
@@ -353,7 +338,6 @@ namespace Google.Cloud.Diagnostics.Common
                 _traceStack.Value = value;
             }
         }
-#endif
 
         private sealed class ImmutableStack<T>
         {

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -192,15 +192,15 @@
     "id": "Google.Cloud.Diagnostics.AspNet",
     "version": "3.0.0-beta11",
     "type": "other",
-    "targetFrameworks": "net45",
-    "testTargetFrameworks": "net452",
+    "targetFrameworks": "net461",
+    "testTargetFrameworks": "net461",
     "description": "Google Stackdriver Instrumentation Libraries for ASP.NET.",
     "tags": [ "Error", "Reporting", "Stackdriver", "ExceptionLogger", "Trace", "Diagnostics" ],
     "dependencies": {
       "Google.Cloud.Diagnostics.Common": "project",
-      "Microsoft.AspNet.WebApi.Core": "5.2.3",
-      "Microsoft.AspNet.WebPages": "3.2.3",
-      "Microsoft.AspNet.Mvc": "5.2.3",
+      "Microsoft.AspNet.WebApi.Core": "5.2.7",
+      "Microsoft.AspNet.WebPages": "3.2.7",
+      "Microsoft.AspNet.Mvc": "5.2.7",
       "Grpc.Core": "default"
     },
     "testDependencies": {
@@ -214,8 +214,8 @@
     "id": "Google.Cloud.Diagnostics.AspNetCore",
     "version": "3.0.0-beta11",
     "type": "other",
-    "targetFrameworks": "netstandard2.0;netstandard1.5;net46",
-    "testTargetFrameworks": "netcoreapp1.0;netcoreapp2.1;net46",
+    "targetFrameworks": "netstandard2.0",
+    "testTargetFrameworks": "netcoreapp2.1;net461",
     "description": "Google Stackdriver Instrumentation Libraries for ASP.NET Core.",
     "tags": [ "Error", "Reporting", "Stackdriver", "ExceptionLogger", "Trace", "Diagnostics" ],
     "dependencies": {
@@ -252,8 +252,8 @@
     "id": "Google.Cloud.Diagnostics.Common",
     "version": "3.0.0-beta11",
     "type": "other",
-    "targetFrameworks": "netstandard2.0;netstandard1.5;net45",
-    "testTargetFrameworks": "netcoreapp2.1;netcoreapp1.0;net452",
+    "targetFrameworks": "netstandard2.0",
+    "testTargetFrameworks": "netcoreapp2.1;net461",
     "description": "Google Stackdriver Instrumentation Libraries Common Components.",
     "tags": [ "Error", "Reporting", "Stackdriver", "ExceptionLogger", "Trace", "Diagnostics" ],
     "dependencies": {


### PR DESCRIPTION
After the change:

- Common: netstandard2.0
- AspNet: net461
- AspNetCore: netstandard2.0

Everything is tested under net461 and (except for AspNet) netcoreapp2.1.

Fixes #2959.