### PR TITLE
Update Google.LongRunning to 2.0.0-beta00

### DIFF
--- a/apis/Google.LongRunning/Google.LongRunning/Google.LongRunning.csproj
+++ b/apis/Google.LongRunning/Google.LongRunning/Google.LongRunning.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.2.0-beta01</Version>
+    <Version>2.0.0-beta00</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1036,7 +1036,7 @@
     "generator": "gapic",
     "protoPath": "google/longrunning",
     "serviceYaml": "longrunning/longrunning.yaml",
-    "version": "1.2.0-beta01",
+    "version": "2.0.0-beta00",
     "type": "grpc",
     "description": "gRPC services for the Google Long Running Operations API. This library is typically used as a dependency for other API client libraries.",
     "tags": [ "LongRunning" ],


### PR DESCRIPTION
This will be the next major version, and we need it ahead of everything else as the microgenerator depends on it.