### PR TITLE
Add synth.py for Bigtable

### DIFF
--- a/apis/Google.Cloud.Bigtable.V2/synth.py
+++ b/apis/Google.Cloud.Bigtable.V2/synth.py
@@ -1,0 +1,18 @@
+import sys
+from synthtool import shell
+from pathlib import Path
+
+# Parent of the script is the API-specific directory
+# Parent of the API-specific directory is the apis directory
+# Parent of the apis directory is the repo root
+root = Path(__file__).parent.parent.parent
+package = Path(__file__).parent.name
+
+bash = '/bin/bash'
+if sys.platform == 'win32':
+  bash = 'C:\\Program Files\\Git\\bin\\bash.exe'
+
+shell.run(
+  (bash, 'generateapis.sh', package),
+  cwd = root,
+  hide_output = False)


### PR DESCRIPTION
This is probably the most challenging API to generate, as it uses Roslyn. Once this works, we'll generate synth.py for all APIs that have a generator.