### PR TITLE
Handle changing resource types for GKE monitored resources

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Logging/GoogleLoggerTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Logging/GoogleLoggerTest.cs
@@ -102,12 +102,29 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Tests
         }
 
         [Fact]
-        public void GetGcpConsoleLogsUrl_MonitoredResourceFromPlatform()
+        public void GetGcpConsoleLogsUrl_Gae()
         {
-            GoogleLogger logger = GetLogger(monitoredResource: MonitoredResourceBuilder.FromPlatform());
+            GoogleLogger logger = GetLogger(monitoredResource: MonitoredResourceBuilder.FromPlatform(new Platform(
+                    new GaePlatformDetails("project-id", "instance", "service", "version"))));
             string query = logger.GetGcpConsoleLogsUrl().Query;
 
-            Assert.Contains($"resource={MonitoredResourceBuilder.FromPlatform().Type}", query);
+            Assert.Contains($"resource=gae_app", query);
+        }
+
+        /// <summary>
+        /// See comment in production code for the purpose of this test.
+        /// </summary>
+        [Fact]
+        public void GetGcpConsoleLogsUrl_GkeContainerToContainer()
+        {
+            var resource = new MonitoredResource
+            {
+                Type = "gke_container"
+            };
+            GoogleLogger logger = GetLogger(monitoredResource: resource);
+            string query = logger.GetGcpConsoleLogsUrl().Query;
+
+            Assert.Contains($"resource=container", query);
         }
 
         [Fact]

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLogger.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/GoogleLogger.cs
@@ -287,9 +287,16 @@ namespace Google.Cloud.Diagnostics.AspNetCore
                 _logTarget.Kind == LogTargetKind.Organization ? $"organizationId={_logTarget.OrganizationId}" :
                 throw new InvalidOperationException($"Unrecognized LogTargetKind: {_logTarget.Kind}");
 
+            string resourceType = _loggerOptions.MonitoredResource.Type;
+            // Log ingestion converts "gke_container" into "container", but we really do need to search for "container",
+            // as the UI doesn't support "gke_container". (Whereas the Monitoring API *only* supports "gke_container".)
+            if (resourceType == "gke_container")
+            {
+                resourceType = "container";
+            }
             IList<string> parameters = new List<string>
             {
-                $"resource={_loggerOptions.MonitoredResource.Type}",
+                $"resource={resourceType}",
                 $"minLogLevel={(int)_loggerOptions.LogLevel.ToLogSeverity()}",
                 $"logName={_fullLogName}",
                 target

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/ProjectTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/ProjectTest.cs
@@ -32,17 +32,30 @@ namespace Google.Cloud.Diagnostics.Common.Tests
                     new GaePlatformDetails("project-id", "instance", "service", "version"))) },
                 { "gce_instance", MonitoredResourceBuilder.FromPlatform(new Platform(
                     new GcePlatformDetails("json", "project-id", "instance", "projects/12345/zones/zone"))) },
-                { "container", MonitoredResourceBuilder.FromPlatform(new Platform(
-                    new GkePlatformDetails("json", "project-id", "cluster", "location", "host", "instance", "zone", "namespace", "pod", "container"))) },
+                { "container", CreateGkeResource("container") },
+                { "gke_container", CreateGkeResource("gke_container") },
+                { "k8s_container", CreateGkeResource("k8s_container") },
                 { "cloud_run_revision", MonitoredResourceBuilder.FromPlatform(new Platform(
                     new CloudRunPlatformDetails("json", "project-id", "location", "service", "revision", "configuration"))) },
                 { "unknown", new MonitoredResource { Type = "unknown", Labels = { { "project_id", "project-id" } } } }
             };
 
+        // There are three different potential resource representations for GKE. We handle them all
+        // the same way, but we need to test that.
+        private static MonitoredResource CreateGkeResource(string resourceType)
+        {
+            var resource = MonitoredResourceBuilder.FromPlatform(new Platform(
+                new GkePlatformDetails("json", "project-id", "cluster", "location", "host", "instance", "zone", "namespace", "pod", "container")));
+            resource.Type = resourceType;
+            return resource;
+        }
+        
         [Theory]
         [InlineData("gae_app", "project-id")]
         [InlineData("gce_instance", "project-id")]
         [InlineData("container", "project-id")]
+        [InlineData("gke_container", "project-id")]
+        [InlineData("k8s_container", "project-id")]
         [InlineData("cloud_run_revision", "project-id")]
         [InlineData("unknown", null)]
         public void GetProjectId(string type, string expectedProjectId)
@@ -66,6 +79,8 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         [InlineData("gae_app", "service")]
         [InlineData("gce_instance", null)]
         [InlineData("container", "container")]
+        [InlineData("gke_container", "container")]
+        [InlineData("k8s_container", "container")]
         [InlineData("cloud_run_revision", "service")]
         [InlineData("unknown", null)]
         public void GetServiceName(string type, string expectedServiceName)
@@ -90,6 +105,8 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         [InlineData("gae_app", "version")]
         [InlineData("gce_instance", null)]
         [InlineData("container", null)]
+        [InlineData("gke_container", null)]
+        [InlineData("k8s_container", null)]
         [InlineData("cloud_run_revision", "revision")]
         [InlineData("unknown", null)]
         public void GetServiceVersion(string type, string expectedServiceVersion)

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Project.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Project.cs
@@ -115,6 +115,8 @@ namespace Google.Cloud.Diagnostics.Common
                 case "gce_instance":
                 case "gae_app":
                 case "container":
+                case "k8s_container":
+                case "gke_container":
                 case "cloud_run_revision":
                     return GetLabel(resource, "project_id");
                 default: return null;
@@ -127,7 +129,10 @@ namespace Google.Cloud.Diagnostics.Common
             switch (resource?.Type)
             {
                 case "gae_app": return GetLabel(resource, "module_id");
-                case "container": return GetLabel(resource, "container_name");
+                case "container":
+                case "gke_container":
+                case "k8s_container":
+                    return GetLabel(resource, "container_name");
                 case "cloud_run_revision": return GetLabel(resource, "service_name");
                 default: return null;
             }


### PR DESCRIPTION
- k8s_container is never created by MonitoredResourceBuilder right now, but will be in the future
- gke_container *will* be created when a GAX change has gone in
- gke_container isn't valid in the logging UI, so we tweak the resource we log