### PR TITLE
Introduce new attribute to populate the Firestore document ID on deserialization

### DIFF
--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Converters/AttributedIdAssignerTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Converters/AttributedIdAssignerTest.cs
@@ -1,0 +1,134 @@
+﻿// Copyright 2019, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Firestore.Converters;
+using System;
+using Xunit;
+using BclType = System.Type;
+
+namespace Google.Cloud.Firestore.Tests.Converters
+{
+    public class AttributedIdAssignerTest
+    {
+        [Fact]
+        public void StringProperty()
+        {
+            var target = new StringPropertyModel();
+            var db = FirestoreDb.Create("project", "database", new FakeFirestoreClient());
+            var doc = db.Document("col/doc");
+            AttributedIdAssigner.MaybeAssignId(target, doc);
+            Assert.Equal(doc.Id, target.Id);
+        }
+
+        [FirestoreData]
+        private class StringPropertyModel
+        {
+            [FirestoreDocumentId]
+            public string Id { get; set; }
+        }
+
+        [Fact]
+        public void DocumentReferenceProperty()
+        {
+            var target = new DocumentReferencePropertyModel();
+            var db = FirestoreDb.Create("project", "database", new FakeFirestoreClient());
+            var doc = db.Document("col/doc");
+            AttributedIdAssigner.MaybeAssignId(target, doc);
+            Assert.Equal(doc, target.Reference);
+        }
+
+        [FirestoreData]
+        private class DocumentReferencePropertyModel
+        {
+            [FirestoreDocumentId]
+            public DocumentReference Reference { get; set; }
+        }
+
+        [Fact]
+        public void MultipleProperties()
+        {
+            var target = new MultiplePropertiesModel();
+            var db = FirestoreDb.Create("project", "database", new FakeFirestoreClient());
+            var doc = db.Document("col/doc");
+            AttributedIdAssigner.MaybeAssignId(target, doc);
+            Assert.Equal(doc.Id, target.Id);
+            Assert.Equal(doc, target.Reference);
+        }
+
+        [FirestoreData]
+        private class MultiplePropertiesModel
+        {
+            // Note: private setters just to check that works too...
+            [FirestoreDocumentId]
+            public string Id { get; private set; }
+
+            [FirestoreDocumentId]
+            public DocumentReference Reference { get; private set; }
+        }
+
+        [Theory]
+        [InlineData(typeof(ReadOnlyProperty))]
+        [InlineData(typeof(WrongPropertyType))]
+        [InlineData(typeof(Indexer))]
+        [InlineData(typeof(StaticProperty))]
+        [InlineData(typeof(AlsoHasFirestorePropertyAttribute))]
+        public void InvalidAttributes(BclType type)
+        {
+            var target = Activator.CreateInstance(type);
+            var db = FirestoreDb.Create("project", "database", new FakeFirestoreClient());
+            var doc = db.Document("col/doc");
+
+            Assert.Throws<InvalidOperationException>(() => AttributedIdAssigner.MaybeAssignId(target, doc));
+        }
+
+        [FirestoreData]
+        private class ReadOnlyProperty
+        {
+            [FirestoreDocumentId]
+            public string Id => "";
+        }
+
+        [FirestoreData]
+        private class WrongPropertyType
+        {
+            [FirestoreDocumentId]
+            public int Id { get; set; }
+        }
+
+        [FirestoreData]
+        private class Indexer
+        {
+            [FirestoreDocumentId]
+            public string this[int index]
+            {
+                get => "";
+                set { }
+            }
+        }
+
+        [FirestoreData]
+        private class StaticProperty
+        {
+            [FirestoreDocumentId]
+            public static string Id { get; set; }
+        }
+
+        [FirestoreData]
+        private class AlsoHasFirestorePropertyAttribute
+        {
+            [FirestoreDocumentId, FirestoreProperty]
+            public string Id { get; set; }
+        }
+    }
+}

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/DocumentSnapshotTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/DocumentSnapshotTest.cs
@@ -289,6 +289,30 @@ namespace Google.Cloud.Firestore.Tests
             Assert.Equal(0, custom.Value);
         }
 
+        [Fact]
+        public void ConvertTo_WithId()
+        {
+            var db = FirestoreDb.Create("proj", "db", new FakeFirestoreClient());
+            var readTime = new Timestamp(10, 2);
+            var proto = new Document
+            {
+                CreateTime = CreateProtoTimestamp(1, 10),
+                UpdateTime = CreateProtoTimestamp(2, 20),
+                Name = "projects/proj/databases/db/documents/col1/doc1/col2/doc2",
+                Fields =
+                {
+                    ["Name"] = ProtoHelpers.CreateValue("text"),
+                    ["Value"] = ProtoHelpers.CreateValue(100)
+                }
+            };
+            var document = DocumentSnapshot.ForDocument(db, proto, readTime);
+
+            var converted = document.ConvertTo<SampleDataWithDocumentId>();
+            Assert.Equal("text", converted.Name);
+            Assert.Equal(100, converted.Value);
+            Assert.Equal("doc2", converted.DocumentId);
+        }
+
         private static DocumentSnapshot GetSampleSnapshot()
         {
             var poco = new SampleData
@@ -326,6 +350,19 @@ namespace Google.Cloud.Firestore.Tests
         {
             [FirestoreProperty]
             public int Score { get; set; }
+        }
+
+        [FirestoreData]
+        private class SampleDataWithDocumentId
+        {
+            [FirestoreDocumentId]
+            public string DocumentId { get; set; }
+
+            [FirestoreProperty]
+            public string Name { get; set; }
+            
+            [FirestoreProperty]
+            public int Value { get; set; }
         }
     }
 }

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Converters/AttributedIdAssigner.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Converters/AttributedIdAssigner.cs
@@ -1,0 +1,120 @@
+﻿// Copyright 2019, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reflection;
+using BclType = System.Type;
+
+namespace Google.Cloud.Firestore.Converters
+{
+    internal sealed class AttributedIdAssigner
+    {
+        private static readonly ConcurrentDictionary<BclType, AttributedIdAssigner> s_assigners =
+            new ConcurrentDictionary<BclType, AttributedIdAssigner>();
+
+        private readonly List<PropertyInfo> _idProperties;
+        private readonly List<PropertyInfo> _referenceProperties;
+
+        private AttributedIdAssigner(List<PropertyInfo> idProperties, List<PropertyInfo> referenceProperties)
+        {
+            _idProperties = idProperties;
+            _referenceProperties = referenceProperties;
+        }
+
+        private void AssignId(object value, DocumentReference reference)
+        {
+            // TODO: Create delegates instead of using reflection on every invocation?
+
+            foreach (var property in _idProperties)
+            {
+                property.SetValue(value, reference.Id);
+            }
+
+            foreach (var property in _referenceProperties)
+            {
+                property.SetValue(value, reference);
+            }
+        }
+
+        internal static void MaybeAssignId(object value, DocumentReference reference)
+        {
+            if (value == null)
+            {
+                return;
+            }
+            var assigner = s_assigners.GetOrAdd(value.GetType(), MaybeCreateAssigner);
+            assigner?.AssignId(value, reference);
+        }
+
+        /// <summary>
+        /// Returns an "ID assigner" suitable for the given BCL type, or null if the type isn't decorated with FirestoreDataAttribute,
+        /// or doesn't have any FirestoreDocumentId attributes.
+        /// </summary>
+        /// <param name="type">The type to inspect for ID properties.</param>
+        /// <returns>An assigner, or null if the type doesn't need any ID assignments performed on it.</returns>
+        private static AttributedIdAssigner MaybeCreateAssigner(BclType type)
+        {
+            var typeInfo = type.GetTypeInfo();
+            if (!typeInfo.IsDefined(typeof(FirestoreDataAttribute)))
+            {
+                return null;
+            }
+
+            // While it's unusual, it's not an error to have multiple properties decorated with [FirestoreDocumentId]
+            List<PropertyInfo> setIdProperties = new List<PropertyInfo>();
+            List<PropertyInfo> setReferenceProperties = new List<PropertyInfo>();
+            // We look for static properties specifically to find problems. We'll never use static properties.
+            foreach (var property in typeInfo.GetProperties(BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+            {
+                string typeName = property.DeclaringType.FullName;
+                FirestoreDocumentIdAttribute idAttribute = property.GetCustomAttribute<FirestoreDocumentIdAttribute>(inherit: true);
+                if (idAttribute == null)
+                {
+                    continue;
+                }
+                var setMethod = property.GetSetMethod(nonPublic: true);
+                GaxPreconditions.CheckState(setMethod != null,
+                    "{0}.{1} has no setter, and should not be decorated with {2}.",
+                    typeName, property.Name, nameof(FirestoreDocumentIdAttribute));
+                GaxPreconditions.CheckState(!setMethod.IsStatic,
+                    "{0}.{1} is static, and should not be decorated with {2}.",
+                    typeName, property.Name, nameof(FirestoreDocumentIdAttribute));
+                GaxPreconditions.CheckState(setMethod.GetParameters().Length == 1,
+                    "{0}.{1} is an indexer, and should not be decorated with {2}.",
+                    typeName, property.Name, nameof(FirestoreDocumentIdAttribute));
+                GaxPreconditions.CheckState(!property.IsDefined(typeof(FirestorePropertyAttribute)),
+                    "{0}.{1} is decorated with FirestorePropertyAttribute, and should not be decorated with {2}.",
+                    typeName, property.Name, nameof(FirestoreDocumentIdAttribute));
+                if (property.PropertyType == typeof(string))
+                {
+                    setIdProperties.Add(property);
+                }
+                else if (property.PropertyType == typeof(DocumentReference))
+                {
+                    setReferenceProperties.Add(property);
+                }
+                else
+                {
+                    throw new InvalidOperationException(
+                        $"{typeName}.{property.Name} is not a string or {nameof(DocumentReference)} property, and should not be decorated with {nameof(FirestoreDocumentIdAttribute)}.");
+                }
+            }
+            return setIdProperties.Count == 0 && setReferenceProperties.Count == 0
+                ? null : new AttributedIdAssigner(setIdProperties, setReferenceProperties);
+        }
+    }
+}

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Converters/AttributedTypeConverter.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Converters/AttributedTypeConverter.cs
@@ -57,6 +57,7 @@ namespace Google.Cloud.Firestore.Converters
                 {
                     continue;
                 }
+                // FIXME: Check that the FirestoreId attribute *isn't* defined.
                 var attributedProperty = new AttributedProperty(property, propertyAttribute);
                 string firestoreName = attributedProperty.FirestoreName;
 

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/DocumentSnapshot.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/DocumentSnapshot.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 using Google.Api.Gax;
+using Google.Cloud.Firestore.Converters;
 using Google.Cloud.Firestore.V1;
 using System;
 using System.Collections.Generic;
@@ -98,7 +99,9 @@ namespace Google.Cloud.Firestore
             {
                 return default;
             }
-            return (T) ValueDeserializer.DeserializeMap(Database, Document.Fields, typeof(T));
+            object deserialized = ValueDeserializer.DeserializeMap(Database, Document.Fields, typeof(T));
+            AttributedIdAssigner.MaybeAssignId(deserialized, Reference);
+            return (T) deserialized;
         }
 
         /// <summary>

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/FirestoreDocumentIdAttribute.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/FirestoreDocumentIdAttribute.cs
@@ -1,0 +1,37 @@
+﻿// Copyright 2019, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Google.Cloud.Firestore
+{
+    /// <summary>
+    /// Attribute indicating that a property should be populated with the Firestore document ID.
+    /// </summary>
+    /// <remarks>
+    /// This attribute must only be applied to properties of string or <see cref="DocumentReference" />.
+    /// This attribute is ignored when serializing a document to Firestore.
+    /// This attribute must not be applied on a property which also has <see cref="FirestorePropertyAttribute"/>.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Property)]
+    public sealed class FirestoreDocumentIdAttribute : Attribute
+    {
+        /// <summary>
+        /// Creates an instance of the attribute.
+        /// </summary>
+        public FirestoreDocumentIdAttribute()
+        {
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3042

Note: unlike the Java attribute, this is only effective at the "root" type (i.e. the type we convert the document to). Propagating the document reference all the way down through nested data would be very invasive, for little practical benefit.