### PR TITLE
Prepare for next-major-version work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ build_timing_log.txt
 
 # Currently, we don't want to keep synthtool metadata. (This may change.)
 synth.metadata
+
+# Temporary local GAX
+gax-dotnet

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="Local GAX" value="./gax-dotnet/nuget" />
+  </packageSources>
+</configuration>

--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,14 @@ set -e
 
 cd $(dirname $0)
 
+# Temporary measure: clone and build GAX locally
+# We don't have public releases for GAX 3.x yet.
+
+if [[ ! -d gax-dotnet/nuget ]]
+then
+  ./fetch-latest-gax.sh
+fi
+
 source toolversions.sh
 
 # Disable automatic test reporting to AppVeyor.

--- a/fetch-latest-gax.sh
+++ b/fetch-latest-gax.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+echo "Fetching and building GAX"
+
+git clone -q https://github.com/googleapis/gax-dotnet.git
+dotnet pack -v quiet -c Release -o $PWD/gax-dotnet/nuget gax-dotnet/Gax.sln


### PR DESCRIPTION
We'll merge this to a new branch, which will allow us to explore the changes required without disturbing other work targeting GAX 2.10.