### PR TITLE
Handle service names and versions in a resource-sensitive way

### DIFF
--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.sln
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.sln
@@ -1,7 +1,6 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26114.2
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29102.190
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Diagnostics.Common", "Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.csproj", "{4291BC6A-A0DA-423F-A88C-B9FF54BAF95A}"
 EndProject
@@ -17,60 +16,119 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Logging.V2", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Diagnostics.Common.IntegrationTests", "Google.Cloud.Diagnostics.Common.IntegrationTests\Google.Cloud.Diagnostics.Common.IntegrationTests.csproj", "{DE96A626-6BAF-4012-889C-E1AAADE5CB3A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.ClientTesting", "..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj", "{13F3BE10-763D-4E0A-BAE0-8F8621EF55EF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.ClientTesting", "..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj", "{13F3BE10-763D-4E0A-BAE0-8F8621EF55EF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{4291BC6A-A0DA-423F-A88C-B9FF54BAF95A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4291BC6A-A0DA-423F-A88C-B9FF54BAF95A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4291BC6A-A0DA-423F-A88C-B9FF54BAF95A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4291BC6A-A0DA-423F-A88C-B9FF54BAF95A}.Debug|x64.Build.0 = Debug|Any CPU
+		{4291BC6A-A0DA-423F-A88C-B9FF54BAF95A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4291BC6A-A0DA-423F-A88C-B9FF54BAF95A}.Debug|x86.Build.0 = Debug|Any CPU
 		{4291BC6A-A0DA-423F-A88C-B9FF54BAF95A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4291BC6A-A0DA-423F-A88C-B9FF54BAF95A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4291BC6A-A0DA-423F-A88C-B9FF54BAF95A}.Release|x64.ActiveCfg = Release|Any CPU
+		{4291BC6A-A0DA-423F-A88C-B9FF54BAF95A}.Release|x64.Build.0 = Release|Any CPU
+		{4291BC6A-A0DA-423F-A88C-B9FF54BAF95A}.Release|x86.ActiveCfg = Release|Any CPU
+		{4291BC6A-A0DA-423F-A88C-B9FF54BAF95A}.Release|x86.Build.0 = Release|Any CPU
 		{12283521-8B1F-460C-9B94-E68482FF3F30}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{12283521-8B1F-460C-9B94-E68482FF3F30}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{12283521-8B1F-460C-9B94-E68482FF3F30}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{12283521-8B1F-460C-9B94-E68482FF3F30}.Debug|x64.Build.0 = Debug|Any CPU
+		{12283521-8B1F-460C-9B94-E68482FF3F30}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{12283521-8B1F-460C-9B94-E68482FF3F30}.Debug|x86.Build.0 = Debug|Any CPU
 		{12283521-8B1F-460C-9B94-E68482FF3F30}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{12283521-8B1F-460C-9B94-E68482FF3F30}.Release|Any CPU.Build.0 = Release|Any CPU
+		{12283521-8B1F-460C-9B94-E68482FF3F30}.Release|x64.ActiveCfg = Release|Any CPU
+		{12283521-8B1F-460C-9B94-E68482FF3F30}.Release|x64.Build.0 = Release|Any CPU
+		{12283521-8B1F-460C-9B94-E68482FF3F30}.Release|x86.ActiveCfg = Release|Any CPU
+		{12283521-8B1F-460C-9B94-E68482FF3F30}.Release|x86.Build.0 = Release|Any CPU
 		{939FA175-86CE-4B80-98E8-EDE676FD7821}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{939FA175-86CE-4B80-98E8-EDE676FD7821}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{939FA175-86CE-4B80-98E8-EDE676FD7821}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{939FA175-86CE-4B80-98E8-EDE676FD7821}.Debug|x64.Build.0 = Debug|Any CPU
+		{939FA175-86CE-4B80-98E8-EDE676FD7821}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{939FA175-86CE-4B80-98E8-EDE676FD7821}.Debug|x86.Build.0 = Debug|Any CPU
 		{939FA175-86CE-4B80-98E8-EDE676FD7821}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{939FA175-86CE-4B80-98E8-EDE676FD7821}.Release|Any CPU.Build.0 = Release|Any CPU
+		{939FA175-86CE-4B80-98E8-EDE676FD7821}.Release|x64.ActiveCfg = Release|Any CPU
+		{939FA175-86CE-4B80-98E8-EDE676FD7821}.Release|x64.Build.0 = Release|Any CPU
+		{939FA175-86CE-4B80-98E8-EDE676FD7821}.Release|x86.ActiveCfg = Release|Any CPU
+		{939FA175-86CE-4B80-98E8-EDE676FD7821}.Release|x86.Build.0 = Release|Any CPU
 		{7408D53D-88E6-42BB-B79A-1B18B027633D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7408D53D-88E6-42BB-B79A-1B18B027633D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7408D53D-88E6-42BB-B79A-1B18B027633D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7408D53D-88E6-42BB-B79A-1B18B027633D}.Debug|x64.Build.0 = Debug|Any CPU
+		{7408D53D-88E6-42BB-B79A-1B18B027633D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7408D53D-88E6-42BB-B79A-1B18B027633D}.Debug|x86.Build.0 = Debug|Any CPU
 		{7408D53D-88E6-42BB-B79A-1B18B027633D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7408D53D-88E6-42BB-B79A-1B18B027633D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7408D53D-88E6-42BB-B79A-1B18B027633D}.Release|x64.ActiveCfg = Release|Any CPU
+		{7408D53D-88E6-42BB-B79A-1B18B027633D}.Release|x64.Build.0 = Release|Any CPU
+		{7408D53D-88E6-42BB-B79A-1B18B027633D}.Release|x86.ActiveCfg = Release|Any CPU
+		{7408D53D-88E6-42BB-B79A-1B18B027633D}.Release|x86.Build.0 = Release|Any CPU
 		{A8382B79-21E7-4AAD-AFF8-AB8707958128}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A8382B79-21E7-4AAD-AFF8-AB8707958128}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A8382B79-21E7-4AAD-AFF8-AB8707958128}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A8382B79-21E7-4AAD-AFF8-AB8707958128}.Debug|x64.Build.0 = Debug|Any CPU
+		{A8382B79-21E7-4AAD-AFF8-AB8707958128}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A8382B79-21E7-4AAD-AFF8-AB8707958128}.Debug|x86.Build.0 = Debug|Any CPU
 		{A8382B79-21E7-4AAD-AFF8-AB8707958128}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A8382B79-21E7-4AAD-AFF8-AB8707958128}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A8382B79-21E7-4AAD-AFF8-AB8707958128}.Release|x64.ActiveCfg = Release|Any CPU
+		{A8382B79-21E7-4AAD-AFF8-AB8707958128}.Release|x64.Build.0 = Release|Any CPU
+		{A8382B79-21E7-4AAD-AFF8-AB8707958128}.Release|x86.ActiveCfg = Release|Any CPU
+		{A8382B79-21E7-4AAD-AFF8-AB8707958128}.Release|x86.Build.0 = Release|Any CPU
 		{35B8D21D-0253-417F-B171-06BF70AA9485}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{35B8D21D-0253-417F-B171-06BF70AA9485}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{35B8D21D-0253-417F-B171-06BF70AA9485}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{35B8D21D-0253-417F-B171-06BF70AA9485}.Debug|x64.Build.0 = Debug|Any CPU
+		{35B8D21D-0253-417F-B171-06BF70AA9485}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{35B8D21D-0253-417F-B171-06BF70AA9485}.Debug|x86.Build.0 = Debug|Any CPU
 		{35B8D21D-0253-417F-B171-06BF70AA9485}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{35B8D21D-0253-417F-B171-06BF70AA9485}.Release|Any CPU.Build.0 = Release|Any CPU
+		{35B8D21D-0253-417F-B171-06BF70AA9485}.Release|x64.ActiveCfg = Release|Any CPU
+		{35B8D21D-0253-417F-B171-06BF70AA9485}.Release|x64.Build.0 = Release|Any CPU
+		{35B8D21D-0253-417F-B171-06BF70AA9485}.Release|x86.ActiveCfg = Release|Any CPU
+		{35B8D21D-0253-417F-B171-06BF70AA9485}.Release|x86.Build.0 = Release|Any CPU
 		{DE96A626-6BAF-4012-889C-E1AAADE5CB3A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{DE96A626-6BAF-4012-889C-E1AAADE5CB3A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DE96A626-6BAF-4012-889C-E1AAADE5CB3A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DE96A626-6BAF-4012-889C-E1AAADE5CB3A}.Debug|x64.Build.0 = Debug|Any CPU
+		{DE96A626-6BAF-4012-889C-E1AAADE5CB3A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DE96A626-6BAF-4012-889C-E1AAADE5CB3A}.Debug|x86.Build.0 = Debug|Any CPU
 		{DE96A626-6BAF-4012-889C-E1AAADE5CB3A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DE96A626-6BAF-4012-889C-E1AAADE5CB3A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DE96A626-6BAF-4012-889C-E1AAADE5CB3A}.Release|x64.ActiveCfg = Release|Any CPU
+		{DE96A626-6BAF-4012-889C-E1AAADE5CB3A}.Release|x64.Build.0 = Release|Any CPU
+		{DE96A626-6BAF-4012-889C-E1AAADE5CB3A}.Release|x86.ActiveCfg = Release|Any CPU
+		{DE96A626-6BAF-4012-889C-E1AAADE5CB3A}.Release|x86.Build.0 = Release|Any CPU
 		{13F3BE10-763D-4E0A-BAE0-8F8621EF55EF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{13F3BE10-763D-4E0A-BAE0-8F8621EF55EF}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{13F3BE10-763D-4E0A-BAE0-8F8621EF55EF}.Debug|x64.ActiveCfg = Debug|x64
-		{13F3BE10-763D-4E0A-BAE0-8F8621EF55EF}.Debug|x64.Build.0 = Debug|x64
-		{13F3BE10-763D-4E0A-BAE0-8F8621EF55EF}.Debug|x86.ActiveCfg = Debug|x86
-		{13F3BE10-763D-4E0A-BAE0-8F8621EF55EF}.Debug|x86.Build.0 = Debug|x86
+		{13F3BE10-763D-4E0A-BAE0-8F8621EF55EF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{13F3BE10-763D-4E0A-BAE0-8F8621EF55EF}.Debug|x64.Build.0 = Debug|Any CPU
+		{13F3BE10-763D-4E0A-BAE0-8F8621EF55EF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{13F3BE10-763D-4E0A-BAE0-8F8621EF55EF}.Debug|x86.Build.0 = Debug|Any CPU
 		{13F3BE10-763D-4E0A-BAE0-8F8621EF55EF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{13F3BE10-763D-4E0A-BAE0-8F8621EF55EF}.Release|Any CPU.Build.0 = Release|Any CPU
-		{13F3BE10-763D-4E0A-BAE0-8F8621EF55EF}.Release|x64.ActiveCfg = Release|x64
-		{13F3BE10-763D-4E0A-BAE0-8F8621EF55EF}.Release|x64.Build.0 = Release|x64
-		{13F3BE10-763D-4E0A-BAE0-8F8621EF55EF}.Release|x86.ActiveCfg = Release|x86
-		{13F3BE10-763D-4E0A-BAE0-8F8621EF55EF}.Release|x86.Build.0 = Release|x86
+		{13F3BE10-763D-4E0A-BAE0-8F8621EF55EF}.Release|x64.ActiveCfg = Release|Any CPU
+		{13F3BE10-763D-4E0A-BAE0-8F8621EF55EF}.Release|x64.Build.0 = Release|Any CPU
+		{13F3BE10-763D-4E0A-BAE0-8F8621EF55EF}.Release|x86.ActiveCfg = Release|Any CPU
+		{13F3BE10-763D-4E0A-BAE0-8F8621EF55EF}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {3DB7DC01-3B7F-4C9C-AF94-342753998850}
 	EndGlobalSection
 EndGlobal

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="2.9.0" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="2.10.0-beta01" />
     <PackageReference Include="Google.Cloud.Logging.V2" Version="2.1.0" />
     <PackageReference Include="Google.Cloud.Trace.V1" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.1" />

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -298,7 +298,7 @@
     "description": "Google Stackdriver Instrumentation Libraries Common Components.",
     "tags": [ "Error", "Reporting", "Stackdriver", "ExceptionLogger", "Trace", "Diagnostics" ],
     "dependencies": {
-      "Google.Api.Gax.Grpc": "default",
+      "Google.Api.Gax.Grpc": "2.10.0-beta01",
       "Google.Cloud.Logging.V2": "2.1.0",
       "Google.Cloud.Trace.V1": "1.0.0",
       "Microsoft.AspNetCore.Http.Abstractions": "2.1.1",


### PR DESCRIPTION
First commit is noisy but harmless - bulk is in second commit. It's a reimplementation of both production code and test, so a bigger change than one might expect, but I think it's right.