### PR TITLE
Allow the UseGoogleDiagnostics method to supply options

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/DiagnosticsWebHostTests.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/DiagnosticsWebHostTests.cs
@@ -84,11 +84,12 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
                     { "build_id", "some-build-id" }
                 }
             };
-
+            // We won't be able to detect the right monitored resource, so specify it explicitly.
+            var loggerOptions = LoggerOptions.Create(monitoredResource: resource);
             var webHostBuilder = new WebHostBuilder()
                 .ConfigureServices(services => services.AddMvcCore())
                 .Configure(app => app.UseMvcWithDefaultRoute())
-                .UseGoogleDiagnostics(monitoredResource: resource);
+                .UseGoogleDiagnostics(TestEnvironment.GetTestProjectId(), EntryData.Service, EntryData.Version, loggerOptions);
 
             using (var server = new TestServer(webHostBuilder))
             using (var client = server.CreateClient())

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/GoogleDiagnosticsStartupFilter.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/GoogleDiagnosticsStartupFilter.cs
@@ -14,6 +14,7 @@
 
 using System;
 using Google.Api;
+using Google.Cloud.Diagnostics.Common;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Logging;
@@ -26,7 +27,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
     internal class GoogleDiagnosticsStartupFilter : IStartupFilter
     {
         private readonly string _projectId;
-        private readonly MonitoredResource _monitoredResource;
+        private readonly LoggerOptions _loggerOptions;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GoogleDiagnosticsStartupFilter"/> class to configure Google Diagnostics services.
@@ -35,14 +36,11 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         /// The Google Cloud Platform project ID. If unspecified and running on GAE or GCE
         /// the project ID will be detected from the platform.
         /// </param>
-        /// <param name="monitoredResource">
-        /// Optional, the monitored resource.  The monitored resource will be automatically detected
-        /// if it is not set and will default to the global resource if the detection fails.
-        /// </param>
-        public GoogleDiagnosticsStartupFilter(string projectId, MonitoredResource monitoredResource = null)
+        /// <param name="loggerOptions">The logger options. May be null.</param>
+        public GoogleDiagnosticsStartupFilter(string projectId, LoggerOptions loggerOptions)
         {
             _projectId = projectId;
-            _monitoredResource = monitoredResource;
+            _loggerOptions = loggerOptions;
         }
 
         /// <summary>
@@ -55,7 +53,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
             return app =>
             {
                 var loggerFactory = app.ApplicationServices.GetServiceCheckNotNull<ILoggerFactory>();
-                loggerFactory.AddGoogle(app.ApplicationServices, _projectId, LoggerOptions.Create(monitoredResource: _monitoredResource));
+                loggerFactory.AddGoogle(app.ApplicationServices, _projectId, _loggerOptions);
                 app.UseGoogleExceptionLogging();
                 app.UseGoogleTrace();
 

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/GoogleDiagnosticsWebHostBuilderExtensions.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/GoogleDiagnosticsWebHostBuilderExtensions.cs
@@ -42,9 +42,20 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         /// A string that represents the version of the service or the source code used for exception logging.
         /// If unspecified and running on GAE the service version will be detected from the platform.
         /// </param>
+        /// <param name="loggerOptions">The options for logging. May be null, in which case default options will be used.</param>
+        /// <param name="traceOptions">The options for tracing. May be null, in which case default options will be used.</param>
+        /// <param name="errorReportingOptions">The options for error reporting. May be null, in which case default options will be used.</param>
         /// <returns>The <see cref="IWebHostBuilder"/> instance.</returns>
-        public static IWebHostBuilder UseGoogleDiagnostics(this IWebHostBuilder builder, string projectId = null, string serviceName = null, string serviceVersion = null)
-            => UseGoogleDiagnostics(builder, projectId, serviceName, serviceVersion, monitoredResource: null);
+        public static IWebHostBuilder UseGoogleDiagnostics(
+            this IWebHostBuilder builder,
+            string projectId = null,
+            string serviceName = null,
+            string serviceVersion = null,
+            LoggerOptions loggerOptions = null,
+            TraceOptions traceOptions = null,
+            ErrorReportingOptions errorReportingOptions = null) =>
+            builder.ConfigureServices(services =>
+                ConfigureGoogleDiagnosticsServices(services, projectId, serviceName, serviceVersion, loggerOptions, traceOptions, errorReportingOptions));
 
         // On .NET Standard 2.0 or higher the IWebHostBuilder.ConfigureServices has a new overload that takes both
         // an IServiceCollection and a WebHostBuilderContext. We can use the context for retrieving information from the
@@ -69,45 +80,62 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         /// Cannot be null but can return a null value for the service version, in such a case
         /// and if running on GAE the service version will be detected from the platform.
         /// </param>
+        /// <param name="loggerOptionsGetter">
+        /// A function that takes a <see cref="WebHostBuilderContext"/> and retrieves the options to use for logging.
+        /// May be null or return a null value for the options; in either of these cases the default options will be used.
+        /// </param>
+        /// <param name="traceOptionsGetter">
+        /// A function that takes a <see cref="WebHostBuilderContext"/> and retrieves the options to use for tracing.
+        /// May be null or return a null value for the options; in either of these cases the default options will be used.
+        /// </param>
+        /// <param name="errorReportingOptionsGetter">
+        /// A function that takes a <see cref="WebHostBuilderContext"/> and retrieves the options to use for errorReporting.
+        /// May be null or return a null value for the options; in either of these cases the default options will be used.
+        /// </param>
         /// <returns>The <see cref="IWebHostBuilder"/> instance.</returns>
-        public static IWebHostBuilder UseGoogleDiagnostics(this IWebHostBuilder builder, Func<WebHostBuilderContext, string> projectIdGetter, Func<WebHostBuilderContext, string> serviceNameGetter, Func<WebHostBuilderContext, string> serviceVersionGetter)
+        public static IWebHostBuilder UseGoogleDiagnostics(
+            this IWebHostBuilder builder,
+            Func<WebHostBuilderContext, string> projectIdGetter,
+            Func<WebHostBuilderContext, string> serviceNameGetter,
+            Func<WebHostBuilderContext, string> serviceVersionGetter,
+            Func<WebHostBuilderContext, LoggerOptions> loggerOptionsGetter = null,
+            Func<WebHostBuilderContext, TraceOptions> traceOptionsGetter = null,
+            Func<WebHostBuilderContext, ErrorReportingOptions> errorReportingOptionsGetter = null)
         {
             GaxPreconditions.CheckNotNull(projectIdGetter, nameof(projectIdGetter));
             GaxPreconditions.CheckNotNull(serviceNameGetter, nameof(serviceNameGetter));
             GaxPreconditions.CheckNotNull(serviceVersionGetter, nameof(serviceVersionGetter));
 
-            builder.ConfigureServices((context, services) =>
-            {
-                ConfigureGoogleDiagnosticsServices(services, projectIdGetter(context), serviceNameGetter(context), serviceVersionGetter(context), null);
-            });
-
-            return builder;
+            return builder.ConfigureServices((context, services) =>
+                ConfigureGoogleDiagnosticsServices(services, projectIdGetter(context), serviceNameGetter(context), serviceVersionGetter(context),
+                    loggerOptionsGetter?.Invoke(context), traceOptionsGetter?.Invoke(context), errorReportingOptionsGetter?.Invoke(null)));
         }
 
-        // Overload which allows passing in a MonitoredResource instance
-        // Internal for testing
-        internal static IWebHostBuilder UseGoogleDiagnostics(this IWebHostBuilder builder, string projectId = null, string serviceName = null, string serviceVersion = null, MonitoredResource monitoredResource = null)
-        {
-            builder.ConfigureServices(services =>
-            {
-                ConfigureGoogleDiagnosticsServices(services, projectId, serviceName, serviceVersion, monitoredResource);
-            });
 
-            return builder;
-        }
-
-        private static void ConfigureGoogleDiagnosticsServices(IServiceCollection services, string projectId, string serviceName, string serviceVersion, MonitoredResource monitoredResource)
+        private static void ConfigureGoogleDiagnosticsServices(
+            IServiceCollection services,
+            string projectId,
+            string serviceName,
+            string serviceVersion,
+            LoggerOptions loggerOptions,
+            TraceOptions traceOptions,
+            ErrorReportingOptions errorReportingOptions)
         {
-            projectId = Project.GetAndCheckProjectId(projectId, monitoredResource);
+            projectId = Project.GetAndCheckProjectId(projectId, null);
 
             services.AddLogEntryLabelProvider<TraceIdLogEntryLabelProvider>();
-            services.AddSingleton<IStartupFilter>(new GoogleDiagnosticsStartupFilter(projectId, monitoredResource));
-            services.AddGoogleTrace(options => options.ProjectId = projectId);
+            services.AddSingleton<IStartupFilter>(new GoogleDiagnosticsStartupFilter(projectId, loggerOptions));
+            services.AddGoogleTrace(options =>
+            {
+                options.ProjectId = projectId;
+                options.Options = traceOptions;
+            });
             services.AddGoogleExceptionLogging(options =>
             {
                 options.ProjectId = projectId;
-                options.ServiceName = Project.GetAndCheckServiceName(serviceName, monitoredResource);
-                options.Version = Project.GetAndCheckServiceVersion(serviceVersion, monitoredResource);
+                options.ServiceName = Project.GetAndCheckServiceName(serviceName, null);
+                options.Version = Project.GetAndCheckServiceVersion(serviceVersion, null);
+                options.Options = errorReportingOptions;
             });
         }
     }


### PR DESCRIPTION
Without this, when options are required for troubleshooting, the user has to change their configuration approach entirely.

@henkmollema If you have the time to review this as well, that would be much appreciated.

Note that this does break *binary* compatibility, but should be fine for *source* compatibility.