### PR TITLE
Fix DatastoreDbBuilder handling of unspecified namespaces

### DIFF
--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreDb.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreDb.cs
@@ -56,6 +56,8 @@ namespace Google.Cloud.Datastore.V1
     /// </remarks>
     public abstract class DatastoreDb
     {
+        internal const string DefaultNamespaceId = "";
+
         /// <summary>
         /// The <see cref="DatastoreClient"/> used for all remote operations.
         /// </summary>
@@ -80,7 +82,7 @@ namespace Google.Cloud.Datastore.V1
         /// <param name="client">The client to use for remote operations. If this is null, an instance will be created
         /// using default settings.</param>
         /// <returns>A <see cref="DatastoreDb"/> operating on the specified partition.</returns>
-        public static DatastoreDb Create(string projectId, string namespaceId = "", DatastoreClient client = null) =>
+        public static DatastoreDb Create(string projectId, string namespaceId = DefaultNamespaceId, DatastoreClient client = null) =>
             new DatastoreDbImpl(projectId, namespaceId, client ?? DatastoreClient.Create());
 
         /// <summary>

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreDbBuilder.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreDbBuilder.cs
@@ -175,13 +175,13 @@ namespace Google.Cloud.Datastore.V1
             internal DatastoreDb Build()
             {
                 var client = _clientBuilder.Build();
-                return DatastoreDb.Create(_projectId, _namespaceId, client);
+                return DatastoreDb.Create(_projectId, _namespaceId ?? DatastoreDb.DefaultNamespaceId, client);
             }
 
             internal async Task<DatastoreDb> BuildAsync(CancellationToken cancellationToken)
             {
                 var client = await _clientBuilder.BuildAsync(cancellationToken).ConfigureAwait(false);
-                return DatastoreDb.Create(_projectId, _namespaceId, client);
+                return DatastoreDb.Create(_projectId, _namespaceId ?? DatastoreDb.DefaultNamespaceId, client);
             }
         }
     }


### PR DESCRIPTION
(This prevented the 2.2.0-beta02 release. Will retag when it's in.)