### PR TITLE
Only write diagnostic log output once

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLogger.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLogger.cs
@@ -22,8 +22,9 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Internal;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
+using System.IO;
 using System.Linq;
+using static System.FormattableString;
 
 namespace Google.Cloud.Diagnostics.AspNetCore
 {
@@ -89,8 +90,6 @@ namespace Google.Cloud.Diagnostics.AspNetCore
             _fullLogName = logTarget.GetFullLogName(_loggerOptions.LogName);
             _serviceProvider = serviceProvider;
             _clock = clock ?? SystemClock.Instance;
-
-            WriteCreationDiagnostics();
         }
 
         /// <inheritdoc />
@@ -303,14 +302,14 @@ namespace Google.Cloud.Diagnostics.AspNetCore
             }.Uri;
         }
 
-        private void WriteCreationDiagnostics()
+        internal void WriteDiagnostics(TextWriter writer)
         {
             // Explicitly not catching exceptions.
             // This should only be activated for diagnostics purposes so in that case
-            // we shouldn't throw exceptions.
+            // we shouldn't try to handle exceptions.
 
-            _loggerOptions.LoggerDiagnosticsOutput?.WriteLine(string.Format(CultureInfo.InvariantCulture, "{0:yyyy-MM-dd'T'HH:mm:ss} - GoogleLogger created. Logs written to: {1}", DateTime.UtcNow, GetGcpConsoleLogsUrl()));
-            _loggerOptions.LoggerDiagnosticsOutput?.Flush();
+            writer.WriteLine(Invariant($"{DateTime.UtcNow:yyyy-MM-dd'T'HH:mm:ss} - GoogleLogger will write logs to: {GetGcpConsoleLogsUrl()}"));
+            writer.Flush();
         }
     }
 }

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLoggerProvider.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLoggerProvider.cs
@@ -50,6 +50,15 @@ namespace Google.Cloud.Diagnostics.AspNetCore
             _logTarget = GaxPreconditions.CheckNotNull(logTarget, nameof(logTarget));
             _loggerOptions = GaxPreconditions.CheckNotNull(loggerOptions, nameof(loggerOptions));
             _serviceProvider = serviceProvider;
+
+            var writer = loggerOptions.LoggerDiagnosticsOutput;
+            if (writer != null)
+            {
+                // The log name is the ASP.NET Core log name, not the "/projects/xyz/logs/abc" log name in the resource.
+                // We don't currently use this in the diagnostics, but if we ever start to do so, SampleLogName seems
+                // like a reasonably clear example.
+                ((GoogleLogger) CreateLogger("SampleLogName")).WriteDiagnostics(writer);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #3258.

(This is ready for review, but I won't merge it yet anyway - I want to try to get a bunch of issues fixed, then test them in a real application before merging, just to be on the safe side.)