### PR TITLE
Workaround for Bigtable Admin ambiguity for LocationName

### DIFF
--- a/apis/Google.Cloud.Bigtable.Admin.V2/postgeneration.sh
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/postgeneration.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+sed -i 's/new LocationName/new V2.LocationName/g' Google.Cloud.Bigtable.Admin.V2.Tests/BigtableInstanceAdminClientTest.g.cs


### PR DESCRIPTION
This is likely to go away when we make the breaking changes imminently.

(This means we can close #3590 and it shouldn't be recreated.)