### PR TITLE
[Spanner] Refactoring session pool code to limit the lock scope when calculating batch size.

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SessionPoolTests.TargetedSessionPoolTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SessionPoolTests.TargetedSessionPoolTests.cs
@@ -94,6 +94,11 @@ namespace Google.Cloud.Spanner.V1.Tests
             {
                 var pool = CreatePool(true);
                 var client = (SessionTestingSpannerClient) pool.Client;
+
+                // Wait a little in real time, session creation is
+                // launched as a (controlled) fire and forget task. Let's make sure it
+                // advances enough so that stats are updated.
+                await Task.Delay(TimeSpan.FromMilliseconds(250));
                 var stats = pool.GetStatisticsSnapshot();
                 Assert.Equal(10, stats.InFlightCreationCount);
                 Assert.Equal(0, stats.ReadPoolCount);
@@ -691,6 +696,10 @@ namespace Google.Cloud.Spanner.V1.Tests
                 var client = (SessionTestingSpannerClient)pool.Client;
                 client.FailAllRpcs = true;
                 pool.MaintainPool();
+
+                // Wait a little in real time so that the start session creation tasks
+                // have had time to execute, they are started in a fire and forget manner.
+                await Task.Delay(TimeSpan.FromMilliseconds(250));
 
                 await client.Scheduler.RunAsync(async () =>
                 {

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SessionPoolTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SessionPoolTests.cs
@@ -228,6 +228,12 @@ namespace Google.Cloud.Spanner.V1.Tests
             var sessionPool = new SessionPool(client, options);
             var acquisitionTask1 = sessionPool.AcquireSessionAsync(s_sampleDatabaseName, new TransactionOptions(), default);
             var acquisitionTask2 = sessionPool.AcquireSessionAsync(s_sampleDatabaseName2, new TransactionOptions(), default);
+
+            // Wait a little in real time because session creation tasks 
+            // are started in a controlled fire and forget manner.
+            // Let's give time for stats to be updated.
+            await Task.Delay(TimeSpan.FromMilliseconds(250));
+
             var stats = sessionPool.GetStatisticsSnapshot();
             Assert.Equal(2, stats.PerDatabaseStatistics.Count);
             Assert.Equal(2, stats.TotalActiveSessionCount);


### PR DESCRIPTION
Proposal for addressing TODO from https://github.com/googleapis/google-cloud-dotnet/pull/3567#discussion_r337437131.