### PR TITLE
Reinstate property specifying DebugType in tests

### DIFF
--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Google.Cloud.Diagnostics.Common.Tests.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Google.Cloud.Diagnostics.Common.Tests.csproj
@@ -24,4 +24,9 @@
     <Reference Condition="'$(TargetFramework)' == 'net452'" Include="Microsoft.CSharp" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
+  <PropertyGroup>
+    <!-- Make sure we get suitable stack traces for tests -->
+    <DebugType>pdbonly</DebugType>
+    <DebugType Condition="'$(TargetFramework)' == 'netcoreapp2.1'">portable</DebugType>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Without this, the error reporting test fails in Windows