### PR TITLE
Remove dotnet restore from tagreleases.sh

### DIFF
--- a/tagreleases.sh
+++ b/tagreleases.sh
@@ -8,5 +8,4 @@ then
   exit 1
 fi
 
-dotnet restore tools > /dev/null
-dotnet run -p tools/Google.Cloud.Tools.TagReleases/Google.Cloud.Tools.TagReleases.csproj $1
+dotnet run -p tools/Google.Cloud.Tools.TagReleases -- $1


### PR DESCRIPTION
This is unnecessary now, and fails on Linux because of projects in tools that want full .NET