### PR TITLE
Release Google.Cloud.Tasks.V2 version 1.1.0-beta02

### DIFF
--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.csproj
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0-beta01</Version>
+    <Version>1.1.0-beta02</Version>
     <TargetFrameworks>netstandard1.5;netstandard2.0;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -909,7 +909,7 @@
     "serviceYaml": "cloudtasks_v2.yaml",
     "productName": "Google Cloud Tasks",
     "productUrl": "https://cloud.google.com/tasks/",
-    "version": "1.1.0-beta01",
+    "version": "1.1.0-beta02",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Tasks API (v2), which manages the execution of large numbers of distributed requests.",
     "tags": [ "Tasks" ],


### PR DESCRIPTION
Changes since 1.1.0-beta01:

- Added Format methods for resource names
- Added HttpRequest message target and related types
- gRPC-generated BindService method