### PR TITLE
Reimplement BigQuery query execution to use GetQueryResults

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/GetQueryResultsOptionsTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/GetQueryResultsOptionsTest.cs
@@ -22,7 +22,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
     public class GetQueryResultsOptionsTest
     {
         [Fact]
-        public void ModifyRequest_NoOp()
+        public void ModifyRequest()
         {
             var options = new GetQueryResultsOptions
             {
@@ -32,48 +32,28 @@ namespace Google.Cloud.BigQuery.V2.Tests
             };
             GetQueryResultsRequest request = new GetQueryResultsRequest(new BigqueryService(), "project", "job");
             options.ModifyRequest(request);
-            Assert.Null(request.PageToken);
-            Assert.Null(request.MaxResults);
+            Assert.Equal("foo", request.PageToken);
+            Assert.Equal(25, request.MaxResults);
+            // ModifyRequest doesn't modify the timeout, as that's done externally
             Assert.Null(request.TimeoutMs);
-        }        
-
-        [Fact]
-        public void ToListRowsOptions_BothPageTokenAndStartIndexSet()
-        {
-            var options = new GetQueryResultsOptions
-            {
-                StartIndex = 10,
-                PageToken = "foo"
-            };
-            Assert.Throws<ArgumentException>(() => options.ToListRowsOptions());
         }
 
-        [Fact]
-        public void ToListRowsOptions_StartIndex()
-        {
-            var options = new GetQueryResultsOptions
-            {
-                StartIndex = 10,
-                PageSize = 25,
-            };
-            var listOptions = options.ToListRowsOptions();
-            Assert.Equal(10UL, listOptions.StartIndex);
-            Assert.Equal(25, listOptions.PageSize);
-            Assert.Null(listOptions.PageToken);
-        }
 
         [Fact]
-        public void ToListRowsOptions_PageToken()
+        public void Clone()
         {
             var options = new GetQueryResultsOptions
             {
                 PageSize = 25,
-                PageToken = "token"
+                StartIndex = 10,
+                Timeout = TimeSpan.FromMinutes(20)
             };
-            var listOptions = options.ToListRowsOptions();
-            Assert.Equal(25, listOptions.PageSize);
-            Assert.Equal("token", listOptions.PageToken);
-            Assert.Null(listOptions.StartIndex);
+            var clone = options.Clone();
+            options.PageSize = 20;
+            options.StartIndex = 5;
+            Assert.Equal(25, clone.PageSize);
+            Assert.Equal(10UL, clone.StartIndex);
+            Assert.Equal(TimeSpan.FromMinutes(20), clone.Timeout);
         }
     }
 }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/ListRowsOptionsTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/ListRowsOptionsTest.cs
@@ -63,18 +63,42 @@ namespace Google.Cloud.BigQuery.V2.Tests
         }
 
         [Fact]
-        public void Clone()
+        public void ToGetQueryResultsOptions_BothPageTokenAndStartIndexSet()
+        {
+            var options = new ListRowsOptions
+            {
+                StartIndex = 10,
+                PageToken = "foo"
+            };
+            Assert.Throws<ArgumentException>(() => options.ToGetQueryResultsOptions());
+        }
+
+        [Fact]
+        public void ToGetQueryResultsOptions_StartIndex()
+        {
+            var options = new ListRowsOptions
+            {
+                StartIndex = 10,
+                PageSize = 25,
+            };
+            var listOptions = options.ToGetQueryResultsOptions();
+            Assert.Equal(10UL, listOptions.StartIndex);
+            Assert.Equal(25, listOptions.PageSize);
+            Assert.Null(listOptions.PageToken);
+        }
+
+        [Fact]
+        public void ToGetQueryResultsOptions_PageToken()
         {
             var options = new ListRowsOptions
             {
                 PageSize = 25,
-                StartIndex = 10
+                PageToken = "token"
             };
-            var clone = options.Clone();
-            options.PageSize = 20;
-            options.StartIndex = 5;
-            Assert.Equal(25, clone.PageSize);
-            Assert.Equal(10UL, clone.StartIndex);
+            var listOptions = options.ToGetQueryResultsOptions();
+            Assert.Equal(25, listOptions.PageSize);
+            Assert.Equal("token", listOptions.PageToken);
+            Assert.Null(listOptions.StartIndex);
         }
     }
 }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClient.Queries.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClient.Queries.cs
@@ -311,6 +311,27 @@ namespace Google.Cloud.BigQuery.V2
         }
         #endregion
 
+        /// <summary>
+        /// "Raw" version of GetQueryResults, with no translation to BigQueryResults.
+        /// </summary>
+        /// <param name="jobReference">A fully-qualified identifier for the job. Must not be null.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <param name="timeoutBase">A base value to use when applying a timeout, or null to use the current date/time.</param>
+        /// <returns>The results of the query.</returns>
+        internal virtual GetQueryResultsResponse GetRawQueryResults(JobReference jobReference, GetQueryResultsOptions options, DateTime? timeoutBase) =>
+            throw new NotImplementedException();
+
+        /// <summary>
+        /// "Raw" version of GetQueryResultsAsync, with no translation to BigQueryResults.
+        /// </summary>
+        /// <param name="jobReference">A fully-qualified identifier for the job. Must not be null.</param>
+        /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
+        /// <param name="timeoutBase">A base value to use when applying a timeout, or null to use the current date/time.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>The results of the query.</returns>
+        internal virtual Task<GetQueryResultsResponse> GetRawQueryResultsAsync(JobReference jobReference, GetQueryResultsOptions options, DateTime? timeoutBase, CancellationToken cancellationToken) =>
+            throw new NotImplementedException();
+
         // Note - these methods are not part of the regular "pattern", so are not in the GetQueryResults region above.
         // We want to remove them, if the underlying GetQueryResultsResponse starts including the table reference.
         // These methods allow us to call GetQueryResultsAsync from BigQueryJob without fetching the job again.

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.Queries.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.Queries.cs
@@ -28,13 +28,11 @@ namespace Google.Cloud.BigQuery.V2
     {
         private sealed class TableRowPageManager : IPageManager<TabledataResource.ListRequest, TableDataList, BigQueryRow>
         {
-            private readonly BigQueryClient _client;
             private readonly TableSchema _schema;
             private readonly Dictionary<string, int> _fieldNameToIndexMap;
 
-            internal TableRowPageManager(BigQueryClient client, TableSchema schema)
+            internal TableRowPageManager(TableSchema schema)
             {
-                _client = client;
                 _schema = schema;
                 _fieldNameToIndexMap = schema.IndexFieldNames();                
             }
@@ -128,7 +126,7 @@ namespace Google.Cloud.BigQuery.V2
             GaxPreconditions.CheckNotNull(tableReference, nameof(tableReference));
             schema = schema ?? GetSchema(tableReference);
 
-            var pageManager = new TableRowPageManager(this, schema);
+            var pageManager = new TableRowPageManager(schema);
             return new RestPagedEnumerable<TabledataResource.ListRequest, TableDataList, BigQueryRow>(
                 () => CreateListRequest(tableReference, options), pageManager);
         }
@@ -141,7 +139,7 @@ namespace Google.Cloud.BigQuery.V2
             // a non-task value. We could defer until the first MoveNext call, but that's tricky.
             schema = schema ?? GetSchema(tableReference);
 
-            var pageManager = new TableRowPageManager(this, schema);
+            var pageManager = new TableRowPageManager(schema);
             return new RestPagedAsyncEnumerable<TabledataResource.ListRequest, TableDataList, BigQueryRow>(
                 () => CreateListRequest(tableReference, options), pageManager);
         }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.Queries.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.Queries.cs
@@ -145,12 +145,6 @@ namespace Google.Cloud.BigQuery.V2
         }
 
         // Request creation
-        private JobsResource.InsertRequest CreateInsertQueryJobRequest(JobConfigurationQuery query, QueryOptions options)
-        {
-            options?.ModifyRequest(query);
-            return CreateInsertJobRequest(new JobConfiguration { Query = query, DryRun = options?.DryRun }, options);
-        }
-
         private JobsResource.InsertRequest CreateInsertQueryJobRequest(string sql, IEnumerable<BigQueryParameter> parameters, QueryOptions options)
         {
             GaxPreconditions.CheckNotNull(sql, nameof(sql));

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryResults.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryResults.cs
@@ -30,8 +30,9 @@ namespace Google.Cloud.BigQuery.V2
     public sealed class BigQueryResults : IEnumerable<BigQueryRow>
     {
         private readonly BigQueryClient _client;
-        private readonly ListRowsOptions _options;
+        private readonly GetQueryResultsOptions _options;
         private readonly GetQueryResultsResponse _response;
+        private readonly Dictionary<string, int> _fieldNames;
 
         /// <summary>
         /// The reference to the query job.
@@ -71,6 +72,11 @@ namespace Google.Cloud.BigQuery.V2
         public long? NumDmlAffectedRows => _response.NumDmlAffectedRows;
 
         /// <summary>
+        /// The rows in the response, or an empty sequence if the response contains no rows.
+        /// </summary>
+        private IEnumerable<BigQueryRow> ResponseRows => ConvertResponseRows(_response);
+
+        /// <summary>
         /// Returns an asynchronous sequence of rows from this set of results.
         /// </summary>
         /// <remarks>
@@ -78,14 +84,7 @@ namespace Google.Cloud.BigQuery.V2
         /// ambiguity.</para>
         /// </remarks>
         /// <returns>An asynchronous sequence of rows from this set of results.</returns>
-        public IAsyncEnumerable<BigQueryRow> GetRowsAsync() => _client.ListRowsAsync(TableReference, Schema, _options);
-
-        /// <summary>
-        /// Returns an iterator over the query results.
-        /// </summary>
-        /// <returns>An iterator over the query results.</returns>
-        public IEnumerator<BigQueryRow> GetEnumerator() =>
-            _client.ListRows(TableReference, Schema, _options).GetEnumerator();
+        public IAsyncEnumerable<BigQueryRow> GetRowsAsync() => new AsyncRowEnumerable(this);
 
         /// <summary>
         /// Returns an iterator over the query results.
@@ -104,12 +103,54 @@ namespace Google.Cloud.BigQuery.V2
         /// <param name="response">The response to a GetQueryResults API call. Must not be null.</param>
         /// <param name="tableReference">A reference to the table containing the results.</param>
         /// <param name="options">Options to use when listing rows. May be null.</param>
+        [Obsolete("Please use the constructor accepting a GetQueryResultsOptions instead")]
         public BigQueryResults(BigQueryClient client, GetQueryResultsResponse response, TableReference tableReference, ListRowsOptions options)
+            : this(client, response, tableReference, options?.ToGetQueryResultsOptions())
+        {
+        }
+
+        /// <summary>
+        /// Constructs a new set of results.
+        /// </summary>
+        /// <remarks>
+        /// This is public to allow tests to construct instances for production code to consume;
+        /// production code should not normally construct instances itself.
+        /// </remarks>
+        /// <param name="client">The client to use for further operations. Must not be null.</param>
+        /// <param name="response">The response to a GetQueryResults API call. Must not be null.</param>
+        /// <param name="tableReference">A reference to the table containing the results.</param>
+        /// <param name="options">Options to use when fetching results. May be null.</param>
+        public BigQueryResults(BigQueryClient client, GetQueryResultsResponse response, TableReference tableReference, GetQueryResultsOptions options)
         {
             _client = GaxPreconditions.CheckNotNull(client, nameof(client));
             _response = GaxPreconditions.CheckNotNull(response, nameof(response));
             TableReference = GaxPreconditions.CheckNotNull(tableReference, nameof(tableReference));
             _options = options;
+            _fieldNames = response.Schema?.IndexFieldNames();
+        }
+
+        /// <summary>
+        /// Returns an iterator over the query results.
+        /// </summary>
+        /// <returns>An iterator over the query results.</returns>
+        public IEnumerator<BigQueryRow> GetEnumerator()
+        {
+            foreach (var row in ResponseRows)
+            {
+                yield return row;
+            }
+            GetQueryResultsOptions clonedOptions = _options?.Clone() ?? new GetQueryResultsOptions();
+            clonedOptions.StartIndex = null;
+            clonedOptions.PageToken = _response.PageToken;
+            while (clonedOptions.PageToken != null)
+            {
+                var response = _client.GetRawQueryResults(JobReference, clonedOptions, timeoutBase: null);
+                foreach (var row in ConvertResponseRows(response))
+                {
+                    yield return row;
+                }
+                clonedOptions.PageToken = response.PageToken;
+            }
         }
 
         /// <summary>
@@ -122,10 +163,32 @@ namespace Google.Cloud.BigQuery.V2
         public BigQueryPage ReadPage(int pageSize)
         {
             GaxPreconditions.CheckArgumentRange(pageSize, nameof(pageSize), 1, int.MaxValue);
-            // Make sure we start off by trying to read the right page size...
-            var options = GetOptionsWithPageSize(pageSize);
-            var page = _client.ListRows(TableReference, Schema, options).ReadPage(pageSize);
-            return new BigQueryPage(page, Schema, JobReference, TableReference);
+            GetQueryResultsOptions clonedOptions = _options?.Clone() ?? new GetQueryResultsOptions();
+            List<BigQueryRow> rows = new List<BigQueryRow>(pageSize);
+
+            // Work out whether to use the response we've already got, or create a new one.
+            GetQueryResultsResponse response = _response;
+            if (_response.Rows?.Count > pageSize)
+            {
+                // Oops. Do it again from scratch, with a useful page size.
+                clonedOptions.PageSize = pageSize;
+                response = _client.GetRawQueryResults(JobReference, clonedOptions, timeoutBase: null);
+            }
+            // First add the rows from the existing response.
+            rows.AddRange(ConvertResponseRows(response));
+            string pageToken = _response.PageToken;
+            clonedOptions.StartIndex = null;
+
+            // Now keep going until we've filled the result set or know there's no more data.
+            while (rows.Count < pageSize && pageToken != null)
+            {
+                clonedOptions.PageToken = pageToken;
+                clonedOptions.PageSize = pageSize - rows.Count;
+                var nextResponse = _client.GetRawQueryResults(JobReference, clonedOptions, timeoutBase: null);
+                rows.AddRange(ConvertResponseRows(nextResponse));
+                pageToken = nextResponse.PageToken;
+            }
+            return new BigQueryPage(rows, Schema, JobReference, TableReference, pageToken);
         }
 
         /// <summary>
@@ -140,27 +203,32 @@ namespace Google.Cloud.BigQuery.V2
         public async Task<BigQueryPage> ReadPageAsync(int pageSize, CancellationToken cancellationToken = default)
         {
             GaxPreconditions.CheckArgumentRange(pageSize, nameof(pageSize), 1, int.MaxValue);
-            // Make sure we start off by trying to read the right page size...
-            var options = GetOptionsWithPageSize(pageSize);
-            var page = await _client.ListRowsAsync(TableReference, Schema, options)
-                .ReadPageAsync(pageSize, cancellationToken)
-                .ConfigureAwait(false);
-            return new BigQueryPage(page, Schema, JobReference, TableReference);
-        }
+            GetQueryResultsOptions clonedOptions = _options?.Clone() ?? new GetQueryResultsOptions();
+            List<BigQueryRow> rows = new List<BigQueryRow>(pageSize);
 
-        private ListRowsOptions GetOptionsWithPageSize(int pageSize)
-        {
-            if (_options == null)
+            // Work out whether to use the response we've already got, or create a new one.
+            GetQueryResultsResponse response = _response;
+            if (_response.Rows?.Count > pageSize)
             {
-                return new ListRowsOptions { PageSize = pageSize };
+                // Oops. Do it again from scratch, with a useful page size.
+                clonedOptions.PageSize = pageSize;
+                response = await _client.GetRawQueryResultsAsync(JobReference, clonedOptions, timeoutBase: null, cancellationToken).ConfigureAwait(false);
             }
-            if (_options.PageSize == pageSize)
+            // First add the rows from the existing response.
+            rows.AddRange(ConvertResponseRows(response));
+            string pageToken = _response.PageToken;
+            clonedOptions.StartIndex = null;
+
+            // Now keep going until we've filled the result set or know there's no more data.
+            while (rows.Count < pageSize && pageToken != null)
             {
-                return _options;
+                clonedOptions.PageToken = pageToken;
+                clonedOptions.PageSize = pageSize - rows.Count;
+                var nextResponse = await _client.GetRawQueryResultsAsync(JobReference, clonedOptions, timeoutBase: null, cancellationToken).ConfigureAwait(false);
+                rows.AddRange(ConvertResponseRows(nextResponse));
+                pageToken = nextResponse.PageToken;
             }
-            var clone = _options.Clone();
-            clone.PageSize = pageSize;
-            return clone;
+            return new BigQueryPage(rows, Schema, JobReference, TableReference, pageToken);
         }
 
         // TODO: Work out how we can get this far (a valid query with results, but with an error as well).
@@ -192,5 +260,58 @@ namespace Google.Cloud.BigQuery.V2
             }
             return this;
         }
+
+        private sealed class AsyncRowEnumerable : IAsyncEnumerable<BigQueryRow>
+        {
+            private readonly BigQueryResults _parent;
+
+            public AsyncRowEnumerable(BigQueryResults parent) => _parent = parent;
+
+            public IAsyncEnumerator<BigQueryRow> GetEnumerator() => new AsyncRowEnumerator(_parent);
+        }
+
+        private sealed class AsyncRowEnumerator : IAsyncEnumerator<BigQueryRow>
+        {
+            private readonly GetQueryResultsOptions _options;
+            private readonly BigQueryResults _parent;
+            private IEnumerator<BigQueryRow> _underlyingEnumerator;
+
+            public AsyncRowEnumerator(BigQueryResults parent)
+            {
+                _parent = parent;
+                _options = parent._options?.Clone() ?? new GetQueryResultsOptions();
+                _options.StartIndex = null;
+                _options.PageToken = parent._response.PageToken;
+                _underlyingEnumerator = parent.ResponseRows.GetEnumerator();
+            }
+
+            public BigQueryRow Current => _underlyingEnumerator.Current;
+
+            public async Task<bool> MoveNext(CancellationToken cancellationToken)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                // Keep asking for rows until we've got one, or we've run out of pages.
+                while (!_underlyingEnumerator.MoveNext())
+                {
+                    if (_options.PageToken == null)
+                    {
+                        return false;
+                    }
+                    var nextResponse = await _parent._client.GetRawQueryResultsAsync(_parent.JobReference, _options, timeoutBase: null, cancellationToken).ConfigureAwait(false);
+                    // Set the page token for the next time we need to fetch
+                    _options.PageToken = nextResponse.PageToken;
+                    _underlyingEnumerator = _parent.ConvertResponseRows(nextResponse).GetEnumerator();
+                }
+                return true;
+            }
+
+            public void Dispose()
+            {
+                // No-op
+            }
+        }
+
+        private IEnumerable<BigQueryRow> ConvertResponseRows(GetQueryResultsResponse response) =>
+            (response.Rows ?? Enumerable.Empty<TableRow>()).Select(r => new BigQueryRow(r, Schema, _fieldNames));
     }
 }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/GetQueryResultsOptions.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/GetQueryResultsOptions.cs
@@ -58,22 +58,32 @@ namespace Google.Cloud.BigQuery.V2
 
         internal void ModifyRequest(GetQueryResultsRequest request)
         {
-            // Nothing to do? We may have something later...
-        }
-
-        internal ListRowsOptions ToListRowsOptions()
-        {
             if (PageToken != null && StartIndex != null)
             {
                 throw new ArgumentException($"Cannot specify both {nameof(PageToken)} and {nameof(StartIndex)}");
             }
 
-            return new ListRowsOptions
+            if (PageSize != null)
             {
-                PageSize = PageSize,
-                StartIndex = StartIndex,
-                PageToken = PageToken
-            };
+                request.MaxResults = PageSize;
+            }
+            if (PageToken != null)
+            {
+                request.PageToken = PageToken;
+            }
+            if (StartIndex != null)
+            {
+                request.StartIndex = StartIndex;
+            }
         }
+
+        internal GetQueryResultsOptions Clone() => new GetQueryResultsOptions
+        {
+            PageSize = PageSize,
+            PageToken = PageToken,
+            StartIndex = StartIndex,
+            Timeout = Timeout
+        };
+
     }
 }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/ListRowsOptions.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/ListRowsOptions.cs
@@ -61,11 +61,20 @@ namespace Google.Cloud.BigQuery.V2
             }
         }
 
-        internal ListRowsOptions Clone() => new ListRowsOptions
+        internal GetQueryResultsOptions ToGetQueryResultsOptions()
         {
-            PageSize = PageSize,
-            PageToken = PageToken,
-            StartIndex = StartIndex
-        };
+            if (PageToken != null && StartIndex != null)
+            {
+                throw new ArgumentException($"Cannot specify both {nameof(PageToken)} and {nameof(StartIndex)}");
+            }
+
+            return new GetQueryResultsOptions
+            {
+                PageSize = PageSize,
+                StartIndex = StartIndex,
+                PageToken = PageToken
+            };
+        }
+
     }
 }

--- a/apis/Google.Cloud.BigQuery.V2/docs/index.md
+++ b/apis/Google.Cloud.BigQuery.V2/docs/index.md
@@ -80,14 +80,18 @@ afterwards using DML:
 
 {{sample:BigQueryClient.DmlSample}}
 
-### Important note on the result returned by DML operations
+### Important note on the result returned by DML operations (in version 1.3.0)
 
-Iterating over the results of a `BigQueryResults` object returned
+In version 1.3.0, iterating over the results of a `BigQueryResults` object returned
 from a DML operation will iterate over the entire table modified by
 that operation. This is a side-effect of the way the underlying API
 is called, but it's rarely useful to iterate over the results. The
 `NumDmlAffectedRows` property of the results object is useful,
 however, in determining how many rows were modified.
+
+From version 1.4.0-beta01 onwards, the `BigQueryResults` object
+returned from a DML operation returns no rows, but
+`NumDmlAffectedRows` still returns the number of affected rows.
 
 ## Creating a table partitioned by time
 


### PR DESCRIPTION
Background: we used to use GetQueryResults, then we were asked to use ListRows - but this slows down queries, as observed in #2876. It turns out that GetQueryResults is now the preferred client library usage, so it's worth changing back to it.

(This review is fine to wait until you're back from the US, Chris.)