### PR TITLE
Use CommandTimeout to control just how long Read() can take to complete.

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SqlResultStream.RetryStateTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SqlResultStream.RetryStateTests.cs
@@ -34,7 +34,7 @@ namespace Google.Cloud.Spanner.V1.Tests
         [InlineData(StatusCode.Aborted, false)]
         [InlineData(StatusCode.Internal, true)]
         [InlineData(StatusCode.Unavailable, true)]
-        [InlineData(StatusCode.DeadlineExceeded, true)]
+        [InlineData(StatusCode.DeadlineExceeded, false)]
         public void CanRetry_SimpleStatusCodes(StatusCode code, bool expectedRetriable)
         {
             var exception = new RpcException(new Status(code, "Bang"));

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/EphemeralTransaction.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/EphemeralTransaction.cs
@@ -114,14 +114,14 @@ namespace Google.Cloud.Spanner.Data
             }
         }
 
-        public Task<ReliableStreamReader> ExecuteQueryAsync(ExecuteSqlRequest request, CancellationToken cancellationToken, int timeoutSeconds)
+        public Task<ReliableStreamReader> ExecuteQueryAsync(ExecuteSqlRequest request, CancellationToken cancellationToken, int timeoutSeconds /* ignored */)
         {
             return ExecuteHelper.WithErrorTranslationAndProfiling(Impl, "EphemeralTransaction.ExecuteQuery", _connection.Logger);
 
             async Task<ReliableStreamReader> Impl()
             {
                 PooledSession session = await _connection.AcquireSessionAsync(_transactionOptions, cancellationToken).ConfigureAwait(false);
-                var callSettings = _connection.CreateCallSettings(settings => settings.ExecuteStreamingSqlSettings, timeoutSeconds, cancellationToken);
+                var callSettings = _connection.CreateCallSettings(settings => settings.ExecuteStreamingSqlSettings, cancellationToken);
                 var reader = session.ExecuteSqlStreamReader(request, callSettings);
                 reader.StreamClosed += delegate { session.ReleaseToPool(forceDelete: false); };
                 return reader;

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/ISpannerTransaction.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/ISpannerTransaction.cs
@@ -32,6 +32,8 @@ namespace Google.Cloud.Spanner.Data
         // do if they need to return an int result type.
         Task<IEnumerable<long>> ExecuteBatchDmlAsync(ExecuteBatchDmlRequest request, CancellationToken cancellationToken, int timeoutSeconds);
 
+        // Note: the timeout here is *not* used for the streaming result set; it's used by VolatileResourceManager to set the commit timeout.
+        // (We may wish to improve this abstraction, but it works for now...)
         Task<ReliableStreamReader> ExecuteQueryAsync(ExecuteSqlRequest request, CancellationToken cancellationToken, int timeoutSeconds);
     }
 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.ExecutableCommand.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.ExecutableCommand.cs
@@ -115,7 +115,7 @@ namespace Google.Cloud.Spanner.Data
 
                 Connection.Logger.SensitiveInfo(() => $"SpannerCommand.ExecuteReader.Query={request.Sql}");
 
-                // Execute the command.
+                // Execute the command. Note that the command timeout here is only used for ambient transactions where we need to set a commit timeout.
                 var resultSet = await effectiveTransaction.ExecuteQueryAsync(request, cancellationToken, CommandTimeout)
                     .ConfigureAwait(false);
                 var conversionOptions = SpannerConversionOptions.ForConnection(Connection);
@@ -123,7 +123,7 @@ namespace Google.Cloud.Spanner.Data
                 // When the data reader is closed, we may need to dispose of the connection.
                 IDisposable resourceToClose = (behavior & CommandBehavior.CloseConnection) == CommandBehavior.CloseConnection ? Connection : null;
 
-                return new SpannerDataReader(Connection.Logger, resultSet, resourceToClose, conversionOptions, enableGetSchemaTable);
+                return new SpannerDataReader(Connection.Logger, resultSet, resourceToClose, conversionOptions, enableGetSchemaTable, CommandTimeout);
             }
 
             internal async Task<IReadOnlyList<CommandPartition>> GetReaderPartitionsAsync(long? partitionSizeBytes, long? maxPartitions, CancellationToken cancellationToken)

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnection.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnection.cs
@@ -640,6 +640,9 @@ namespace Google.Cloud.Spanner.Data
             }
         }
 
+        internal CallSettings CreateCallSettings(Func<SpannerSettings, CallSettings> settingsProvider, CancellationToken cancellationToken) =>
+            settingsProvider(Builder.SessionPoolManager.SpannerSettings).WithCancellationToken(cancellationToken);
+
         internal CallSettings CreateCallSettings(Func<SpannerSettings, CallSettings> settingsProvider, int timeoutSeconds, CancellationToken cancellationToken)
         {
             var originalSettings = settingsProvider(Builder.SessionPoolManager.SpannerSettings);

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerTransaction.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerTransaction.cs
@@ -229,13 +229,13 @@ namespace Google.Cloud.Spanner.Data
 
         Task<ReliableStreamReader> ISpannerTransaction.ExecuteQueryAsync(
             ExecuteSqlRequest request,
-            CancellationToken cancellationToken, // Not used in this case
-            int timeoutSeconds)
+            CancellationToken cancellationToken,
+            int timeoutSeconds) // Ignored
         {
             GaxPreconditions.CheckNotNull(request, nameof(request));
             CheckCompatibleMode(TransactionMode.ReadOnly);
             // We're not making any Spanner requests here, so we don't need profiling or error translation.
-            var callSettings = SpannerConnection.CreateCallSettings(settings => settings.ExecuteStreamingSqlSettings, timeoutSeconds, cancellationToken);
+            var callSettings = SpannerConnection.CreateCallSettings(settings => settings.ExecuteStreamingSqlSettings, cancellationToken);
             return Task.FromResult(_session.ExecuteSqlStreamReader(request, callSettings));
         }
 

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SqlResultStream.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SqlResultStream.cs
@@ -128,8 +128,9 @@ namespace Google.Cloud.Spanner.V1
                 {
                     if (_grpcCall == null)
                     {
-                        // TODO: Handle the case where the original call settings have a cancellation token too.
-                        _grpcCall = _client.ExecuteStreamingSql(_request, _callSettings.WithCancellationToken(cancellationToken)).GrpcCall;
+                        // Note: no cancellation token here; if we've been given a short cancellation token,
+                        // it ought to apply to just the MoveNext call, not the original request.
+                        _grpcCall = _client.ExecuteStreamingSql(_request, _callSettings).GrpcCall;
                     }
                     bool hasNext = await _grpcCall.ResponseStream
                         .MoveNext(cancellationToken)

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SqlResultStream.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SqlResultStream.cs
@@ -237,9 +237,6 @@ namespace Google.Cloud.Spanner.V1
                     // It matches on messages "HTTP/2 error code: INTERNAL_ERROR", "Connection closed with unknown cause", "Received unexpected EOS on DATA frame from server".
                     // I'd rather not use the message text if possible.
                     case StatusCode.Internal:
-                    // TODO: Check that this is valid. The Java code doesn't allow it, but it seems reasonable for a large
-                    // result set to require multiple calls to fetch all the data.
-                    case StatusCode.DeadlineExceeded:
                     case StatusCode.Unavailable:
                         return true;
                     case StatusCode.ResourceExhausted:


### PR DESCRIPTION
This mimics SqlDataReader, and also solves the issue of long-running queries - we don't need to worry about them taking more than the default time (1 minute) to complete, as that's now only applied on a per-read basis.

Fixes #2809.