### PR TITLE
[Spanner] Adds support for retrying Spanner transactions on commit abort.

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/RetriableTransactionTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/RetriableTransactionTests.cs
@@ -1,0 +1,200 @@
+﻿// Copyright 2019 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Cloud.Spanner.Data.IntegrationTests
+{
+    [Collection(nameof(DmlTableFixture))]
+    public class RetriableTransactionTests
+    {
+        private readonly DmlTableFixture _fixture;
+        private readonly string _selectSql;
+        private readonly string _updateSql;
+        private readonly string _insertSql;
+
+        public RetriableTransactionTests(DmlTableFixture fixture)
+        {
+            _fixture = fixture;
+            _selectSql = $"SELECT OriginalValue FROM {_fixture.TableName} WHERE UpdateMe AND Key=@Key";
+            _updateSql = $"UPDATE {_fixture.TableName} SET Value = Value + 1 WHERE UpdateMe AND Key=@Key";
+            _insertSql = $"INSERT INTO {_fixture.TableName} (Key, OriginalValue, Value, UpdateMe, DeleteMe, CopyMe) SELECT Key, OriginalValue + 10, Value, UpdateMe, DeleteMe, CopyMe FROM {_fixture.TableName} WHERE CopyMe AND KEY=@Key";
+        }
+
+        [Fact]
+        public async Task FirstCallSucceeds()
+        {
+            string key = _fixture.CreateTestRows();
+            int calls = 0;
+            int rowsAffected;
+            using (var connection = _fixture.GetConnection())
+            {
+                rowsAffected = await connection.RunWithRetriableTransactionAsync(
+                    transaction => WorkAsync(connection, transaction));
+            }
+
+            async Task<int> WorkAsync(SpannerConnection connection, SpannerTransaction transaction)
+            {
+                calls++;
+
+                // Read some data, because we should be able to.
+                await SelectAndReadFixtureData(key, connection, transaction);
+
+                int rows = 0;
+
+                // This should update rows 1 and 4.
+                rows += await DmlUpdateFixtureData(key, connection, transaction);
+                // This should delete row 4. But that will happen on commit after everything else.
+                rows += await DeleteFixtureData(key, connection, transaction);
+                // This will first insert 3 and 4 as 13 and 14.
+                // Then will update 1, 4 and 14.
+                rows += (int)(await BatchDmlInsertUpdateFixtureData(key, connection, transaction)).Sum();
+
+                return rows;
+            }
+
+            Assert.Equal(8, rowsAffected);
+            Assert.Equal(1, calls);
+
+            var actual = _fixture.FetchValues(key);
+            var expected = new Dictionary<int, int>
+            {
+                { 0, 0 }, // Not updated
+                { 1, 3 }, // Updated by DML, and then by Batch.
+                { 2, 2 }, // Not updated
+                { 3, 3 }, // Not updated
+              //{ 4, 6 }, // Updated by DML, and then by Batch. Deleted at the end.
+                { 13, 3 }, // Inserted by Batch.
+                { 14, 6 }, // Inserted by Batch. Updated by batch.
+            };
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public async Task RetriesOnce()
+        {
+            string key = _fixture.CreateTestRows();
+            int calls = 0;
+            int rowsUpdated;
+            using (var connection = _fixture.GetConnection())
+            {
+                rowsUpdated = await connection.RunWithRetriableTransactionAsync(transaction => WorkAsync(connection, transaction));
+            }
+
+            async Task<int> WorkAsync(SpannerConnection connection, SpannerTransaction transaction)
+            {
+                calls++;
+
+                // Let's update some data with the retriable transaction.
+                int rows = await DmlUpdateFixtureData(key, connection, transaction);
+
+                // The first time let's update the data again using a different transaction.
+                // This will cause the retriable transaction to abort.
+                if (calls == 1)
+                {
+                    try
+                    {
+                        using (var conflictingTransaction = await connection.BeginTransactionAsync())
+                        {
+                            int conflictingRows = await DmlUpdateFixtureData(key, connection, conflictingTransaction);
+                            await conflictingTransaction.CommitAsync();
+                            Assert.Equal(2, conflictingRows);
+                        }
+                    }
+                    catch (SpannerException e)
+                    {
+                        // If there is an exception catched here we just want to propagate it,
+                        // and make the test fail. We need to wrap it so it doesn't trigger
+                        // the retry.
+                        throw new Exception("This shouldn't have happened.", e);
+                    }
+                }
+
+                return rows;
+                // And now that we are done, the retriable transaction should be committed.
+                // On the first time this method is called, the commit will abort because our 
+                // update was on now stale data and the retry should be triggered.
+            }
+
+            Assert.Equal(2, rowsUpdated);
+            Assert.Equal(2, calls);
+
+            var actual = _fixture.FetchValues(key);
+            var expected = new Dictionary<int, int>
+            {
+                { 0, 0 }, // Not updated
+                { 1, 3 }, // Updated twice, once by the conflicting transaction, once by the main work.
+                { 2, 2 }, // Not updated
+                { 3, 3 }, // Not updated
+                { 4, 6 }  // Updated twice, once by the conflicting transaction, once by the main work.
+            };
+
+            Assert.Equal(expected, actual);
+        }
+
+        private async Task<IReadOnlyList<long>> BatchDmlInsertUpdateFixtureData(string key, SpannerConnection connection, SpannerTransaction transaction)
+        {
+            var command = transaction.CreateBatchDmlCommand();
+            command.Add(_insertSql, new SpannerParameterCollection
+            {
+                { "Key", SpannerDbType.String, key }
+            });
+            command.Add(_updateSql, new SpannerParameterCollection
+            {
+                { "Key", SpannerDbType.String, key }
+            });
+            return await command.ExecuteNonQueryAsync();
+        }
+
+        private async Task<int> DmlUpdateFixtureData(string key, SpannerConnection connection, SpannerTransaction transaction)
+        {
+            using (var command = connection.CreateDmlCommand(_updateSql))
+            {
+                command.Transaction = transaction;
+                command.Parameters.Add("Key", SpannerDbType.String, key);
+                return await command.ExecuteNonQueryAsync();
+            }
+        }
+
+        private async Task<int> DeleteFixtureData(string key, SpannerConnection connection, SpannerTransaction transaction)
+        {
+            var parameters = new SpannerParameterCollection
+            {
+                { "Key", SpannerDbType.String, key },
+                { "OriginalValue", SpannerDbType.Int64, 4 }
+            };
+            using (var command = connection.CreateDeleteCommand(_fixture.TableName, parameters))
+            {
+                command.Transaction = transaction;
+                return await command.ExecuteNonQueryAsync();
+            }
+        }
+
+        private async Task SelectAndReadFixtureData(string key, SpannerConnection connection, SpannerTransaction transaction)
+        {
+            using (var command = connection.CreateSelectCommand(_selectSql))
+            {
+                command.Transaction = transaction;
+                command.Parameters.Add("Key", SpannerDbType.String, key);
+                var reader = await command.ExecuteReaderAsync();
+                while (await reader.ReadAsync()) ;
+            }
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/Google.Cloud.Spanner.Data.Tests.csproj
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/Google.Cloud.Spanner.Data.Tests.csproj
@@ -38,5 +38,8 @@
     <Compile Update="SpannerDbTypeTests.*.cs">
       <DependentUpon>SpannerDbTypeTests.cs</DependentUpon>
     </Compile>
+    <Compile Update="SpannerConnectionTests.*.cs">
+      <DependentUpon>SpannerConnectionTests.cs</DependentUpon>
+    </Compile>
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/RetriableTransactionOptionsTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/RetriableTransactionOptionsTests.cs
@@ -1,0 +1,64 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Linq;
+using Xunit;
+
+namespace Google.Cloud.Spanner.Data.Tests
+{
+    public class RetriableTransactionOptionsTests
+    {
+        [Fact]
+        public void DefaultJitter()
+        {
+            var options = RetriableTransactionOptions.CreateDefault();
+
+            var delay = TimeSpan.FromTicks(TimeSpan.TicksPerMillisecond);
+            var delayTicks = (int)delay.Ticks;
+            // The jitter on RetriableTransactionOptions should jitter between
+            // delay and delay * 2.
+            var expectedMinDelayTicks = delayTicks;
+            var expectedMaxDelayTicks = delayTicks * 2;
+            var expectedMedianDelayTicks = (expectedMinDelayTicks + expectedMaxDelayTicks) / 2;
+
+            var delays = Enumerable.Range(0, 10_000)
+                .Select(_ => options.Jitter(delay))
+                .ToList();
+            var underMedianCount = delays.LongCount(ts => ts.Ticks <= expectedMedianDelayTicks);
+
+            Assert.InRange(underMedianCount, 4_000, 6_000);
+        }
+
+        [Fact]
+        public void NoJitter()
+        {
+            var options = RetriableTransactionOptions.CreateWithNoJitter();
+            var delay = TimeSpan.FromTicks(TimeSpan.TicksPerMillisecond);
+            var delayTicks = (int)delay.Ticks;
+            var expectedJitteredTicks = delayTicks;
+
+            // This shouldn't jitter at all, 50_000 seems a good enough sample
+            // to test that.
+            var delays = Enumerable.Range(0, 50_000)
+                .Select(_ => options.Jitter(delay))
+                .ToList();
+            var min = delays.Min();
+            var max = delays.Max();
+
+            Assert.Equal(expectedJitteredTicks, min.Ticks);
+            Assert.Equal(expectedJitteredTicks, max.Ticks);
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerBatchCommandTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerBatchCommandTests.cs
@@ -14,10 +14,11 @@
 
 using Google.Api.Gax;
 using Google.Cloud.Spanner.V1;
-using Moq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Google.Cloud.Spanner.Data.Tests
@@ -153,6 +154,9 @@ namespace Google.Cloud.Spanner.Data.Tests
             public IClock Clock => SystemClock.Instance;
             public SessionPoolOptions Options { get; } = new SessionPoolOptions();
             public void Release(PooledSession session, bool deleteSession) =>  throw new NotImplementedException();
+
+            public Task<PooledSession> WithFreshTransactionOrNewAsync(PooledSession session, TransactionOptions transactionOptions, CancellationToken cancellationToken) =>
+                throw new NotImplementedException();
         }
     }
 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerConnectionTests.AbortedTransactionRetryTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerConnectionTests.AbortedTransactionRetryTests.cs
@@ -1,0 +1,328 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax.Testing;
+using Google.Cloud.Spanner.Common.V1;
+using Google.Cloud.Spanner.V1;
+using Google.Cloud.Spanner.V1.Internal.Logging;
+using Google.Cloud.Spanner.V1.Tests;
+using Grpc.Core;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Cloud.Spanner.Data.Tests
+{
+    public partial class SpannerConnectionTests
+    {
+        public sealed class TransactionAbortedRetryTests
+        {
+            // Combining backoff and jittering for retries
+            // when the RpcException doesn't specify a wait time.
+            // InitialDelay = 250ms, BackoffMultiplier = 2, JitterMultiplier = 2
+            // Those are all hard-coded, client code can't change them.
+            private const int InitialDelayBackoffMs = 250;
+            private const int BackoffMultiplier = 2;
+            private const int JitterMultiplier = 2;
+
+            private const int ExceptionRetryDelayMs = 300;
+            // We respect the retry from the Exception
+            private const int ExceptionBackoffMultiplier = 1;
+
+            [Fact]
+            public async Task FirstCallSucceeds()
+            {
+                var spannerClientMock = SpannerClientHelpers
+                    .CreateMockClient(Logger.DefaultLogger, MockBehavior.Strict)
+                    .SetupBatchCreateSessionsAsync()
+                    .SetupBeginTransactionAsync()
+                    .SetupExecuteBatchDmlAsync()
+                    .SetupCommitAsync();
+                SpannerConnection connection = BuildSpannerConnection(spannerClientMock);
+
+                var scheduler = (FakeScheduler)connection.Builder.SessionPoolManager.SpannerSettings.Scheduler;
+                var time0 = scheduler.Clock.GetCurrentDateTimeUtc();
+                var callee = new Callee(scheduler);
+
+                await scheduler.RunAsync(async () =>
+                {
+                    var result = await connection.RunWithRetriableTransactionAsync(transaction => callee.DatabaseWorkAsync(connection, transaction));
+                    Assert.Equal(1, result);
+                });
+
+                callee.AssertBackoffTimesInRange(time0);
+                callee.AssertLastCallTime(scheduler.Clock.GetCurrentDateTimeUtc());
+            }
+
+            [Fact]
+            public async Task CommitAbortsTwice()
+            {
+                var spannerClientMock = SpannerClientHelpers
+                    .CreateMockClient(Logger.DefaultLogger, MockBehavior.Strict)
+                    .SetupBatchCreateSessionsAsync()
+                    .SetupBeginTransactionAsync()
+                    .SetupExecuteBatchDmlAsync()
+                    .SetupCommitAsync_Fails(failures: 2, statusCode: StatusCode.Aborted)
+                    .SetupRollbackAsync();
+
+                SpannerConnection connection = BuildSpannerConnection(spannerClientMock);
+
+                var scheduler = (FakeScheduler)connection.Builder.SessionPoolManager.SpannerSettings.Scheduler;
+                var time0 = scheduler.Clock.GetCurrentDateTimeUtc();
+                var callee = new Callee(scheduler);
+
+                await scheduler.RunAsync(async () =>
+                {
+                    var result = await connection.RunWithRetriableTransactionAsync(transaction => callee.DatabaseWorkAsync(connection, transaction));
+                    Assert.Equal(3, result);
+                });
+
+                callee.AssertBackoffTimesInRange(time0);
+                callee.AssertLastCallTime(scheduler.Clock.GetCurrentDateTimeUtc());
+            }
+
+            // The transaction can be aborted on commit or on any of the operations.
+            [Fact]
+            public async Task BatchDmlAbortsTwice()
+            {
+                var spannerClientMock = SpannerClientHelpers
+                    .CreateMockClient(Logger.DefaultLogger, MockBehavior.Strict)
+                    .SetupBatchCreateSessionsAsync()
+                    .SetupBeginTransactionAsync()
+                    .SetupExecuteBatchDmlAsync_Fails(failures: 2, statusCode: StatusCode.Aborted)
+                    .SetupCommitAsync()
+                    .SetupRollbackAsync();
+
+                SpannerConnection connection = BuildSpannerConnection(spannerClientMock);
+
+                var scheduler = (FakeScheduler)connection.Builder.SessionPoolManager.SpannerSettings.Scheduler;
+                var time0 = scheduler.Clock.GetCurrentDateTimeUtc();
+                var callee = new Callee(scheduler);
+
+                await scheduler.RunAsync(async () =>
+                {
+                    var result = await connection.RunWithRetriableTransactionAsync(transaction => callee.DatabaseWorkAsync(connection, transaction));
+                    Assert.Equal(3, result);
+                });
+
+                callee.AssertBackoffTimesInRange(time0);
+                callee.AssertLastCallTime(scheduler.Clock.GetCurrentDateTimeUtc());
+            }
+
+            [Fact]
+            public async Task CommitAbortsTwice_RecommendedDelay()
+            {
+                var spannerClientMock = SpannerClientHelpers
+                    .CreateMockClient(Logger.DefaultLogger, MockBehavior.Strict)
+                    .SetupBatchCreateSessionsAsync()
+                    .SetupBeginTransactionAsync()
+                    .SetupExecuteBatchDmlAsync()
+                    .SetupCommitAsync_Fails(failures: 2, statusCode: StatusCode.Aborted, exceptionRetryDelay: TimeSpan.FromMilliseconds(ExceptionRetryDelayMs))
+                    .SetupRollbackAsync();
+
+                SpannerConnection connection = BuildSpannerConnection(spannerClientMock);
+
+                var scheduler = (FakeScheduler)connection.Builder.SessionPoolManager.SpannerSettings.Scheduler;
+                var time0 = scheduler.Clock.GetCurrentDateTimeUtc();
+                var callee = new Callee(scheduler, initialDelayMs: ExceptionRetryDelayMs, backoffMultiplier: ExceptionBackoffMultiplier);
+
+                await scheduler.RunAsync(async () =>
+                {
+                    var result = await connection.RunWithRetriableTransactionAsync(transaction => callee.DatabaseWorkAsync(connection, transaction));
+                    Assert.Equal(3, result);
+                });
+
+                callee.AssertBackoffTimesInRange(time0);
+                callee.AssertLastCallTime(scheduler.Clock.GetCurrentDateTimeUtc());
+            }
+
+            [Fact]
+            public async Task CommitAbortsAlways_RespectsOverallDeadline()
+            {
+                var spannerClientMock = SpannerClientHelpers
+                    .CreateMockClient(Logger.DefaultLogger, MockBehavior.Strict)
+                    .SetupBatchCreateSessionsAsync()
+                    .SetupBeginTransactionAsync()
+                    .SetupExecuteBatchDmlAsync()
+                    .SetupCommitAsync_FailsAlways(statusCode: StatusCode.Aborted)
+                    .SetupRollbackAsync();
+
+                SpannerConnection connection = BuildSpannerConnection(spannerClientMock);
+
+                var scheduler = (FakeScheduler)connection.Builder.SessionPoolManager.SpannerSettings.Scheduler;
+                // This test needs a little bit more of real time, else it's flaky.
+                scheduler.RealTimeTimeout = TimeSpan.FromSeconds(60);
+                var time0 = scheduler.Clock.GetCurrentDateTimeUtc();
+                var callee = new Callee(scheduler);
+
+                await scheduler.RunAsync(async () =>
+                {
+                    var exception = await Assert.ThrowsAsync<SpannerException>(() => connection.RunWithRetriableTransactionAsync(transaction => callee.DatabaseWorkAsync(connection, transaction)));
+                    Assert.True(exception.IsRetryable && !exception.SessionExpired);
+                    Assert.Contains("Bang!", exception.InnerException.Message);
+                });
+
+                // The minimum calls that can be made (assuming maximum jitter always) in that time is 60 * 60 / 32 * 2 which is 56.25,
+                // plus 1 because the first one has no delay.
+                // The maximum number of calls that can be made in 1 hour:
+                // - Given that 2^7 * 250 = 32000, the first 8 calls take, at a minimum 31_750ms, approx 32s.
+                // - The rest will happen at most (60 * 60 - 32) / 32 which is 111.5
+                callee.AssertCalledInRange(57, 120);
+                // The overall deadline is of 1 hour. The maximum backoff delay is of 32s.
+                // Because of jitter retries can stop at any time after 60mins - 64s, let's give it 2 minutes of range.
+                Assert.InRange(scheduler.Clock.GetCurrentDateTimeUtc(), time0.AddMinutes(58), time0.AddMinutes(60));
+            }
+
+            [Fact]
+            public async Task CommitFailsOtherThanAborted()
+            {
+                var spannerClientMock = SpannerClientHelpers
+                    .CreateMockClient(Logger.DefaultLogger, MockBehavior.Strict)
+                    .SetupBatchCreateSessionsAsync()
+                    .SetupBeginTransactionAsync()
+                    .SetupExecuteBatchDmlAsync()
+                    .SetupCommitAsync_Fails(failures: 1, StatusCode.Unknown)
+                    .SetupRollbackAsync();
+
+                SpannerConnection connection = BuildSpannerConnection(spannerClientMock);
+
+                var scheduler = (FakeScheduler)connection.Builder.SessionPoolManager.SpannerSettings.Scheduler;
+                var time0 = scheduler.Clock.GetCurrentDateTimeUtc();
+                var callee = new Callee(scheduler);
+
+                await scheduler.RunAsync(async () =>
+                {
+                    var exception = await Assert.ThrowsAsync<SpannerException>(
+                        () => connection.RunWithRetriableTransactionAsync(
+                            transaction => callee.DatabaseWorkAsync(connection, transaction)));
+                    Assert.Contains("Bang!", exception.InnerException.Message);
+                });
+
+                callee.AssertBackoffTimesInRange(time0);
+                callee.AssertLastCallTime(scheduler.Clock.GetCurrentDateTimeUtc());
+            }
+
+            [Fact]
+            public async Task WorkFails()
+            {
+                var spannerClientMock = SpannerClientHelpers
+                    .CreateMockClient(Logger.DefaultLogger, MockBehavior.Strict)
+                    .SetupBatchCreateSessionsAsync()
+                    .SetupBeginTransactionAsync()
+                    .SetupRollbackAsync();
+
+                SpannerConnection connection = BuildSpannerConnection(spannerClientMock);
+
+                var scheduler = (FakeScheduler)connection.Builder.SessionPoolManager.SpannerSettings.Scheduler;
+                var time0 = scheduler.Clock.GetCurrentDateTimeUtc();
+                var callee = new Callee(scheduler);
+
+                await scheduler.RunAsync(async () =>
+                {
+                    var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => connection.RunWithRetriableTransactionAsync(callee.Fails));
+                    Assert.Contains("Bang!", exception.Message);
+                });
+
+                callee.AssertBackoffTimesInRange(time0);
+                callee.AssertLastCallTime(scheduler.Clock.GetCurrentDateTimeUtc());
+            }
+
+            private SpannerConnection BuildSpannerConnection(Mock<SpannerClient> spannerClientMock)
+            {
+                var spannerClient = spannerClientMock.Object;
+                var sessionPoolOptions = new SessionPoolOptions
+                {
+                    MaintenanceLoopDelay = TimeSpan.Zero
+                };
+
+                var sessionPoolManager = new SessionPoolManager(sessionPoolOptions, spannerClient.Settings.Logger, (_o, _s, _l) => Task.FromResult(spannerClient));
+                sessionPoolManager.SpannerSettings.Scheduler = spannerClient.Settings.Scheduler;
+                sessionPoolManager.SpannerSettings.Clock = spannerClient.Settings.Clock;
+
+                SpannerConnectionStringBuilder builder = new SpannerConnectionStringBuilder
+                {
+                    DataSource = DatabaseName.Format(SpannerClientHelpers.ProjectId, SpannerClientHelpers.Instance, SpannerClientHelpers.Database),
+                    SessionPoolManager = sessionPoolManager
+                };
+
+                return new SpannerConnection(builder);
+            }
+
+            private class Callee
+            {
+                private readonly FakeScheduler _scheduler;
+                private readonly IList<DateTime> _callTimes = new List<DateTime>();
+                // For checking call times.
+                private readonly long _initialDelayTicks;
+                private readonly int _backoffMultiplier;
+                private readonly int _jitterMultiplier;
+
+                public Callee(FakeScheduler scheduler, int initialDelayMs = InitialDelayBackoffMs, int backoffMultiplier = BackoffMultiplier, int jitterMultiplier = JitterMultiplier)
+                {
+                    _scheduler = scheduler;
+                    _initialDelayTicks = initialDelayMs * TimeSpan.TicksPerMillisecond;
+                    _backoffMultiplier = backoffMultiplier;
+                    _jitterMultiplier = jitterMultiplier;
+                }
+
+                public async Task<int> DatabaseWorkAsync(SpannerConnection connection, SpannerTransaction transaction)
+                {
+                    _callTimes.Add(_scheduler.Clock.GetCurrentDateTimeUtc());
+
+                    var insert = connection.CreateInsertCommand("table_1",
+                        new SpannerParameterCollection
+                        {
+                        new SpannerParameter("column_1", SpannerDbType.Int64, 10)
+                        });
+                    insert.Transaction = transaction;
+
+                    var dml = transaction.CreateBatchDmlCommand();
+                    dml.Add("UPDATE table_1 SET column_1 = column1 + 5");
+
+                    await insert.ExecuteNonQueryAsync();
+                    await dml.ExecuteNonQueryAsync();
+
+                    return _callTimes.Count;
+                }
+
+                public Task<int> Fails(SpannerTransaction transaction)
+                {
+                    _callTimes.Add(_scheduler.Clock.GetCurrentDateTimeUtc());
+                    throw new InvalidOperationException("Bang!");
+                }
+
+                public void AssertBackoffTimesInRange(DateTime time0)
+                {
+                    Assert.Equal(time0, _callTimes[0]);
+                    long lastCallTicks = time0.Ticks;
+                    for (int i = 1; i < _callTimes.Count; i++)
+                    {
+                        var minDelayTicks = (long)Math.Pow(_backoffMultiplier, i - 1) * _initialDelayTicks;
+                        var maxDelayTicks = minDelayTicks * _jitterMultiplier;
+
+                        Assert.InRange(_callTimes[i].Ticks, lastCallTicks + minDelayTicks, lastCallTicks + maxDelayTicks);
+                        lastCallTicks = _callTimes[i].Ticks;
+                    }
+                }
+
+                public void AssertLastCallTime(DateTime time) => Assert.Equal(time, _callTimes.Last());
+
+                public void AssertCalledInRange(int min, int max) => Assert.InRange(_callTimes.Count, min, max);
+            }
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerConnectionTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerConnectionTests.cs
@@ -17,7 +17,7 @@ using Xunit;
 
 namespace Google.Cloud.Spanner.Data.Tests
 {
-    public class SpannerConnectionTests
+    public partial class SpannerConnectionTests
     {
         [Fact]
         public void OpenWithNoDatabase_InvalidCredentials()

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/PooledSessionTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/PooledSessionTests.cs
@@ -360,6 +360,9 @@ namespace Google.Cloud.Spanner.V1.Tests
             {
                 ReleasedSessionDeleted = deleteSession;
             }
+
+            public Task<PooledSession> WithFreshTransactionOrNewAsync(PooledSession session, TransactionOptions transactionOptions, CancellationToken cancellationToken) =>
+                throw new NotImplementedException();
         }
     }
 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SpannerClientHelpers.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SpannerClientHelpers.cs
@@ -12,30 +12,212 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Api.Gax.Grpc;
 using Google.Api.Gax.Testing;
 using Google.Cloud.Spanner.V1.Internal.Logging;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+using Google.Rpc;
+using Grpc.Core;
 using Moq;
+using Moq.Language;
+using System;
+using System.Threading.Tasks;
+using Status = Grpc.Core.Status;
 
 namespace Google.Cloud.Spanner.V1.Tests
 {
     /// <summary>
-    /// Helpers for tests that need SpannerClient instances.
+    /// Helpers for tests that need general SpannerClient instances.
+    /// The mocks generated with these helpers guarantee the basic
+    /// SpannerClient workings. If you need more granularity in what
+    /// SpannerClient methods return you should write specific mocks.
     /// </summary>
     internal static class SpannerClientHelpers
     {
+        internal const string ProjectId = "dummy-project";
+        internal const string Instance = "dummy-instance";
+        internal const string Database = "dummy-database";
+        private static readonly string s_retryInfoMetadataKey = RetryInfo.Descriptor.FullName + "-bin";
+
         /// <summary>
         /// Creates a mock SpannerClient configured with settings that include a fake clock
         /// and a fake scheduler.
         /// </summary>
         internal static Mock<SpannerClient> CreateMockClient(Logger logger, MockBehavior behavior = MockBehavior.Strict)
         {
+            var fakeScheduler = new FakeScheduler();
             var settings = SpannerSettings.GetDefault();
-            settings.Clock = new FakeClock();
-            settings.Scheduler = new FakeScheduler();
+            settings.Scheduler = fakeScheduler;
+            settings.Clock = fakeScheduler.Clock;
             settings.Logger = logger;
             var mock = new Mock<SpannerClient>(behavior);
             mock.SetupProperty(client => client.Settings, settings);
             return mock;
+        }
+
+        internal static Mock<SpannerClient> SetupBatchCreateSessionsAsync(this Mock<SpannerClient> spannerClientMock)
+        {
+            spannerClientMock
+                .Setup(client => client.BatchCreateSessionsAsync(It.IsNotNull<BatchCreateSessionsRequest>(), It.IsAny<CallSettings>()))
+                .Returns<BatchCreateSessionsRequest, CallSettings>((request, _) =>
+                {
+                    BatchCreateSessionsResponse response = new BatchCreateSessionsResponse();
+
+                    for (int i = 0; i < request.SessionCount; i++)
+                    {
+                        var session = request.SessionTemplate.Clone();
+                        session.CreateTime = session.ApproximateLastUseTime = spannerClientMock.GetNowTimestamp();
+                        session.Expired = false;
+                        session.Name = Guid.NewGuid().ToString();
+                        session.SessionName = new SessionName(ProjectId, Instance, Database, session.Name);
+
+                        response.Session.Add(session);
+                    }
+
+                    return Task.FromResult(response);
+                });
+            return spannerClientMock;
+        }
+
+        internal static Mock<SpannerClient> SetupBeginTransactionAsync(this Mock<SpannerClient> spannerClientMock)
+        {
+            spannerClientMock
+                .Setup(client => client.BeginTransactionAsync(It.IsNotNull<BeginTransactionRequest>(), It.IsAny<CallSettings>()))
+                .Returns(Task.FromResult(
+                    new Transaction
+                    {
+                        Id = ByteString.CopyFromUtf8(Guid.NewGuid().ToString())
+                    }));
+            return spannerClientMock;
+        }
+
+        internal static Mock<SpannerClient> SetupExecuteBatchDmlAsync(this Mock<SpannerClient> spannerClientMock)
+        {
+            spannerClientMock
+                .Setup(client => client.ExecuteBatchDmlAsync(It.IsNotNull<ExecuteBatchDmlRequest>(), It.IsAny<CallSettings>()))
+                .Returns(Task.FromResult(
+                    new ExecuteBatchDmlResponse
+                    {
+                        Status = new Rpc.Status
+                        {
+                            Code = (int)StatusCode.OK
+                        },
+                        ResultSets =
+                        {
+                            new ResultSet
+                            {
+                                Stats = new ResultSetStats
+                                {
+                                    RowCountExact = 10
+                                }
+                            }
+                        }
+                    }));
+            return spannerClientMock;
+        }
+
+        internal static Mock<SpannerClient> SetupExecuteBatchDmlAsync_Fails(this Mock<SpannerClient> spannerClientMock, int failures, StatusCode statusCode, string exceptionMessage = "Bang!", TimeSpan? exceptionRetryDelay = null)
+        {
+            spannerClientMock
+                .SetupSequence(client => client.ExecuteBatchDmlAsync(It.IsNotNull<ExecuteBatchDmlRequest>(), It.IsAny<CallSettings>()))
+                .SetupFailures(failures, statusCode, exceptionMessage, exceptionRetryDelay)
+                .Returns(Task.FromResult(
+                    new ExecuteBatchDmlResponse
+                    {
+                        Status = new Rpc.Status
+                        {
+                            Code = (int)StatusCode.OK
+                        },
+                        ResultSets =
+                        {
+                            new ResultSet
+                            {
+                                Stats = new ResultSetStats
+                                {
+                                    RowCountExact = 10
+                                }
+                            }
+                        }
+                    }));
+            return spannerClientMock;
+        }
+
+        internal static Mock<SpannerClient> SetupCommitAsync(this Mock<SpannerClient> spannerClientMock)
+        {
+            spannerClientMock
+                .Setup(client => client.CommitAsync(It.IsNotNull<CommitRequest>(), It.IsAny<CallSettings>()))
+                .Returns(Task.FromResult(
+                    new CommitResponse
+                    {
+                        CommitTimestamp = spannerClientMock.GetNowTimestamp()
+                    }));
+            return spannerClientMock;
+        }
+
+        internal static Mock<SpannerClient> SetupCommitAsync_Fails(this Mock<SpannerClient> spannerClientMock, int failures, StatusCode statusCode, string exceptionMessage = "Bang!", TimeSpan? exceptionRetryDelay = null)
+        {
+            spannerClientMock
+                .SetupSequence(client => client.CommitAsync(It.IsNotNull<CommitRequest>(), It.IsAny<CallSettings>()))
+                .SetupFailures(failures, statusCode, exceptionMessage, exceptionRetryDelay)
+                .Returns(Task.FromResult(
+                    new CommitResponse
+                    {
+                        CommitTimestamp = spannerClientMock.GetNowTimestamp()
+                    }));
+            return spannerClientMock;
+        }
+
+        internal static Mock<SpannerClient> SetupCommitAsync_FailsAlways(this Mock<SpannerClient> spannerClientMock, StatusCode statusCode, string exceptionMessage = "Bang!", TimeSpan? exceptionRetryDelay = null)
+        {
+            spannerClientMock
+                .Setup(client => client.CommitAsync(It.IsNotNull<CommitRequest>(), It.IsAny<CallSettings>()))
+                .Throws(BuildRpcException(exceptionRetryDelay, statusCode, exceptionMessage));
+
+            return spannerClientMock;
+        }
+
+        internal static Mock<SpannerClient> SetupRollbackAsync(this Mock<SpannerClient> spannerClientMock)
+        {
+            spannerClientMock
+                .Setup(client => client.RollbackAsync(It.IsNotNull<RollbackRequest>(), It.IsAny<CallSettings>()))
+                .Returns(Task.FromResult(true));
+            return spannerClientMock;
+        }
+
+        private static ISetupSequentialResult<TResult> SetupFailures<TResult>(this ISetupSequentialResult<TResult> setup, int failures, StatusCode statusCode, string exceptionMessage, TimeSpan? exceptionRetryDelay)
+        {
+            var exception = BuildRpcException(exceptionRetryDelay, statusCode, exceptionMessage);
+            for (int i = 0; i < failures; i++)
+            {
+                setup = setup.Throws(exception);
+            }
+
+            return setup;
+        }
+
+        private static RpcException BuildRpcException(TimeSpan? exceptionRetryDelay, StatusCode exceptionStatus, string exceptionMessage)
+        {
+            var status = new Status(exceptionStatus, exceptionMessage);
+            if (!exceptionRetryDelay.HasValue)
+            {
+                return new RpcException(status);
+            }
+            RetryInfo retry = new RetryInfo
+            {
+                RetryDelay = Duration.FromTimeSpan(exceptionRetryDelay.Value)
+            };
+            Metadata trailers = new Metadata
+            {
+                { s_retryInfoMetadataKey, retry.ToByteArray() }
+            };
+            return new RpcException(status, trailers);
+        }
+
+        private static Timestamp GetNowTimestamp(this Mock<SpannerClient> spannerClientMock)
+        {
+            var clock = spannerClientMock.Object.Settings.Clock;
+            return Timestamp.FromDateTime(clock.GetCurrentDateTimeUtc());
         }
     }
 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/RetriableTransaction.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/RetriableTransaction.cs
@@ -1,0 +1,135 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using Google.Cloud.Spanner.V1;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Cloud.Spanner.Data
+{
+    internal sealed class RetriableTransaction
+    {
+        private readonly SpannerConnection _connection;
+        private readonly IClock _clock;
+        private readonly IScheduler _scheduler;
+        private readonly RetriableTransactionOptions _options;
+
+        internal RetriableTransaction(SpannerConnection connection, IClock clock, IScheduler scheduler, RetriableTransactionOptions options = null)
+        {
+            _connection = GaxPreconditions.CheckNotNull(connection, nameof(connection));
+            _clock = GaxPreconditions.CheckNotNull(clock, nameof(clock));
+            _scheduler = GaxPreconditions.CheckNotNull(scheduler, nameof(scheduler));
+            _options = options ?? RetriableTransactionOptions.CreateDefault();
+        }
+
+        internal async Task<TResult> RunAsync<TResult>(Func<SpannerTransaction, Task<TResult>> asyncWork, CancellationToken cancellationToken = default)
+        {
+            GaxPreconditions.CheckNotNull(asyncWork, nameof(asyncWork));
+
+            // Session will be initialized and subsequently modified by CommitAttempt.
+            PooledSession session = null;
+            try
+            {
+                return await ExecuteWithRetryAsync(CommitAttempt, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                session?.Dispose();
+            }
+
+            async Task<TResult> CommitAttempt()
+            {
+                return await ExecuteHelper.WithErrorTranslationAndProfiling(
+                    async () =>
+                    {
+                        SpannerTransaction transaction = null;
+
+                        try
+                        {
+                            session = await (session?.WithFreshTransactionOrNewAsync(SpannerConnection.s_readWriteTransactionOptions, cancellationToken) ?? _connection.AcquireReadWriteSessionAsync(cancellationToken)).ConfigureAwait(false);
+                            transaction = new SpannerTransaction(_connection, TransactionMode.ReadWrite, session, null);
+
+                            TResult result = await asyncWork(transaction).ConfigureAwait(false);
+                            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+
+                            return result;
+                        }
+                        // We only catch to attempt a rollback, and that is possible if we have a transaction already.
+                        // If the exception was thrown when refreshing the session the we don't have a transaction yet.
+                        catch when (transaction != null)
+                        {
+                            try
+                            {
+                                await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                            }
+                            catch (Exception e)
+                            {
+                                // If the commit failed, calling Rollback will fail as well.
+                                // We don't want that or any other rollback exception to propagate,
+                                // it will not trigger the retry
+                                _connection.Logger.Warn("A rollback attempt failed on RetriableTransaction.RunAsync.CommitAttempt", e);
+                            }
+
+                            // Throw, the retry helper will know when to retry.
+                            throw;
+                        }
+                        finally
+                        {
+                            if (transaction != null)
+                            {
+                                // Let's make sure that the associated session is not released to the pool
+                                // because we'll be attempting to get a fresh transaction for this same session first.
+                                // If that fails will attempt a new session acquisition.
+                                // This session will be disposed of by the pool if it can't be refreshed or by the RunAsync method
+                                // if we are not retrying anymore.
+                                transaction.DisposeBehavior = DisposeBehavior.Detach;
+                                transaction.Dispose();
+                            }
+                        }
+                    }, "RetriableTransaction.RunAsync.CommitAttempt", _connection.Logger).ConfigureAwait(false);
+            }
+        }
+
+        internal async Task<TResult> ExecuteWithRetryAsync<TResult>(Func<Task<TResult>> fn, CancellationToken cancellationToken)
+        {
+            DateTime? overallDeadline = _options.CalculateDeadline(_clock);
+            TimeSpan retryDelay = _options.InitialDelay;
+            while (true)
+            {
+                try
+                {
+                    var result = await fn().ConfigureAwait(false);
+                    return result;
+                }
+                catch (SpannerException e) when (e.IsRetryable && !e.SessionExpired)
+                {
+                    // If there's a recommended retry delay specified on the exception
+                    // we should respect it.
+                    retryDelay = e.RecommendedRetryDelay ?? retryDelay;
+
+                    TimeSpan actualDelay = _options.Jitter(retryDelay);
+                    DateTime expectedRetryTime = _clock.GetCurrentDateTimeUtc() + actualDelay;
+                    if (expectedRetryTime > overallDeadline)
+                    {
+                        throw;
+                    }
+                    await _scheduler.Delay(actualDelay, cancellationToken).ConfigureAwait(false);
+                    retryDelay = _options.NextDelay(retryDelay);
+                }
+            }
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/RetriableTransactionOptions.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/RetriableTransactionOptions.cs
@@ -1,0 +1,71 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using Google.Api.Gax.Grpc;
+using System;
+
+namespace Google.Cloud.Spanner.Data
+{
+    internal sealed class RetriableTransactionOptions
+    {
+        private static readonly BackoffSettings s_defaultBackoff = new BackoffSettings(
+            delay: TimeSpan.FromMilliseconds(250),
+            maxDelay: TimeSpan.FromSeconds(32),
+            delayMultiplier: 2);
+        private static readonly Expiration s_defaultOverallExpiry = Expiration.FromTimeout(TimeSpan.FromHours(1));
+
+        internal readonly Func<TimeSpan, TimeSpan> _jitter;
+
+        private RetriableTransactionOptions(Func<TimeSpan, TimeSpan> jitter = null) =>
+            _jitter = jitter ?? MinimumBoundJitter;
+
+        internal static RetriableTransactionOptions CreateDefault() => new RetriableTransactionOptions();
+
+        internal static RetriableTransactionOptions CreateWithNoJitter() => new RetriableTransactionOptions(delay => delay);
+
+        internal TimeSpan InitialDelay => s_defaultBackoff.Delay;
+
+        internal DateTime? CalculateDeadline(IClock clock) => s_defaultOverallExpiry.CalculateDeadline(clock);
+
+        internal TimeSpan Jitter(TimeSpan delay) => _jitter(delay);
+
+        internal TimeSpan NextDelay(TimeSpan currentDelay) => s_defaultBackoff.NextDelay(currentDelay);
+
+        // See http://stackoverflow.com/questions/36376888 for why we don't have a thread-local RNG.
+        // We might create multiple instances of MinimumBoundJitter so this is static to make sure
+        // that we'll only have a single Random instance.
+        private static readonly Random s_random = new Random();
+        private static readonly object s_lock = new object();
+        private static TimeSpan MinimumBoundJitter(TimeSpan minDelay)
+        {
+            if (minDelay <= TimeSpan.Zero)
+            {
+                return minDelay;
+            }
+
+            double jitterMultiplier;
+            lock (s_lock)
+            {
+                jitterMultiplier = s_random.NextDouble();
+            }
+
+            var minDelayTicks = minDelay.Ticks;
+            // Always jitter in between minDelay and minDelay * 2.
+            var jitter = minDelayTicks * jitterMultiplier;
+            var actualDelayTicks = minDelayTicks + jitter;
+            return TimeSpan.FromTicks((long)actualDelayTicks);
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPool.DetachedSessionPool.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPool.DetachedSessionPool.cs
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace Google.Cloud.Spanner.V1
 {
     public partial class SessionPool
@@ -35,6 +39,10 @@ namespace Google.Cloud.Spanner.V1
                     Parent.DeleteSessionFireAndForget(session);
                 }
             }
+
+            public override Task<PooledSession> WithFreshTransactionOrNewAsync(PooledSession session, TransactionOptions transactionOptions, CancellationToken cancellationToken) =>
+                throw new InvalidOperationException(
+                    $"{nameof(session)} is a detached session. Its transaction can't be refreshed and it can't be substituted by a new session.");
         }
     }
 }

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPool.ISessionPool.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPool.ISessionPool.cs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 using Google.Api.Gax;
-using Google.Cloud.Spanner.V1.Internal.Logging;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Google.Cloud.Spanner.V1
 {
@@ -27,6 +27,7 @@ namespace Google.Cloud.Spanner.V1
         {
             SpannerClient Client { get; }
             IClock Clock { get; }
+            Task<PooledSession> WithFreshTransactionOrNewAsync(PooledSession session, TransactionOptions transactionOptions, CancellationToken cancellationToken);
             void Release(PooledSession session, bool deleteSession);
             SessionPoolOptions Options { get; }
         }

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPool.SessionPoolBase.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPool.SessionPoolBase.cs
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 using Google.Api.Gax;
-using Google.Cloud.Spanner.V1.Internal.Logging;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Google.Cloud.Spanner.V1
 {
@@ -29,6 +30,7 @@ namespace Google.Cloud.Spanner.V1
             public IClock Clock => Parent._clock;
             public SessionPoolOptions Options => Parent.Options;
             protected SessionPool Parent { get; }
+            public abstract Task<PooledSession> WithFreshTransactionOrNewAsync(PooledSession session, TransactionOptions transactionOptions, CancellationToken cancellationToken);
             public abstract void Release(PooledSession session, bool deleteSession);
             protected SessionPoolBase(SessionPool parent) => Parent = parent;
         }


### PR DESCRIPTION
@jskeet just a quick look for now, sanity checking and that everything is where it should be. Taking a look a commit at a time might be helpfull.