### PR TITLE
[BigQuery] Loosens the restriction on JobConfigurationQuery.DestinationTable not being null.

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/QueryTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/QueryTest.cs
@@ -676,6 +676,21 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
         }
 
         [Fact]
+        public void ScriptQuery()
+        {
+            var client = BigQueryClient.Create(_fixture.ProjectId);
+
+            string sql = "DECLARE accumulator INT64 DEFAULT 5; SELECT accumulator;";
+            var results = client.ExecuteQuery(sql, null).ThrowOnAnyError();
+
+            Assert.True(results.SafeTotalRows.HasValue);
+            Assert.Equal<ulong>(1, results.SafeTotalRows.Value);
+
+            var row = results.Single();
+            Assert.Equal((long)5, row[0]);
+        }
+
+        [Fact]
         public void GisQuery()
         {
             var client = BigQueryClient.Create(_fixture.ProjectId);

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryJobTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryJobTest.cs
@@ -86,23 +86,6 @@ namespace Google.Cloud.BigQuery.V2.Tests
         }
 
         [Fact]
-        public async Task GetQueryResults_NoDestinationTable()
-        {
-            var resource = new Job
-            {
-                JobReference = new JobReference { ProjectId = "project", JobId = "job" },
-                Configuration = new JobConfiguration
-                {
-                    DryRun = true,
-                    Query = new JobConfigurationQuery { } // No destination table
-                }
-            };
-            var job = new BigQueryJob(new SimpleClient(), resource);
-            Assert.Throws<InvalidOperationException>(() => job.GetQueryResults());
-            await Assert.ThrowsAsync<InvalidOperationException>(() => job.GetQueryResultsAsync());
-        }
-
-        [Fact]
         public async Task GetQueryResults_NoJobReference()
         {
             var resource = new Job

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.Queries.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.Queries.cs
@@ -81,7 +81,6 @@ namespace Google.Cloud.BigQuery.V2
         internal override BigQueryResults GetQueryResults(JobReference jobReference, TableReference tableReference, GetQueryResultsOptions options)
         {
             GaxPreconditions.CheckNotNull(jobReference, nameof(jobReference));
-            GaxPreconditions.CheckNotNull(tableReference, nameof(tableReference));
 
             DateTime start = Clock.GetCurrentDateTimeUtc();
             while (true)
@@ -112,7 +111,6 @@ namespace Google.Cloud.BigQuery.V2
         internal override async Task<BigQueryResults> GetQueryResultsAsync(JobReference jobReference, TableReference tableReference, GetQueryResultsOptions options, CancellationToken cancellationToken)
         {
             GaxPreconditions.CheckNotNull(jobReference, nameof(jobReference));
-            GaxPreconditions.CheckNotNull(tableReference, nameof(tableReference));
 
             DateTime start = Clock.GetCurrentDateTimeUtc();
             while (true)

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryPage.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryPage.cs
@@ -31,7 +31,8 @@ namespace Google.Cloud.BigQuery.V2
         public JobReference JobReference { get; }
 
         /// <summary>
-        /// Reference to the table this result set was fetched from.
+        /// Reference to the table this result set may has been fetched from.
+        /// May be null. (For example, script queries don't store results in tables.)
         /// </summary>
         public TableReference TableReference { get; }
 
@@ -59,7 +60,8 @@ namespace Google.Cloud.BigQuery.V2
         /// <param name="rows">The rows returned in the query. Must not be null.</param>
         /// <param name="schema">The schema of the results. Must not be null.</param>
         /// <param name="jobReference">Reference to the job this result set was fetched from. Must not be null.</param>
-        /// <param name="tableReference">Reference to the table this result set was fetched from. Must not be null.</param>
+        /// <param name="tableReference">Reference to the table this result set may has been fetched from.
+        /// May be null. (For example, script queries don't store results in tables.)</param>
         /// <param name="nextPageToken">The page token to use to fetch further results. May be null, indicating
         /// that there are no more results.</param>
         public BigQueryPage(List<BigQueryRow> rows, TableSchema schema, JobReference jobReference, TableReference tableReference, string nextPageToken)
@@ -67,7 +69,7 @@ namespace Google.Cloud.BigQuery.V2
             Rows = GaxPreconditions.CheckNotNull(rows, nameof(rows));
             Schema = GaxPreconditions.CheckNotNull(schema, nameof(schema));
             JobReference = GaxPreconditions.CheckNotNull(jobReference, nameof(jobReference));
-            TableReference = GaxPreconditions.CheckNotNull(tableReference, nameof(tableReference));
+            TableReference = tableReference;
             NextPageToken = nextPageToken;
         }
 
@@ -79,7 +81,7 @@ namespace Google.Cloud.BigQuery.V2
             Rows = page.ToList();
             Schema = GaxPreconditions.CheckNotNull(schema, nameof(schema));
             JobReference = GaxPreconditions.CheckNotNull(jobReference, nameof(jobReference));
-            TableReference = GaxPreconditions.CheckNotNull(tableReference, nameof(tableReference));
+            TableReference = tableReference;
             NextPageToken = page.NextPageToken;
         }
     }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryResults.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryResults.cs
@@ -46,6 +46,7 @@ namespace Google.Cloud.BigQuery.V2
 
         /// <summary>
         /// The reference to the table containing the query results.
+        /// May be null. (For example, script queries don't store results in tables.)
         /// </summary>
         public TableReference TableReference { get; }
 
@@ -101,7 +102,8 @@ namespace Google.Cloud.BigQuery.V2
         /// </remarks>
         /// <param name="client">The client to use for further operations. Must not be null.</param>
         /// <param name="response">The response to a GetQueryResults API call. Must not be null.</param>
-        /// <param name="tableReference">A reference to the table containing the results.</param>
+        /// <param name="tableReference">A reference to the table containing the results.
+        /// May be null. (For example, script queries don't store results in tables.)</param>
         /// <param name="options">Options to use when listing rows. May be null.</param>
         [Obsolete("Please use the constructor accepting a GetQueryResultsOptions instead")]
         public BigQueryResults(BigQueryClient client, GetQueryResultsResponse response, TableReference tableReference, ListRowsOptions options)
@@ -118,13 +120,14 @@ namespace Google.Cloud.BigQuery.V2
         /// </remarks>
         /// <param name="client">The client to use for further operations. Must not be null.</param>
         /// <param name="response">The response to a GetQueryResults API call. Must not be null.</param>
-        /// <param name="tableReference">A reference to the table containing the results.</param>
+        /// <param name="tableReference">A reference to the table containing the results.
+        /// May be null. (For example, script queries don't store results in tables.)</param>
         /// <param name="options">Options to use when fetching results. May be null.</param>
         public BigQueryResults(BigQueryClient client, GetQueryResultsResponse response, TableReference tableReference, GetQueryResultsOptions options)
         {
             _client = GaxPreconditions.CheckNotNull(client, nameof(client));
             _response = GaxPreconditions.CheckNotNull(response, nameof(response));
-            TableReference = GaxPreconditions.CheckNotNull(tableReference, nameof(tableReference));
+            TableReference = tableReference;
             _options = options;
             _fieldNames = response.Schema?.IndexFieldNames();
         }


### PR DESCRIPTION
Script queries don't store results in destination tables.

I've checked that we weren't using the destination table and also all tests passed locally.