### PR TITLE
GoogleStackdriverTarget - Include ServiceContext by default

### DIFF
--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/GoogleStackdriverTarget.cs
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/GoogleStackdriverTarget.cs
@@ -473,6 +473,23 @@ namespace Google.Cloud.Logging.NLog
             {
                 var jsonStruct = new Struct();
                 jsonStruct.Fields.Add("message", Value.ForString(RenderLogEvent(Layout, loggingEvent)));
+                if (ServiceContextName != null)
+                {
+                    var serviceName = RenderLogEvent(ServiceContextName, loggingEvent);
+                    if (!string.IsNullOrEmpty(serviceName))
+                    {
+                        // Include ServiceContext to allow errors to be automatically forwarded
+                        var serviceVersion = RenderLogEvent(ServiceContextVersion, loggingEvent);
+                        if (string.IsNullOrEmpty(serviceVersion))
+                            serviceVersion = "0.0.0.0";
+
+                        var serviceContext = new Struct();
+                        jsonStruct.Fields.Add("serviceContext", Value.ForStruct(serviceContext));
+                        serviceContext.Fields.Add("service", Value.ForString(serviceName));
+                        serviceContext.Fields.Add("version", Value.ForString(serviceVersion));
+                    }
+                }
+
                 var propertiesStruct = new Struct();
                 jsonStruct.Fields.Add("properties", Value.ForStruct(propertiesStruct));
 

--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/GoogleStackdriverTarget_Configuration.cs
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/GoogleStackdriverTarget_Configuration.cs
@@ -52,6 +52,16 @@ namespace Google.Cloud.Logging.NLog
         public int TaskPendingLimit { get; set; } = 5;
 
         /// <summary>
+        /// Configures "service" for the "serviceContext" when <see cref="SendJsonPayload" /> = true
+        /// </summary>
+        public Layout ServiceContextName { get; set; } = "${appdomain:cached=true:format=\\{1\\}}";
+
+        /// <summary>
+        /// Configures "version" for the "serviceContext" when <see cref="SendJsonPayload" /> = true
+        /// </summary>
+        public Layout ServiceContextVersion { get; set; } = "${assembly-version:cached=true:type=File}";
+
+        /// <summary>
         /// The resource type of log entries.
         /// Default value depends on the detected platform. See the remarks section for details.
         /// </summary>


### PR DESCRIPTION
Looks like serviceContext should be included according to docs:

https://cloud.google.com/error-reporting/docs/formatting-error-messages#json_representation