### PR TITLE
Remove service name and version requirement for error reporting

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/ErrorReporting/ErrorReportingExceptionFilter.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/ErrorReporting/ErrorReportingExceptionFilter.cs
@@ -54,10 +54,8 @@ namespace Google.Cloud.Diagnostics.AspNet
         /// defined by <see cref="GoogleCredential.GetApplicationDefaultAsync"/>.
         /// </summary>
         /// <param name="projectId">The Google Cloud Platform project ID. Must not be null.</param>
-        /// <param name="serviceName">An identifier of the service, such as the name of the executable or job.
-        ///     Must not be null.</param>
-        /// <param name="version">Represents the source code version that the developer provided. 
-        ///     Must not be null.</param>
+        /// <param name="serviceName">An identifier of the service, such as the name of the executable or job. May be null.</param>
+        /// <param name="version">Represents the source code version that the developer provided. May be null.</param>
         /// <param name="options">Optional, error reporting options.</param>
         public static ErrorReportingExceptionFilter Create(string projectId, string serviceName, string version,
             ErrorReportingOptions options = null)
@@ -76,10 +74,8 @@ namespace Google.Cloud.Diagnostics.AspNet
         /// current platform.
         /// </para>
         /// </summary>
-        /// <param name="serviceName">An identifier of the service, such as the name of the executable or job.
-        ///     Must not be null.</param>
-        /// <param name="version">Represents the source code version that the developer provided. 
-        ///     Must not be null.</param>
+        /// <param name="serviceName">An identifier of the service, such as the name of the executable or job. May be null.</param>
+        /// <param name="version">Represents the source code version that the developer provided. May be null.</param>
         /// <param name="options">Optional, error reporting options.</param>
         public static ErrorReportingExceptionFilter Create(
             string serviceName, string version, ErrorReportingOptions options = null)

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/ErrorReporting/ErrorReportingExceptionLogger.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/ErrorReporting/ErrorReportingExceptionLogger.cs
@@ -54,8 +54,8 @@ namespace Google.Cloud.Diagnostics.AspNet
         /// defined by <see cref="GoogleCredential.GetApplicationDefaultAsync"/>.
         /// </summary>
         /// <param name="projectId">The Google Cloud Platform project ID. Must not be null.</param>
-        /// <param name="serviceName">An identifier of the service, such as the name of the executable or job. Must not be null.</param>
-        /// <param name="version">Represents the source code version that the developer provided. Must not be null.</param> 
+        /// <param name="serviceName">An identifier of the service, such as the name of the executable or job. May be null.</param>
+        /// <param name="version">Represents the source code version that the developer provided. May be null.</param> 
         ///  <param name="options">Optional, error reporting options.</param>
         public static ErrorReportingExceptionLogger Create(string projectId, string serviceName, string version,
             ErrorReportingOptions options = null)
@@ -74,8 +74,8 @@ namespace Google.Cloud.Diagnostics.AspNet
         /// current platform.
         /// </para>
         /// </summary>
-        /// <param name="serviceName">An identifier of the service, such as the name of the executable or job. Must not be null.</param>
-        /// <param name="version">Represents the source code version that the developer provided. Must not be null.</param> 
+        /// <param name="serviceName">An identifier of the service, such as the name of the executable or job. May be null.</param>
+        /// <param name="version">Represents the source code version that the developer provided. May be null.</param> 
         ///  <param name="options">Optional, error reporting options.</param>
         public static ErrorReportingExceptionLogger Create(
             string serviceName, string version, ErrorReportingOptions options = null)

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/ErrorReporting/GoogleExceptionLogger.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/ErrorReporting/GoogleExceptionLogger.cs
@@ -55,10 +55,8 @@ namespace Google.Cloud.Diagnostics.AspNet
         /// Creates an instance of <see cref="GoogleExceptionLogger"/>.
         /// </summary>
         /// <param name="projectId">The Google Cloud Platform project ID. Must not be null.</param>
-        /// <param name="serviceName">An identifier of the service, such as the name of the executable or job.
-        ///     Must not be null.</param>
-        /// <param name="version">Represents the source code version that the developer provided. 
-        ///     Must not be null.</param>
+        /// <param name="serviceName">An identifier of the service, such as the name of the executable or job. May be null.</param>
+        /// <param name="version">Represents the source code version that the developer provided. May be null.</param>
         /// <param name="options">Optional, error reporting options.</param>
         public static GoogleExceptionLogger Create(string projectId, string serviceName, string version,
             ErrorReportingOptions options = null)
@@ -76,10 +74,8 @@ namespace Google.Cloud.Diagnostics.AspNet
         /// current platform.
         /// </para>
         /// </summary>
-        /// <param name="serviceName">An identifier of the service, such as the name of the executable or job.
-        ///     Must not be null.</param>
-        /// <param name="version">Represents the source code version that the developer provided. 
-        ///     Must not be null.</param>
+        /// <param name="serviceName">An identifier of the service, such as the name of the executable or job. May be null.</param>
+        /// <param name="version">Represents the source code version that the developer provided. May be null.</param>
         /// <param name="options">Optional, error reporting options.</param>
         public static GoogleExceptionLogger Create(string serviceName, string version,
             ErrorReportingOptions options = null)

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/ErrorReporting/GoogleWebApiExceptionLogger.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/ErrorReporting/GoogleWebApiExceptionLogger.cs
@@ -57,10 +57,8 @@ namespace Google.Cloud.Diagnostics.AspNet
         /// Creates an instance of <see cref="GoogleWebApiExceptionLogger"/>.
         /// </summary>
         /// <param name="projectId">The Google Cloud Platform project ID. Must not be null.</param>
-        /// <param name="serviceName">An identifier of the service, such as the name of the executable or job.
-        ///     Must not be null.</param>
-        /// <param name="version">Represents the source code version that the developer provided. 
-        ///     Must not be null.</param>
+        /// <param name="serviceName">An identifier of the service, such as the name of the executable or job. May be null.</param>
+        /// <param name="version">Represents the source code version that the developer provided. May be null.</param>
         /// <param name="options">Optional, error reporting options.</param>
         public static GoogleWebApiExceptionLogger Create(string projectId, string serviceName, string version,
             ErrorReportingOptions options = null)
@@ -78,10 +76,8 @@ namespace Google.Cloud.Diagnostics.AspNet
         /// current platform.
         /// </para>
         /// </summary>
-        /// <param name="serviceName">An identifier of the service, such as the name of the executable or job.
-        ///     Must not be null.</param>
-        /// <param name="version">Represents the source code version that the developer provided. 
-        ///     Must not be null.</param>
+        /// <param name="serviceName">An identifier of the service, such as the name of the executable or job. May be null.</param>
+        /// <param name="version">Represents the source code version that the developer provided. May be null.</param>
         /// <param name="options">Optional, error reporting options.</param>
         public static GoogleWebApiExceptionLogger Create(string serviceName, string version,
             ErrorReportingOptions options = null)

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/ErrorReporting/ErrorReportingExceptionLoggerExtension.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/ErrorReporting/ErrorReportingExceptionLoggerExtension.cs
@@ -95,12 +95,9 @@ namespace Google.Cloud.Diagnostics.AspNetCore
 
             var serviceOptions = new ErrorReportingServiceOptions();
             setupAction(serviceOptions);
-            var serviceName = GaxPreconditions.CheckNotNull(serviceOptions.ServiceName, nameof(serviceOptions.ServiceName));
-            var version = GaxPreconditions.CheckNotNull(serviceOptions.Version, nameof(serviceOptions.Version));
-
             services.AddHttpContextAccessor();
             services.AddSingleton(ContextExceptionLogger.Create(
-                serviceOptions.ProjectId, serviceName, version, serviceOptions.Options));
+                serviceOptions.ProjectId, serviceOptions.ServiceName, serviceOptions.Version, serviceOptions.Options));
             return services.AddSingleton(CreateExceptionLogger);
         }
 

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/GoogleDiagnosticsWebHostBuilderExtensions.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/GoogleDiagnosticsWebHostBuilderExtensions.cs
@@ -133,8 +133,8 @@ namespace Google.Cloud.Diagnostics.AspNetCore
             services.AddGoogleExceptionLogging(options =>
             {
                 options.ProjectId = projectId;
-                options.ServiceName = Project.GetAndCheckServiceName(serviceName, null);
-                options.Version = Project.GetAndCheckServiceVersion(serviceVersion, null);
+                options.ServiceName = Project.GetServiceName(serviceName, null);
+                options.Version = Project.GetServiceVersion(serviceVersion, null);
                 options.Options = errorReportingOptions;
             });
         }

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/ProjectTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/ProjectTest.cs
@@ -24,7 +24,7 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         public void GetAndCheckProjectId()
         {
             var projectId = "pid";
-            var resourceProjectId = "pid";
+            var resourceProjectId = "resource-pid";
             var monitoredResource = new MonitoredResource
             {
                 Type = "some-type",
@@ -57,7 +57,7 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         public void GetAndCheckServiceName()
         {
             var serviceName = "my-app";
-            var resourceServiceName = "my-app";
+            var resourceServiceName = "resource-my-app";
             var monitoredResource = new MonitoredResource
             {
                 Type = "some-type",
@@ -90,7 +90,7 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         public void GetServiceName()
         {
             var serviceName = "my-app";
-            var resourceServiceName = "my-app";
+            var resourceServiceName = "resource-my-app";
             var monitoredResource = new MonitoredResource
             {
                 Type = "some-type",
@@ -122,7 +122,7 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         public void GetAndCheckServiceVersion()
         {
             var serviceVersion = "1.0.0";
-            var resourceServiceVersion = "1.0.0";
+            var resourceServiceVersion = "resource-1.0.0";
             var monitoredResource = new MonitoredResource
             {
                 Type = "some-type",
@@ -155,7 +155,7 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         public void GetServiceVersion()
         {
             var serviceVersion = "1.0.0";
-            var resourceServiceVersion = "1.0.0";
+            var resourceServiceVersion = "resource-1.0.0";
             var monitoredResource = new MonitoredResource
             {
                 Type = "some-type",
@@ -186,8 +186,7 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         [Fact]
         public void DoesNotCacheSpecifiedMonitoredResourceInstance()
         {
-            var projectId1 = "pid-1";
-            var resourceProjectId1 = "pid-1";
+            var resourceProjectId1 = "resource-pid-1";
             var monitoredResource1 = new MonitoredResource
             {
                 Type = "some-type",
@@ -196,13 +195,12 @@ namespace Google.Cloud.Diagnostics.Common.Tests
                     { "project_id", resourceProjectId1 }
                 }
             };
-            Assert.Equal(projectId1, Project.GetAndCheckProjectId(null, monitoredResource1));
+            Assert.Equal(resourceProjectId1, Project.GetAndCheckProjectId(null, monitoredResource1));
 
             // Create a second MonitoredResource instance and pass it to GetAndCheckProjectId.
             // Assert that the first MonitoredResource instance is not cached by checking if the project ID is correct.
             // Only auto-detected MonitoredResource instances should be cached.
-            var projectId2 = "pid-2";
-            var resourceProjectId2 = "pid-2";
+            var resourceProjectId2 = "resource-pid-2";
             var monitoredResource2 = new MonitoredResource
             {
                 Type = "some-type",
@@ -211,7 +209,7 @@ namespace Google.Cloud.Diagnostics.Common.Tests
                     { "project_id", resourceProjectId2 }
                 }
             };
-            Assert.Equal(projectId2, Project.GetAndCheckProjectId(null, monitoredResource2));
+            Assert.Equal(resourceProjectId2, Project.GetAndCheckProjectId(null, monitoredResource2));
         }
     }
 }

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/ProjectTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/ProjectTest.cs
@@ -87,6 +87,38 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         }
 
         [Fact]
+        public void GetServiceName()
+        {
+            var serviceName = "my-app";
+            var resourceServiceName = "my-app";
+            var monitoredResource = new MonitoredResource
+            {
+                Type = "some-type",
+                Labels =
+                {
+                    { "module_id", resourceServiceName }
+                }
+            };
+
+            // The string service name is not null and the MonitoredResource contains a service name
+            // so the string service name is returned.  We do this as the explicitly set service name should be
+            // defaulted to.
+            Assert.Equal(serviceName, Project.GetServiceName(serviceName, monitoredResource));
+
+            // The string service name is not null and the MonitoredResource does not contain a service name
+            // so the string service name is returned.
+            Assert.Equal(serviceName, Project.GetServiceName(serviceName, new MonitoredResource()));
+
+            // The string service name is null and the MonitoredResource does contains a service name
+            // so the service name from the MonitoredResource is returned.
+            Assert.Equal(resourceServiceName, Project.GetServiceName(null, monitoredResource));
+
+            // The string service name is null and the MonitoredResource does not contain a service name
+            // so the service name is null.
+            Assert.Null(Project.GetServiceVersion(null, new MonitoredResource()));
+        }
+
+        [Fact]
         public void GetAndCheckServiceVersion()
         {
             var serviceVersion = "1.0.0";
@@ -117,6 +149,38 @@ namespace Google.Cloud.Diagnostics.Common.Tests
             // so we throw an InvalidOperationException.
             var ex = Assert.Throws<InvalidOperationException>(() => Project.GetAndCheckServiceVersion(null, new MonitoredResource()));
             Assert.Equal("No Google App Engine service version was passed in or detected.", ex.Message);
+        }
+
+        [Fact]
+        public void GetServiceVersion()
+        {
+            var serviceVersion = "1.0.0";
+            var resourceServiceVersion = "1.0.0";
+            var monitoredResource = new MonitoredResource
+            {
+                Type = "some-type",
+                Labels =
+                {
+                    { "version_id", resourceServiceVersion }
+                }
+            };
+
+            // The string service version is not null and the MonitoredResource contains a service version
+            // so the string service version is returned.  We do this as the explicitly set service version should be
+            // defaulted to.
+            Assert.Equal(serviceVersion, Project.GetServiceVersion(serviceVersion, monitoredResource));
+
+            // The string service version is not null and the MonitoredResource does not contain a service version
+            // so the string service version is returned.
+            Assert.Equal(serviceVersion, Project.GetServiceVersion(serviceVersion, new MonitoredResource()));
+
+            // The string service version is null and the MonitoredResource does contains a service version
+            // so the service version from the MonitoredResource is returned.
+            Assert.Equal(resourceServiceVersion, Project.GetServiceVersion(null, monitoredResource));
+
+            // The string service version is null and the MonitoredResource does not contain a service version
+            // so the service version is null.
+            Assert.Null(Project.GetServiceVersion(null, new MonitoredResource()));
         }
 
         [Fact]

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/ErrorReporting/ContextExceptionLogger.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/ErrorReporting/ContextExceptionLogger.cs
@@ -26,16 +26,11 @@ namespace Google.Cloud.Diagnostics.Common
         /// </summary>
         /// <param name="projectId">The Google Cloud Platform project ID.  If unspecified and running
         /// on GAE or GCE the project ID will be detected from the platform.</param>
-        /// <param name="serviceName"> An identifier of the service, such as the name of the executable or job. Must not be null.</param>
-        /// <param name="version">Represents the source code version that the developer provided. Must not be null.</param>
+        /// <param name="serviceName"> An identifier of the service, such as the name of the executable or job. May be null.</param>
+        /// <param name="version">Represents the source code version that the developer provided. May be null.</param>
         /// <param name="options">The error reporting options. Can be null, if null default options will be used.</param>
         /// <returns>An <see cref="IContextExceptionLogger"/> for the given options.</returns>
-        public static IContextExceptionLogger Create(string projectId, string serviceName,
-            string version, ErrorReportingOptions options)
-        {
-            GaxPreconditions.CheckNotNull(serviceName, nameof(serviceName));
-            GaxPreconditions.CheckNotNull(version, nameof(version));
-            return ErrorReportingContextExceptionLogger.Create(projectId, serviceName, version, options);
-        }
+        public static IContextExceptionLogger Create(string projectId, string serviceName, string version, ErrorReportingOptions options) =>
+            ErrorReportingContextExceptionLogger.Create(projectId, serviceName, version, options);
     }
 }

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/ErrorReporting/ErrorReportingContextExceptionLogger.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/ErrorReporting/ErrorReportingContextExceptionLogger.cs
@@ -47,31 +47,27 @@ namespace Google.Cloud.Diagnostics.Common
             GaxPreconditions.CheckState(eventTarget.Kind == EventTargetKind.Logging, $"Invalid {nameof(EventTarget)}");
             _logName = GaxPreconditions.CheckNotNull(eventTarget.LogTarget, nameof(eventTarget.LogTarget)).GetFullLogName(eventTarget.LogName);
 
-            _serviceContext = new Struct
+            _serviceContext = new Struct();
+            if (serviceName != null)
             {
-                Fields =
-                {
-                    { "service", Value.ForString(GaxPreconditions.CheckNotNull(serviceName, nameof(serviceName))) },
-                    { "version", Value.ForString(GaxPreconditions.CheckNotNull(version, nameof(version))) }
-                }
-            };
+                _serviceContext.Fields["service"] = Value.ForString(serviceName);
+            }
+            if (version != null)
+            {
+                _serviceContext.Fields["version"] = Value.ForString(version);
+            }
         }
 
         /// <summary>
         /// Creates an instance of <see cref="ErrorReportingContextExceptionLogger"/>
         /// </summary>
-        /// <param name="projectId">The Google Cloud Platform project ID. Can be null.</param>
-        /// <param name="serviceName">An identifier of the service, such as the name of the executable or job.
-        ///     Must not be null.</param>
-        /// <param name="version">Represents the source code version that the developer provided. 
-        ///     Must not be null.</param>
+        /// <param name="projectId">The Google Cloud Platform project ID. May be null.</param>
+        /// <param name="serviceName">An identifier of the service, such as the name of the executable or job. May be null.</param>
+        /// <param name="version">Represents the source code version that the developer provided. May be null.</param>
         /// <param name="options">Optional, error reporting options.</param>
         internal static IContextExceptionLogger Create(string projectId, string serviceName, string version,
             ErrorReportingOptions options = null)
         {
-            GaxPreconditions.CheckNotNullOrEmpty(serviceName, nameof(serviceName));
-            GaxPreconditions.CheckNotNullOrEmpty(version, nameof(version));
-
             options = options ?? ErrorReportingOptions.Create(projectId);
             var consumer = options.CreateConsumer();
             return new ErrorReportingContextExceptionLogger(consumer, serviceName, version, options);

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Project.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Project.cs
@@ -57,8 +57,16 @@ namespace Google.Cloud.Diagnostics.Common
             => GetAndCheckLabel(serviceName, "module_id", "Google App Engine service name", monitoredResource);
 
         /// <summary>
-        /// Determines the correct service version from a string <paramref name="serviceVersion"/> and a <see cref="MonitoredResource"/>.
+        /// Determines the correct service version from a string <paramref name="serviceName"/> and a <see cref="MonitoredResource"/>.
         /// If the specified service name is not null, it is returned. Otherwise, if the service name of
+        /// the MonitoredResource is not null, it is returned. It both are null, null is resturned.
+        /// </summary>
+        public static string GetServiceName(string serviceName, MonitoredResource monitoredResource = null)
+            => GetLabel(serviceName, "module_id", monitoredResource);
+
+        /// <summary>
+        /// Determines the correct service version from a string <paramref name="serviceVersion"/> and a <see cref="MonitoredResource"/>.
+        /// If the specified service version is not null, it is returned. Otherwise, if the service version of
         /// the MonitoredResource is not null, it is returned. It both are null,
         /// an <see cref="InvalidOperationException"/> is thrown.
         /// </summary>
@@ -68,6 +76,14 @@ namespace Google.Cloud.Diagnostics.Common
         /// <returns>The Google App Engine service version.</returns>
         public static string GetAndCheckServiceVersion(string serviceVersion, MonitoredResource monitoredResource = null)
             => GetAndCheckLabel(serviceVersion, "version_id", "Google App Engine service version", monitoredResource);
+
+        /// <summary>
+        /// Determines the correct service version from a string <paramref name="serviceVersion"/> and a <see cref="MonitoredResource"/>.
+        /// If the specified service version is not null, it is returned. Otherwise, if the service version of
+        /// the MonitoredResource is not null, it is returned. It both are null, null is resturned.
+        /// </summary>
+        public static string GetServiceVersion(string serviceVersion, MonitoredResource monitoredResource = null)
+            => GetLabel(serviceVersion, "version_id", monitoredResource);
 
         /// <summary>
         /// Returns <paramref name="specifiedLabel"/> if specified, otherwise attempts to resolve the <paramref name="labelKey"/>
@@ -92,6 +108,27 @@ namespace Google.Cloud.Diagnostics.Common
             }
 
             throw new InvalidOperationException($"No {labelName} was passed in or detected.");
+        }
+
+        /// <summary>
+        /// Returns <paramref name="specifiedLabel"/> if specified, otherwise attempts to resolve the <paramref name="labelKey"/>
+        /// from the given, detected or cached <see cref="MonitoredResource"/> instance. If no value can be found, a null
+        /// reference is returned.
+        /// </summary>
+        /// <param name="specifiedLabel">The label value specified by the caller.</param>
+        /// <param name="labelKey">The key of the label.</param>
+        /// <param name="monitoredResource">Optional, the <see cref="MonitoredResource"/> instance.</param>
+        /// <returns>The resolved value of the label.</returns>
+        private static string GetLabel(string specifiedLabel, string labelKey, MonitoredResource monitoredResource = null)
+        {
+            if (specifiedLabel != null)
+            {
+                return specifiedLabel;
+            }
+
+            monitoredResource = monitoredResource ?? _detectedMonitoredResource ?? (_detectedMonitoredResource = MonitoredResourceBuilder.FromPlatform());
+            monitoredResource.Labels.TryGetValue(labelKey, out var resourceLabel);
+            return resourceLabel;
         }
     }
 }


### PR DESCRIPTION
It's fine just not to provide them when logging: the error reporting UI works with no problems, etc.

Fixes #3263.