### PR TITLE
Release Google.Cloud.TextToSpeech.V1 version 1.1.0-beta01

### DIFF
--- a/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.csproj
+++ b/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0-beta01</Version>
     <TargetFrameworks>netstandard1.5;netstandard2.0;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
@@ -23,8 +23,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="2.9.0" />
-    <PackageReference Include="Grpc.Core" Version="1.22.0" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="2.10.0-beta04" />
+    <PackageReference Include="Grpc.Core" Version="1.22.1" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -965,12 +965,12 @@
     "protoPath": "google/cloud/texttospeech/v1",
     "productName": "Google Cloud Text-to-Speech",
     "productUrl": "https://cloud.google.com/text-to-speech",
-    "version": "1.0.0",
+    "version": "1.1.0-beta01",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Text-to-Speech API, synthesizes natural-sounding speech by applying powerful neural network models.",
     "dependencies": {
-      "Google.Api.Gax.Grpc": "2.9.0",
-      "Grpc.Core": "1.22.0"
+      "Google.Api.Gax.Grpc": "2.10.0-beta04",
+      "Grpc.Core": "1.22.1"
     },
     "tags": [ "Speech", "Text-to-speech" ]
   },


### PR DESCRIPTION
This is the first release using our new code generator.

This release contains no new features, but deprecates the following
members of TextToSpeechSettings:

- IdempotentRetryFilter
- NonIdempotentRetryFilter
- GetDefaultRetryBackoff()
- GetDefaultTimeoutBackoff()

These members are still present, but marked as obsolete. They return the same values that they always did, but may no longer reflect the default settings for the RPCs.