### PR TITLE
Change the detect-pr-changes job to only run on PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ jobs:
       script: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
     - name: "Change detection"
       script: ./detect-pr-changes.sh
+      # This job is *only* for PRs, not pushed branches.
+      branches:
+        only:
+        - no_branches_match_this
     - name: "Cloud APIs A-L"
       env: API_REGEX='Google\.Cloud\.[A-L].*'
     - name: "Cloud APIs M-Z"


### PR DESCRIPTION
When we create this PR, we should still see detect-pr-changes running, and it will fail until #3588 is merged.