### PR TITLE
Update Storage dependency

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Rest" Version="2.10.0-beta04" />
-    <PackageReference Include="Google.Apis.Storage.v1" Version="1.41.1.1684" />
+    <PackageReference Include="Google.Apis.Storage.v1" Version="1.41.1.1716" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -900,7 +900,7 @@
     "description": "Recommended Google client library to access the Google Cloud Storage API. It wraps the Google.Apis.Storage.v1 client library, making common operations simpler in client code. Google Cloud Storage stores and retrieves potentially large, immutable data objects.",
     "dependencies": {
       "Google.Api.Gax.Rest": "2.10.0-beta04",
-      "Google.Apis.Storage.v1": "1.41.1.1684"
+      "Google.Apis.Storage.v1": "1.41.1.1716"
     },
     "testDependencies": {
       "Google.Cloud.Iam.V1": "1.2.0",


### PR DESCRIPTION
This is required mostly because the BucketPolicyOnly / UniformBucketLevelAccess API has been updated in our dependency.
(I'm slightly surprised our library was still building with the old dependency... there was a breaking change that was reverted.)