### PR TITLE
Tune SqlResultStream backoff delays

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SqlResultStream.RetryStateTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SqlResultStream.RetryStateTests.cs
@@ -20,7 +20,6 @@ using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
 using Moq;
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 using static Google.Cloud.Spanner.V1.SqlResultStream;
@@ -142,8 +141,8 @@ namespace Google.Cloud.Spanner.V1.Tests
             var mock = new Mock<IScheduler>(MockBehavior.Strict);
             // Delay taken from retry info
             mock.Setup(s => s.Delay(TimeSpan.FromSeconds(3), default)).Returns(Task.FromResult(0));
-            // Delay taken from backoff settings (which have still doubled, even when the first value wasn't used)
-            mock.Setup(s => s.Delay(TimeSpan.FromSeconds(2), default)).Returns(Task.FromResult(0));
+            // Delay taken from backoff settings (which weren't affected by the first exception, because it contained backoff information)
+            mock.Setup(s => s.Delay(TimeSpan.FromSeconds(1), default)).Returns(Task.FromResult(0));
 
             // The first exception contains retry info, so we don't use the backoff settings
             var retryInfo = new Rpc.RetryInfo { RetryDelay = Duration.FromTimeSpan(TimeSpan.FromSeconds(3)) };


### PR DESCRIPTION
- Change settings to be the same as in Java
- Don't progress the exponential backoff if the exception has backoff timing

There's still a difference between this code and Java, in that we reset the backoff on success. I think that's still reasonable.

Fixes #3166 as far as we need to.