### PR TITLE
Remove old workaround for docfx installation issue

### DIFF
--- a/toolversions.sh
+++ b/toolversions.sh
@@ -82,14 +82,6 @@ install_grpc() {
 install_docfx() {
   if [[ ! -f $DOCFX ]]
   then
-    # Not ideal, but only part of the temporary fix later...
-    if [[ "$VSINSTALLDIR" == "" ]]
-    then
-      echo "Unable to detect VS installation directory when installing docfx."
-      echo "Rerun from git bash launched from a VS 2017 command prompt, just once!"
-      exit 1
-    fi
-
     (echo "Fetching docfx v${DOCFX_VERSION}";
      mkdir -p $TOOL_PACKAGES;
      cd $TOOL_PACKAGES;
@@ -98,8 +90,6 @@ install_docfx() {
      curl -sSL https://github.com/dotnet/docfx/releases/download/v${DOCFX_VERSION}/docfx.zip -o tmp.zip;
      unzip -q tmp.zip;
      rm tmp.zip;
-     # Temporary fix for https://github.com/googleapis/google-cloud-dotnet/issues/1969
-     cp -f "$VSINSTALLDIR"/MSBuild/15.0/Bin/Microsoft.Build*.dll .
      )
   fi  
 }


### PR DESCRIPTION
It seems this was fixed in 2.39, but we didn't remove the workaround... which then causes problems when using VS2019.

Fixes #3003.