### PR TITLE
Fix regex for matching a trace context header

### DIFF
--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Trace/TraceHeaderContextTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Trace/TraceHeaderContextTest.cs
@@ -27,10 +27,10 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         /// </summary>
         private string CreateTraceHeaderValue(int? mask = null)
         {
-            string headerValue = $"{TraceId}/{SpanId};";
+            string headerValue = $"{TraceId}/{SpanId}";
             if (mask != null)
             {
-                headerValue += "o=" + mask;
+                headerValue += ";o=" + mask;
             }
             return headerValue;
         }
@@ -145,7 +145,7 @@ namespace Google.Cloud.Diagnostics.Common.Tests
             Assert.Equal($"{TraceId}/{SpanId};o=1", context.ToString());
 
             context = TraceHeaderContext.Create(TraceId, SpanId, null);
-            Assert.Equal($"{TraceId}/{SpanId};", context.ToString());
+            Assert.Equal($"{TraceId}/{SpanId}", context.ToString());
 
             context = TraceHeaderContext.Create(TraceId, SpanId, false);
             Assert.Equal($"{TraceId}/{SpanId};o=0", context.ToString());

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/TraceHeaderContext.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/TraceHeaderContext.cs
@@ -41,10 +41,10 @@ namespace Google.Cloud.Diagnostics.Common
         /// A regex to match the trace header. 
         /// - ([A-Fa-f0-9]{32}): The trace id, a 32 character hex value.
         /// - ([0-9]+): The span id, a 64 bit integer.
-        /// - (o=([0-3])): The trace mask, 1-3 denote it should be traced.
+        /// - (?:;o=([0-3])): The trace mask, 1-3 denote it should be traced. (The ?: makes the outer group non-capturing.)
         /// </summary>
         internal static readonly Regex TraceHeaderRegex =
-            new Regex(@"^([A-Fa-f0-9]{32})/([0-9]+);(o=([0-3]))?$", RegexOptions.Compiled);
+            new Regex(@"^([A-Fa-f0-9]{32})/([0-9]+)(?:;o=([0-3]))?$", RegexOptions.Compiled);
 
         /// <summary>Gets the trace id or null if none is available.</summary>
         public string TraceId { get; }
@@ -88,8 +88,8 @@ namespace Google.Cloud.Diagnostics.Common
             {
                 return InvalidTraceHeaderContext;
             }
-            bool hasMask = match.Groups.Count > 4 && match.Groups[4].Success;
-            bool? shouldTrace = hasMask ? Convert.ToInt32(match.Groups[4].Value) > 0 : (bool?) null;
+            bool hasMask = match.Groups.Count > 3 && match.Groups[3].Success;
+            bool? shouldTrace = hasMask ? Convert.ToInt32(match.Groups[3].Value) > 0 : (bool?) null;
             return new TraceHeaderContext(traceId, spanId, shouldTrace);
         }
 
@@ -134,10 +134,10 @@ namespace Google.Cloud.Diagnostics.Common
         /// </summary>
         public override string ToString()
         {
-            var header = $"{TraceId}/{SpanId};";
+            var header = $"{TraceId}/{SpanId}";
             if (ShouldTrace != null)
             {
-                header += ShouldTrace.Value ? "o=1" : "o=0";
+                header += ShouldTrace.Value ? ";o=1" : ";o=0";
             }
             return header;
         }


### PR DESCRIPTION
The ";o=[0-3]" is *all* optional; when it's not present, the semi-colon isn't present.

Fixes #3055.