### PR TITLE
Add .NET Core 3.0 target for diagnostics libraries

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests.csproj
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp3.0;netcoreapp2.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>
@@ -13,7 +13,7 @@
   <PropertyGroup>
     <DebugSymbols>true</DebugSymbols>
     <DebugType Condition="'$(TargetFramework)' == 'net461'">pdbonly</DebugType>
-    <DebugType Condition="'$(TargetFramework)' == 'netcoreapp2.1'">portable</DebugType>
+    <DebugType Condition="'$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp3.0'">portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Google.Api.Gax.Testing" Version="2.9.0" />
@@ -30,10 +30,13 @@
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.0" />
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.0.0-preview6.19307.2" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Logging/LoggingTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Logging/LoggingTest.cs
@@ -256,7 +256,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
 
         public virtual void ConfigureServices(IServiceCollection services)
         {
-            services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+            services.AddHttpContextAccessor();
             services.AddGoogleTrace(options =>
             {
                 options.ProjectId = ProjectId;

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/Google.Cloud.Diagnostics.AspNetCore.Snippets.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/Google.Cloud.Diagnostics.AspNetCore.Snippets.csproj
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp3.0;netcoreapp2.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>
@@ -14,7 +14,7 @@
     <DebugSymbols>true</DebugSymbols>
     <Optimize Condition="'$(TargetFramework)' == 'net461'">false</Optimize>
     <DebugType Condition="'$(TargetFramework)' == 'net461'">pdbonly</DebugType>
-    <DebugType Condition="'$(TargetFramework)' == 'netcoreapp2.1'">portable</DebugType>
+    <DebugType Condition="'$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp3.0'">portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Google.Api.Gax.Testing" Version="2.9.0" />
@@ -28,15 +28,14 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.12" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http">
-      <Version>2.1.1</Version>
-    </PackageReference>
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.0.0-preview6.19307.2" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/TraceSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/TraceSnippets.cs
@@ -167,7 +167,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
         public void ConfigureServices(IServiceCollection services)
         {
             // The line below is needed for trace ids to be added to logs.
-            services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+            services.AddHttpContextAccessor();
 
             // Replace ProjectId with your Google Cloud Project ID.
             services.AddGoogleTrace(options =>
@@ -203,7 +203,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
         public void ConfigureServices(IServiceCollection services)
         {
             // The line below is needed for trace ids to be added to logs.
-            services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+            services.AddHttpContextAccessor();
 
             // Replace ProjectId with your Google Cloud Project ID.
             services.AddGoogleTrace(options =>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Google.Cloud.Diagnostics.AspNetCore.Tests.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Google.Cloud.Diagnostics.AspNetCore.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp3.0;netcoreapp2.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>
@@ -23,12 +23,14 @@
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.12" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.0.0" />
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Logging/LabelProviders/EnvironmentNameLogEntryLabelProviderTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Logging/LabelProviders/EnvironmentNameLogEntryLabelProviderTest.cs
@@ -35,9 +35,13 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Tests
         public void AddsEnvironmentNameLabel()
         {
             // Arrange
+#if NETCOREAPP3_0
+            var hostingEnvironmentMock = new Mock<IWebHostEnvironment>();
+            hostingEnvironmentMock.Setup(x => x.EnvironmentName).Returns(Microsoft.Extensions.Hosting.Environments.Production);
+#else
             var hostingEnvironmentMock = new Mock<IHostingEnvironment>();
             hostingEnvironmentMock.Setup(x => x.EnvironmentName).Returns(EnvironmentName.Production);
-
+#endif
             var instance = new EnvironmentNameLogEntryLabelProvider(hostingEnvironmentMock.Object);
             var labels = new Dictionary<string, string>();
 
@@ -48,7 +52,11 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Tests
             Assert.Single(labels);
             var label = labels.Single();
             Assert.Equal("aspnetcore_environment", label.Key);
+#if NETCOREAPP3_0
+            Assert.Equal(Microsoft.Extensions.Hosting.Environments.Production, label.Value);
+#else
             Assert.Equal(EnvironmentName.Production, label.Value);
+#endif
         }
 
         [Theory]
@@ -57,8 +65,13 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Tests
         public void SkipsNullOrEmptyEnvironmentName(string label)
         {
             // Arrange
+#if NETCOREAPP3_0
+            var hostingEnvironmentMock = new Mock<IWebHostEnvironment>();
+            hostingEnvironmentMock.Setup(x => x.EnvironmentName).Returns(label);
+#else
             var hostingEnvironmentMock = new Mock<IHostingEnvironment>();
             hostingEnvironmentMock.Setup(x => x.EnvironmentName).Returns(label);
+#endif
 
             var instance = new EnvironmentNameLogEntryLabelProvider(hostingEnvironmentMock.Object);
             var labels = new Dictionary<string, string>();

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Trace/LabelsTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Trace/LabelsTest.cs
@@ -33,14 +33,14 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Tests
         }
 
         [Fact]
-        public void FromDefaultHttpRequest()
+        public void FromHttpRequest()
         {
             var request = new DefaultHttpRequest(new DefaultHttpContext { TraceIdentifier = "trace-id" });
             request.ContentLength = 123;
             request.Host = new HostString("google.com");
             request.Method = "PUT";
 
-            var labels = Labels.FromDefaultHttpRequest(request);
+            var labels = Labels.FromHttpRequest(request);
             Assert.Equal(4, labels.Count);
             Assert.Equal("123", labels[LabelsCommon.HttpRequestSize]);
             Assert.Equal("google.com", labels[LabelsCommon.HttpHost]);
@@ -49,12 +49,12 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Tests
         }
 
         [Fact]
-        public void FromDefaultHttpResponse()
+        public void FromHttpResponse()
         {
             var response = new DefaultHttpResponse(new DefaultHttpContext());
             response.StatusCode = 404;
 
-            var labels = Labels.FromDefaultHttpResponse(response);
+            var labels = Labels.FromHttpResponse(response);
             Assert.Equal(1, labels.Count);
             Assert.Equal("404", labels[LabelsCommon.HttpStatusCode]);
         }

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/ErrorReporting/ErrorReportingExceptionLoggerExtension.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/ErrorReporting/ErrorReportingExceptionLoggerExtension.cs
@@ -62,7 +62,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         /// Uses middleware that will report all uncaught exceptions to the Stackdriver
         /// Error Reporting API.
         /// </summary>
-        /// <param name="app">The application builder. Must not be null.</param>   
+        /// <param name="app">The application builder. Must not be null.</param>
         public static IApplicationBuilder UseGoogleExceptionLogging(this IApplicationBuilder app)
         {
             GaxPreconditions.CheckNotNull(app, nameof(app));
@@ -98,8 +98,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
             var serviceName = GaxPreconditions.CheckNotNull(serviceOptions.ServiceName, nameof(serviceOptions.ServiceName));
             var version = GaxPreconditions.CheckNotNull(serviceOptions.Version, nameof(serviceOptions.Version));
 
-            // Only add the HttpContextAccessor if it's not already added.
-            services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+            services.AddHttpContextAccessor();
             services.AddSingleton(ContextExceptionLogger.Create(
                 serviceOptions.ProjectId, serviceName, version, serviceOptions.Options));
             return services.AddSingleton(CreateExceptionLogger);

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.csproj
@@ -2,8 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Version>3.0.0-beta13</Version>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>
@@ -22,7 +21,7 @@
     <CodeAnalysisRuleSet>..\..\..\grpc.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
+    <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="4.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Cloud.Diagnostics.AspNetCore.Analyzers" Version="1.0.0-beta02" />
     <ProjectReference Include="..\..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.csproj" />
     <PackageReference Include="Grpc.Core" Version="1.22.0" PrivateAssets="None" />
@@ -31,11 +30,13 @@
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
     <None Include="../../../LICENSE" Pack="true" PackagePath="" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.3" />
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.2" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLogger.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLogger.cs
@@ -19,7 +19,6 @@ using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Internal;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -200,7 +199,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
             while (currentLogScope != null)
             {
                 // Determine if the state of the scope are format params
-                if (currentLogScope.State is FormattedLogValues scopeFormatParams)
+                if (currentLogScope.State is IReadOnlyList<KeyValuePair<string, object>> scopeFormatParams)
                 {
                     scopeParamsList.Add(CreateStructValue(scopeFormatParams));
                 }

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/LabelProviders/EnvironmentNameLogEntryLabelProvider.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/LabelProviders/EnvironmentNameLogEntryLabelProvider.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using System.Collections.Generic;
 using Google.Api.Gax;
 using Microsoft.AspNetCore.Hosting;
@@ -20,17 +19,25 @@ using Microsoft.AspNetCore.Hosting;
 namespace Google.Cloud.Diagnostics.AspNetCore
 {
     /// <summary>
-    /// A <see cref="ILogEntryLabelProvider"/> implementation which adds the <see cref="IHostingEnvironment.EnvironmentName"/> to the log entry labels.
+    /// A <see cref="ILogEntryLabelProvider"/> implementation which adds the environment name to the log entry labels.
     /// </summary>
     public class EnvironmentNameLogEntryLabelProvider : ILogEntryLabelProvider
     {
+#if NETCOREAPP3_0
+        private readonly IWebHostEnvironment _hostingEnvironment;
+#elif NETSTANDARD2_0
         private readonly IHostingEnvironment _hostingEnvironment;
+#endif
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EnvironmentNameLogEntryLabelProvider"/> class.
         /// </summary>
-        /// <param name="hostingEnvironment">The <see cref="IHostingEnvironment"/> instance to retrieve the environment name from.</param>
+        /// <param name="hostingEnvironment">The hosting environment instance to retrieve the environment name from.</param>
+#if NETCOREAPP3_0
+        public EnvironmentNameLogEntryLabelProvider(IWebHostEnvironment hostingEnvironment)
+#elif NETSTANDARD2_0
         public EnvironmentNameLogEntryLabelProvider(IHostingEnvironment hostingEnvironment)
+#endif
         {
             _hostingEnvironment = GaxPreconditions.CheckNotNull(hostingEnvironment, nameof(hostingEnvironment));
         }
@@ -38,7 +45,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         /// <inheritdoc/>
         public void Invoke(Dictionary<string, string> labels)
         {
-            if(!string.IsNullOrEmpty(_hostingEnvironment.EnvironmentName))
+            if (!string.IsNullOrEmpty(_hostingEnvironment.EnvironmentName))
             {
                 labels["aspnetcore_environment"] = _hostingEnvironment.EnvironmentName;
             }

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/CloudTraceExtension.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/CloudTraceExtension.cs
@@ -18,7 +18,6 @@ using Google.Cloud.Trace.V1;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using System;
 
 namespace Google.Cloud.Diagnostics.AspNetCore
@@ -117,9 +116,8 @@ namespace Google.Cloud.Diagnostics.AspNetCore
 
             services.AddSingleton(tracerFactory);
 
-            // Only add the HttpContextAccessor if it's not already added.
             // This is needed to get the `TraceHeaderContext`. See `CreateTraceHeaderContext`.
-            services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+            services.AddHttpContextAccessor();
 
             services.AddSingleton(ManagedTracer.CreateDelegatingTracer(ContextTracerManager.GetCurrentTracer));
 

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/Labels.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/Labels.cs
@@ -14,7 +14,6 @@
 
 using Google.Api.Gax;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Internal;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -27,7 +26,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
     /// </summary>
     internal static class Labels
     {
-        ///<summary>The label to denote the ASP.NET Core request trace identifier.</summary> 
+        ///<summary>The label to denote the ASP.NET Core request trace identifier.</summary>
         public const string CoreTraceId = "/aspnetcore/trace_identifier";
 
         /// <summary>
@@ -42,12 +41,12 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         internal static Dictionary<string, string> FromHttpContext(HttpContext httpContext)
         {
             GaxPreconditions.CheckNotNull(httpContext, nameof(httpContext));
-            var requestHeaders = FromDefaultHttpRequest(new DefaultHttpRequest(httpContext));
-            var responseHeader = FromDefaultHttpResponse(new DefaultHttpResponse(httpContext));
+            var requestHeaders = FromHttpRequest(httpContext.Request);
+            var responseHeader = FromHttpResponse(httpContext.Response);
             return requestHeaders.Union(responseHeader).ToDictionary(k => k.Key, v => v.Value);
         }
 
-        internal static Dictionary<string, string> FromDefaultHttpRequest(DefaultHttpRequest request)
+        internal static Dictionary<string, string> FromHttpRequest(HttpRequest request)
         {
             GaxPreconditions.CheckNotNull(request, nameof(request));
             var labels = new Dictionary<string, string>
@@ -65,7 +64,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
             return labels;
         }
 
-        internal static Dictionary<string, string> FromDefaultHttpResponse(DefaultHttpResponse response)
+        internal static Dictionary<string, string> FromHttpResponse(HttpResponse response)
         {
             GaxPreconditions.CheckNotNull(response, nameof(response));
             return new Dictionary<string, string>

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Google.Cloud.Diagnostics.Common.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Google.Cloud.Diagnostics.Common.IntegrationTests.csproj
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp3.0;netcoreapp2.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>
@@ -14,15 +14,12 @@
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.csproj" />
     <ProjectReference Include="..\..\Google.Cloud.ErrorReporting.V1Beta1\Google.Cloud.ErrorReporting.V1Beta1\Google.Cloud.ErrorReporting.V1Beta1.csproj" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="1.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Moq" Version="4.12.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.12" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Google.Cloud.Diagnostics.Common.Tests.csproj" />

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Google.Cloud.Diagnostics.Common.Tests.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Google.Cloud.Diagnostics.Common.Tests.csproj
@@ -1,35 +1,27 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp3.0;netcoreapp2.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
+    <!-- Make sure we get suitable stack traces for tests -->
+    <DebugType>pdbonly</DebugType>
+    <DebugType Condition="'$(TargetFramework)' == 'netcoreapp2.0' Or '$(TargetFramework)' == 'netcoreapp3.0'">portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.csproj" />
     <ProjectReference Include="..\..\Google.Cloud.ErrorReporting.V1Beta1\Google.Cloud.ErrorReporting.V1Beta1\Google.Cloud.ErrorReporting.V1Beta1.csproj" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="1.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Moq" Version="4.12.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.12" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
-    <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
-    <Reference Include="System.Web" />
-  </ItemGroup>
-  <PropertyGroup>
-    <!-- Make sure we get suitable stack traces for tests -->
-    <DebugType>pdbonly</DebugType>
-    <DebugType Condition="'$(TargetFramework)' == 'netcoreapp2.0'">portable</DebugType>
-  </PropertyGroup>
 </Project>

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
@@ -2,8 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Version>3.0.0-beta13</Version>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>
@@ -21,18 +20,20 @@
     <RepositoryUrl>https://github.com/googleapis/google-cloud-dotnet</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
+    <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="4.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="2.9.0" />
-    <PackageReference Include="Google.Cloud.Logging.V2" Version="2.1.0" />
+    <PackageReference Include="Google.Cloud.Logging.V2" Version="2.2.0" />
     <PackageReference Include="Google.Cloud.Trace.V1" Version="1.0.0" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />
+    <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
     <None Include="../../../LICENSE" Pack="true" PackagePath="" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.0.2" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />
-    <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.0.0-preview6.19304.6" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Starting a draft PR with a stab to add .NET Core 3 target for the diagnostics libraries and to figure out whether it's feasible to get this out to NuGet since the libraries are still in beta. Currently we're unable to get diagnostics working for .NET Core 3.0 apps hosted on GCP due to some breaking changes in .NET Core 3.0 which affect the diagnostics libraries. It would be nice if we could start trying out .NET Core 3.0 apps with diagnostics on GCP since an RC is scheduled for July and GA in September ([source](https://github.com/dotnet/core/blob/master/roadmap.md)).

I'm trying to get .NET Core 3.0 builds running on Travis and AppVeyor. However, this might not be desirable for all the other projects in this repo. We should figure out what to do here.

What's in this PR:
- Cross-compile for .NET Core 3.0 and .NET Standard (both `Common` and `AspNetCore`)
- Upgrade ASP.NET Core packages to latest 2.1 versions (LTS) for the NET Standard 2.0 target since 2.0 is EOL
- Utilize `AddHttpContextAccessor` extension added in 2.1
- Removed use of internal API which were removed in ASP.NET Core 3.0, mainly logging and HTTP context stuff
- Added `#ifdefs` for the new ASP.NET Core 3.0 hosting interfaces
- Updated to latest versions of other dependencies
- Remove unnecessary packages and other MSBuild stuff

cc @jskeet 