### PR TITLE
Introduce client builders for Bigtable

### DIFF
--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GenerateClient/Program.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GenerateClient/Program.cs
@@ -101,7 +101,7 @@ namespace Google.Cloud.Bigtable.V2.GenerateClient
 
         private static async Task<int> Main(string[] args)
         {
-            RemoveClientBuilder();
+            FixClientBuilder();
 
             // TODO: Figure out why `dotnet run` from generateapis.sh is sending 6 args instead of 3 as in: arg1 arg2 arg3 arg1 arg2 arg3
             if (args.Length < 3)
@@ -278,16 +278,14 @@ namespace Google.Cloud.Bigtable.V2.GenerateClient
         }
 
         /// <summary>
-        /// Temporary measure to remove the BigtableClientBuilder and the ChannelPool property. Bigtable uses a call invoker
-        /// pool instead of a channel pool; we'll need to work out what we want the builder to look like for this.
-        /// See https://github.com/googleapis/google-cloud-dotnet/issues/3117 for status.
+        /// Remove the parts of the generated BigtableServiceApiClientBuilder that are provided manual by partial classes.
         /// </summary>
-        private static void RemoveClientBuilder()
+        private static void FixClientBuilder()
         {
             var layout = DirectoryLayout.ForApi("Google.Cloud.Bigtable.V2");
             SourceFile.Load(Path.Combine(layout.SourceDirectory, "Google.Cloud.Bigtable.V2", "BigtableServiceApiClient.cs"))
                 .RemoveProperty("BigtableServiceApiClient", "ChannelPool")
-                .RemoveType("BigtableServiceApiClientBuilder")
+                .RemoveMethod("BigtableServiceApiClientBuilder", "GetChannelPool")
                 .Save();
         }
 

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.IntegrationTests/Google.Cloud.Bigtable.V2.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.IntegrationTests/Google.Cloud.Bigtable.V2.IntegrationTests.csproj
@@ -11,7 +11,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="2.7.0" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="2.8.0-beta01" />
     <ProjectReference Include="..\..\Google.Cloud.Bigtable.Admin.V2\Google.Cloud.Bigtable.Admin.V2\Google.Cloud.Bigtable.Admin.V2.csproj" />
     <ProjectReference Include="..\Google.Cloud.Bigtable.V2\Google.Cloud.Bigtable.V2.csproj" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Snippets/Google.Cloud.Bigtable.V2.Snippets.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Snippets/Google.Cloud.Bigtable.V2.Snippets.csproj
@@ -11,7 +11,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="2.7.0" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="2.8.0-beta01" />
     <ProjectReference Include="..\..\Google.Cloud.Bigtable.Admin.V2\Google.Cloud.Bigtable.Admin.V2\Google.Cloud.Bigtable.Admin.V2.csproj" />
     <ProjectReference Include="..\Google.Cloud.Bigtable.V2\Google.Cloud.Bigtable.V2.csproj" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/Google.Cloud.Bigtable.V2.Tests.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/Google.Cloud.Bigtable.V2.Tests.csproj
@@ -11,7 +11,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="2.7.0" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="2.8.0-beta01" />
     <ProjectReference Include="..\..\Google.Cloud.Bigtable.Admin.V2\Google.Cloud.Bigtable.Admin.V2\Google.Cloud.Bigtable.Admin.V2.csproj" />
     <ProjectReference Include="..\Google.Cloud.Bigtable.V2\Google.Cloud.Bigtable.V2.csproj" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableClientBuilder.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableClientBuilder.cs
@@ -1,0 +1,58 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax.Grpc;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Cloud.Bigtable.V2
+{
+    /// <summary>
+    /// Builder class for <see cref="BigtableClient"/> to provide simple configuration of credentials, endpoint etc.
+    /// </summary>
+    public sealed partial class BigtableClientBuilder : ClientBuilderBase<BigtableClient>
+    {
+        /// <summary>
+        /// The settings to use for RPCs, or null for the default settings.
+        /// </summary>
+        public BigtableServiceApiSettings Settings { get; set; }
+
+        /// <inheritdoc/>
+        public override BigtableClient Build()
+        {
+            var builder = new BigtableServiceApiClientBuilder(this);
+            return BigtableClient.Create(builder.Build());
+        }
+
+        /// <inheritdoc />
+        public override async Task<BigtableClient> BuildAsync(CancellationToken cancellationToken = default)
+        {
+            var builder = new BigtableServiceApiClientBuilder(this);
+            return BigtableClient.Create(await builder.BuildAsync(cancellationToken).ConfigureAwait(false));
+        }
+
+        // Overrides for abstract methods that will never actually be called.
+
+        /// <inheritdoc />
+        protected override ChannelPool GetChannelPool() => throw new NotImplementedException();
+
+        /// <inheritdoc />
+        protected override ServiceEndpoint GetDefaultEndpoint() => throw new NotImplementedException();
+
+        /// <inheritdoc />
+        protected override IReadOnlyList<string> GetDefaultScopes() => throw new NotImplementedException();
+    }
+}

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableServiceApiClient.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableServiceApiClient.cs
@@ -290,6 +290,39 @@ namespace Google.Cloud.Bigtable.V2
     }
 
     /// <summary>
+    /// Builder class for <see cref="BigtableServiceApiClient"/> to provide simple configuration of credentials, endpoint etc.
+    /// </summary>
+    public sealed partial class BigtableServiceApiClientBuilder : gaxgrpc::ClientBuilderBase<BigtableServiceApiClient>
+    {
+        /// <summary>
+        /// The settings to use for RPCs, or null for the default settings.
+        /// </summary>
+        public BigtableServiceApiSettings Settings { get; set; }
+
+        /// <inheritdoc/>
+        public override BigtableServiceApiClient Build()
+        {
+            Validate();
+            grpccore::CallInvoker callInvoker = CreateCallInvoker();
+            return BigtableServiceApiClient.Create(callInvoker, Settings);
+        }
+
+        /// <inheritdoc />
+        public override async stt::Task<BigtableServiceApiClient> BuildAsync(st::CancellationToken cancellationToken = default)
+        {
+            Validate();
+            grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);
+            return BigtableServiceApiClient.Create(callInvoker, Settings);
+        }
+
+        /// <inheritdoc />
+        protected override gaxgrpc::ServiceEndpoint GetDefaultEndpoint() => BigtableServiceApiClient.DefaultEndpoint;
+
+        /// <inheritdoc />
+        protected override scg::IReadOnlyList<string> GetDefaultScopes() => BigtableServiceApiClient.DefaultScopes;
+    }
+
+    /// <summary>
     /// Bigtable client wrapper, for convenient use.
     /// </summary>
     public abstract partial class BigtableServiceApiClient

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0-beta01</Version>
     <TargetFrameworks>netstandard1.5;netstandard2.0;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
@@ -23,8 +23,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="2.7.0" />
-    <PackageReference Include="Google.Api.Gax.Grpc.Gcp" Version="2.7.0" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="2.8.0-beta01" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Gcp" Version="2.8.0-beta01" />
     <ProjectReference Include="..\..\Google.Cloud.Bigtable.Common.V2\Google.Cloud.Bigtable.Common.V2\Google.Cloud.Bigtable.Common.V2.csproj" />
     <PackageReference Include="Grpc.Core" Version="1.21.0" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -112,18 +112,18 @@
     "id": "Google.Cloud.Bigtable.V2",
     "productName": "Google Bigtable",
     "productUrl": "https://cloud.google.com/bigtable/",
-    "version": "1.0.0",
+    "version": "1.1.0-beta01",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Bigtable API.",
     "tags": [ "Bigtable" ],
     "dependencies": {
-      "Google.Api.Gax.Grpc": "2.7.0",
-      "Google.Api.Gax.Grpc.Gcp": "2.7.0",
+      "Google.Api.Gax.Grpc": "2.8.0-beta01",
+      "Google.Api.Gax.Grpc.Gcp": "2.8.0-beta01",
       "Google.Cloud.Bigtable.Common.V2": "project",
       "Grpc.Core": "1.21.0"
     },
     "testDependencies": {
-      "Google.Api.Gax.Grpc.Testing": "2.7.0",
+      "Google.Api.Gax.Grpc.Testing": "2.8.0-beta01",
       "Google.Cloud.Bigtable.Admin.V2": "project",
     }
   },


### PR DESCRIPTION
BigtableClientBuilder has no settings beyond BigtableServiceApiClientBuilder; it's just more convenient.

(The GAX update is required to get at channel options.)

Fixes #3117.