### PR TITLE
TimestampProtoConverter's TargetType should presumably be wkt::Timestamp.

### DIFF
--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Converters/SimpleConverters.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Converters/SimpleConverters.cs
@@ -182,7 +182,7 @@ namespace Google.Cloud.Firestore.Converters
 
     internal sealed class TimestampProtoConverter : ConverterBase
     {
-        internal TimestampProtoConverter() : base(typeof(DateTime)) { }
+        internal TimestampProtoConverter() : base(typeof(wkt::Timestamp)) { }
         public override Value Serialize(SerializationContext context, object value) => new Value { TimestampValue = ((wkt::Timestamp) value).Clone() };
         protected override object DeserializeTimestamp(DeserializationContext context, wkt::Timestamp value) => value.Clone();
     }


### PR DESCRIPTION
I noticed this while adapting this code for our Unity support...  Note that this probably doesn't have any effect except in error messages, so not a big deal.