### PR TITLE
Support for HMAC keys associated with service accounts in GCS

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/HmacKeysTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/HmacKeysTest.cs
@@ -1,0 +1,157 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Auth.OAuth2;
+using Google.Apis.Storage.v1.Data;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Cloud.Storage.V1.IntegrationTests
+{
+    [Collection(nameof(StorageFixture))]
+    public class HmacKeysTest
+    {
+        private readonly StorageFixture _fixture;
+
+        public HmacKeysTest(StorageFixture fixture) => _fixture = fixture;
+
+        [Fact]
+        public void Lifecycle()
+        {
+            var client = _fixture.Client;
+            var projectId = _fixture.ProjectId;
+            var serviceAccountEmail = GetServiceAccountEmail();
+            // This is generally a valid service account for a project.
+            string alternativeServiceAccountEmail = $"{projectId}@appspot.gserviceaccount.com";
+
+            // If we find this fails in CI, we'll need to work out an alternative plan.
+            Assert.NotEqual(serviceAccountEmail, alternativeServiceAccountEmail);
+
+            Assert.Empty(client.ListHmacKeys(projectId));
+            var key = client.CreateHmacKey(projectId, serviceAccountEmail);
+            // TODO: When the discovery doc has been updated, this should be an HmacKeyMetadata
+            dynamic metadata = key.Metadata;
+            string accessId = metadata.accessId;
+
+            // We should always get a 40 character secret, which is valid base64.
+            Assert.Equal(40, key.Secret.Length);
+            Convert.FromBase64String(key.Secret);
+
+            // We should now be able to find the key when listing it, either with no filter or filtering by the right email address.
+            var listed = Assert.Single(client.ListHmacKeys(projectId));
+            Assert.Equal(accessId, listed.AccessId);
+            listed = Assert.Single(client.ListHmacKeys(projectId, serviceAccountEmail));
+            Assert.Equal(accessId, listed.AccessId);
+
+            // But not when filtering with the wrong email address.
+            Assert.Empty(client.ListHmacKeys(projectId, alternativeServiceAccountEmail));
+
+            // We should be able to update the key to disable it.
+            // Note: We shouldn't need to create this ourselves...
+            var fixme = new HmacKeyMetadata
+            {
+                ProjectId = projectId,
+                AccessId = accessId,
+                State = HmacKeyStates.Inactive
+            };
+            var updated = client.UpdateHmacKey(fixme);
+            Assert.Equal(fixme.State, updated.State);
+
+            // We should be able to fetch the key and see that it's been updated
+            var fetched = client.GetHmacKey(projectId, accessId);
+            Assert.Equal(fixme.State, fetched.State);
+
+            // We should be able to delete the key
+            client.DeleteHmacKey(projectId, accessId);
+
+            var deleted = client.GetHmacKey(projectId, accessId);
+            Assert.Equal(HmacKeyStates.Deleted, deleted.State);
+
+            // The deleted key should not show normally in list operations, but should show if we ask for deleted ones
+            Assert.Empty(client.ListHmacKeys(projectId));
+            Assert.Single(client.ListHmacKeys(projectId, options: new ListHmacKeysOptions { ShowDeletedKeys = true }),
+                k => k.AccessId == accessId);
+        }
+
+        [Fact]
+        public async Task LifecycleAsync()
+        {
+            var client = _fixture.Client;
+            var projectId = _fixture.ProjectId;
+            var serviceAccountEmail = GetServiceAccountEmail();
+            string alternativeServiceAccountEmail = $"{projectId}@appspot.gserviceaccount.com";
+
+            // If we find this fails in CI, we'll need to work out an alternative plan.
+            Assert.NotEqual(serviceAccountEmail, alternativeServiceAccountEmail);
+
+            Assert.Empty(await client.ListHmacKeysAsync(projectId).ToList());
+            var key = await client.CreateHmacKeyAsync(projectId, serviceAccountEmail);
+            // TODO: When the discovery doc has been updated, this should be an HmacKeyMetadata
+            dynamic metadata = key.Metadata;
+            string accessId = metadata.accessId;
+
+            // We should always get a 40 character secret, which is valid base64.
+            Assert.Equal(40, key.Secret.Length);
+            Convert.FromBase64String(key.Secret);
+
+            // We should now be able to find the key when listing it, either with no filter or filtering by the right email address.
+            var listed = Assert.Single(await client.ListHmacKeysAsync(projectId).ToList());
+            Assert.Equal(accessId, listed.AccessId);
+            listed = Assert.Single(await client.ListHmacKeysAsync(projectId, serviceAccountEmail).ToList());
+            Assert.Equal(accessId, listed.AccessId);
+            // But not when filtering with the wrong email address
+            Assert.Empty(await client.ListHmacKeysAsync(projectId, alternativeServiceAccountEmail).ToList());
+
+            // We should be able to update the key to disable it.
+            // Note: We shouldn't need to create this ourselves...
+            var fixme = new HmacKeyMetadata
+            {
+                ProjectId = projectId,
+                AccessId = accessId,
+                State = HmacKeyStates.Inactive
+            };
+            var updated = await client.UpdateHmacKeyAsync(fixme);
+            Assert.Equal(fixme.State, updated.State);
+
+            // We should be able to fetch the key and see that it's been updated
+            var fetched = await client.GetHmacKeyAsync(projectId, accessId);
+            Assert.Equal(fixme.State, fetched.State);
+
+            // We should be able to delete the key
+            await client.DeleteHmacKeyAsync(projectId, accessId);
+            var deleted = await client.GetHmacKeyAsync(projectId, accessId);
+            Assert.Equal(HmacKeyStates.Deleted, deleted.State);
+
+            // The deleted key should not show normally in list operations, but should show if we ask for deleted ones
+            Assert.Empty(await client.ListHmacKeysAsync(projectId).ToList());
+            Assert.Single(await client.ListHmacKeysAsync(projectId, options: new ListHmacKeysOptions { ShowDeletedKeys = true }).ToList(),
+                k => k.AccessId == accessId);
+        }
+
+        private static string GetServiceAccountEmail()
+        {
+            var cred = GoogleCredential.GetApplicationDefault().UnderlyingCredential;
+            switch (cred)
+            {
+                case ServiceAccountCredential sac:
+                    return sac.Id;
+                // TODO: We may well need to handle ComputeCredential for Kokoro.
+                default:
+                    throw new InvalidOperationException($"Unable to retrieve service account email address for credential type {cred.GetType()}");
+            }
+        }
+    }
+}

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/ListHmacKeysOptionsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/ListHmacKeysOptionsTest.cs
@@ -1,0 +1,49 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+using static Google.Apis.Storage.v1.ProjectsResource.HmacKeysResource;
+
+namespace Google.Cloud.Storage.V1.Tests
+{
+    public class ListHmacKeysOptionsTest
+    {
+        [Fact]
+        public void ModifyRequest_DefaultOptions()
+        {
+            var request = new ListRequest(null, "project");
+            var options = new ListHmacKeysOptions();
+            options.ModifyRequest(request);
+            Assert.Null(request.ShowDeletedKeys);
+            Assert.Null(request.MaxResults);
+            Assert.Null(request.PageToken);
+        }
+
+        [Fact]
+        public void ModifyRequest_AllOptions()
+        {
+            var request = new ListRequest(null, "project");
+            var options = new ListHmacKeysOptions
+            {
+                PageSize = 10,
+                PageToken = "nextpage",
+                ShowDeletedKeys = true
+            };
+            options.ModifyRequest(request);
+            Assert.Equal(10, request.MaxResults);
+            Assert.Equal("nextpage", request.PageToken);
+            Assert.True(request.ShowDeletedKeys);
+        }
+    }
+}

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/CreateHmacKeyOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/CreateHmacKeyOptions.cs
@@ -1,0 +1,28 @@
+﻿// Copyright 2019 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using static Google.Apis.Storage.v1.ProjectsResource;
+
+namespace Google.Cloud.Storage.V1
+{
+    /// <summary>
+    /// Options for <c>CreateHmacKey</c> operations.
+    /// </summary>
+    public sealed class CreateHmacKeyOptions
+    {
+        internal void ModifyRequest(HmacKeysResource.CreateRequest request)
+        {
+        }
+    }
+}

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/DeleteHmacKeyOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/DeleteHmacKeyOptions.cs
@@ -1,0 +1,28 @@
+﻿// Copyright 2019 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Storage.v1;
+
+namespace Google.Cloud.Storage.V1
+{
+    /// <summary>
+    /// Options for <c>DeleteHmacKey</c> operations.
+    /// </summary>
+    public sealed class DeleteHmacKeyOptions
+    {
+        internal void ModifyRequest(ProjectsResource.HmacKeysResource.DeleteRequest request)
+        {
+        }
+    }
+}

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/GetHmacKeyOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/GetHmacKeyOptions.cs
@@ -1,0 +1,28 @@
+﻿// Copyright 2019 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Storage.v1;
+
+namespace Google.Cloud.Storage.V1
+{
+    /// <summary>
+    /// Options for <c>GetHmacKey</c> operations.
+    /// </summary>
+    public sealed class GetHmacKeyOptions
+    {
+        internal void ModifyRequest(ProjectsResource.HmacKeysResource.GetRequest request)
+        {
+        }
+    }
+}

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Rest" Version="2.6.0" />
-    <PackageReference Include="Google.Apis.Storage.v1" Version="1.38.0.1517" />
+    <PackageReference Include="Google.Apis.Storage.v1" Version="1.38.2.1545" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/HmacKeyStates.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/HmacKeyStates.cs
@@ -1,0 +1,42 @@
+﻿// Copyright 2019 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Storage.v1.Data;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Google.Cloud.Storage.V1
+{
+    /// <summary>
+    /// String constants for the names of the storage classes, as used in <see cref="HmacKeyMetadata.State" />.
+    /// </summary>
+    public static class HmacKeyStates
+    {
+        /// <summary>
+        /// The key is active, and can be used for signing. It cannot be deleted in this state.
+        /// </summary>
+        public const string Active = "ACTIVE";
+
+        /// <summary>
+        /// The key is inactive, and can be used for signing. It can be deleted.
+        /// </summary>
+        public const string Inactive = "INACTIVE";
+
+        /// <summary>
+        /// The key has been deleted.
+        /// </summary>
+        public const string Deleted = "DELETE";
+    }
+}

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/ListHmacKeysOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/ListHmacKeysOptions.cs
@@ -1,0 +1,59 @@
+﻿// Copyright 2019 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using Google.Apis.Storage.v1;
+
+namespace Google.Cloud.Storage.V1
+{
+    /// <summary>
+    /// Options for <c>ListHmacKey</c> operations.
+    /// </summary>
+    public sealed class ListHmacKeysOptions
+    {
+        /// <summary>
+        /// The number of results to return per page. (This modifies the per-request page size;
+        /// it does not affect the total number of results returned.)
+        /// </summary>
+        public int? PageSize { get; set; }
+
+        /// <summary>
+        /// If set, this token is used to indicate a continued list operation.
+        /// The value should be taken from the <c>NextPageToken</c> property of either
+        /// a <see cref="Page{TResource}"/> or a raw response from <see cref="PagedEnumerable{TResponse, TResource}.AsRawResponses"/>.
+        /// </summary>
+        public string PageToken { get; set; }
+
+        /// <summary>
+        /// If set, this determines whether deleted keys are included in the results.
+        /// </summary>
+        public bool? ShowDeletedKeys { get; set; }
+
+        internal void ModifyRequest(ProjectsResource.HmacKeysResource.ListRequest request)
+        {
+            if (PageSize != null)
+            {
+                request.MaxResults = PageSize;
+            }
+            if (PageToken != null)
+            {
+                request.PageToken = PageToken;
+            }
+            if (ShowDeletedKeys != null)
+            {
+                request.ShowDeletedKeys = ShowDeletedKeys;
+            }
+        }
+    }
+}

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClient.HmacKeys.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClient.HmacKeys.cs
@@ -1,0 +1,141 @@
+﻿// Copyright 2019 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using Google.Apis.Storage.v1.Data;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Cloud.Storage.V1
+{
+    public partial class StorageClient
+    {
+        /// <summary>
+        /// Synchronously creates a new HMAC key associated with a service account.
+        /// </summary>
+        /// <param name="projectId">The project ID in which to create the HMAC key. Must not be null.</param>
+        /// <param name="serviceAccountEmail">The service account to associate with the HMAC key. Must not be null.</param>
+        /// <param name="options">Additional options for the operation. May be null, in which case appropriate defaults will be used.</param>
+        /// <returns>The new HMAC key, including the secret information in <see cref="HmacKey.Secret"/>. This secret is only ever returned when creating a key.</returns>
+        public virtual HmacKey CreateHmacKey(string projectId, string serviceAccountEmail, CreateHmacKeyOptions options = null) =>
+            throw new NotImplementedException();
+
+        /// <summary>
+        /// Asynchronously creates a new HMAC key associated with a service account.
+        /// </summary>
+        /// <param name="projectId">The project ID in which to create the HMAC key. Must not be null.</param>
+        /// <param name="serviceAccountEmail">The service account to associate with the HMAC key. Must not be null.</param>
+        /// <param name="options">Additional options for the operation. May be null, in which case appropriate defaults will be used.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task representing the asynchronous operation, with a result returning the
+        /// the new HMAC key, including the secret information in <see cref="HmacKey.Secret"/>. This secret is only ever returned when creating a key.</returns>
+        public virtual Task<HmacKey> CreateHmacKeyAsync(string projectId, string serviceAccountEmail, CreateHmacKeyOptions options = null, CancellationToken cancellationToken = default) =>
+            throw new NotImplementedException();
+
+        /// <summary>
+        /// Synchronously fetches metadata for the specified HMAC key.
+        /// </summary>
+        /// <param name="projectId">The project containing the HMAC key. Must not be null.</param>
+        /// <param name="accessId">The ID of the HMAC key. Must not be null.</param>
+        /// <param name="options">Additional options for the operation. May be null, in which case appropriate defaults will be used.</param>
+        /// <returns>The HMAC key metadata</returns>
+        public virtual HmacKeyMetadata GetHmacKey(string projectId, string accessId, GetHmacKeyOptions options = null) =>
+            throw new NotImplementedException();
+
+        /// <summary>
+        /// Asynchronously fetches metadata for the specified HMAC key.
+        /// </summary>
+        /// <param name="projectId">The project containing the HMAC key. Must not be null.</param>
+        /// <param name="accessId">The ID of the HMAC key. Must not be null.</param>
+        /// <param name="options">Additional options for the operation. May be null, in which case appropriate defaults will be used.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task representing the asynchronous operation, with a result returning the HMAC key metadata.</returns>
+        public virtual Task<HmacKeyMetadata> GetHmacKeyAsync(string projectId, string accessId, GetHmacKeyOptions options = null, CancellationToken cancellationToken = default) =>
+            throw new NotImplementedException();
+
+        /// <summary>
+        /// Lists the HMAC keys in a given project, synchronously but lazily, optionally filtering by service account email address.
+        /// </summary>
+        /// <remarks>
+        /// This method fetches the buckets lazily, making requests to the underlying service
+        /// for a page of results at a time, as required. No network requests are made until the returned sequence is enumerated.
+        /// This means that any exception due to an invalid request will be deferred until that time. Callers should be prepared
+        /// for exceptions to be thrown while enumerating the results. In addition to failures due to invalid requests, network
+        /// or service failures can cause exceptions even after the first results have been returned.
+        /// </remarks>
+        /// <param name="projectId">The project containing the HMAC keys. Must not be null.</param>
+        /// <param name="serviceAccountEmail">The service account email address to list keys for. May be null, in which case all HMAC keys associated with the project are returned.</param>
+        /// <param name="options">Additional options for the operation. May be null, in which case appropriate defaults will be used.</param>
+        /// <returns>A sequence of HMAC keys within the project.</returns>
+        public virtual PagedEnumerable<HmacKeysMetadata, HmacKeyMetadata> ListHmacKeys(string projectId, string serviceAccountEmail = null, ListHmacKeysOptions options = null) =>
+            throw new NotImplementedException();
+
+        /// <summary>
+        /// Lists the HMAC keys in a given project, asynchronously and lazily, optionally filtering by service account email address.
+        /// </summary>
+        /// <remarks>
+        /// This method fetches the buckets lazily, making requests to the underlying service
+        /// for a page of results at a time, as required. No network requests are made until the returned sequence is enumerated.
+        /// This means that any exception due to an invalid request will be deferred until that time. Callers should be prepared
+        /// for exceptions to be thrown while enumerating the results. In addition to failures due to invalid requests, network
+        /// or service failures can cause exceptions even after the first results have been returned.
+        /// </remarks>
+        /// <param name="projectId">The project containing the HMAC keys. Must not be null.</param>
+        /// <param name="serviceAccountEmail">The service account email address to list keys for. May be null, in which case all HMAC keys associated with the project are returned.</param>
+        /// <param name="options">Additional options for the operation. May be null, in which case appropriate defaults will be used.</param>
+        /// <returns>An asynchronous sequence of HMAC keys within the project.</returns>
+        public virtual PagedAsyncEnumerable<HmacKeysMetadata, HmacKeyMetadata> ListHmacKeysAsync(string projectId, string serviceAccountEmail = null, ListHmacKeysOptions options = null) =>
+            throw new NotImplementedException();
+
+        /// <summary>
+        /// Synchronously updates an HMAC key's metadata.
+        /// </summary>
+        /// <param name="key">The key to update. Must not be null, and the <see cref="HmacKeyMetadata.ProjectId"/> and <see cref="HmacKeyMetadata.AccessId"/> properties must be set.</param>
+        /// <param name="options">Additional options for the operation. May be null, in which case appropriate defaults will be used.</param>
+        /// <returns>The updated key metadata.</returns>
+        public virtual HmacKeyMetadata UpdateHmacKey(HmacKeyMetadata key, UpdateHmacKeyOptions options = null) =>
+            throw new NotImplementedException();
+
+        /// <summary>
+        /// Asynchronously updates an HMAC key's metadata.
+        /// </summary>
+        /// <param name="key">The key to update. Must not be null, and the <see cref="HmacKeyMetadata.ProjectId"/> and <see cref="HmacKeyMetadata.AccessId"/> properties must be set.</param>
+        /// <param name="options">Additional options for the operation. May be null, in which case appropriate defaults will be used.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task representing the asynchronous operation, with a result returning the updated key metadata.</returns>
+        public virtual Task<HmacKeyMetadata> UpdateHmacKeyAsync(HmacKeyMetadata key, UpdateHmacKeyOptions options = null, CancellationToken cancellationToken = default) =>
+            throw new NotImplementedException();
+
+        /// <summary>
+        /// Synchronously deletes an HMAC key, which must already have been deactivated.
+        /// </summary>
+        /// <param name="projectId">The ID of the project containing the HMAC key to delete. </param>
+        /// <param name="accessId">The ID of the HMAC key to delete. Must not be null.</param>
+        /// <param name="options">Additional options for the operation. May be null, in which case appropriate defaults will be used.</param>
+        public virtual void DeleteHmacKey(string projectId, string accessId, DeleteHmacKeyOptions options = null) =>
+            throw new NotImplementedException();
+
+        /// <summary>
+        /// Asynchronously deletes an HMAC key, which must already have been deactivated.
+        /// </summary>
+        /// <param name="projectId">The ID of the project containing the HMAC key to delete. </param>
+        /// <param name="accessId">The ID of the HMAC key to delete. Must not be null.</param>
+        /// <param name="options">Additional options for the operation. May be null, in which case appropriate defaults will be used.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        public virtual Task DeleteHmacKeyAsync(string projectId, string accessId, DeleteHmacKeyOptions options = null, CancellationToken cancellationToken = default) =>
+            throw new NotImplementedException();
+    }
+}

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.HmacKeys.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.HmacKeys.cs
@@ -1,0 +1,134 @@
+﻿// Copyright 2019 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using Google.Api.Gax.Rest;
+using Google.Apis.Storage.v1.Data;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using static Google.Apis.Storage.v1.ProjectsResource;
+
+namespace Google.Cloud.Storage.V1
+{
+    public partial class StorageClientImpl
+    {
+        private sealed class HmacKeyPageManager : IPageManager<HmacKeysResource.ListRequest, HmacKeysMetadata, HmacKeyMetadata>
+        {
+            internal static readonly HmacKeyPageManager Instance = new HmacKeyPageManager();
+            public string GetNextPageToken(HmacKeysMetadata response) => response.NextPageToken;
+            public IEnumerable<HmacKeyMetadata> GetResources(HmacKeysMetadata response) => response.Items;
+            public void SetPageSize(HmacKeysResource.ListRequest request, int pageSize) => request.MaxResults = pageSize;
+            public void SetPageToken(HmacKeysResource.ListRequest request, string pageToken) => request.PageToken = pageToken;
+        }
+
+        /// <inheritdoc />
+        public override HmacKey CreateHmacKey(string projectId, string serviceAccountEmail, CreateHmacKeyOptions options = null) =>
+            CreateCreateHmacKeyRequest(projectId, serviceAccountEmail, options).Execute();
+
+        /// <inheritdoc />
+        public override Task<HmacKey> CreateHmacKeyAsync(string projectId, string serviceAccountEmail, CreateHmacKeyOptions options = null, CancellationToken cancellationToken = default) =>
+            CreateCreateHmacKeyRequest(projectId, serviceAccountEmail, options).ExecuteAsync(cancellationToken);
+
+        /// <inheritdoc />
+        public override HmacKeyMetadata GetHmacKey(string projectId, string accessId, GetHmacKeyOptions options = null) =>
+            CreateGetHmacKeyRequest(projectId, accessId, options).Execute();
+
+        /// <inheritdoc />
+        public override Task<HmacKeyMetadata> GetHmacKeyAsync(string projectId, string accessId, GetHmacKeyOptions options = null, CancellationToken cancellationToken = default) =>
+            CreateGetHmacKeyRequest(projectId, accessId, options).ExecuteAsync(cancellationToken);
+
+        /// <inheritdoc />
+        public override PagedEnumerable<HmacKeysMetadata, HmacKeyMetadata> ListHmacKeys(string projectId, string serviceAccountEmail = null, ListHmacKeysOptions options = null)
+        {
+            GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
+            return new RestPagedEnumerable<HmacKeysResource.ListRequest, HmacKeysMetadata, HmacKeyMetadata>(
+                () => CreateListHmacKeysRequest(projectId, serviceAccountEmail, options), HmacKeyPageManager.Instance);
+        }
+
+        /// <inheritdoc />
+        public override PagedAsyncEnumerable<HmacKeysMetadata, HmacKeyMetadata> ListHmacKeysAsync(string projectId, string serviceAccountEmail = null, ListHmacKeysOptions options = null)
+        {
+            GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
+            return new RestPagedAsyncEnumerable<HmacKeysResource.ListRequest, HmacKeysMetadata, HmacKeyMetadata>(
+                () => CreateListHmacKeysRequest(projectId, serviceAccountEmail, options), HmacKeyPageManager.Instance);
+        }
+
+        /// <inheritdoc />
+        public override HmacKeyMetadata UpdateHmacKey(HmacKeyMetadata key, UpdateHmacKeyOptions options = null) =>
+            CreateUpdateHmacKeyRequest(key, options).Execute();
+
+        /// <inheritdoc />
+        public override Task<HmacKeyMetadata> UpdateHmacKeyAsync(HmacKeyMetadata key, UpdateHmacKeyOptions options = null, CancellationToken cancellationToken = default) =>
+            CreateUpdateHmacKeyRequest(key, options).ExecuteAsync(cancellationToken);
+
+        /// <inheritdoc />
+        public override void DeleteHmacKey(string projectId, string accessId, DeleteHmacKeyOptions options = null) =>
+            CreateDeleteHmacKeyRequest(projectId, accessId, options).Execute();
+
+        /// <inheritdoc />
+        public override Task DeleteHmacKeyAsync(string projectId, string accessId, DeleteHmacKeyOptions options = null, CancellationToken cancellationToken = default) =>
+            CreateDeleteHmacKeyRequest(projectId, accessId, options).ExecuteAsync(cancellationToken);
+
+        private HmacKeysResource.CreateRequest CreateCreateHmacKeyRequest(string projectId, string serviceAccountEmail, CreateHmacKeyOptions options)
+        {
+            GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
+            GaxPreconditions.CheckNotNull(serviceAccountEmail, nameof(serviceAccountEmail));
+            var request = Service.Projects.HmacKeys.Create(projectId, serviceAccountEmail);
+            request.ModifyRequest += _versionHeaderAction;
+            options?.ModifyRequest(request);
+            return request;
+        }
+
+        private HmacKeysResource.GetRequest CreateGetHmacKeyRequest(string projectId, string accessId, GetHmacKeyOptions options)
+        {
+            GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
+            GaxPreconditions.CheckNotNull(accessId, nameof(accessId));
+            var request = Service.Projects.HmacKeys.Get(projectId, accessId);
+            request.ModifyRequest += _versionHeaderAction;
+            options?.ModifyRequest(request);
+            return request;
+        }
+
+        private HmacKeysResource.UpdateRequest CreateUpdateHmacKeyRequest(HmacKeyMetadata key, UpdateHmacKeyOptions options)
+        {
+            GaxPreconditions.CheckNotNull(key, nameof(key));
+            GaxPreconditions.CheckArgument(key.ProjectId != null, nameof(key), "Key must contain a project ID");
+            GaxPreconditions.CheckArgument(key.AccessId != null, nameof(key), "Key must contain an access ID");
+            var request = Service.Projects.HmacKeys.Update(key, key.ProjectId, key.AccessId);
+            request.ModifyRequest += _versionHeaderAction;
+            options?.ModifyRequest(request);
+            return request;
+        }
+
+        private HmacKeysResource.DeleteRequest CreateDeleteHmacKeyRequest(string projectId, string accessId, DeleteHmacKeyOptions options)
+        {
+            GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
+            GaxPreconditions.CheckNotNull(accessId, nameof(accessId));
+            var request = Service.Projects.HmacKeys.Delete(projectId, accessId);
+            request.ModifyRequest += _versionHeaderAction;
+            options?.ModifyRequest(request);
+            return request;
+        }
+
+        private HmacKeysResource.ListRequest CreateListHmacKeysRequest(string projectId, string serviceAccountEmail, ListHmacKeysOptions options)
+        {
+            var request = Service.Projects.HmacKeys.List(projectId);
+            request.ServiceAccountEmail = serviceAccountEmail; // Note: may be null
+            request.ModifyRequest += _versionHeaderAction;
+            options?.ModifyRequest(request);
+            return request;
+        }
+    }
+}

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/UpdateHmacKeyOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/UpdateHmacKeyOptions.cs
@@ -1,0 +1,29 @@
+﻿// Copyright 2019 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Storage.v1;
+using System;
+
+namespace Google.Cloud.Storage.V1
+{
+    /// <summary>
+    /// Options for <c>UpdateHmacKey</c> operations.
+    /// </summary>
+    public sealed class UpdateHmacKeyOptions
+    {
+        internal void ModifyRequest(ProjectsResource.HmacKeysResource.UpdateRequest request)
+        {
+        }
+    }
+}

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -794,7 +794,7 @@
     "description": "Recommended Google client library to access the Google Cloud Storage API. It wraps the Google.Apis.Storage.v1 client library, making common operations simpler in client code. Google Cloud Storage stores and retrieves potentially large, immutable data objects.",
     "dependencies": {
       "Google.Api.Gax.Rest": "2.6.0",
-      "Google.Apis.Storage.v1": "1.38.0.1517"
+      "Google.Apis.Storage.v1": "1.38.2.1545"
     },
     "testDependencies": {
       "Google.Cloud.Iam.V1": "1.2.0",


### PR DESCRIPTION
No support is provided in this library for the actual signing operation, but creating a key reveals (once only) the secret information required for signing.

The Discovery doc is being updated so that HmacKey.Metadata will be an HmacKeyMetadata, at which point the test can be fixed.

We'll need to see whether the approach taken for detecting a service account email address works in Kokoro; more work may be needed for that.