### PR TITLE
Generate csproj files for samples

### DIFF
--- a/tools/Google.Cloud.Tools.ProjectGenerator/Program.cs
+++ b/tools/Google.Cloud.Tools.ProjectGenerator/Program.cs
@@ -125,7 +125,7 @@ namespace Google.Cloud.Tools.ProjectGenerator
                 }
                 foreach (var api in apis)
                 {
-                    GenerateSolutionFiles(Path.Combine(root, "apis", api.Id), api);
+                    // GenerateSolutionFiles(Path.Combine(root, "apis", api.Id), api);
                 }
                 foreach (var api in apis)
                 {


### PR DESCRIPTION
In `tools/Google.Cloud.Tools.ProjectGenerator/Program.cs`, when a `*.Samples` directory is detected, generate a `.csproj` files in this directory for samples.

The project file is very similar to that of the snippets, with one more dependency on a public package `CommandLineParser`.

We don't have any published samples yet (there are no `Google.Cloud.{Api}.{Version}.Samples` yet), but being able to generate a project file for future samples makes testing much easier for us.