### PR TITLE
Remove unnecessary condition when deciding how to batch Write elements

### DIFF
--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/WriteBatch.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/WriteBatch.cs
@@ -260,9 +260,10 @@ namespace Google.Cloud.Firestore
                     UpdateMask = includeEmptyUpdatePath || updatePaths.Count > 0 ? new DocumentMask { FieldPaths = { updatePaths.Select(fp => fp.EncodedPath) } } : null
                 }, true));
                 includeTransformInWriteResults = false;
+                // Don't include the precondition in the Transform write, if there is one.
                 precondition = null;
             }
-            if (sentinelFields.Count > 0 || precondition != null)
+            if (sentinelFields.Count > 0)
             {
                 Elements.Add(new BatchElement(new Write
                 {


### PR DESCRIPTION
This was left over from a previous time. The conformance tests pass with no changes.

(Suggested by the team while investigating #3204.)