### PR TITLE
Adds clustering data to the info returned about BQ tables

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryClientImplTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryClientImplTest.cs
@@ -606,9 +606,11 @@ namespace Google.Cloud.BigQuery.V2.Tests
                 TableReference = new TableReference { DatasetId = "dataset", TableId = "id", ProjectId = "project" },
                 TimePartitioning = new TimePartitioning { ExpirationMs = 10000, Type = "DAY" },
                 Type = "VIEW",
-                View = new TableList.TablesData.ViewData { UseLegacySql = true }
+                View = new TableList.TablesData.ViewData { UseLegacySql = true },
+                Clustering = new Clustering { Fields = new[] { "ClusterCol1", "ClusterCol2" } },
+                CreationTime = (int)(DateTime.UtcNow - new DateTime(1970, 1, 1)).TotalSeconds,
+                ExpirationTime = (int)(DateTime.UtcNow - new DateTime(1970, 1, 1)).TotalSeconds
             };
-
             var tableResource = BigQueryClientImpl.TablePageManager.ConvertResource(listResource);
             Assert.Equal("friendly name", tableResource.FriendlyName);
             Assert.Equal("id", tableResource.Id);
@@ -617,6 +619,9 @@ namespace Google.Cloud.BigQuery.V2.Tests
             Assert.Same(listResource.TableReference, tableResource.TableReference);
             Assert.Equal("VIEW", tableResource.Type);
             Assert.True(tableResource.View.UseLegacySql);
+            Assert.Equal(listResource.Clustering.Fields, tableResource.Clustering.Fields);
+            Assert.Equal(listResource.CreationTime, tableResource.CreationTime);
+            Assert.Equal(listResource.ExpirationTime, tableResource.ExpirationTime);
         }
 
         [Fact]

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.TableCrud.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.TableCrud.cs
@@ -49,6 +49,9 @@ namespace Google.Cloud.BigQuery.V2
             internal static Table ConvertResource(TableList.TablesData resource) =>
                 new Table
                 {
+                    Clustering = resource.Clustering,
+                    CreationTime = resource.CreationTime,
+                    ExpirationTime = resource.ExpirationTime,
                     FriendlyName = resource.FriendlyName,
                     Id = resource.Id,
                     Kind = resource.Kind,


### PR DESCRIPTION
While trying to use the API to return back the list of clustering columns for a table I noticed BigQueryTable.Resource.Clustering was empty.  It looks as if it was not being mapped to the returned data from the API call although the Clustering property existed in the table class.  

This commit added a unit test and populates the table's clustering info.