### PR TITLE
Run Bigtable postgeneration script on .NET Core even on Linux

### DIFF
--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GenerateClient/Google.Cloud.Bigtable.V2.GenerateClient.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GenerateClient/Google.Cloud.Bigtable.V2.GenerateClient.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/apis/Google.Cloud.Bigtable.V2/postgeneration.sh
+++ b/apis/Google.Cloud.Bigtable.V2/postgeneration.sh
@@ -4,15 +4,7 @@ set -e
 
 sed -i -r -f BigtableServiceApiClient.sed Google.Cloud.Bigtable.V2/BigtableServiceApiClient.cs
 
-case "$OSTYPE" in
-  win* | msys* | cygwin*)
-    dotnet run -p Google.Cloud.Bigtable.V2.GenerateClient \
-      Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj \
-      BigtableServiceApiClient \
-      BigtableClient
-    ;;
-  *)
-    echo "Skipping BigtableClient generation; currently limited to Windows"
-    ;;
-esac
-
+dotnet run -p Google.Cloud.Bigtable.V2.GenerateClient \
+  Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj \
+  BigtableServiceApiClient \
+  BigtableClient


### PR DESCRIPTION
This appears to work now... I can't remember exactly what didn't work before.