### PR TITLE
Update the dependencies used in documentation

### DIFF
--- a/docs/dependencies-docfx/docfx-gax-dotnet.json
+++ b/docs/dependencies-docfx/docfx-gax-dotnet.json
@@ -1,22 +1,22 @@
 {
   "metadata": [
     {
-      "src": [{ "files": ["src/Google.Api.CommonProtos/Google.Api.CommonProtos.csproj"] }],
+      "src": [{ "files": ["Google.Api.CommonProtos/Google.Api.CommonProtos.csproj"] }],
       "properties": { "TargetFramework": "net45" },
       "dest": "api/Google.Api.CommonProtos",
     },
     {
-      "src": [{ "files": ["src/Google.Api.Gax/Google.Api.Gax.csproj"] }],
+      "src": [{ "files": ["Google.Api.Gax/Google.Api.Gax.csproj"] }],
       "properties": { "TargetFramework": "net45" },
       "dest": "api/Google.Api.Gax",
     },
     {
-      "src": [{ "files": ["src/Google.Api.Gax.Rest/Google.Api.Gax.Rest.csproj"] }],
+      "src": [{ "files": ["Google.Api.Gax.Rest/Google.Api.Gax.Rest.csproj"] }],
       "properties": { "TargetFramework": "net45" },
       "dest": "api/Google.Api.Gax.Rest",
     },
     {
-      "src": [{ "files": ["src/Google.Api.Gax.Grpc/Google.Api.Gax.Grpc.csproj"] }],
+      "src": [{ "files": ["Google.Api.Gax.Grpc/Google.Api.Gax.Grpc.csproj"] }],
       "properties": { "TargetFramework": "net45" },
       "dest": "api/Google.Api.Gax.Grpc",
     },

--- a/docs/dependencies-docfx/docfx-grpc.json
+++ b/docs/dependencies-docfx/docfx-grpc.json
@@ -1,7 +1,7 @@
 {
   "metadata": [
     {
-      "src": [{ "files": ["src/csharp/Grpc.Core/Grpc.Core.csproj"] }],
+      "src": [{ "files": ["src/csharp/Grpc.Core/Grpc.Core.csproj", "src/csharp/Grpc.Core.Api/Grpc.Core.Api.csproj"] }],
       "properties": { "TargetFramework": "net45" },
       "dest": "api/Grpc.Core",
     }

--- a/docs/fetchdependencies.sh
+++ b/docs/fetchdependencies.sh
@@ -4,8 +4,8 @@ set -e
 source ../toolversions.sh
 install_docfx
 
-declare -r PROTOBUF_BRANCH=3.6.x
-declare -r GRPC_BRANCH=v1.13.x
+declare -r PROTOBUF_BRANCH=3.8.x
+declare -r GRPC_BRANCH=v1.22.x
 
 # Blow away any previous files and clone the repo
 rm -rf dependencies


### PR DESCRIPTION
This is a relatively short-term measure. We should *at least* be publishing GAX to googleapis.dev and linking to it there, then ideally doing so for Protobuf and Grpc as well, after talking to the teams involved.