### PR TITLE
samplegen: implement ApplicationChooser

### DIFF
--- a/generateapis.sh
+++ b/generateapis.sh
@@ -171,7 +171,6 @@ generate_gapicgenerator() {
   args+=(--output=$API_TMP_DIR)
   args+=(--language=csharp)
   args+=(--package=$PROTO_PACKAGE)
-  args+=(--dev_samples)
 
   # Suppress protobuf warnings in Java 9/10. By the time they
   # become a problem, we won't be using Java...

--- a/generateapis.sh
+++ b/generateapis.sh
@@ -171,6 +171,7 @@ generate_gapicgenerator() {
   args+=(--output=$API_TMP_DIR)
   args+=(--language=csharp)
   args+=(--package=$PROTO_PACKAGE)
+  args+=(--dev_samples)
 
   # Suppress protobuf warnings in Java 9/10. By the time they
   # become a problem, we won't be using Java...

--- a/tools/Google.Cloud.SampleUtil/ApplicationChooser.cs
+++ b/tools/Google.Cloud.SampleUtil/ApplicationChooser.cs
@@ -21,8 +21,23 @@ using System.Threading.Tasks;
 
 namespace Google.Cloud.SampleUtil
 {
+    /// <summary>
+    /// Class allowing a user to choose a sample to run, after
+    /// examining an assembly for all classes containing a static Main method, either
+    /// parameterless or with a string array parameter.
+    /// The ApplicationChooser is designed to run in both interactive mode (not 
+    /// implemented yet) and non-interactive mode.
+    /// In the interactive mode, the options are presented in a list ordered 
+    /// first by those with a Description attribute (by that description) and 
+    /// then those without (ordered by name).
+    /// In the non-interactive mode, the ApplicationChooser will invoke the sample
+    /// with the sample file name (the first positional commandline argument).
+    /// </summary>
     public class ApplicationChooser
     {
+        /// <summary>
+        /// Looks up a sample based on its name, and invoke it with the remaining arguments.
+        /// </summary>	
         public static void Run(string[] args)
         {
             if (args.Length == 0)
@@ -32,8 +47,8 @@ namespace Google.Cloud.SampleUtil
             string sample = args[0];
             var assembly = Assembly.GetEntryAssembly();
 
-            // Create a dictionary, so that we can easily look up a sample entry point with
-            // a sample file name.
+            // Create a dictionary, so that we can easily look up a sample entry point based on
+            // the filename of the sample.
             var samples = assembly
                           .DefinedTypes
                           .Select(t => GetEntryPoint(t))

--- a/tools/Google.Cloud.SampleUtil/ApplicationChooser.cs
+++ b/tools/Google.Cloud.SampleUtil/ApplicationChooser.cs
@@ -1,0 +1,110 @@
+// Copyright 2019 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Cloud.SampleUtil
+{
+	public class ApplicationChooser
+	{
+		public static void Run(string[] args)
+		{
+			if (args.Length == 0)
+			{
+				throw new NotImplementedException("Interative mode isn't implemented yet.");
+			}
+			string sample = args[0];
+			var assembly = Assembly.GetEntryAssembly();
+
+			// Create a dictionary, so that we can easily look up a sample entry point with
+			// a sample file name.
+			var samples = assembly
+			    .DefinedTypes
+			    .Select(t => GetEntryPoint(t))
+			    .Where(ep => ep != null && ep != assembly.EntryPoint)
+			    .ToDictionary(ep => ep.DeclaringType.Name.Replace("Main", string.Empty), ep => ep);
+
+			MethodBase main = samples[sample];
+			if (main == null)
+			{
+				throw new ArgumentException($"Can't find sample: {sample}");
+			}
+			try
+            {
+				Task task = main.Invoke(null, new object[] { args }) as Task;
+	            if (task != null)
+	            {
+	                task.GetAwaiter().GetResult();
+	            }
+	        }
+	        catch (Exception e)
+            {
+                // Normally we fail due to an exception within the
+                // code invoked via reflection.
+                // Unwrap the TargetInvocationException that would otherwise
+                // be wrapped in.
+                if (e is TargetInvocationException tie)
+                {
+                    e = tie.InnerException;
+                }
+                Console.WriteLine("Exception: {0}", e);
+            }
+		}
+
+		/// <summary>
+        /// Returns the entry point for a sample, or null if no entry points can be used.
+        /// An entry point taking string[] is preferred to one with no parameters.
+        /// </summary>
+	    private static MethodBase GetEntryPoint(TypeInfo type)
+	    {
+	    	if (type.IsGenericTypeDefinition || type.IsGenericType)
+            {
+                return null;
+            }
+            var methods = type.DeclaredMethods
+                .Where(m => m.IsStatic && m.Name == "Main" && !m.IsGenericMethodDefinition);
+
+            MethodInfo parameterless = null;
+            MethodInfo stringArrayParameter = null;
+
+            foreach (MethodInfo method in methods)
+            {
+                ParameterInfo[] parameters = method.GetParameters();
+                if (parameters.Length == 0)
+                {
+                    parameterless = method;
+                }
+                else
+                {
+                    if (parameters.Length == 1 &&
+                        !parameters[0].IsOut &&
+                        !parameters[0].IsOptional &&
+                        parameters[0].ParameterType == typeof(string[]))
+                    {
+                        stringArrayParameter = method;
+                    }
+                }
+            }
+
+            // Entry point of a sample should always have parameters, but allow one
+            // without parameters to be more resilient to sample style changes.
+            return stringArrayParameter ?? parameterless;
+	    }
+	}
+}

--- a/tools/Google.Cloud.SampleUtil/ApplicationChooser.cs
+++ b/tools/Google.Cloud.SampleUtil/ApplicationChooser.cs
@@ -35,10 +35,10 @@ namespace Google.Cloud.SampleUtil
 			// Create a dictionary, so that we can easily look up a sample entry point with
 			// a sample file name.
 			var samples = assembly
-			    .DefinedTypes
-			    .Select(t => GetEntryPoint(t))
-			    .Where(ep => ep != null && ep != assembly.EntryPoint)
-			    .ToDictionary(ep => ep.DeclaringType.Name.Replace("Main", string.Empty), ep => ep);
+				.DefinedTypes
+				.Select(t => GetEntryPoint(t))
+				.Where(ep => ep != null && ep != assembly.EntryPoint)
+				.ToDictionary(ep => ep.DeclaringType.Name.Replace("Main", string.Empty), ep => ep);
 
 			MethodBase main = samples[sample];
 			if (main == null)
@@ -46,65 +46,65 @@ namespace Google.Cloud.SampleUtil
 				throw new ArgumentException($"Can't find sample: {sample}");
 			}
 			try
-            {
+			{
 				Task task = main.Invoke(null, new object[] { args }) as Task;
-	            if (task != null)
-	            {
-	                task.GetAwaiter().GetResult();
-	            }
-	        }
-	        catch (Exception e)
-            {
-                // Normally we fail due to an exception within the
-                // code invoked via reflection.
-                // Unwrap the TargetInvocationException that would otherwise
-                // be wrapped in.
-                if (e is TargetInvocationException tie)
-                {
-                    e = tie.InnerException;
-                }
-                Console.WriteLine("Exception: {0}", e);
-            }
+				if (task != null)
+				{
+					task.GetAwaiter().GetResult();
+				}
+			}
+			catch (Exception e)
+			{
+				// Normally we fail due to an exception within the
+				// code invoked via reflection.
+				// Unwrap the TargetInvocationException that would otherwise
+				// be wrapped in.
+				if (e is TargetInvocationException tie)
+				{
+					e = tie.InnerException;
+				}
+				Console.WriteLine("Exception: {0}", e);
+			}
 		}
 
 		/// <summary>
-        /// Returns the entry point for a sample, or null if no entry points can be used.
-        /// An entry point taking string[] is preferred to one with no parameters.
-        /// </summary>
-	    private static MethodBase GetEntryPoint(TypeInfo type)
-	    {
-	    	if (type.IsGenericTypeDefinition || type.IsGenericType)
-            {
-                return null;
-            }
-            var methods = type.DeclaredMethods
-                .Where(m => m.IsStatic && m.Name == "Main" && !m.IsGenericMethodDefinition);
+		/// Returns the entry point for a sample, or null if no entry points can be used.
+		/// An entry point taking string[] is preferred to one with no parameters.
+		/// </summary>
+		private static MethodBase GetEntryPoint(TypeInfo type)
+		{
+			if (type.IsGenericTypeDefinition || type.IsGenericType)
+			{
+				return null;
+			}
+			var methods = type.DeclaredMethods
+				.Where(m => m.IsStatic && m.Name == "Main" && !m.IsGenericMethodDefinition);
 
-            MethodInfo parameterless = null;
-            MethodInfo stringArrayParameter = null;
+			MethodInfo parameterless = null;
+			MethodInfo stringArrayParameter = null;
 
-            foreach (MethodInfo method in methods)
-            {
-                ParameterInfo[] parameters = method.GetParameters();
-                if (parameters.Length == 0)
-                {
-                    parameterless = method;
-                }
-                else
-                {
-                    if (parameters.Length == 1 &&
-                        !parameters[0].IsOut &&
-                        !parameters[0].IsOptional &&
-                        parameters[0].ParameterType == typeof(string[]))
-                    {
-                        stringArrayParameter = method;
-                    }
-                }
-            }
+			foreach (MethodInfo method in methods)
+			{
+				ParameterInfo[] parameters = method.GetParameters();
+				if (parameters.Length == 0)
+				{
+					parameterless = method;
+				}
+				else
+				{
+					if (parameters.Length == 1 &&
+						!parameters[0].IsOut &&
+						!parameters[0].IsOptional &&
+						parameters[0].ParameterType == typeof(string[]))
+					{
+						stringArrayParameter = method;
+					}
+				}
+			}
 
-            // Entry point of a sample should always have parameters, but allow one
-            // without parameters to be more resilient to sample style changes.
-            return stringArrayParameter ?? parameterless;
-	    }
+			// Entry point of a sample should always have parameters, but allow one
+			// without parameters to be more resilient to sample style changes.
+			return stringArrayParameter ?? parameterless;
+		}
 	}
 }

--- a/tools/Google.Cloud.SampleUtil/ApplicationChooser.cs
+++ b/tools/Google.Cloud.SampleUtil/ApplicationChooser.cs
@@ -42,7 +42,7 @@ namespace Google.Cloud.SampleUtil
         {
             if (args.Length == 0)
             {
-                throw new NotImplementedException("Interative mode isn't implemented yet.");
+                throw new NotImplementedException("Interactive mode isn't implemented yet.");
             }
             string sample = args[0];
             var assembly = Assembly.GetEntryAssembly();
@@ -53,7 +53,7 @@ namespace Google.Cloud.SampleUtil
                           .DefinedTypes
                           .Select(t => GetEntryPoint(t))
                           .Where(ep => ep != null && ep != assembly.EntryPoint)
-                          .ToDictionary(ep => ep.DeclaringType.Name.Replace("Main", string.Empty), ep => ep);
+                          .ToDictionary(ep => GetSampleSourceFile(ep.DeclaringType.Name));
 
             MethodBase main = samples[sample];
             if (main == null)
@@ -120,6 +120,20 @@ namespace Google.Cloud.SampleUtil
             // Entry point of a sample should always have parameters, but allow one
             // without parameters to be more resilient to sample style changes.
             return stringArrayParameter ?? parameterless;
+        }
+
+        /// <summary>
+        /// Returns the source file name of a sample from the declaring type of it's Main.
+        /// Normally the declaring type should end with "Main", and all we need to do
+        /// is removing it.
+        /// </summary>
+        private static String GetSampleSourceFile(String declaringType)
+        {
+            if (declaringType.EndsWith("Main"))
+            {
+                return declaringType.Substring(0, declaringType.LastIndexOf("Main"));
+            }
+            throw new ArgumentException($"Expecting input to end with `Main`, got {declaringType}");
         }
     }
 }

--- a/tools/Google.Cloud.SampleUtil/ApplicationChooser.cs
+++ b/tools/Google.Cloud.SampleUtil/ApplicationChooser.cs
@@ -21,90 +21,90 @@ using System.Threading.Tasks;
 
 namespace Google.Cloud.SampleUtil
 {
-	public class ApplicationChooser
-	{
-		public static void Run(string[] args)
-		{
-			if (args.Length == 0)
-			{
-				throw new NotImplementedException("Interative mode isn't implemented yet.");
-			}
-			string sample = args[0];
-			var assembly = Assembly.GetEntryAssembly();
+    public class ApplicationChooser
+    {
+        public static void Run(string[] args)
+        {
+            if (args.Length == 0)
+            {
+                throw new NotImplementedException("Interative mode isn't implemented yet.");
+            }
+            string sample = args[0];
+            var assembly = Assembly.GetEntryAssembly();
 
-			// Create a dictionary, so that we can easily look up a sample entry point with
-			// a sample file name.
-			var samples = assembly
-				.DefinedTypes
-				.Select(t => GetEntryPoint(t))
-				.Where(ep => ep != null && ep != assembly.EntryPoint)
-				.ToDictionary(ep => ep.DeclaringType.Name.Replace("Main", string.Empty), ep => ep);
+            // Create a dictionary, so that we can easily look up a sample entry point with
+            // a sample file name.
+            var samples = assembly
+                          .DefinedTypes
+                          .Select(t => GetEntryPoint(t))
+                          .Where(ep => ep != null && ep != assembly.EntryPoint)
+                          .ToDictionary(ep => ep.DeclaringType.Name.Replace("Main", string.Empty), ep => ep);
 
-			MethodBase main = samples[sample];
-			if (main == null)
-			{
-				throw new ArgumentException($"Can't find sample: {sample}");
-			}
-			try
-			{
-				Task task = main.Invoke(null, new object[] { args }) as Task;
-				if (task != null)
-				{
-					task.GetAwaiter().GetResult();
-				}
-			}
-			catch (Exception e)
-			{
-				// Normally we fail due to an exception within the
-				// code invoked via reflection.
-				// Unwrap the TargetInvocationException that would otherwise
-				// be wrapped in.
-				if (e is TargetInvocationException tie)
-				{
-					e = tie.InnerException;
-				}
-				Console.WriteLine("Exception: {0}", e);
-			}
-		}
+            MethodBase main = samples[sample];
+            if (main == null)
+            {
+                throw new ArgumentException($"Can't find sample: {sample}");
+            }
+            try
+            {
+                Task task = main.Invoke(null, new object[] { args }) as Task;
+                if (task != null)
+                {
+                    task.GetAwaiter().GetResult();
+                }
+            }
+            catch (Exception e)
+            {
+                // Normally we fail due to an exception within the
+                // code invoked via reflection.
+                // Unwrap the TargetInvocationException that would otherwise
+                // be wrapped in.
+                if (e is TargetInvocationException tie)
+                {
+                    e = tie.InnerException;
+                }
+                Console.WriteLine("Exception: {0}", e);
+            }
+        }
 
-		/// <summary>
-		/// Returns the entry point for a sample, or null if no entry points can be used.
-		/// An entry point taking string[] is preferred to one with no parameters.
-		/// </summary>
-		private static MethodBase GetEntryPoint(TypeInfo type)
-		{
-			if (type.IsGenericTypeDefinition || type.IsGenericType)
-			{
-				return null;
-			}
-			var methods = type.DeclaredMethods
-				.Where(m => m.IsStatic && m.Name == "Main" && !m.IsGenericMethodDefinition);
+        /// <summary>
+        /// Returns the entry point for a sample, or null if no entry points can be used.
+        /// An entry point taking string[] is preferred to one with no parameters.
+        /// </summary>
+        private static MethodBase GetEntryPoint(TypeInfo type)
+        {
+            if (type.IsGenericTypeDefinition || type.IsGenericType)
+            {
+                return null;
+            }
+            var methods = type.DeclaredMethods
+                          .Where(m => m.IsStatic && m.Name == "Main" && !m.IsGenericMethodDefinition);
 
-			MethodInfo parameterless = null;
-			MethodInfo stringArrayParameter = null;
+            MethodInfo parameterless = null;
+            MethodInfo stringArrayParameter = null;
 
-			foreach (MethodInfo method in methods)
-			{
-				ParameterInfo[] parameters = method.GetParameters();
-				if (parameters.Length == 0)
-				{
-					parameterless = method;
-				}
-				else
-				{
-					if (parameters.Length == 1 &&
-						!parameters[0].IsOut &&
-						!parameters[0].IsOptional &&
-						parameters[0].ParameterType == typeof(string[]))
-					{
-						stringArrayParameter = method;
-					}
-				}
-			}
+            foreach (MethodInfo method in methods)
+            {
+                ParameterInfo[] parameters = method.GetParameters();
+                if (parameters.Length == 0)
+                {
+                    parameterless = method;
+                }
+                else
+                {
+                    if (parameters.Length == 1 &&
+                            !parameters[0].IsOut &&
+                            !parameters[0].IsOptional &&
+                            parameters[0].ParameterType == typeof(string[]))
+                    {
+                        stringArrayParameter = method;
+                    }
+                }
+            }
 
-			// Entry point of a sample should always have parameters, but allow one
-			// without parameters to be more resilient to sample style changes.
-			return stringArrayParameter ?? parameterless;
-		}
-	}
+            // Entry point of a sample should always have parameters, but allow one
+            // without parameters to be more resilient to sample style changes.
+            return stringArrayParameter ?? parameterless;
+        }
+    }
 }

--- a/tools/Google.Cloud.SampleUtil/Google.Cloud.SampleUtil.csproj
+++ b/tools/Google.Cloud.SampleUtil/Google.Cloud.SampleUtil.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PackageId>Google.Cloud.SampleUtil</PackageId>
+    <IsPackable>false</IsPackable>
     <Description>Utilities for running code samples.</Description>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>

--- a/tools/Google.Cloud.SampleUtil/Google.Cloud.SampleUtil.csproj
+++ b/tools/Google.Cloud.SampleUtil/Google.Cloud.SampleUtil.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Google.Cloud.SampleUtil</PackageId>
+    <Description>Utilities for running code samples.</Description>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Google.Cloud.Tools.Common\Google.Cloud.Tools.Common.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tools/Google.Cloud.Tools.ProjectGenerator/Program.cs
+++ b/tools/Google.Cloud.Tools.ProjectGenerator/Program.cs
@@ -38,7 +38,7 @@ namespace Google.Cloud.Tools.ProjectGenerator
             { "Google.Cloud.ClientTesting", @"..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" },
             { "Google.Cloud.Diagnostics.Common.Tests", @"..\..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.Tests\Google.Cloud.Diagnostics.Common.Tests.csproj" },
             { "Google.Cloud.Diagnostics.Common.IntegrationTests", @"..\..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.IntegrationTests\Google.Cloud.Diagnostics.Common.IntegrationTests.csproj" },
-            { "Google.Cloud.Tools.SampleUtil", @"..\..\..\tools\Google.Cloud.SampleUtil\Google.Cloud.SampleUtil.csproj"}
+            { "Google.Cloud.SampleUtil", @"..\..\..\tools\Google.Cloud.SampleUtil\Google.Cloud.SampleUtil.csproj"}
         };
 
         private const string DefaultRestTargetFrameworks = "netstandard1.3;netstandard2.0;net45";
@@ -95,7 +95,7 @@ namespace Google.Cloud.Tools.ProjectGenerator
         private static readonly Dictionary<string, string> CommonSampleDependencies = new Dictionary<string, string>
         {
             { "CommandLineParser", "2.6.0" },
-            { "Google.Cloud.Tools.SampleUtil", }
+            { "Google.Cloud.SampleUtil", "project"}
         };
 
         private const string CompatibilityAnalyzer = "Microsoft.DotNet.Analyzers.Compatibility";
@@ -490,7 +490,7 @@ shell.run(
                     new XElement("TargetFramework", "netcoreapp2.1"),
                     new XElement("OutputType", "Exe"),
                     new XElement("LangVersion", "latest"),
-                    new XElement("IsPackable", false)
+                    new XElement("IsPackable", false),
                     new XElement("StartupObject", api.Id + ".Samples.Program"));
 
             string project = Path.GetFileName(directory);

--- a/tools/Google.Cloud.Tools.ProjectGenerator/Program.cs
+++ b/tools/Google.Cloud.Tools.ProjectGenerator/Program.cs
@@ -37,7 +37,8 @@ namespace Google.Cloud.Tools.ProjectGenerator
             { "Google.Cloud.AnalyzersTesting", @"..\..\..\tools\Google.Cloud.AnalyzersTesting\Google.Cloud.AnalyzersTesting.csproj" },
             { "Google.Cloud.ClientTesting", @"..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" },
             { "Google.Cloud.Diagnostics.Common.Tests", @"..\..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.Tests\Google.Cloud.Diagnostics.Common.Tests.csproj" },
-            { "Google.Cloud.Diagnostics.Common.IntegrationTests", @"..\..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.IntegrationTests\Google.Cloud.Diagnostics.Common.IntegrationTests.csproj" }
+            { "Google.Cloud.Diagnostics.Common.IntegrationTests", @"..\..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.IntegrationTests\Google.Cloud.Diagnostics.Common.IntegrationTests.csproj" },
+            { "Google.Cloud.Tools.SampleUtil", @"..\..\..\tools\Google.Cloud.SampleUtil\Google.Cloud.SampleUtil.csproj"}
         };
 
         private const string DefaultRestTargetFrameworks = "netstandard1.3;netstandard2.0;net45";
@@ -93,7 +94,8 @@ namespace Google.Cloud.Tools.ProjectGenerator
 
         private static readonly Dictionary<string, string> CommonSampleDependencies = new Dictionary<string, string>
         {
-            { "CommandLineParser", "2.6.0" }
+            { "CommandLineParser", "2.6.0" },
+            { "Google.Cloud.Tools.SampleUtil", }
         };
 
         private const string CompatibilityAnalyzer = "Microsoft.DotNet.Analyzers.Compatibility";
@@ -488,7 +490,8 @@ shell.run(
                     new XElement("TargetFramework", "netcoreapp2.1"),
                     new XElement("OutputType", "Exe"),
                     new XElement("LangVersion", "latest"),
-                    new XElement("IsPackable", false));
+                    new XElement("IsPackable", false)
+                    new XElement("StartupObject", api.Id + ".Samples.Program"));
 
             string project = Path.GetFileName(directory);
             var dependenciesElement = CreateDependenciesElement(project, dependencies, api.IsReleaseVersion, testProject: true, apiNames: apiNames);


### PR DESCRIPTION
- Implement an `ApplicationChooser` with extensive copy and paste from Jon's `DemoCode` repo (non-interactive mode only)
- Update the project generator to generator project files for samples that reference the `ApplicationChooser`, as well as configures the `StartupObject` to `Google.Cloud.SomeApi.V1.Samples.Program`
- An upcoming PR in gapic-generator to generate the `Program.cs` per API will come shortly
