### PR TITLE
Feature: trace name provider

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Trace/CloudTraceMiddlewareTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Trace/CloudTraceMiddlewareTest.cs
@@ -67,7 +67,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Tests
 
             Assert.Equal(NullManagedTracer.Instance, ContextTracerManager.GetCurrentTracer());
 
-            var middleware = new CloudTraceMiddleware(delegateMock.Object, fakeFactory);
+            var middleware = new CloudTraceMiddleware(delegateMock.Object, fakeFactory, new DefaultCloudTraceNameProvider());
             await middleware.Invoke(context, _traceHeaderContext);
 
             // Since the current tracer is AsyncLocal<>, it will be back to the default after awaiting the middleware invoke
@@ -92,7 +92,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Tests
 
             Func<TraceHeaderContext, IManagedTracer> fakeFactory = f => tracerMock.Object;
 
-            var middleware = new CloudTraceMiddleware(delegateMock.Object, fakeFactory);
+            var middleware = new CloudTraceMiddleware(delegateMock.Object, fakeFactory, new DefaultCloudTraceNameProvider());
             await Assert.ThrowsAsync<DivideByZeroException>(
                 () => middleware.Invoke(context, _traceHeaderContext));
 
@@ -117,7 +117,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Tests
 
             Func<TraceHeaderContext, IManagedTracer> fakeFactory = f => tracerMock.Object;
 
-            var middleware = new CloudTraceMiddleware(delegateMock.Object, fakeFactory);
+            var middleware = new CloudTraceMiddleware(delegateMock.Object, fakeFactory, new DefaultCloudTraceNameProvider());
             await Assert.ThrowsAsync<AggregateException>(
                 () => middleware.Invoke(context, _traceHeaderContext));
 
@@ -137,7 +137,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Tests
 
             Func<TraceHeaderContext, IManagedTracer> fakeFactory = f => tracerMock.Object;
 
-            var middleware = new CloudTraceMiddleware(delegateMock.Object, fakeFactory);
+            var middleware = new CloudTraceMiddleware(delegateMock.Object, fakeFactory, new DefaultCloudTraceNameProvider());
             await middleware.Invoke(context, _traceHeaderContext);
 
             // Since the current tracer is AsyncLocal<>, it will be back to the default after awaiting the middleware invoke

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/CloudTraceExtension.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/CloudTraceExtension.cs
@@ -117,7 +117,8 @@ namespace Google.Cloud.Diagnostics.AspNetCore
             services.AddSingleton(tracerFactory);
             services.AddHttpContextAccessor();
             services.AddSingleton(ManagedTracer.CreateDelegatingTracer(ContextTracerManager.GetCurrentTracer));
-
+            services.AddTransient<ICloudTraceNameProvider, DefaultCloudTraceNameProvider>();
+            
             // On .Net Standard 2.0 or higher, we can use the System.Net.Http.IHttpClientFactory defined in Microsoft.Extensions.Http,
             // for which we need a DelagatingHandler with no InnerHandler set. This is the recommended way.
             // It should be registered as follows.

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/DefaultCloudTraceNameProvider.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/DefaultCloudTraceNameProvider.cs
@@ -1,0 +1,31 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.AspNetCore.Http;
+using System.Threading.Tasks;
+
+namespace Google.Cloud.Diagnostics.AspNetCore
+{
+    /// <summary>
+    /// Default cloud trace name provider that uses the request path as the name.
+    /// Useful for MVC apps and REST apis 
+    /// </summary>
+    internal class DefaultCloudTraceNameProvider : ICloudTraceNameProvider
+    {
+        public Task<string> GetTraceNameAsync(HttpContext httpContext)
+        {
+            return Task.FromResult(httpContext.Request.Path.ToString());
+        }
+    }
+}

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/ICloudTraceNameProvider.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Trace/ICloudTraceNameProvider.cs
@@ -1,0 +1,33 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.AspNetCore.Http;
+using System.Threading.Tasks;
+
+namespace Google.Cloud.Diagnostics.AspNetCore
+{
+    /// <summary>
+    /// Interface for implementing providers that can name trace spans 
+    /// </summary>
+    public interface ICloudTraceNameProvider
+    {
+        /// <summary>
+        /// When overriden in an implementing class it will return the name of the trace span based off the content
+        /// in the HttpContext
+        /// </summary>
+        /// <param name="httpContext">The current request's HttpContext</param>
+        /// <returns>A string with the name of the trace</returns>
+        Task<string> GetTraceNameAsync(HttpContext httpContext);
+    }
+}


### PR DESCRIPTION
This PR closes #3704 by

1. Adding a public `ICloudTraceNameProvider` interface with a default implementation that takes the current request's path
2. Taking in the `ICloudTraceNameProvider` in the Cloud trace middleware, replacing the call to `context.Request.Path`

Interface and implementation is added by the `AddGoogleTrace` container extension method.