### PR TITLE
Minor fix in pubsub

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/PublisherClient.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/PublisherClient.cs
@@ -597,7 +597,8 @@ namespace Google.Cloud.PubSub.V1
                 {
                     if (state.State == OrderingKeyState.Error)
                     {
-                        state.SetState(OrderingKeyState.Normal);
+                        // Remove ordering-key, which signals this ordering-key is in Normal state.
+                        _keyedState.Remove(orderingKey);
                     }
                 }
             }


### PR DESCRIPTION
Not removing the key from the _keyedState dictionary can cause a memory leak if no further messages are sent with this ordering-key. The key not existing in the dictionary has the same meaning as the state being set to Normal.