### PR TITLE
Test/document that GoogleLoggerProvider.Create works with null service provider

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLoggerProvider.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLoggerProvider.cs
@@ -64,7 +64,8 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         /// <summary>
         /// Create an <see cref="ILoggerProvider"/> for Google Stackdriver Logging.
         /// </summary>
-        /// <param name="serviceProvider">The service provider to resolve additional services from.</param>
+        /// <param name="serviceProvider">The service provider to resolve additional services from.
+        /// May be null, in which case additional services (such as custom labels) will not be used.</param>
         /// <param name="projectId">Optional if running on Google App Engine or Google Compute Engine.
         ///     The Google Cloud Platform project ID. If unspecified and running on GAE or GCE the project ID will be
         ///     detected from the platform.</param>
@@ -82,7 +83,8 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         /// Create an <see cref="ILoggerProvider"/> for Google Stackdriver Logging.
         /// </summary>
         /// <param name="logTarget">Where to log to. Must not be null.</param>
-        /// <param name="serviceProvider">The service provider to resolve additional services from.</param>
+        /// <param name="serviceProvider">Optional, the service provider to resolve additional services from. May be null,
+        /// in which case additional services (such as custom labels) will not be used.</param>
         /// <param name="options">Optional, options for the logger.</param>
         /// <param name="client">Optional, logging client.</param>
         public static GoogleLoggerProvider Create(LogTarget logTarget, IServiceProvider serviceProvider,


### PR DESCRIPTION
Fixes #3257 (as far as we can).