### PR TITLE
Release Storage 2.4.0-beta03

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.4.0-beta02</Version>
+    <Version>2.4.0-beta03</Version>
     <TargetFrameworks>netstandard1.3;netstandard2.0;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.3;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Rest" Version="2.9.0" />
-    <PackageReference Include="Google.Apis.Storage.v1" Version="1.40.2.1635" />
+    <PackageReference Include="Google.Apis.Storage.v1" Version="1.40.3.1635" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -893,11 +893,11 @@
     "id": "Google.Cloud.Storage.V1",
     "productName": "Google Cloud Storage",
     "productUrl": "https://cloud.google.com/storage/",
-    "version": "2.4.0-beta02",
+    "version": "2.4.0-beta03",
     "type": "rest",
     "description": "Recommended Google client library to access the Google Cloud Storage API. It wraps the Google.Apis.Storage.v1 client library, making common operations simpler in client code. Google Cloud Storage stores and retrieves potentially large, immutable data objects.",
     "dependencies": {
-      "Google.Apis.Storage.v1": "1.40.2.1635"
+      "Google.Apis.Storage.v1": "1.40.3.1635"
     },
     "testDependencies": {
       "Google.Cloud.Iam.V1": "1.2.0",


### PR DESCRIPTION
- Updated dependency fixes #3254
- BucketPolicyOnly has been renamed to UniformBucketLevelAccess