### PR TITLE
Refactoring to introduce a DeserializationContext type.

### DIFF
--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Benchmarks/ValueDeserializerBenchmark.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Benchmarks/ValueDeserializerBenchmark.cs
@@ -23,28 +23,30 @@ namespace Google.Cloud.Firestore.Benchmarks
         public static FirestoreDb FakeDb { get; } =
             FirestoreDb.Create("project", "database", new FakeFirestoreClient());
 
+        private static DeserializationContext Context => new DeserializationContext(FakeDb);
+
         [Benchmark]
         public object DeserializeMap_Attributed() =>
-            ValueDeserializer.DeserializeMap(FakeDb, SampleData.SerializedMap, typeof(HighScore));
+            ValueDeserializer.DeserializeMap(Context, SampleData.SerializedMap, typeof(HighScore));
 
         [Benchmark]
         public object Deserialize_Attributed() =>
-            ValueDeserializer.Deserialize(FakeDb, SampleData.Serialized, typeof(HighScore));
+            ValueDeserializer.Deserialize(Context, SampleData.Serialized, typeof(HighScore));
 
         [Benchmark]
         public object DeserializeMap_Dictionary() =>
-            ValueDeserializer.DeserializeMap(FakeDb, SampleData.SerializedMap, typeof(Dictionary<string, object>));
+            ValueDeserializer.DeserializeMap(Context, SampleData.SerializedMap, typeof(Dictionary<string, object>));
 
         [Benchmark]
         public object Deserialize_Dictionary() =>
-            ValueDeserializer.Deserialize(FakeDb, SampleData.Serialized, typeof(Dictionary<string, object>));
+            ValueDeserializer.Deserialize(Context, SampleData.Serialized, typeof(Dictionary<string, object>));
 
         [Benchmark]
         public object DeserializeMap_Expando() =>
-            ValueDeserializer.DeserializeMap(FakeDb, SampleData.SerializedMap, typeof(ExpandoObject));
+            ValueDeserializer.DeserializeMap(Context, SampleData.SerializedMap, typeof(ExpandoObject));
 
         [Benchmark]
         public object Deserialize_Expando() =>
-            ValueDeserializer.Deserialize(FakeDb, SampleData.Serialized, typeof(ExpandoObject));
+            ValueDeserializer.Deserialize(Context, SampleData.Serialized, typeof(ExpandoObject));
     }
 }

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Converters/AttributedTypeConverterTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Converters/AttributedTypeConverterTest.cs
@@ -146,7 +146,8 @@ namespace Google.Cloud.Firestore.Tests.Converters
                 { "WriteOnly", new Value { IntegerValue = 200 } },
             };
             var db = FirestoreDb.Create("project", "database", new FakeFirestoreClient());
-            Model model = (Model) converter.DeserializeMap(db, map);
+            var context = new DeserializationContext(db);
+            Model model = (Model) converter.DeserializeMap(context, map);
             Assert.Equal(now, model.Created);
             Assert.Equal(50, model.ReadWrite);
             Assert.Equal(100, model.SeparatedBackingProperty);

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Converters/CustomConverterTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Converters/CustomConverterTest.cs
@@ -30,11 +30,12 @@ namespace Google.Cloud.Firestore.Tests.Converters
         public void NullReturnsProhibited()
         {
             var db = FirestoreDb.Create("proj", "db", new FakeFirestoreClient());
+            var context = new DeserializationContext(db);
             var converter = CustomConverter.ForConverterType(typeof(NullReturningConverter), typeof(string));
             Assert.Throws<InvalidOperationException>(() => converter.Serialize(""));
             Assert.Throws<InvalidOperationException>(() => converter.SerializeMap("", new Dictionary<string, Value>()));
-            Assert.Throws<InvalidOperationException>(() => converter.DeserializeValue(db, new Value { StringValue = "" }));
-            Assert.Throws<InvalidOperationException>(() => converter.DeserializeMap(db, new Dictionary<string, Value>()));
+            Assert.Throws<InvalidOperationException>(() => converter.DeserializeValue(context, new Value { StringValue = "" }));
+            Assert.Throws<InvalidOperationException>(() => converter.DeserializeMap(context, new Dictionary<string, Value>()));
         }
 
         [Fact]

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/SerializationTestData.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/SerializationTestData.cs
@@ -30,6 +30,7 @@ namespace Google.Cloud.Firestore.Tests
     internal static class SerializationTestData
     {
         internal static FirestoreDb Database { get; } = FirestoreDb.Create("proj", "db", new FakeFirestoreClient());
+        internal static DeserializationContext Context => new DeserializationContext(Database);
 
         public static IEnumerable<object[]> BclAndValues { get; } = new List<object[]>
         {

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/ValueDeserializerTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/ValueDeserializerTest.cs
@@ -40,7 +40,7 @@ namespace Google.Cloud.Firestore.Tests
         public void DeserializeToExpando()
         {
             var value = new Value { MapValue = new MapValue { Fields = { { "name", new Value { StringValue = "Jon" } }, { "score", new Value { IntegerValue = 10L } } } } };
-            dynamic result = ValueDeserializer.Deserialize(SerializationTestData.Database, value, typeof(ExpandoObject));
+            dynamic result = ValueDeserializer.Deserialize(SerializationTestData.Context, value, typeof(ExpandoObject));
             Assert.Equal("Jon", result.name);
             Assert.Equal(10L, result.score);
         }
@@ -49,7 +49,7 @@ namespace Google.Cloud.Firestore.Tests
         public void DeserializeToObjectDictionary()
         {
             var value = new Value { MapValue = new MapValue { Fields = { { "name", new Value { StringValue = "Jon" } }, { "score", new Value { IntegerValue = 10L } } } } };
-            var result = ValueDeserializer.Deserialize(SerializationTestData.Database, value, typeof(object));
+            var result = ValueDeserializer.Deserialize(SerializationTestData.Context, value, typeof(object));
             Assert.IsType<Dictionary<string, object>>(result);
             var expected = new Dictionary<string, object>
             {
@@ -63,7 +63,7 @@ namespace Google.Cloud.Firestore.Tests
         public void DeserializeToSpecificDictionary()
         {
             var value = new Value { MapValue = new MapValue { Fields = { { "x", new Value { IntegerValue = 10L } }, { "y", new Value { IntegerValue = 20L } } } } };
-            var result = ValueDeserializer.Deserialize(SerializationTestData.Database, value, typeof(Dictionary<string, int>));
+            var result = ValueDeserializer.Deserialize(SerializationTestData.Context, value, typeof(Dictionary<string, int>));
             Assert.IsType<Dictionary<string, int>>(result);
             var expected = new Dictionary<string, int>
             {
@@ -379,7 +379,8 @@ namespace Google.Cloud.Firestore.Tests
             var value = ValueSerializer.Serialize(valueToSerialize);
             string warning = null;
             var db = FirestoreDb.Create("proj", "db", new FakeFirestoreClient()).WithWarningLogger(Log);
-            ValueDeserializer.Deserialize(db, value, typeof(T));
+            var context = new DeserializationContext(db);
+            ValueDeserializer.Deserialize(context, value, typeof(T));
             return warning;
 
             void Log(string message)
@@ -395,7 +396,7 @@ namespace Google.Cloud.Firestore.Tests
 
         // Just a convenience method to avoid having to specify all of this on each call.
         private static object DeserializeDefault(Value value, BclType targetType) =>
-            ValueDeserializer.Deserialize(SerializationTestData.Database, value, targetType);
+            ValueDeserializer.Deserialize(SerializationTestData.Context, value, targetType);
 
         /// <summary>
         /// An interface that we can't deserialize to, because Dictionary{,} doesn't implement it.

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Converters/ArrayConverter.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Converters/ArrayConverter.cs
@@ -31,12 +31,12 @@ namespace Google.Cloud.Firestore.Converters
             _elementType = elementType;
         }
 
-        protected override object DeserializeArray(FirestoreDb db, RepeatedField<Value> values)
+        protected override object DeserializeArray(DeserializationContext context, RepeatedField<Value> values)
         {
             Array array = Array.CreateInstance(_elementType, values.Count);
             for (int i = 0; i < values.Count; i++)
             {
-                var converted = ValueDeserializer.Deserialize(db, values[i], _elementType);
+                var converted = ValueDeserializer.Deserialize(context, values[i], _elementType);
                 array.SetValue(converted, i);
             }
             return array;

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Converters/AttributedTypeConverter.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Converters/AttributedTypeConverter.cs
@@ -96,7 +96,7 @@ namespace Google.Cloud.Firestore.Converters
                 : CustomConverter.ForConverterType(attribute.ConverterType, targetType);
         }
 
-        public override object DeserializeMap(FirestoreDb db, IDictionary<string, Value> values)
+        public override object DeserializeMap(DeserializationContext context, IDictionary<string, Value> values)
         {
             // TODO: Consider using a compiled expression tree for this.
             object ret;
@@ -113,7 +113,7 @@ namespace Google.Cloud.Firestore.Converters
             {
                 if (_writableProperties.TryGetValue(pair.Key, out var property))
                 {
-                    property.SetValue(db, pair.Value, ret);
+                    property.SetValue(context, pair.Value, ret);
                 }
                 else
                 {
@@ -122,7 +122,7 @@ namespace Google.Cloud.Firestore.Converters
                         case UnknownPropertyHandling.Ignore:
                             break;
                         case UnknownPropertyHandling.Warn:
-                            db.LogWarning($"No writable property for Firestore field {pair.Key} in type {TargetType.FullName}");
+                            context.Database.LogWarning($"No writable property for Firestore field {pair.Key} in type {TargetType.FullName}");
                             break;
                         case UnknownPropertyHandling.Throw:
                             throw new ArgumentException($"No writable property for Firestore field {pair.Key} in type {TargetType.FullName}");
@@ -194,12 +194,12 @@ namespace Google.Cloud.Firestore.Converters
                     : _converter.Serialize(propertyValue);
             }
 
-            internal void SetValue(FirestoreDb db, Value value, object target)
+            internal void SetValue(DeserializationContext context, Value value, object target)
             {
                 object converted =
-                    _converter == null ? ValueDeserializer.Deserialize(db, value, _propertyInfo.PropertyType)
+                    _converter == null ? ValueDeserializer.Deserialize(context, value, _propertyInfo.PropertyType)
                     : value.ValueTypeCase == Value.ValueTypeOneofCase.NullValue ? null
-                    : _converter.DeserializeValue(db, value);
+                    : _converter.DeserializeValue(context, value);
                 _propertyInfo.SetValue(target, converted);
             }
         }

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Converters/ConverterBase.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Converters/ConverterBase.cs
@@ -38,33 +38,33 @@ namespace Google.Cloud.Firestore.Converters
             TargetType = targetType;
         }
 
-        public virtual object DeserializeMap(FirestoreDb db, IDictionary<string, Value> values) =>
+        public virtual object DeserializeMap(DeserializationContext context, IDictionary<string, Value> values) =>
             throw new ArgumentException($"Unable to convert map value to {TargetType}");
 
-        public virtual object DeserializeValue(FirestoreDb db, Value value)
+        public virtual object DeserializeValue(DeserializationContext context, Value value)
         {
             switch (value.ValueTypeCase)
             {
                 case Value.ValueTypeOneofCase.ArrayValue:
-                    return DeserializeArray(db, value.ArrayValue.Values);
+                    return DeserializeArray(context, value.ArrayValue.Values);
                 case Value.ValueTypeOneofCase.BooleanValue:
-                    return DeserializeBoolean(db, value.BooleanValue);
+                    return DeserializeBoolean(context, value.BooleanValue);
                 case Value.ValueTypeOneofCase.BytesValue:
-                    return DeserializeBytes(db, value.BytesValue);
+                    return DeserializeBytes(context, value.BytesValue);
                 case Value.ValueTypeOneofCase.DoubleValue:
-                    return DeserializeDouble(db, value.DoubleValue);
+                    return DeserializeDouble(context, value.DoubleValue);
                 case Value.ValueTypeOneofCase.GeoPointValue:
-                    return DeserializeGeoPoint(db, value.GeoPointValue);
+                    return DeserializeGeoPoint(context, value.GeoPointValue);
                 case Value.ValueTypeOneofCase.IntegerValue:
-                    return DeserializeInteger(db, value.IntegerValue);
+                    return DeserializeInteger(context, value.IntegerValue);
                 case Value.ValueTypeOneofCase.MapValue:
-                    return DeserializeMap(db, value.MapValue.Fields);
+                    return DeserializeMap(context, value.MapValue.Fields);
                 case Value.ValueTypeOneofCase.ReferenceValue:
-                    return DeserializeReference(db, value.ReferenceValue);
+                    return DeserializeReference(context, value.ReferenceValue);
                 case Value.ValueTypeOneofCase.StringValue:
-                    return DeserializeString(db, value.StringValue);
+                    return DeserializeString(context, value.StringValue);
                 case Value.ValueTypeOneofCase.TimestampValue:
-                    return DeserializeTimestamp(db, value.TimestampValue);
+                    return DeserializeTimestamp(context, value.TimestampValue);
                 default:
                     throw new ArgumentException($"Unable to convert value type {value.ValueTypeCase}");
             }
@@ -75,31 +75,31 @@ namespace Google.Cloud.Firestore.Converters
         public virtual void SerializeMap(object value, IDictionary<string, Value> map) =>
             throw new ArgumentException($"Unable to convert {TargetType} to a map");
 
-        protected virtual object DeserializeArray(FirestoreDb db, RepeatedField<Value> values) =>
+        protected virtual object DeserializeArray(DeserializationContext context, RepeatedField<Value> values) =>
             throw new ArgumentException($"Unable to convert array value to {TargetType}");
 
-        protected virtual object DeserializeBoolean(FirestoreDb db, bool value) =>
+        protected virtual object DeserializeBoolean(DeserializationContext context, bool value) =>
             throw new ArgumentException($"Unable to convert Boolean value to {TargetType}");
 
-        protected virtual object DeserializeBytes(FirestoreDb db, ByteString value) =>
+        protected virtual object DeserializeBytes(DeserializationContext context, ByteString value) =>
             throw new ArgumentException($"Unable to convert bytes value to {TargetType}");
 
-        protected virtual object DeserializeDouble(FirestoreDb db, double value) =>
+        protected virtual object DeserializeDouble(DeserializationContext context, double value) =>
             throw new ArgumentException($"Unable to convert double value to {TargetType}");
 
-        protected virtual object DeserializeGeoPoint(FirestoreDb db, LatLng value) =>
+        protected virtual object DeserializeGeoPoint(DeserializationContext context, LatLng value) =>
             throw new ArgumentException($"Unable to convert LatLng value to {TargetType}");
 
-        protected virtual object DeserializeInteger(FirestoreDb db, long value) =>
+        protected virtual object DeserializeInteger(DeserializationContext context, long value) =>
             throw new ArgumentException($"Unable to convert integer value to {TargetType}");
 
-        protected virtual object DeserializeReference(FirestoreDb db, string value) =>
+        protected virtual object DeserializeReference(DeserializationContext context, string value) =>
             throw new ArgumentException($"Unable to convert reference value to {TargetType}");
 
-        protected virtual object DeserializeString(FirestoreDb db, string value) =>
+        protected virtual object DeserializeString(DeserializationContext context, string value) =>
             throw new ArgumentException($"Unable to convert string value to {TargetType}");
 
-        protected virtual object DeserializeTimestamp(FirestoreDb db, wkt::Timestamp value) =>
+        protected virtual object DeserializeTimestamp(DeserializationContext context, wkt::Timestamp value) =>
             throw new ArgumentException($"Unable to convert Timestamp value to {TargetType}");
     }
 }

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Converters/CustomConverter.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Converters/CustomConverter.cs
@@ -62,17 +62,17 @@ namespace Google.Cloud.Firestore.Converters
             _wrappedConverter = wrappedConverter;
         }
 
-        public object DeserializeMap(FirestoreDb db, IDictionary<string, Value> values)
+        public object DeserializeMap(DeserializationContext context, IDictionary<string, Value> values)
         {
-            var poco = ValueDeserializer.DeserializeMap(db, values, typeof(Dictionary<string, object>));
+            var poco = ValueDeserializer.DeserializeMap(context, values, typeof(Dictionary<string, object>));
             var converted = _wrappedConverter.FromFirestore(poco);
             GaxPreconditions.CheckState(converted != null, "Converter deserialized to null value");
             return converted;
         }
 
-        public object DeserializeValue(FirestoreDb db, Value value)
+        public object DeserializeValue(DeserializationContext context, Value value)
         {
-            var poco = ValueDeserializer.Deserialize(db, value, typeof(object));
+            var poco = ValueDeserializer.Deserialize(context, value, typeof(object));
             var converted = _wrappedConverter.FromFirestore(poco);
             GaxPreconditions.CheckState(converted != null, "Converter deserialized to null value");
             return converted;

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Converters/DictionaryConverter.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Converters/DictionaryConverter.cs
@@ -47,14 +47,14 @@ namespace Google.Cloud.Firestore.Converters
             }
         }
 
-        public override object DeserializeMap(FirestoreDb db, IDictionary<string, Value> values)
+        public override object DeserializeMap(DeserializationContext context, IDictionary<string, Value> values)
         {
             // TODO: Compile an expression tree on construction, or at least accept an optional delegate for construction
             // (allowing for special-casing of Dictionary<string, object>).
             var ret = (IDictionary<string, TValue>) Activator.CreateInstance(_concreteType);
             foreach (var pair in values)
             {
-                ret.Add(pair.Key, (TValue) ValueDeserializer.Deserialize(db, pair.Value, typeof(TValue)));
+                ret.Add(pair.Key, (TValue) ValueDeserializer.Deserialize(context, pair.Value, typeof(TValue)));
             }
             return ret;
         }

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Converters/EnumConverter.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Converters/EnumConverter.cs
@@ -36,7 +36,7 @@ namespace Google.Cloud.Firestore.Converters
             _converter = s_primitiveConverters.GetOrAdd(targetType, t => PrimitiveConverter.ForType(t));
         }
 
-        protected override object DeserializeInteger(FirestoreDb db, long value) => _converter.Int64ToEnum(value);
+        protected override object DeserializeInteger(DeserializationContext context, long value) => _converter.Int64ToEnum(value);
 
         public override Value Serialize(object value) => new Value { IntegerValue = _converter.EnumToInt64(value) };
 

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Converters/IFirestoreInternalConverter.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Converters/IFirestoreInternalConverter.cs
@@ -25,18 +25,18 @@ namespace Google.Cloud.Firestore.Converters
         /// <summary>
         /// Deserializes a single (possibly map- or list-based) Firestore value to a POCO.
         /// </summary>
-        /// <param name="db">The database the value was fetched from. Used when deserializing document references. Never null.</param>
+        /// <param name="context">The context for the deserialization operation. Never null.</param>
         /// <param name="value">The Firestore value to deserialize. Never null.</param>
         /// <returns>The deserialized value. Should never be null.</returns>
-        object DeserializeValue(FirestoreDb db, Value value);
+        object DeserializeValue(DeserializationContext context, Value value);
 
         /// <summary>
         /// Deserializes a map (as a dictionary of name/value pairs) to a POCO.
         /// </summary>
-        /// <param name="db">The database the value was fetched from. Used when deserializing document references. Never null.</param>
+        /// <param name="context">The context for the deserialization operation. Never null.</param>
         /// <param name="values">The name/value pairs to deserialize. Never null.</param>
         /// <returns>The deserialized value. Should never be null.</returns>
-        object DeserializeMap(FirestoreDb db, IDictionary<string, Value> values);
+        object DeserializeMap(DeserializationContext context, IDictionary<string, Value> values);
 
         /// <summary>
         /// Serializes a single POCO to a Firestore representation.

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Converters/ListConverter.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Converters/ListConverter.cs
@@ -48,13 +48,13 @@ namespace Google.Cloud.Firestore.Converters
             }
         }
 
-        protected override object DeserializeArray(FirestoreDb db, RepeatedField<Value> values)
+        protected override object DeserializeArray(DeserializationContext context, RepeatedField<Value> values)
         {
             // TODO: See if using a compiled expression tree is faster.
             var list = (IList) Activator.CreateInstance(TargetType);
             foreach (var value in values)
             {
-                var deserialized = ValueDeserializer.Deserialize(db, value, _elementType);
+                var deserialized = ValueDeserializer.Deserialize(context, value, _elementType);
                 list.Add(deserialized);
             }
             return list;

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Converters/SimpleConverters.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Converters/SimpleConverters.cs
@@ -26,7 +26,7 @@ namespace Google.Cloud.Firestore.Converters
     {
         internal StringConverter() : base(typeof(string)) { }
         public override Value Serialize(object value) => new Value { StringValue = (string) value };
-        protected override object DeserializeString(FirestoreDb db, string value) => value;
+        protected override object DeserializeString(DeserializationContext context, string value) => value;
     }
 
     internal abstract class IntegerConverterBase : ConverterBase
@@ -36,128 +36,128 @@ namespace Google.Cloud.Firestore.Converters
         }
 
         // All integer types allow conversion from double as well.
-        protected override object DeserializeDouble(FirestoreDb db, double value) =>
-            DeserializeInteger(db, checked((long) value));
+        protected override object DeserializeDouble(DeserializationContext context, double value) =>
+            DeserializeInteger(context, checked((long) value));
     }
 
     internal sealed class ByteConverter : IntegerConverterBase
     {
         internal ByteConverter() : base(typeof(byte)) { }
         public override Value Serialize(object value) => new Value { IntegerValue = (byte) value };
-        protected override object DeserializeInteger(FirestoreDb db, long value) => checked((byte) value);
+        protected override object DeserializeInteger(DeserializationContext context, long value) => checked((byte) value);
     }
 
     internal sealed class SByteConverter : IntegerConverterBase
     {
         internal SByteConverter() : base(typeof(sbyte)) { }
         public override Value Serialize(object value) => new Value { IntegerValue = (sbyte) value };
-        protected override object DeserializeInteger(FirestoreDb db, long value) => checked((sbyte) value);
+        protected override object DeserializeInteger(DeserializationContext context, long value) => checked((sbyte) value);
     }
 
     internal sealed class Int16Converter : IntegerConverterBase
     {
         internal Int16Converter() : base(typeof(short)) { }
         public override Value Serialize(object value) => new Value { IntegerValue = (short) value };
-        protected override object DeserializeInteger(FirestoreDb db, long value) => checked((short) value);
+        protected override object DeserializeInteger(DeserializationContext context, long value) => checked((short) value);
     }
 
     internal sealed class UInt16Converter : IntegerConverterBase
     {
         internal UInt16Converter() : base(typeof(ushort)) { }
         public override Value Serialize(object value) => new Value { IntegerValue = (ushort) value };
-        protected override object DeserializeInteger(FirestoreDb db, long value) => checked((ushort) value);
+        protected override object DeserializeInteger(DeserializationContext context, long value) => checked((ushort) value);
     }
 
     internal sealed class Int32Converter : IntegerConverterBase
     {
         internal Int32Converter() : base(typeof(int)) { }
         public override Value Serialize(object value) => new Value { IntegerValue = (int) value };
-        protected override object DeserializeInteger(FirestoreDb db, long value) => checked((int) value);
+        protected override object DeserializeInteger(DeserializationContext context, long value) => checked((int) value);
     }
 
     internal sealed class UInt32Converter : IntegerConverterBase
     {
         internal UInt32Converter() : base(typeof(uint)) { }
         public override Value Serialize(object value) => new Value { IntegerValue = (uint) value };
-        protected override object DeserializeInteger(FirestoreDb db, long value) => checked((uint) value);
+        protected override object DeserializeInteger(DeserializationContext context, long value) => checked((uint) value);
     }
 
     internal sealed class Int64Converter : IntegerConverterBase
     {
         internal Int64Converter() : base(typeof(long)) { }
         public override Value Serialize(object value) => new Value { IntegerValue = (long) value };
-        protected override object DeserializeInteger(FirestoreDb db, long value) => value;
+        protected override object DeserializeInteger(DeserializationContext context, long value) => value;
     }
 
     internal sealed class UInt64Converter : IntegerConverterBase
     {
         internal UInt64Converter() : base(typeof(ulong)) { }
         public override Value Serialize(object value) => new Value { IntegerValue = checked((long) (ulong) value) };
-        protected override object DeserializeInteger(FirestoreDb db, long value) => checked((ulong) value);
+        protected override object DeserializeInteger(DeserializationContext context, long value) => checked((ulong) value);
     }
 
     internal sealed class SingleConverter : ConverterBase
     {
         internal SingleConverter() : base(typeof(float)) { }
         public override Value Serialize(object value) => new Value { DoubleValue = (float) value };
-        protected override object DeserializeDouble(FirestoreDb db, double value) => (float) value;
+        protected override object DeserializeDouble(DeserializationContext context, double value) => (float) value;
         // We allow serialization from integer values as some interactions with Firestore end up storing
         // an integer value even when a double value is expected, if the value happens to be an integer.
         // See https://github.com/googleapis/google-cloud-dotnet/issues/3013
-        protected override object DeserializeInteger(FirestoreDb db, long value) => (float) value;
+        protected override object DeserializeInteger(DeserializationContext context, long value) => (float) value;
     }
 
     internal sealed class DoubleConverter : ConverterBase
     {
         internal DoubleConverter() : base(typeof(double)) { }
         public override Value Serialize(object value) => new Value { DoubleValue = (double) value };
-        protected override object DeserializeDouble(FirestoreDb db, double value) => value;
+        protected override object DeserializeDouble(DeserializationContext context, double value) => value;
         // We allow serialization from integer values as some interactions with Firestore end up storing
         // an integer value even when a double value is expected, if the value happens to be an integer.
         // See https://github.com/googleapis/google-cloud-dotnet/issues/3013
-        protected override object DeserializeInteger(FirestoreDb db, long value) => (double) value;
+        protected override object DeserializeInteger(DeserializationContext context, long value) => (double) value;
     }
 
     internal sealed class BooleanConverter : ConverterBase
     {
         internal BooleanConverter() : base(typeof(bool)) { }
         public override Value Serialize(object value) => new Value { BooleanValue = (bool) value };
-        protected override object DeserializeBoolean(FirestoreDb db, bool value) => value;
+        protected override object DeserializeBoolean(DeserializationContext context, bool value) => value;
     }
 
     internal sealed class TimestampConverter : ConverterBase
     {
         internal TimestampConverter() : base(typeof(Timestamp)) { }
         public override Value Serialize(object value) => new Value { TimestampValue = ((Timestamp) value).ToProto() };
-        protected override object DeserializeTimestamp(FirestoreDb db, wkt::Timestamp value) => Timestamp.FromProto(value);
+        protected override object DeserializeTimestamp(DeserializationContext context, wkt::Timestamp value) => Timestamp.FromProto(value);
     }
 
     internal sealed class GeoPointConverter : ConverterBase
     {
         internal GeoPointConverter() : base(typeof(GeoPoint)) { }
         public override Value Serialize(object value) => new Value { GeoPointValue = ((GeoPoint) value).ToProto() };
-        protected override object DeserializeGeoPoint(FirestoreDb db, LatLng value) => GeoPoint.FromProto(value);
+        protected override object DeserializeGeoPoint(DeserializationContext context, LatLng value) => GeoPoint.FromProto(value);
     }
 
     internal sealed class ByteStringConverter : ConverterBase
     {
         internal ByteStringConverter() : base(typeof(ByteString)) { }
         public override Value Serialize(object value) => new Value { BytesValue = (ByteString) value };
-        protected override object DeserializeBytes(FirestoreDb db, ByteString value) => value;
+        protected override object DeserializeBytes(DeserializationContext context, ByteString value) => value;
     }
 
     internal sealed class ByteArrayConverter : ConverterBase
     {
         internal ByteArrayConverter() : base(typeof(byte[])) { }
         public override Value Serialize(object value) => new Value { BytesValue = ByteString.CopyFrom((byte[]) value) };
-        protected override object DeserializeBytes(FirestoreDb db, ByteString value) => value.ToByteArray();
+        protected override object DeserializeBytes(DeserializationContext context, ByteString value) => value.ToByteArray();
     }
 
     internal sealed class BlobConverter : ConverterBase
     {
         internal BlobConverter() : base(typeof(Blob)) { }
         public override Value Serialize(object value) => new Value { BytesValue = ((Blob) value).ByteString };
-        protected override object DeserializeBytes(FirestoreDb db, ByteString value) => Blob.FromByteString(value);
+        protected override object DeserializeBytes(DeserializationContext context, ByteString value) => Blob.FromByteString(value);
     }
 
     internal sealed class SentinelValueConverter : ConverterBase
@@ -170,41 +170,42 @@ namespace Google.Cloud.Firestore.Converters
     {
         internal DateTimeConverter() : base(typeof(DateTime)) { }
         public override Value Serialize(object value) => new Value { TimestampValue = wkt::Timestamp.FromDateTime((DateTime) value) };
-        protected override object DeserializeTimestamp(FirestoreDb db, wkt::Timestamp value) => value.ToDateTime();
+        protected override object DeserializeTimestamp(DeserializationContext context, wkt::Timestamp value) => value.ToDateTime();
     }
 
     internal sealed class DateTimeOffsetConverter : ConverterBase
     {
         internal DateTimeOffsetConverter() : base(typeof(DateTimeOffset)) { }
         public override Value Serialize(object value) => new Value { TimestampValue = wkt::Timestamp.FromDateTimeOffset((DateTimeOffset) value) };
-        protected override object DeserializeTimestamp(FirestoreDb db, wkt::Timestamp value) => value.ToDateTimeOffset();
+        protected override object DeserializeTimestamp(DeserializationContext context, wkt::Timestamp value) => value.ToDateTimeOffset();
     }
 
     internal sealed class TimestampProtoConverter : ConverterBase
     {
         internal TimestampProtoConverter() : base(typeof(DateTime)) { }
         public override Value Serialize(object value) => new Value { TimestampValue = ((wkt::Timestamp) value).Clone() };
-        protected override object DeserializeTimestamp(FirestoreDb db, wkt::Timestamp value) => value.Clone();
+        protected override object DeserializeTimestamp(DeserializationContext context, wkt::Timestamp value) => value.Clone();
     }
 
     internal sealed class ValueConverter : ConverterBase
     {
         internal ValueConverter() : base(typeof(Value)) { }
         public override Value Serialize(object value) => ((Value) value).Clone();
-        public override object DeserializeValue(FirestoreDb db, Value value) => value.Clone();
+        public override object DeserializeValue(DeserializationContext context, Value value) => value.Clone();
     }
 
     internal sealed class LatLngConverter : ConverterBase
     {
         internal LatLngConverter() : base(typeof(LatLng)) { }
         public override Value Serialize(object value) => new Value { GeoPointValue = ((LatLng) value).Clone() };
-        protected override object DeserializeGeoPoint(FirestoreDb db, LatLng value) => value.Clone();
+        protected override object DeserializeGeoPoint(DeserializationContext context, LatLng value) => value.Clone();
     }
 
     internal sealed class DocumentReferenceConverter : ConverterBase
     {
         internal DocumentReferenceConverter() : base(typeof(DocumentReference)) { }
         public override Value Serialize(object value) => new Value { ReferenceValue = ((DocumentReference) value).Path };
-        protected override object DeserializeReference(FirestoreDb db, string value) => db.GetDocumentReferenceFromResourceName(value);
+        protected override object DeserializeReference(DeserializationContext context, string value) =>
+            context.Database.GetDocumentReferenceFromResourceName(value);
     }
 }

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/DeserializationContext.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/DeserializationContext.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2019, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+
+namespace Google.Cloud.Firestore
+{
+    /// <summary>
+    /// Provides context for deserialization operations.
+    /// </summary>
+    internal sealed class DeserializationContext
+    {
+        /// <summary>
+        /// The database containing the document being deserialized. This is never null.
+        /// </summary>
+        internal FirestoreDb Database { get; }
+
+        /// <summary>
+        /// Constructs a new context.
+        /// </summary>
+        /// <param name="database">The database containing the document being deserialized. Must not be null.</param>
+        internal DeserializationContext(FirestoreDb database)
+        {
+            Database = GaxPreconditions.CheckNotNull(database, nameof(database));
+        }
+    }
+}

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/DocumentSnapshot.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/DocumentSnapshot.cs
@@ -99,7 +99,8 @@ namespace Google.Cloud.Firestore
             {
                 return default;
             }
-            object deserialized = ValueDeserializer.DeserializeMap(Database, Document.Fields, typeof(T));
+            var context = new DeserializationContext(Database);
+            object deserialized = ValueDeserializer.DeserializeMap(context, Document.Fields, typeof(T));
             AttributedIdAssigner.MaybeAssignId(deserialized, Reference);
             return (T) deserialized;
         }
@@ -137,7 +138,8 @@ namespace Google.Cloud.Firestore
         {
             var raw = ExtractValue(path);
             GaxPreconditions.CheckState(raw != null, $"Field {path} not found in document");
-            return (T) ValueDeserializer.Deserialize(Database, raw, typeof(T));
+            var context = new DeserializationContext(Database);
+            return (T) ValueDeserializer.Deserialize(context, raw, typeof(T));
         }
 
         /// <summary>
@@ -161,7 +163,8 @@ namespace Google.Cloud.Firestore
                 value = default(T);
                 return false;
             }
-            value = (T) ValueDeserializer.Deserialize(Database, raw, typeof(T));
+            var context = new DeserializationContext(Database);
+            value = (T) ValueDeserializer.Deserialize(context, raw, typeof(T));
             return true;
         }
 

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/ValueDeserializer.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/ValueDeserializer.cs
@@ -34,14 +34,14 @@ namespace Google.Cloud.Firestore
         /// <summary>
         /// Deserializes from a Firestore Value proto to a .NET type.
         /// </summary>
-        /// <param name="db">The database to use when deserializing DocumentReferences. Must not be null.</param>
+        /// <param name="context">The context for the deserialization operation. Never null.</param>
         /// <param name="value">The value to deserialize. Must not be null.</param>
         /// <param name="targetType">The target type. The method tries to convert to this type. If the type is
         /// object, it uses the default representation of the value.</param>
         /// <returns>The deserialized value</returns>
-        internal static object Deserialize(FirestoreDb db, Value value, BclType targetType)
+        internal static object Deserialize(DeserializationContext context, Value value, BclType targetType)
         {
-            GaxPreconditions.CheckNotNull(db, nameof(db));
+            GaxPreconditions.CheckNotNull(context, nameof(context));
             GaxPreconditions.CheckNotNull(value, nameof(value));
 
             // If we're asked for a Value, just clone it, even for null values.
@@ -67,16 +67,16 @@ namespace Google.Cloud.Firestore
             // We deserialize to T and Nullable<T> the same way for all non-null values. Use the converter
             // associated with the non-nullable version of the target type.
             BclType nonNullableTargetType = underlyingType ?? targetType;
-            return ConverterCache.GetConverter(nonNullableTargetType).DeserializeValue(db, value);
+            return ConverterCache.GetConverter(nonNullableTargetType).DeserializeValue(context, value);
         }
 
-        internal static object DeserializeMap(FirestoreDb db, IDictionary<string, Value> values, BclType targetType)
+        internal static object DeserializeMap(DeserializationContext context, IDictionary<string, Value> values, BclType targetType)
         {
             if (targetType == typeof(object))
             {
                 targetType = typeof(Dictionary<string, object>);
             }
-            return ConverterCache.GetConverter(targetType).DeserializeMap(db, values);
+            return ConverterCache.GetConverter(targetType).DeserializeMap(context, values);
         }
 
         private static BclType GetTargetType(Value value)


### PR DESCRIPTION
Previously every deserialization method accepted a FirestoreDb; that doesn't give us enough information in all cases - in particular, if we want to populate FirestoreDocumentId everywhere.

This is the first part of fixing #3158.