### PR TITLE
Remove internal type usage to unblock .NET Core 3

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Trace/LabelsTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Trace/LabelsTest.cs
@@ -40,7 +40,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Tests
             request.Host = new HostString("google.com");
             request.Method = "PUT";
 
-            var labels = Labels.FromDefaultHttpRequest(request);
+            var labels = Labels.FromHttpRequest(request);
             Assert.Equal(4, labels.Count);
             Assert.Equal("123", labels[LabelsCommon.HttpRequestSize]);
             Assert.Equal("google.com", labels[LabelsCommon.HttpHost]);
@@ -54,7 +54,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Tests
             var response = new DefaultHttpResponse(new DefaultHttpContext());
             response.StatusCode = 404;
 
-            var labels = Labels.FromDefaultHttpResponse(response);
+            var labels = Labels.FromHttpResponse(response);
             Assert.Equal(1, labels.Count);
             Assert.Equal("404", labels[LabelsCommon.HttpStatusCode]);
         }

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLogger.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLogger.cs
@@ -19,7 +19,6 @@ using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Internal;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -199,7 +198,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
             while (currentLogScope != null)
             {
                 // Determine if the state of the scope are format params
-                if (currentLogScope.State is FormattedLogValues scopeFormatParams)
+                if (currentLogScope.State is IEnumerable<KeyValuePair<string, object>> scopeFormatParams)
                 {
                     scopeParamsList.Add(CreateStructValue(scopeFormatParams));
                 }

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/Labels.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/Labels.cs
@@ -14,7 +14,6 @@
 
 using Google.Api.Gax;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Internal;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -42,12 +41,12 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         internal static Dictionary<string, string> FromHttpContext(HttpContext httpContext)
         {
             GaxPreconditions.CheckNotNull(httpContext, nameof(httpContext));
-            var requestHeaders = FromDefaultHttpRequest(new DefaultHttpRequest(httpContext));
-            var responseHeader = FromDefaultHttpResponse(new DefaultHttpResponse(httpContext));
+            var requestHeaders = FromHttpRequest(httpContext.Request);
+            var responseHeader = FromHttpResponse(httpContext.Response);
             return requestHeaders.Union(responseHeader).ToDictionary(k => k.Key, v => v.Value);
         }
 
-        internal static Dictionary<string, string> FromDefaultHttpRequest(DefaultHttpRequest request)
+        internal static Dictionary<string, string> FromHttpRequest(HttpRequest request)
         {
             GaxPreconditions.CheckNotNull(request, nameof(request));
             var labels = new Dictionary<string, string>
@@ -65,7 +64,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
             return labels;
         }
 
-        internal static Dictionary<string, string> FromDefaultHttpResponse(DefaultHttpResponse response)
+        internal static Dictionary<string, string> FromHttpResponse(HttpResponse response)
         {
             GaxPreconditions.CheckNotNull(response, nameof(response));
             return new Dictionary<string, string>


### PR DESCRIPTION
Unblocks .NET Core 3.0 usage as requested in #3259 without targetting .NET Core 3.0 yet, by removing the use of deleted/internal types in .NET Core 3.0.

I did a small test and got it working on a .NET Core 3.0 app with the following host builder setup:

```cs
public static IHostBuilder CreateHostBuilder(string[] args) =>
    Host.CreateDefaultBuilder(args)
        .ConfigureWebHostDefaults(webBuilder =>
        {
            webBuilder.UseGoogleDiagnostics();
            webBuilder.UseStartup<Startup>();
        });
```