### PR TITLE
Fix release build script

### DIFF
--- a/.kokoro/release.sh
+++ b/.kokoro/release.sh
@@ -8,10 +8,6 @@ SCRIPT_DIR=$(dirname "$SCRIPT")
 cd $SCRIPT_DIR
 cd ..
 
-echo "Cloning submodules"
-git submodule init
-git submodule update
-
 export GOOGLE_APPLICATION_CREDENTIALS="$KOKORO_KEYSTORE_DIR/73609_cloud-sharp-jenkins-compute-service-account"
 export REQUESTER_PAYS_CREDENTIALS="$KOKORO_KEYSTORE_DIR/73609_gcloud-devel-service-account"
 export DOCS_CREDENTIALS="$KOKORO_KEYSTORE_DIR/73713_docuploader_service_account"

--- a/buildrelease.sh
+++ b/buildrelease.sh
@@ -43,7 +43,7 @@ fi
 cd $(dirname $0)
 
 rm -rf releasebuild
-git clone ${clone_path_prefix}googleapis/google-cloud-dotnet.git releasebuild -c core.autocrlf=input
+git clone ${clone_path_prefix}googleapis/google-cloud-dotnet.git releasebuild -c core.autocrlf=input --recursive
 cd releasebuild
 export CI=true # Forces SourceLink in the main build.
 


### PR DESCRIPTION
We don't need to initialize submodules in the root directory, but we do need to in the releasebuild directory.

(This caused the Storage release to fail; I'll retag and release once this is in.)