### PR TITLE
Revert "Remove generation script workaround for microgenerator issue"

### DIFF
--- a/generateapis.sh
+++ b/generateapis.sh
@@ -100,6 +100,10 @@ generate_microgenerator() {
     $GOOGLEAPIS/google/cloud/common_resources.proto
     2>&1 | grep -v "but not used" || true # Ignore import warnings (and grep exit code)
 
+  # The microgenerator currently creates Google.Cloud directories due to being given
+  # the common resources proto. Clean up for now; this is being fixed in the generator.
+  rm -rf $API_TMP_DIR/Google.Cloud{,.Snippets,.Tests}
+
   # We generate our own project files
   rm $(find tmp -name '*.csproj')
   


### PR DESCRIPTION
This reverts commit e70e9fa670bd23cabcb6e4159486847e5726d74c.

It looks like empty directories are still being created. Let's clean them up for now, and then address this again when everything has settled down.