### PR TITLE
Remove attempted fix for docuploader

### DIFF
--- a/uploaddocs.sh
+++ b/uploaddocs.sh
@@ -13,9 +13,8 @@ declare -r DOCS_OUTPUT_DIR=$2
 declare -r SERVICE_ACCOUNT_JSON=$(realpath $3)
 declare -r STAGING_BUCKET=$4
 
-# Make sure the temporary directory used by Python exists
-mkdir -p dirname $(python -c 'import tempfile; print(tempfile.NamedTemporaryFile().name)')
-
+# Make sure we have the most recent version of pip, then install the gcp-docuploader package
+python -m pip install --upgrade pip
 python -m pip install -q gcp-docuploader
 
 for nupkg in $NUPKG_DIR/*.nupkg


### PR DESCRIPTION
It looks like this is actually due to tar interpreting the colon in the filename unfortuantely.

However, it also looks like pip is out of date on Kokoro; this commit addresses that.