### PR TITLE
Release Google.Cloud.BigQuery.V2 version 1.4.0-beta07

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.4.0-beta06</Version>
+    <Version>1.4.0-beta07</Version>
     <TargetFrameworks>netstandard1.3;netstandard2.0;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.3;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.BigQuery.V2/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.V2/docs/history.md
@@ -1,9 +1,12 @@
 # Version history
 
-# 1.4.0-beta06, 2019-11-13
+# 1.4.0-beta07, 2019-11-19
 
 Changes since 1.3.0:
 
+- Add TemplateSuffix, SkipInvalidRows and SuppressInsertErrors to InsertOptions.
+- Add DefaultPartitionExpiration and DefaultEncryptionConfiguration to CreateDatasetOptions.
+- Add table CreationTime, ExpirationTime and Clustering info to ListTables output.
 - Loosen the restriction on JobConfigurationQuery.DestinationTable not being null.
 - Provide option for using Avro logical types for load/extract.
 - Adds creation time filtering to BigQuery job listing.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -68,7 +68,7 @@
     "id": "Google.Cloud.BigQuery.V2",
     "productName": "Google BigQuery",
     "productUrl": "https://cloud.google.com/bigquery/",
-    "version": "1.4.0-beta06",
+    "version": "1.4.0-beta07",
     "type": "rest",
     "description": "Recommended Google client library to access the BigQuery API. It wraps the Google.Apis.Bigquery.v2 client library, making common operations simpler in client code. BigQuery is a data platform for customers to create, manage, share and query data.",
     "dependencies": {


### PR DESCRIPTION
- Add TemplateSuffix, SkipInvalidRows and SuppressInsertErrors to InsertOptions.
- Add DefaultPartitionExpiration and DefaultEncryptionConfiguration to CreateDatasetOptions.
- Add table CreationTime, ExpirationTime and Clustering info to ListTables output.