### PR TITLE
Support for IAM conditions in Storage when fetching bucket policies

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/GetBucketIamPolicyOptionsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/GetBucketIamPolicyOptionsTest.cs
@@ -26,6 +26,7 @@ namespace Google.Cloud.Storage.V1.Tests
             var options = new GetBucketIamPolicyOptions();
             options.ModifyRequest(request);
             Assert.Null(request.UserProject);
+            Assert.Null(request.OptionsRequestedPolicyVersion);
         }
 
         [Fact]
@@ -34,10 +35,12 @@ namespace Google.Cloud.Storage.V1.Tests
             var request = new GetIamPolicyRequest(null, "bucket");
             var options = new GetBucketIamPolicyOptions
             {
-                UserProject = "proj"
+                UserProject = "proj",
+                RequestedPolicyVersion = 3
             };
             options.ModifyRequest(request);
             Assert.Equal("proj", request.UserProject);
+            Assert.Equal(3, request.OptionsRequestedPolicyVersion);
         }
     }
 }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/GetBucketIamPolicyOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/GetBucketIamPolicyOptions.cs
@@ -27,11 +27,23 @@ namespace Google.Cloud.Storage.V1
         /// </summary>
         public string UserProject { get; set; }
 
+        /// <summary>
+        /// The version of IAM policies to request. If a policy with a condition is requested
+        /// without setting this, the server will return an error. This must be set to a value of 3
+        /// to retrieve IAM policies containing conditions. This is to prevent client code that
+        /// isn't aware of IAM conditions from interpreting and modifying policies incorrectly.
+        /// </summary>
+        public int? RequestedPolicyVersion { get; set; }
+
         internal void ModifyRequest(GetIamPolicyRequest request)
         {
             if (UserProject != null)
             {
                 request.UserProject = UserProject;
+            }
+            if (RequestedPolicyVersion != null)
+            {
+                request.OptionsRequestedPolicyVersion = RequestedPolicyVersion.Value;
             }
         }
     }


### PR DESCRIPTION
The implementation can't be completed yet as the request field doesn't exist in the REST representation, but the TODO shows where it would be.

Sample usage:

```csharp
var policy = client.GetBucketIamPolicy(bucket, new GetBucketIamPolicyOptions { SupportedIamPolicyVersion = 3 });
```

Currently I don't propose adding a client-wide user-settable default; we can do that later as an extra feature if it's requested.