### PR TITLE
Datastore emulator support

### DIFF
--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/DatastoreDbTest.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/DatastoreDbTest.cs
@@ -35,7 +35,7 @@ namespace Google.Cloud.Datastore.V1.IntegrationTests
         [Fact]
         public void Lookup_FullPartition()
         {
-            var db = DatastoreDb.Create(_fixture.ProjectId, _fixture.NamespaceId);
+            var db = _fixture.CreateDatastoreDb();
             var keyFactory = db.CreateKeyFactory("test");
             var entity = new Entity
             {
@@ -52,7 +52,7 @@ namespace Google.Cloud.Datastore.V1.IntegrationTests
         [Fact]
         public void Lookup_NamespaceOnly()
         {
-            var db = DatastoreDb.Create(_fixture.ProjectId, _fixture.NamespaceId);
+            var db = _fixture.CreateDatastoreDb();
             var keyFactory = db.CreateKeyFactory("test");
             var entity = new Entity
             {
@@ -71,7 +71,7 @@ namespace Google.Cloud.Datastore.V1.IntegrationTests
         public async Task Lookup_NoPartition()
         {
             // Deliberately in the empty namespace, which won't be cleaned up automatically - hence the db.Delete call later.
-            var db = DatastoreDb.Create(_fixture.ProjectId);
+            var db = _fixture.CreateDatastoreDb(namespaceId: "");
             var keyFactory = db.CreateKeyFactory("test");
             var entity = new Entity
             {
@@ -98,7 +98,7 @@ namespace Google.Cloud.Datastore.V1.IntegrationTests
         [Fact]
         public async Task Lookup()
         {
-            var db = DatastoreDb.Create(_fixture.ProjectId, _fixture.NamespaceId);
+            var db = _fixture.CreateDatastoreDb();
             var keyFactory = db.CreateKeyFactory("lookup_test");
             var entity = new Entity { Key = keyFactory.CreateKey("x"), ["description"] = "predefined_key" };
             db.Insert(entity);
@@ -111,7 +111,7 @@ namespace Google.Cloud.Datastore.V1.IntegrationTests
         [Fact]
         public void RunQuery_NoResults()
         {
-            var db = DatastoreDb.Create(_fixture.ProjectId, _fixture.NamespaceId);
+            var db = _fixture.CreateDatastoreDb();
             var query = db.RunQueryLazily(new Query("absent"));
             // Each of the checks below will run the query again, as the query is only lazily
             // evaluated.
@@ -123,7 +123,7 @@ namespace Google.Cloud.Datastore.V1.IntegrationTests
         [Fact]
         public void SyncQueries()
         {
-            var db = DatastoreDb.Create(_fixture.ProjectId, _fixture.NamespaceId);
+            var db = _fixture.CreateDatastoreDb();
             var keyFactory = db.CreateKeyFactory("syncqueries");
             using (var transaction = db.BeginTransaction())
             {
@@ -149,7 +149,7 @@ namespace Google.Cloud.Datastore.V1.IntegrationTests
         [Fact]
         public async Task AsyncQueries()
         {
-            var db = DatastoreDb.Create(_fixture.ProjectId, _fixture.NamespaceId);
+            var db = _fixture.CreateDatastoreDb();
             var keyFactory = db.CreateKeyFactory("asyncqueries");
             using (var transaction = await db.BeginTransactionAsync())
             {
@@ -175,7 +175,7 @@ namespace Google.Cloud.Datastore.V1.IntegrationTests
         [Fact]
         public void BeginTransaction_ReadOnly()
         {
-            var db = DatastoreDb.Create(_fixture.ProjectId, _fixture.NamespaceId);
+            var db = _fixture.CreateDatastoreDb();
             var keyFactory = db.CreateKeyFactory("readonly_test");
             var options = TransactionOptions.CreateReadOnly();
             using (var transaction = db.BeginTransaction(options))
@@ -189,7 +189,7 @@ namespace Google.Cloud.Datastore.V1.IntegrationTests
         [Fact]
         public async Task BeginTransactionAsync_ReadOnly()
         {
-            var db = DatastoreDb.Create(_fixture.ProjectId, _fixture.NamespaceId);
+            var db = _fixture.CreateDatastoreDb();
             var keyFactory = db.CreateKeyFactory("readonly_test");
             var options = TransactionOptions.CreateReadOnly();
             using (var transaction = await db.BeginTransactionAsync(options))
@@ -203,7 +203,7 @@ namespace Google.Cloud.Datastore.V1.IntegrationTests
         [Fact]
         public void BeginTransaction_ReadWrite()
         {
-            var db = DatastoreDb.Create(_fixture.ProjectId, _fixture.NamespaceId);
+            var db = _fixture.CreateDatastoreDb();
             var keyFactory = db.CreateKeyFactory("readonly_test");
             var options = TransactionOptions.CreateReadWrite();
             using (var transaction = db.BeginTransaction(options))
@@ -216,7 +216,7 @@ namespace Google.Cloud.Datastore.V1.IntegrationTests
         [Fact]
         public async Task BeginTransactionAsync_ReadWrite()
         {
-            var db = DatastoreDb.Create(_fixture.ProjectId, _fixture.NamespaceId);
+            var db = _fixture.CreateDatastoreDb();
             var keyFactory = db.CreateKeyFactory("readonly_test");
             var options = TransactionOptions.CreateReadWrite();
             using (var transaction = await db.BeginTransactionAsync(options))
@@ -236,7 +236,7 @@ namespace Google.Cloud.Datastore.V1.IntegrationTests
         [Fact]
         public void Insert_ResultKeys()
         {
-            var db = DatastoreDb.Create(_fixture.ProjectId, _fixture.NamespaceId);
+            var db = _fixture.CreateDatastoreDb();
             var keyFactory = db.CreateKeyFactory("insert_test");
             var entities = new[]
             {
@@ -258,7 +258,7 @@ namespace Google.Cloud.Datastore.V1.IntegrationTests
         [Fact]
         public void Upsert_ResultKeys()
         {
-            var db = DatastoreDb.Create(_fixture.ProjectId, _fixture.NamespaceId);
+            var db = _fixture.CreateDatastoreDb();
             var keyFactory = db.CreateKeyFactory("upsert_test");
             var insertedKey = db.Insert(new Entity { Key = keyFactory.CreateIncompleteKey(), ["description"] = "original" });
 
@@ -281,7 +281,7 @@ namespace Google.Cloud.Datastore.V1.IntegrationTests
         [Fact]
         public async Task InsertAsync_ResultKeys()
         {
-            var db = DatastoreDb.Create(_fixture.ProjectId, _fixture.NamespaceId);
+            var db = _fixture.CreateDatastoreDb();
             var keyFactory = db.CreateKeyFactory("insertasync_test");
             var entities = new[]
             {
@@ -303,7 +303,7 @@ namespace Google.Cloud.Datastore.V1.IntegrationTests
         [Fact]
         public async Task UpsertAsync_ResultKeys()
         {
-            var db = DatastoreDb.Create(_fixture.ProjectId, _fixture.NamespaceId);
+            var db = _fixture.CreateDatastoreDb();
             var keyFactory = db.CreateKeyFactory("upsertasync_test");
             var insertedKey = db.Insert(new Entity { Key = keyFactory.CreateIncompleteKey(), ["description"] = "original" });
 
@@ -326,7 +326,7 @@ namespace Google.Cloud.Datastore.V1.IntegrationTests
         [Fact]
         public void Update()
         {
-            var db = DatastoreDb.Create(_fixture.ProjectId, _fixture.NamespaceId);
+            var db = _fixture.CreateDatastoreDb();
             var keyFactory = db.CreateKeyFactory("update_test");
 
             var insertedKey = db.Insert(new Entity { Key = keyFactory.CreateIncompleteKey(), ["description"] = "original" });
@@ -342,7 +342,7 @@ namespace Google.Cloud.Datastore.V1.IntegrationTests
         [Fact]
         public async Task UpdateAsync()
         {
-            var db = DatastoreDb.Create(_fixture.ProjectId, _fixture.NamespaceId);
+            var db = _fixture.CreateDatastoreDb();
             var keyFactory = db.CreateKeyFactory("update_test");
 
             var insertedKey = await db.InsertAsync(new Entity { Key = keyFactory.CreateIncompleteKey(), ["description"] = "original" });
@@ -358,7 +358,7 @@ namespace Google.Cloud.Datastore.V1.IntegrationTests
         [Fact]
         public void Delete()
         {
-            var db = DatastoreDb.Create(_fixture.ProjectId, _fixture.NamespaceId);
+            var db = _fixture.CreateDatastoreDb();
             var keyFactory = db.CreateKeyFactory("update_test");
 
             var insertedKey = db.Insert(new Entity { Key = keyFactory.CreateIncompleteKey(), ["description"] = "original" });
@@ -370,7 +370,7 @@ namespace Google.Cloud.Datastore.V1.IntegrationTests
         [Fact]
         public async Task DeleteAsync()
         {
-            var db = DatastoreDb.Create(_fixture.ProjectId, _fixture.NamespaceId);
+            var db = _fixture.CreateDatastoreDb();
             var keyFactory = db.CreateKeyFactory("update_test");
 
             var insertedKey = await db.InsertAsync(new Entity { Key = keyFactory.CreateIncompleteKey(), ["description"] = "original" });
@@ -382,7 +382,7 @@ namespace Google.Cloud.Datastore.V1.IntegrationTests
         [Fact]
         public void TimestampFromProjection()
         {
-            var db = DatastoreDb.Create(_fixture.ProjectId, _fixture.NamespaceId);
+            var db = _fixture.CreateDatastoreDb();
             string kind = "projection_test";
             var keyFactory = db.CreateKeyFactory(kind);
 

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/DatastoreFixture.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/DatastoreFixture.cs
@@ -86,5 +86,17 @@ namespace Google.Cloud.Datastore.V1.IntegrationTests
                 }
             }
         }
+
+        public DatastoreDb CreateDatastoreDb(string namespaceId = null)
+        {
+            string effectiveNamespace = namespaceId ?? NamespaceId;
+            var builder = new DatastoreDbBuilder
+            {
+                ProjectId = ProjectId,
+                NamespaceId = effectiveNamespace,
+                EmulatorDetection = EmulatorDetection.ProductionOrEmulator
+            };
+            return builder.Build();
+        }
     }
 }

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/DatastoreTransactionTest.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/DatastoreTransactionTest.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.Datastore.V1.IntegrationTests
         [Fact]
         public void SyncQueries_ImplicityUsePartition()
         {
-            var db = DatastoreDb.Create(_fixture.ProjectId, _fixture.NamespaceId);
+            var db = _fixture.CreateDatastoreDb();
             var parentKey = PrepareQueryTest(db);
             using (var transaction = db.BeginTransaction())
             {
@@ -58,7 +58,7 @@ namespace Google.Cloud.Datastore.V1.IntegrationTests
         [Fact]
         public async Task AsyncQueries_ImplicityUsePartition()
         {
-            var db = DatastoreDb.Create(_fixture.ProjectId, _fixture.NamespaceId);
+            var db = _fixture.CreateDatastoreDb();
             var parentKey = PrepareQueryTest(db);
             using (var transaction = db.BeginTransaction())
             {
@@ -100,7 +100,7 @@ namespace Google.Cloud.Datastore.V1.IntegrationTests
         [Fact]
         public void Delete()
         {
-            var db = DatastoreDb.Create(_fixture.ProjectId, _fixture.NamespaceId);
+            var db = _fixture.CreateDatastoreDb();
             var keyFactory = db.CreateKeyFactory("book");
             var entity = new Entity { Key = keyFactory.CreateIncompleteKey(), ["title"] = "Programming F#" };
 
@@ -129,7 +129,7 @@ namespace Google.Cloud.Datastore.V1.IntegrationTests
 
         private async Task CommitTest(Func<DatastoreTransaction, Task<CommitResponse>> commitCall)
         {
-            var db = DatastoreDb.Create(_fixture.ProjectId, _fixture.NamespaceId);
+            var db = _fixture.CreateDatastoreDb();
             var keyFactory = db.CreateKeyFactory("book");
             var updatedEntity = new Entity { Key = keyFactory.CreateIncompleteKey(), ["description"] = "Inserted before transaction" };
             db.Insert(updatedEntity);

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreClientBuilder.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreClientBuilder.cs
@@ -1,0 +1,82 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax.Grpc;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Cloud.Datastore.V1
+{
+    // Note: the generator would just generate an internal property to start with, so there'd be no need for this
+    // partial.
+    public partial class DatastoreClient
+    {
+        internal static ChannelPool ChannelPool => s_channelPool;
+    }
+
+    // Note: this partial class would be generated.
+    /// <summary>
+    /// Builder class for <see cref="DatastoreClient"/> to provide simple configuration of credentials, endpoint etc.
+    /// </summary>
+    public sealed partial class DatastoreClientBuilder : ClientBuilderBase<DatastoreClient>
+    {
+        /// <summary>
+        /// The settings to use for RPCs, or null for the default settings.
+        /// </summary>
+        public DatastoreSettings Settings { get; set; }
+
+        /// <inheritdoc />
+        public override DatastoreClient Build()
+        {
+            Validate();
+            var callInvoker = CreateCallInvoker();
+            return DatastoreClient.Create(callInvoker, Settings);
+        }
+
+        /// <inheritdoc />
+        public override async Task<DatastoreClient> BuildAsync(CancellationToken cancellationToken = default)
+        {
+            Validate();
+            var callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);
+            return DatastoreClient.Create(callInvoker, Settings);
+        }
+
+        /// <inheritdoc />
+        protected override ServiceEndpoint GetDefaultEndpoint() => DatastoreClient.DefaultEndpoint;
+
+        /// <inheritdoc />
+        protected override IReadOnlyList<string> GetDefaultScopes() => DatastoreClient.DefaultScopes;
+
+        /// <inheritdoc />
+        protected override ChannelPool GetChannelPool() => DatastoreClient.ChannelPool;
+    }
+
+    // Note: this partial class wouldn't be generated
+    public sealed partial class DatastoreClientBuilder : ClientBuilderBase<DatastoreClient>
+    {
+        /// <summary>
+        /// Creates a new instance with no settings.
+        /// </summary>
+        public DatastoreClientBuilder()
+        {
+        }
+
+        internal DatastoreClientBuilder(DatastoreDbBuilder builder)
+        {
+            Settings = builder.Settings;
+            CopyCommonSettings(builder);
+        }
+    }
+}

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreDbBuilder.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreDbBuilder.cs
@@ -1,0 +1,188 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using Google.Api.Gax.Grpc;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Cloud.Datastore.V1
+{
+    /// <summary>
+    /// Builder class for <see cref="DatastoreClient"/> to provide simple configuration of credentials, endpoint etc.
+    /// </summary>
+    public sealed partial class DatastoreDbBuilder : ClientBuilderBase<DatastoreDb>
+    {
+        /// <summary>
+        /// The settings to use for RPCs, or null for the default settings.
+        /// </summary>
+        public DatastoreSettings Settings { get; set; }
+
+        private EmulatorDetection _emulatorDetection;
+
+        /// <summary>
+        /// Specifies how the builder responds to the presence of emulator environment variables as described
+        /// by https://cloud.google.com/datastore/docs/tools/datastore-emulator.
+        /// </summary>
+        /// <remarks>
+        /// This property defaults to <see cref="EmulatorDetection.None"/>, meaning that environment variables are
+        /// ignored.
+        /// </remarks>
+        public EmulatorDetection EmulatorDetection
+        {
+            get => _emulatorDetection;
+            set => _emulatorDetection = GaxPreconditions.CheckEnumValue(value, nameof(value));
+        }
+
+        /// <summary>
+        /// The project ID, or null if this has not yet been configured. Note that a project ID must be configured
+        /// (or detected via an emulator environment variable) before building the <see cref="DatastoreDb"/>.
+        /// </summary>
+        public string ProjectId { get; set; }
+        
+        /// <summary>
+        /// Common code for handling the emulator configuration.
+        /// </summary>
+        private ConfiguredBuilder PrepareBuilder()
+        {
+            var clientBuilder = new DatastoreClientBuilder(this);
+            string projectId = ProjectId;
+
+            if (EmulatorDetection != EmulatorDetection.None)
+            {
+                var emulatorConfig = EmulatorConfiguration.FromEnvironment();
+                switch (EmulatorDetection)
+                {
+                    case EmulatorDetection.ProductionOnly:
+                        GaxPreconditions.CheckState(
+                            emulatorConfig.ProjectId == null && emulatorConfig.Endpoint == null,
+                            "Emulator environment variables are set, contrary to use of {0}.{1}",
+                            nameof(EmulatorDetection), nameof(EmulatorDetection.ProductionOnly));
+                        break;
+                    case EmulatorDetection.EmulatorOnly:
+                        GaxPreconditions.CheckState(
+                            emulatorConfig.Endpoint != null,
+                            "Expected {0} environment variable to be set", EmulatorConfiguration.EmulatorHostVariable);
+                        ApplyEmulatorConfiguration();
+                        break;
+                    case EmulatorDetection.ProductionOrEmulator:
+                        if (emulatorConfig.Endpoint != null)
+                        {
+                            ApplyEmulatorConfiguration();
+                        }
+                        else
+                        {
+                            GaxPreconditions.CheckState(emulatorConfig.ProjectId == null, "{0} should not be set when {1} is not", EmulatorConfiguration.EmulatorProjectVariable, EmulatorConfiguration.EmulatorHostVariable);
+                        }
+                        break;
+                }
+
+                void ApplyEmulatorConfiguration()
+                {
+                    // TODO: Do we want to require this? Or should a configured emulator override any credentials?
+                    GaxPreconditions.CheckState(clientBuilder.Endpoint == null, "{0} should not be set when connecting to an emulator", nameof(clientBuilder.Endpoint));
+                    GaxPreconditions.CheckState(clientBuilder.CallInvoker == null, "{0} should not be set when connecting to an emulator", nameof(clientBuilder.CallInvoker));
+                    GaxPreconditions.CheckState(clientBuilder.ChannelCredentials == null, "{0} should not be set when connecting to an emulator", nameof(clientBuilder.ChannelCredentials));
+                    GaxPreconditions.CheckState(clientBuilder.CredentialsPath == null, "{0} should not be set when connecting to an emulator", nameof(clientBuilder.CredentialsPath));
+                    GaxPreconditions.CheckState(clientBuilder.JsonCredentials == null, "{0} should not be set when connecting to an emulator", nameof(clientBuilder.JsonCredentials));
+                    GaxPreconditions.CheckState(clientBuilder.Scopes == null, "{0} should not be set when connecting to an emulator", nameof(clientBuilder.Scopes));
+                    GaxPreconditions.CheckState(clientBuilder.TokenAccessMethod == null, "{0} should not be set when connecting to an emulator", nameof(clientBuilder.TokenAccessMethod));
+                    clientBuilder.Endpoint = emulatorConfig.Endpoint;
+                    clientBuilder.ChannelCredentials = Grpc.Core.ChannelCredentials.Insecure;
+                    projectId = projectId ?? emulatorConfig.ProjectId;
+                }
+            }
+            GaxPreconditions.CheckState(!string.IsNullOrEmpty(projectId), "The project ID must be configured");
+            return new ConfiguredBuilder(projectId, NamespaceId, clientBuilder);
+        }
+
+        /// <summary>
+        /// The namespace ID, or null to use the default.
+        /// </summary>
+        public string NamespaceId { get; set; }
+
+        /// <inheritdoc />
+        public override DatastoreDb Build() =>
+            PrepareBuilder().Build();
+
+        /// <inheritdoc />
+        public override Task<DatastoreDb> BuildAsync(CancellationToken cancellationToken = default) =>
+            PrepareBuilder().BuildAsync(cancellationToken);
+
+        // We never end up using these methods, at least with the current implementation
+        /// <inheritdoc />
+        protected override ServiceEndpoint GetDefaultEndpoint() =>
+            throw new InvalidOperationException($"This method should never execute in {nameof(DatastoreDbBuilder)}");
+
+        /// <inheritdoc />
+        protected override IReadOnlyList<string> GetDefaultScopes() =>
+            throw new InvalidOperationException($"This method should never execute in {nameof(DatastoreDbBuilder)}");
+
+        /// <inheritdoc />
+        protected override ChannelPool GetChannelPool() =>
+            throw new InvalidOperationException($"This method should never execute in {nameof(DatastoreDbBuilder)}");
+
+        private class EmulatorConfiguration
+        {
+            internal const string EmulatorHostVariable = "DATASTORE_EMULATOR_HOST";
+            internal const string EmulatorProjectVariable = "DATASTORE_PROJECT_ID";
+            internal ServiceEndpoint Endpoint { get; }
+            internal string ProjectId { get; }
+
+            private EmulatorConfiguration(ServiceEndpoint endpoint, string projectId)
+            {
+                Endpoint = endpoint;
+                ProjectId = projectId;
+            }
+
+            internal static EmulatorConfiguration FromEnvironment()
+            {
+                // Note: we treat present-but-empty environment variables as if they were absent.
+                string hostAndPort = Environment.GetEnvironmentVariable(EmulatorHostVariable)?.Trim();
+                string projectId = Environment.GetEnvironmentVariable(EmulatorProjectVariable)?.Trim();
+                var endpoint = string.IsNullOrEmpty(hostAndPort) ? null : ServiceEndpoint.Parse(hostAndPort);
+                return new EmulatorConfiguration(endpoint, projectId == "" ? null : projectId);
+            }
+        }
+
+        private class ConfiguredBuilder
+        {
+            private string _projectId;
+            private string _namespaceId;
+            private DatastoreClientBuilder _clientBuilder;
+
+            internal ConfiguredBuilder(string projectId, string namespaceId, DatastoreClientBuilder clientBuilder)
+            {
+                _projectId = projectId;
+                _namespaceId = namespaceId;
+                _clientBuilder = clientBuilder;
+            }
+
+            internal DatastoreDb Build()
+            {
+                var client = _clientBuilder.Build();
+                return DatastoreDb.Create(_projectId, _namespaceId, client);
+            }
+
+            internal async Task<DatastoreDb> BuildAsync(CancellationToken cancellationToken)
+            {
+                var client = await _clientBuilder.BuildAsync(cancellationToken).ConfigureAwait(false);
+                return DatastoreDb.Create(_projectId, _namespaceId, client);
+            }
+        }
+    }
+}

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/EmulatorDetection.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/EmulatorDetection.cs
@@ -1,0 +1,50 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Google.Cloud.Datastore.V1
+{
+    /// <summary>
+    /// Specifies how the use of the Datastore emulator is detected via environment variables,
+    /// when used by <see cref="DatastoreDbBuilder"/>.
+    /// </summary>
+    public enum EmulatorDetection
+    {
+        /// <summary>
+        /// Ignore environment variables entirely.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Always connect to the production servers, but throw an exception if
+        /// environment variables exist that would suggest the emulator is expected.
+        /// </summary>
+        ProductionOnly = 1,
+
+        /// <summary>
+        /// Always connect to the emulator, throwing an exception if the environment
+        /// variables are not configured.
+        /// </summary>
+        EmulatorOnly = 2,
+
+        /// <summary>
+        /// Connect to the emulator if suitable environment variables are present,
+        /// or production otherwise. This is a convenient option, but risks damage to
+        /// production databases or running up unexpected bills if tests are accidentally
+        /// run in production due to environment variables being absent unexpectedly.
+        /// (Using separate projects for production and testing is a best practice for
+        /// preventing the first issue, but may be unrealistic for small or hobby projects.)
+        /// </summary>
+        ProductionOrEmulator = 3
+    }
+}

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.csproj
@@ -23,8 +23,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="2.6.0" />
-    <PackageReference Include="Grpc.Core" Version="1.18.0" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.CommonProtos" Version="1.6.0" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="2.7.0-beta02" />
+    <PackageReference Include="Grpc.Core" Version="1.19.0" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -156,6 +156,11 @@
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Datastore API, which accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.",
     "tags": [ "Datastore" ],
+    "dependencies": {
+      "Google.Api.CommonProtos": "1.6.0",
+      "Google.Api.Gax.Grpc": "2.7.0-beta02",
+      "Grpc.Core": "1.19.0",
+    },
     "testDependencies": {
       "Google.Api.Gax.Grpc.Testing": "default"
     }


### PR DESCRIPTION
Worth reviewing one commit at a time.

There's a TODO with a possible fix (which needs a GAX change) in DatastoreDbBuilder; thoughts on that possible fix very welcome.

We *could* merge this now (or after addressing the TODO) so long as we don't need to create a new GA release of Datastore before we create a GA release of GAX and ideally the generator for the builder.

If merged, would fix #2499.