### PR TITLE
Implement support for BigQuery GEOGRAPHY type

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/BigQueryFixture.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/BigQueryFixture.cs
@@ -242,6 +242,7 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
                 { "single_int64", BigQueryDbType.Int64 },
                 { "single_float64", BigQueryDbType.Float64 },
                 { "single_numeric", BigQueryDbType.Numeric },
+                { "single_geography", BigQueryDbType.Geography },
                 { "single_record", recordSchema },
                 
                 // Repeated fields
@@ -255,6 +256,7 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
                 { "array_int64", BigQueryDbType.Int64, BigQueryFieldMode.Repeated },
                 { "array_float64", BigQueryDbType.Float64, BigQueryFieldMode.Repeated },
                 { "array_numeric", BigQueryDbType.Numeric, BigQueryFieldMode.Repeated },
+                { "array_geography", BigQueryDbType.Geography, BigQueryFieldMode.Repeated },
                 { "array_record", recordSchema, BigQueryFieldMode.Repeated },                
             }.Build());
 

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/BigQueryParameterTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/BigQueryParameterTest.cs
@@ -107,6 +107,14 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             Assert.Equal(2, (long)row["length"]);
         }
 
+        [Fact]
+        public void GeographyParameter()
+        {
+            var row = GetSingleRow("SELECT @p AS WKT",
+                new BigQueryParameter("p", BigQueryDbType.Geography, BigQueryGeography.Parse("POINT(1 2)")));
+            Assert.Equal(BigQueryGeography.Parse("POINT(1 2)"), (BigQueryGeography) row["WKT"]);
+        }
+
         private BigQueryRow GetSingleRow(string sql, params BigQueryParameter[] parameters)
         {
             var client = BigQueryClient.Create(_fixture.ProjectId);

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/ExhaustiveTypesTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/ExhaustiveTypesTest.cs
@@ -66,6 +66,7 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             Assert.Equal(123456789012L, (long) row["single_int64"]);
             Assert.Equal(1.25, (double) row["single_float64"]);
             Assert.Equal(BigQueryNumeric.Parse("1234567890123456789012345678.123456789"), (BigQueryNumeric) row["single_numeric"]);
+            Assert.Equal(BigQueryGeography.Parse("POINT(1 2)"), (BigQueryGeography) row["single_geography"]);
 
             var singleRecord = (Dictionary<string, object>) row["single_record"];
             Assert.Equal("nested string", (string) singleRecord["single_string"]);
@@ -91,6 +92,8 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             Assert.Equal(new[] { -1.25, 2.5 }, (double[]) row["array_float64"]);
             Assert.Equal(new[] { BigQueryNumeric.Parse("1234567890123456789012345678.123456789"), BigQueryNumeric.Parse("123.456") },
                 (BigQueryNumeric[]) row["array_numeric"]);
+            Assert.Equal(new[] { BigQueryGeography.Parse("POINT(1 2)"), BigQueryGeography.Parse("POINT(1 3)") },
+                (BigQueryGeography[]) row["array_geography"]);
 
             var arrayRecords = (Dictionary<string, object>[]) row["array_record"];
 
@@ -121,6 +124,7 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             AssertParameterRoundTrip(client, new BigQueryParameter(BigQueryDbType.Timestamp, new DateTime(2017, 2, 14, 17, 25, 30, DateTimeKind.Utc)));
             AssertParameterRoundTrip(client, new BigQueryParameter(BigQueryDbType.Time, new TimeSpan(0, 1, 2, 3, 456)));
             AssertParameterRoundTrip(client, new BigQueryParameter(BigQueryDbType.Numeric, BigQueryNumeric.Parse("1234567890123456789012345678.123456789")));
+            AssertParameterRoundTrip(client, new BigQueryParameter(BigQueryDbType.Geography, BigQueryGeography.Parse("POINT(1 2)")));
 
             AssertParameterRoundTrip(client, new BigQueryParameter(BigQueryDbType.Array, new[] { "foo", "bar" }));
             AssertParameterRoundTrip(client, new BigQueryParameter(BigQueryDbType.Array, new[] { true, false }));
@@ -141,6 +145,8 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
                 new[] { new TimeSpan(0, 1, 2, 3, 456), new TimeSpan(0, 23, 59, 59, 987) }));
             AssertParameterRoundTrip(client, new BigQueryParameter(BigQueryDbType.Array,
                 new[] { BigQueryNumeric.Parse("1234567890123456789012345678.123456789"), BigQueryNumeric.Parse("123.456") }));
+            AssertParameterRoundTrip(client, new BigQueryParameter(BigQueryDbType.Array,
+                new[] { BigQueryGeography.Parse("POINT(1 2)"), BigQueryGeography.Parse("POINT(1 3)") }));
         }
 
         private void AssertParameterRoundTrip(BigQueryClient client, BigQueryParameter parameter)
@@ -191,6 +197,7 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             ["single_int64"] = 123456789012L, // Larger than an int32
             ["single_float64"] = 1.25,
             ["single_numeric"] = BigQueryNumeric.Parse("1234567890123456789012345678.123456789"),
+            ["single_geography"] = BigQueryGeography.Parse("POINT(1 2)"),
             ["single_record"] = new BigQueryInsertRow
             {
                 ["single_string"] = "nested string",
@@ -208,6 +215,7 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             ["array_int64"] = new[] { 1234567890123L, 12345678901234L },
             ["array_float64"] = new[] { -1.25, 2.5 },
             ["array_numeric"] = new[] { BigQueryNumeric.Parse("1234567890123456789012345678.123456789"), BigQueryNumeric.Parse("123.456") },
+            ["array_geography"] = new[] { BigQueryGeography.Parse("POINT(1 2)"), BigQueryGeography.Parse("POINT(1 3)") },
             ["array_record"] = new[] {
                     new BigQueryInsertRow
                     {

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/QueryTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/QueryTest.cs
@@ -675,6 +675,23 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             Assert.Empty(results);
         }
 
+        [Fact]
+        public void GisQuery()
+        {
+            var client = BigQueryClient.Create(_fixture.ProjectId);
+
+            string sql = @"SELECT ST_GeogPoint(longitude, latitude) AS WKT, num_bikes_available
+                           FROM `bigquery-public-data.new_york.citibike_stations`
+                           WHERE num_bikes_available > 30
+                           LIMIT 10";
+            var results = client.ExecuteQuery(sql, parameters: null);
+            foreach (var row in results)
+            {
+                var geography = (BigQueryGeography) row["WKT"];
+                Assert.StartsWith("POINT", geography.Text);
+            }
+        }
+
         private class TitleComparer : IEqualityComparer<BigQueryRow>
         {
             public bool Equals(BigQueryRow x, BigQueryRow y) => (string)x["title"] == (string)y["title"];

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryGeographyTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryGeographyTest.cs
@@ -1,0 +1,44 @@
+﻿// Copyright 2019 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.ClientTesting;
+using Xunit;
+
+namespace Google.Cloud.BigQuery.V2.Tests
+{
+    public class BigQueryGeographyTest
+    {
+        [Fact]
+        public void Parse()
+        {
+            var text = "POINT(30 10)";
+            var geography = BigQueryGeography.Parse(text);
+            Assert.Equal(text, geography.Text);
+            Assert.Equal(text, geography.ToString());
+        }
+
+        [Fact]
+        public void Equality()
+        {
+            EqualityTester.AssertEqual(BigQueryGeography.Parse("POINT(30 10)"),
+                new[] { BigQueryGeography.Parse("POINT(30 10)") },
+                new[]
+                {
+                    BigQueryGeography.Parse("POINT (30 10)"), // Whitespace is relevant
+                    BigQueryGeography.Parse("POINT"),
+                    BigQueryGeography.Parse("LINESTRING (30 10, 10 30, 40 40)")
+                });
+        }
+    }
+}

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryParameterTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryParameterTest.cs
@@ -134,6 +134,12 @@ namespace Google.Cloud.BigQuery.V2.Tests
             ScalarTest("Numeric parameter", BigQueryDbType.Numeric, BigQueryNumeric.Parse("123.45"), "123.45"),
             ScalarTest("Numeric parameter, string value", BigQueryDbType.Numeric, "string value", "string value"),
             ScalarTest("Numeric parameter, null value", BigQueryDbType.Numeric, null, null),
+
+            // Geography (where the underlying value is just the string)
+            ScalarTest("Geography parameter, BigQueryGeography value", BigQueryDbType.Geography, BigQueryGeography.Parse("POINT"), "POINT"),
+            ScalarTest("Geogprahy parameter, string value", BigQueryDbType.Numeric, "POINT", "POINT"),
+            ScalarTest("Geography parameter, null value", BigQueryDbType.Geography, null, null),
+
         };
 
         public static IEnumerable<object[]> InvalidParameterData => new[]
@@ -159,6 +165,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
             new object[] { "Double", 1.0d, BigQueryDbType.Float64 },
             new object[] { "TimeSpan", TimeSpan.FromHours(1), BigQueryDbType.Time },
             new object[] { "Numeric", BigQueryNumeric.Parse("123.45"), BigQueryDbType.Numeric },
+            new object[] { "Geography", BigQueryGeography.Parse("POINT"), BigQueryDbType.Geography },
             new object[] { "DateTime (local)", new DateTime(2016, 10, 31, 0, 0, 0, DateTimeKind.Local), BigQueryDbType.DateTime },
             new object[] { "DateTime (unspecified)", new DateTime(2016, 10, 31, 0, 0, 0, DateTimeKind.Unspecified), BigQueryDbType.DateTime },
             new object[] { "DateTime (UTC)", new DateTime(2016, 10, 31, 0, 0, 0, DateTimeKind.Utc), BigQueryDbType.DateTime },
@@ -180,6 +187,8 @@ namespace Google.Cloud.BigQuery.V2.Tests
             new object[] { "DateTime[]", new DateTime[0], BigQueryDbType.DateTime },
             new object[] { "DateTimeOffset[]", new DateTimeOffset[0], BigQueryDbType.Timestamp },
             new object[] { "Byte[][]", new byte[0][], BigQueryDbType.Bytes },
+            new object[] { "BigQueryNumeric[]", new BigQueryNumeric[0], BigQueryDbType.Numeric },
+            new object[] { "BigQueryGeography[]", new BigQueryGeography[0], BigQueryDbType.Geography },
         };
 
         [Theory]

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryRowTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryRowTest.cs
@@ -38,6 +38,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
                 { "dateTime", BigQueryDbType.DateTime },
                 { "time", BigQueryDbType.Time },
                 { "numeric", BigQueryDbType.Numeric },
+                { "geography", BigQueryDbType.Geography },
                 { "struct", new TableSchemaBuilder { { "x", BigQueryDbType.Int64 }, { "y", BigQueryDbType.String } } }
             }.Build();
             var rawRow = new TableRow
@@ -54,6 +55,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
                     new TableCell { V = "2017-08-09T12:34:56.123" },
                     new TableCell { V = "12:34:56.123" },
                     new TableCell { V = "1234567890123456789012345678.123456789" },
+                    new TableCell { V = "POINT(1 2)" },
                     new TableCell { V = new JObject { ["f"] = new JArray {new JObject { ["v"] = "100" }, new JObject { ["v"] = "xyz" } } } }
                 }
             };
@@ -68,6 +70,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
             Assert.Equal(new DateTime(2017, 8, 9, 12, 34, 56, 123, DateTimeKind.Utc), (DateTime)row["dateTime"]);
             Assert.Equal(new TimeSpan(0, 12, 34, 56, 123), (TimeSpan)row["time"]);
             Assert.Equal(BigQueryNumeric.Parse("1234567890123456789012345678.123456789"), (BigQueryNumeric) row["numeric"]);
+            Assert.Equal(BigQueryGeography.Parse("POINT(1 2)"), (BigQueryGeography) row["geography"]);
             Assert.Equal(new Dictionary<string, object> { { "x", 100L }, { "y", "xyz" } }, (Dictionary<string, object>)row["struct"]);
         }
 
@@ -86,6 +89,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
                 { "dateTime", BigQueryDbType.DateTime, BigQueryFieldMode.Repeated },
                 { "time", BigQueryDbType.Time, BigQueryFieldMode.Repeated },
                 { "numeric", BigQueryDbType.Numeric, BigQueryFieldMode.Repeated },
+                { "geography", BigQueryDbType.Geography, BigQueryFieldMode.Repeated },
                 { "struct", new TableSchemaBuilder { { "x", BigQueryDbType.Int64 }, { "y", BigQueryDbType.String } }, BigQueryFieldMode.Repeated }
             }.Build();
             var rawRow = new TableRow
@@ -102,6 +106,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
                     new TableCell { V = CreateArray("2017-08-09T12:34:56.123","2017-08-09T12:34:57.123") },
                     new TableCell { V = CreateArray("12:34:56.123", "12:34:57.123") },
                     new TableCell { V = CreateArray("1234567890123456789012345678.123456789", "0.000000001") },
+                    new TableCell { V = CreateArray("POINT(1 3)", "POINT(2 4)") },
                     new TableCell { V = new JArray {
                         new JObject { ["v"] = new JObject { ["f"] = new JArray { new JObject { ["v"] = "100" }, new JObject { ["v"] = "xyz" } } } },
                         new JObject { ["v"] = new JObject { ["f"] = new JArray { new JObject { ["v"] = "200" }, new JObject { ["v"] = "abc" } } } }
@@ -122,6 +127,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
                 (DateTime[])row["dateTime"]);
             Assert.Equal(new[] { new TimeSpan(0, 12, 34, 56, 123), new TimeSpan(0, 12, 34, 57, 123) }, (TimeSpan[])row["time"]);
             Assert.Equal(new[] { BigQueryNumeric.Parse("1234567890123456789012345678.123456789"), BigQueryNumeric.Parse("0.000000001") }, (BigQueryNumeric[]) row["numeric"]);
+            Assert.Equal(new[] { BigQueryGeography.Parse("POINT(1 3)"), BigQueryGeography.Parse("POINT(2 4)") }, (BigQueryGeography[]) row["geography"]);
             Assert.Equal(new[]
                 {
                     new Dictionary<string, object> { { "x", 100L }, { "y", "xyz" } },

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryDbType.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryDbType.cs
@@ -81,7 +81,11 @@ namespace Google.Cloud.BigQuery.V2
         /// A fixed-point number with 38 digits of precision, and always
         /// 9 decimal places.
         /// </summary>
-        Numeric
+        Numeric,
+        /// <summary>
+        /// A collection of points, lines, and polygons, which is represented as a point set, or a subset of the surface of the Earth.
+        /// </summary>
+        Geography
     }
 
     internal static class BigQueryDbTypeExtensions
@@ -102,7 +106,8 @@ namespace Google.Cloud.BigQuery.V2
             { BigQueryDbType.Timestamp, "TIMESTAMP" },
             { BigQueryDbType.Array, "ARRAY" },
             { BigQueryDbType.Struct, "STRUCT" },
-            { BigQueryDbType.Numeric, "NUMERIC" }
+            { BigQueryDbType.Numeric, "NUMERIC" },
+            { BigQueryDbType.Geography, "GEOGRAPHY" }
         };
 
         internal static string ToParameterApiType(this BigQueryDbType type) => s_typeToNameMapping[type];

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryGeography.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryGeography.cs
@@ -1,0 +1,73 @@
+﻿// Copyright 2019 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using System;
+
+namespace Google.Cloud.BigQuery.V2
+{
+    /// <summary>
+    /// Representation of the BigQuery GEOGRAPHY type, representing geospatial information.
+    /// Equality is determined on a simple textual basis.
+    /// </summary>
+    public sealed class BigQueryGeography : IEquatable<BigQueryGeography>
+    {
+        /// <summary>
+        /// The text of the vector geometry, in WKT (Well-known Text) format.
+        /// </summary>
+        public string Text { get; }
+
+        private BigQueryGeography(string text) =>
+            Text = GaxPreconditions.CheckNotNull(text, nameof(text));
+
+        /// <summary>
+        /// Creates a BigQueryGeography object based on the given text.
+        /// </summary>
+        /// <remarks>
+        /// Currently, this method will accept any non-null string reference. In the future it
+        /// may perform genuine parsing of the Well-Known Text format.
+        /// </remarks>
+        /// <param name="text">Text to parse. Must not be null.</param>
+        /// <returns>A BigQueryGeography with the specified text.</returns>
+        public static BigQueryGeography Parse(string text) => new BigQueryGeography(text);
+
+        /// <summary>
+        /// Returns a hash code for this object.
+        /// </summary>
+        /// <returns>A hash code for this object.</returns>
+        public override int GetHashCode() => Text.GetHashCode();
+
+        /// <summary>
+        /// Compares this value with <paramref name="obj"/> for equality.
+        /// </summary>
+        /// <param name="obj">The value to compare with this one.</param>
+        /// <returns><c>true</c> if <paramref name="obj"/> is an equal <see cref="BigQueryGeography"/> value; <c>false</c> otherwise.</returns>
+        public override bool Equals(object obj) => Equals(obj as BigQueryGeography);
+
+
+        /// <summary>
+        /// Compares this value with <paramref name="other"/> for equality.
+        /// </summary>
+        /// <param name="other">The value to compare with this one.</param>
+        /// <returns><c>true</c> if <paramref name="other"/> is an equal <see cref="BigQueryGeography"/> value; <c>false</c> otherwise.</returns>
+        public bool Equals(BigQueryGeography other) => other?.Text == Text;
+
+        /// <summary>
+        /// Returns the textual representation of this value.
+        /// </summary>
+        /// <returns>The textual representation of this value</returns>
+        public override string ToString() => Text;
+
+    }
+}

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryInsertRow.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryInsertRow.cs
@@ -46,6 +46,7 @@ namespace Google.Cloud.BigQuery.V2
     ///   <item><description><c>System.DateTimeOffset</c></description></item>
     ///   <item><description><c>System.TimeSpan</c></description></item>
     ///   <item><description><c>Google.Cloud.BigQuery.V2.BigQueryNumeric</c></description></item>
+    ///   <item><description><c>Google.Cloud.BigQuery.V2.BigQueryGeography</c></description></item>
     ///   <item><description>A <c>Google.Cloud.BigQuery.V2.InsertRow</c> (for record/struct fields)</description></item>
     ///   <item><description>Any <c>IReadOnlyList&lt;T&gt;</c> of one of the above types (for repeated fields). This
     ///   includes arrays and <c>List&lt;T&gt;</c> values.</description></item>
@@ -86,6 +87,7 @@ namespace Google.Cloud.BigQuery.V2
             typeof(DateTime), typeof(DateTimeOffset),
             typeof(TimeSpan),
             typeof(BigQueryNumeric),
+            typeof(BigQueryGeography),
             typeof(BigQueryInsertRow)
         };
 
@@ -227,6 +229,8 @@ namespace Google.Cloud.BigQuery.V2
                     return (new DateTime(1970, 1, 1) + ts).ToString("HH:mm:ss.FFFFFF", CultureInfo.InvariantCulture);
                 case BigQueryNumeric numeric:
                     return numeric.ToString();
+                case BigQueryGeography geography:
+                    return geography.ToString();
                 case BigQueryInsertRow row:
                     return row.GetJsonValues();
             }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryParameter.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryParameter.cs
@@ -52,6 +52,7 @@ namespace Google.Cloud.BigQuery.V2
     ///   <item><description><c>Time</c>: <c>System.DateTime</c>, <c>System.DateTimeOffset</c>, <c>System.TimeSpan</c></description></item>
     ///   <item><description><c>Timestamp</c>: <c>System.DateTime</c>, <c>System.DateTimeOffset</c></description></item>
     ///   <item><description><c>Numeric</c>: <c>Google.Cloud.BigQuery.V1.BigQueryNumeric</c></description></item>
+    ///   <item><description><c>Geography</c>: <c>Google.Cloud.BigQuery.V1.BigQueryGeography</c></description></item>
     ///   <item><description><c>Array</c>: An <c>IReadOnlyList&lt;T&gt;</c> of any of the above types corresponding to the <see cref="ArrayElementType"/>,
     ///   which will be inferred from the value's element type if not otherwise specified.</description></item>
     /// </list>
@@ -86,7 +87,8 @@ namespace Google.Cloud.BigQuery.V2
             typeof(bool),
             typeof(string), typeof(byte[]),
             typeof(DateTime), typeof(DateTimeOffset), typeof(TimeSpan),
-            typeof(BigQueryNumeric)
+            typeof(BigQueryNumeric),
+            typeof(BigQueryGeography),
         };
 
         private static List<TypeInfo> s_validRepeatedTypes = s_validSingleTypes
@@ -113,6 +115,7 @@ namespace Google.Cloud.BigQuery.V2
             { typeof(DateTimeOffset), BigQueryDbType.Timestamp },
             { typeof(TimeSpan), BigQueryDbType.Time },
             { typeof(BigQueryNumeric), BigQueryDbType.Numeric },
+            { typeof(BigQueryGeography), BigQueryDbType.Geography },
         };
 
         /// <summary>
@@ -271,6 +274,10 @@ namespace Google.Cloud.BigQuery.V2
                         ?? parameter.UseNullScalarOrThrow(value);
                 case BigQueryDbType.Numeric:
                     return parameter.PopulateScalar<BigQueryNumeric>(value, x => x.ToString())
+                        ?? parameter.PopulateScalar<string>(value, x => x)
+                        ?? parameter.UseNullScalarOrThrow(value);
+                case BigQueryDbType.Geography:
+                    return parameter.PopulateScalar<BigQueryGeography>(value, x => x.Text)
                         ?? parameter.PopulateScalar<string>(value, x => x)
                         ?? parameter.UseNullScalarOrThrow(value);
                 case BigQueryDbType.Timestamp:

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryRow.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryRow.cs
@@ -76,6 +76,7 @@ namespace Google.Cloud.BigQuery.V2
         private static readonly Func<string, byte[]> BytesConverter = v => Convert.FromBase64String(v);
         private static readonly Func<string, bool> BooleanConverter = v => v == "true";
         private static readonly Func<string, BigQueryNumeric> NumericConverter = BigQueryNumeric.Parse;
+        private static readonly Func<string, BigQueryGeography> GeographyConverter = BigQueryGeography.Parse;
 
         /// <summary>
         /// Retrieves a cell value by field name.
@@ -131,6 +132,8 @@ namespace Google.Cloud.BigQuery.V2
                         return ConvertRecordArray(array, field);
                     case BigQueryDbType.Numeric:
                         return ConvertArray(array, NumericConverter);
+                    case BigQueryDbType.Geography:
+                        return ConvertArray(array, GeographyConverter);
                     default:
                         throw new InvalidOperationException($"Unhandled field type {type} {rawValue.GetType()}");
                 }
@@ -157,6 +160,8 @@ namespace Google.Cloud.BigQuery.V2
                     return DateTimeConverter((string) rawValue);
                 case BigQueryDbType.Numeric:
                     return NumericConverter((string) rawValue);
+                case BigQueryDbType.Geography:
+                    return GeographyConverter((string) rawValue);
                 case BigQueryDbType.Struct:
                     return ConvertRecord((JObject)rawValue, field);
                 default:


### PR DESCRIPTION
We took the deliberate design decision to introduce a new class here, for various reasons:

- Parameter types can be inferred
- C# 7 pattern matching works nicely
- Extension methods can be added to BigQueryGeography, e.g. to convert to a type exposed by another library

The design decision to use a class rather than a struct is for a couple of reasons:

- new BigQueryGeography() isn't a useful value
- Although currently we only have a single field, that may change over time - we wouldn't want a struct growing large