### PR TITLE
unicode() was removed in Python 3 because all str are Unicode

### DIFF
--- a/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1.IntegrationTests/Emulator/metadata_server.py
+++ b/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1.IntegrationTests/Emulator/metadata_server.py
@@ -19,6 +19,11 @@ from oauth2client import service_account
 from werkzeug.wrappers import Request
 import common, errno, getopt, hashlib, json, logging, os, socket, string, sys, threading, time, urllib
 
+try:
+  unicode
+except NameError:
+  unicode = str
+
 class ServerState:
   _credential_scopes = ["https://www.googleapis.com/auth/cloud-platform",
                         "https://www.googleapis.com/auth/userinfo.email"]
@@ -27,7 +32,7 @@ class ServerState:
     self._lock = threading.RLock()
     self.project_id = project_id
     self.numeric_project_id = numeric_project_id
-    
+
     self._credentials = {}
     if use_default_credentials:
       self._useDefaultCredentials()
@@ -484,7 +489,7 @@ class MetadataValue(object):
   def verifyShape(self, data, lock):
     """Verifies the shapes of the new data, possibly coercing the type if necessary, and returns it.
     Returns None if the data is invalid.
-    
+
     Arg:
       data: the new data to verify.
       lock: the lock to use to create new metadata values if necessary.
@@ -526,7 +531,7 @@ class MetadataValue(object):
 
     if alt and self.isDirectory() and self.canRequestChildren():
       return (None, bad_request_error)
-  
+
     return self.prepareNonRecursiveResult(is_json)
 
   def prepareNonRecursiveResult(self, is_json):
@@ -560,7 +565,7 @@ class MetadataValue(object):
 
   def waitForChange(self, timeout_sec):
     """Wait for the data or any of its descendants to change for the specified amount of time.
-    
+
     Arg:
       timeout_sec: The maximum number of seconds to wait.
     """
@@ -583,7 +588,7 @@ class MetadataDirectory(MetadataValue):
 
   def __getitem__(self, key):
     return self._value.__getitem__(key)
-  
+
   def __setitem__(self, key, value):
     self._value.__setitem__(key, value)
 
@@ -641,7 +646,7 @@ class MetadataDict(MetadataDirectory):
   def childIter(self):
     """Gets an iterator for all child data."""
     for key in self:
-      yield self[key] 
+      yield self[key]
 
   def deleteChild(self, child_name):
     """Attempts to delete the child with the specified name and returns whether the operation was successful.
@@ -750,7 +755,7 @@ class MetadataDict(MetadataDirectory):
     """Sets the value indicating whether the dictionary has a fixed set of keys or not. If has_fixed_keys is
     False, the dictionary can have an arbitrary set of keys, but the values associated with those keys must
     conform to a certain data shape.
-    
+
     Args:
       has_fixed_keys: Indicates whether the dictionary is expected to have a fixed set of keys or not.
     """
@@ -790,7 +795,7 @@ class MetadataIndexedList(MetadataDirectory):
         return self[index]
     except ValueError:
       pass
-    
+
     return None
 
   def getValueToJSONEncode(self):
@@ -851,7 +856,7 @@ class MetadataList(MetadataDirectory):
   def __init__(self, items, lock):
     assert isinstance(items, list)
     MetadataDirectory.__init__(self, items, lock)
-    
+
   def canRequestChildren(self):
     return False
 
@@ -877,7 +882,7 @@ class MetadataList(MetadataDirectory):
   def prepareNonRecursiveResult(self, is_json):
     if is_json:
       return (json.dumps(self.getValueToJSONEncode(), separators=(u',', u':')), None)
-    
+
     result = u''
     for item in self:
       (item_result, error) = item.prepareNonRecursiveResult(is_json)

--- a/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1.IntegrationTests/Emulator/metadata_server_test.py
+++ b/apis/Google.Cloud.Metadata.V1/Google.Cloud.Metadata.V1.IntegrationTests/Emulator/metadata_server_test.py
@@ -15,6 +15,11 @@
 from collections import OrderedDict
 import common, datetime, json, os, threading, time, urllib, urllib2
 
+try:
+  unicode
+except NameError:
+  unicode = str
+
 # These tests can be run with pytest: http://doc.pytest.org/en/latest/index.html
 
 try:
@@ -44,7 +49,7 @@ def expect_content_absolute(url, expected, expected_content_type, expect_metadat
 
   check_header(headers, common.server, common.server_value)
   check_header(headers, common.content_type, expected_content_type)
-  
+
   contents = response.read()
   assert expected == contents
 
@@ -98,7 +103,7 @@ def expect_error_updating_content(path, new_data, expected_code):
                             data,
                             headers={common.metadata_flavor: common.metadata_flavor_google,
                                      common.content_type: common.content_type_text})
-  
+
   try:
     response = urllib2.urlopen(request)
     # This will always fail but I'm asserting so the response appears in the test results
@@ -117,12 +122,12 @@ def check_path(path, expected, default='text'):
     expected_text = ''.join(s + '\n' for s in expected)
   else:
     expected_text = unicode(expected)
-    
+
   etag1 = expect_content(path,
                          expected_text if default == 'text' else expected_json,
                          common.content_type_text if default == 'text' else common.content_type_json)
   etag2 = expect_content(path + "?alt=text", expected_text, common.content_type_text)
-  etag3 = expect_content(path + "?alt=json", expected_json, common.content_type_json) 
+  etag3 = expect_content(path + "?alt=json", expected_json, common.content_type_json)
   assert len(etag1) == 16
   assert etag1 == etag2
   assert etag1 == etag3
@@ -176,7 +181,7 @@ def check_dir_recursive(path, expected, test_trailing_slash=True, use_recursive_
     etag4 = expect_content(path + '/' + query, expected_text, common.content_type_text, expect_metadata_header)
   else:
     etag4 = etag3
-  
+
   query = '?recursive=true&alt=json' if use_recursive_field else '?alt=json'
   etag5 = expect_content(path + query, expected, common.content_type_json, expect_metadata_header)
   if test_trailing_slash:
@@ -209,7 +214,7 @@ def update_content(path, new_data):
                             data,
                             headers={common.metadata_flavor: common.metadata_flavor_google,
                                      common.content_type: common.content_type_text})
-  
+
   try:
     urllib2.urlopen(request)
   except urllib2.URLError as e:


### PR DESCRIPTION
This linting step was used to find the syntax errors in #3250 