### PR TITLE
Release Google.Cloud.Firestore 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ The following libraries are available at a [GA](#versioning) quality level:
   * [V2 API docs](https://googleapis.github.io/google-cloud-dotnet/docs/Google.Cloud.Dlp.V2/) (GA)
   * The Google.Cloud.Dlp.V2Beta1 package has now been deprecated, and is unlisted on nuget.org.
     Please update to Google.Cloud.Dlp.V2.
+* [Google Cloud Firestore](https://cloud.google.com/firestore/): two packages are available, both GA:
+  * [Google.Cloud.Firestore](http://googleapis.github.io/google-cloud-dotnet/docs/Google.Cloud.Firestore/): High-level client library for Google Cloud Firestore (recommended)
+  * [Google.Cloud.Firestore.V1](http://googleapis.github.io/google-cloud-dotnet/docs/Google.Cloud.Firestore.V1/): Low-level access to Firestore API
 * [Google Cloud Key Management Service (KMS)](https://cloud.google.com/kms/) - [API docs](http://googleapis.github.io/google-cloud-dotnet/docs/Google.Cloud.Kms.V1/) (GA)
 * [Google Stackdriver Logging](https://cloud.google.com/logging/) - [API docs](http://googleapis.github.io/google-cloud-dotnet/docs/Google.Cloud.Logging.V2/) (GA)
   * Integration with Log4Net is provided via [Google.Cloud.Logging.Log4Net](http://googleapis.github.io/google-cloud-dotnet/docs/Google.Cloud.Logging.Log4Net/) (GA)
@@ -63,19 +66,12 @@ The following libraries are available at a [beta](#versioning) quality level:
 * [Google Cloud Container Analysis](https://cloud.google.com/container-registry/docs/container-analysis/) - [API docs](http://googleapis.github.io/google-cloud-dotnet/docs/Google.Cloud.DevTools.ContainerAnalysis.V1) (beta)
   * This is an implementaiton of the [Grafeas](https://grafeas.io) API - [API docs](http://googleapis.github.io/google-cloud-dotnet/docs/Grafeas.V1) (beta)
 * [Stackdriver Error Reporting](https://cloud.google.com/error-reporting/) - [API docs](http://googleapis.github.io/google-cloud-dotnet/docs/Google.Cloud.ErrorReporting.V1Beta1/) (beta)
-* [Google Cloud Firestore](https://cloud.google.com/firestore/): two packages are available, both beta:
-  * [Google.Cloud.Firestore](http://googleapis.github.io/google-cloud-dotnet/docs/Google.Cloud.Firestore/): High-level client library for Google Cloud Firestore (recommended)
-  * [Google.Cloud.Firestore.V1](http://googleapis.github.io/google-cloud-dotnet/docs/Google.Cloud.Firestore.V1/): Low-level access to Firestore API
-
 The following libraries are available at an [alpha](#versioning) quality level:
 
 * Google Cloud Metadata - [API docs](http://googleapis.github.io/google-cloud-dotnet/docs/Google.Cloud.Metadata.V1) (alpha)
 
 See the [API documentation](http://googleapis.github.io/google-cloud-dotnet/docs/) for details of the status
 of each library.
-
-> Note: This client is a work-in-progress, and may occasionally
-> make backwards-incompatible changes.
 
 If you need support for other Google APIs, check out the
 [Google .NET API Client library](https://github.com/google/google-api-dotnet-client)

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.csproj
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta22</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Google.Cloud.Firestore.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Google.Cloud.Firestore.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta22</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -399,7 +399,7 @@
     "id": "Google.Cloud.Firestore",
     "productName": "Firestore",
     "productUrl": "https://firebase.google.com/docs/firestore/",
-    "version": "1.0.0-beta22",
+    "version": "1.0.0",
     "type": "other",
     "targetFrameworks": "netstandard2.0;net45",
     "testTargetFrameworks": "netcoreapp2.1;net452",
@@ -410,7 +410,7 @@
       "Grpc.Core": "1.22.0"
     },
     "testDependencies": {
-      "Google.Api.Gax.Testing": "default",
+      "Google.Api.Gax.Testing": "2.9.0",
       "Grpc.Core.Testing": "1.22.0",
       "System.ValueTuple": "4.4.0"
     }
@@ -423,14 +423,16 @@
     "serviceYaml": "firestore_v1.yaml",
     "productName": "Firestore",
     "productUrl": "https://firebase.google.com",
-    "version": "1.0.0-beta22",
+    "version": "1.0.0",
     "type": "grpc",
     "targetFrameworks": "netstandard2.0;net45",
     "testTargetFrameworks": "netcoreapp2.1;net452",
     "description": "Low-level Google client library to access the Firestore API. Users are recommended to use the Google.Cloud.Firestore package instead.",
     "tags": [ "firestore", "firebase" ],
     "dependencies": {
-      "Google.LongRunning": "1.1.0"
+      "Google.Api.Gax.Grpc": "2.9.0",
+      "Google.LongRunning": "1.1.0",
+      "Grpc.Core": "1.22.0"
     }
   },
 

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -31,6 +31,9 @@ GA:
     Please update to Google.Cloud.Dlp.V2.
 - [Google.Cloud.Diagnostics.AspNet](Google.Cloud.Diagnostics.AspNet/index.html)
 - [Google.Cloud.Diagnostics.AspNetCore](Google.Cloud.Diagnostics.AspNetCore/index.html)
+- Google Cloud Firestore:
+  - [Google.Cloud.Firestore](Google.Cloud.Firestore/index.html): High-level client library for Google Cloud Firestore (recommended)
+  - [Google.Cloud.Firestore.V1](Google.Cloud.Firestore.V1/index.html): Low-level access to Firestore API
 - [Google.Cloud.Kms.V1](Google.Cloud.Kms.V1/index.html)
 - [Google.Cloud.Language.V1](Google.Cloud.Language.V1/index.html)
 - [Google.Cloud.Logging.V2](Google.Cloud.Logging.V2/index.html)
@@ -65,9 +68,6 @@ Beta:
 - [Google.Cloud.Asset.V1Beta1](Google.Cloud.Asset.V1Beta1/index.html)
 - [Google.Cloud.DevTools.ContainerAnalysis.V1](Google.Cloud.DevTools.ContainerAnalysis.V1/index.html)
 - [Google.Cloud.ErrorReporting.V1Beta1](Google.Cloud.ErrorReporting.V1Beta1/index.html)
-- Google Cloud Firestore:
-  - [Google.Cloud.Firestore](Google.Cloud.Firestore/index.html): High-level client library for Google Cloud Firestore (recommended)
-  - [Google.Cloud.Firestore.V1](Google.Cloud.Firestore.V1/index.html): Low-level access to Firestore API
 - [Google.Cloud.Redis.V1Beta1](Google.Cloud.Redis.V1Beta1/index.html)
 - [Grafeas.V1](Grafeas.V1/index.html)
 


### PR DESCRIPTION
(And Google.Cloud.Firestore.V1 1.0.0.)

This is the first GA release of the .NET Firestore Server SDK.