### PR TITLE
Fix release process

### DIFF
--- a/.kokoro/release.sh
+++ b/.kokoro/release.sh
@@ -43,4 +43,5 @@ else
 fi
 
 # Process the build log in releasebuild
+cd releasebuild
 ./processbuildtiminglog.sh


### PR DESCRIPTION
The real build is done in releasebuild, so that's where we need to process the build log.