### PR TITLE
NLog GoogleStackdriverTarget improve handling of dangerous object properties

### DIFF
--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/GoogleStackdriverTarget.cs
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/GoogleStackdriverTarget.cs
@@ -135,6 +135,12 @@ namespace Google.Cloud.Logging.NLog
                 ReferenceLoopHandling = Newtonsoft.Json.ReferenceLoopHandling.Ignore
             };
             jsonSettings.Converters.Add(new Newtonsoft.Json.Converters.StringEnumConverter());
+            jsonSettings.Error = (sender, args) =>
+            {
+                // Serialization of properties that throws exceptions should not break everything
+                InternalLogger.Warn(args.ErrorContext.Error, "GoogleStackdriver(Name={0}): Error serializing exception property: {1}", Name, args.ErrorContext.Member);
+                args.ErrorContext.Handled = true;
+            };
             var jsonSerializer = Newtonsoft.Json.JsonSerializer.CreateDefault(jsonSettings);
             return o => {
                 try


### PR DESCRIPTION
Avoid breaking down when single object-property throws exceptions during Json.Net serialization.