### PR TITLE
Implement In and ArrayContainsAny Firestore queries

### DIFF
--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/QueryTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/QueryTest.cs
@@ -235,7 +235,78 @@ namespace Google.Cloud.Firestore.Tests
                 From = { new CollectionSelector { CollectionId = "col" } }
             };
             Assert.Equal(expected, query.ToStructuredQuery());
-        }        
+        }
+
+        [Fact]
+        public void WhereIn_String()
+        {
+            var query = GetEmptyQuery().WhereIn("a.b", new[] { 10, 20 });
+            var expected = new StructuredQuery
+            {
+                Where = Filter(new FieldFilter { Field = Field("a.b"), Op = FieldFilter.Types.Operator.In, Value = CreateArray(CreateValue(10), CreateValue(20)) }),
+                From = { new CollectionSelector { CollectionId = "col" } }
+            };
+            Assert.Equal(expected, query.ToStructuredQuery());
+        }
+
+        [Fact]
+        public void WhereIn_FieldPath()
+        {
+            var query = GetEmptyQuery().WhereIn(new FieldPath("a", "b"), new[] { 10, 20 });
+            var expected = new StructuredQuery
+            {
+                Where = Filter(new FieldFilter { Field = Field("a.b"), Op = FieldFilter.Types.Operator.In, Value = CreateArray(CreateValue(10), CreateValue(20)) }),
+                From = { new CollectionSelector { CollectionId = "col" } }
+            };
+            Assert.Equal(expected, query.ToStructuredQuery());
+        }
+
+        [Fact]
+        public void WhereArrayContainsAny_String()
+        {
+            var query = GetEmptyQuery().WhereArrayContainsAny("a.b", new[] { 10, 20 });
+            var expected = new StructuredQuery
+            {
+                Where = Filter(new FieldFilter { Field = Field("a.b"), Op = FieldFilter.Types.Operator.ArrayContainsAny, Value = CreateArray(CreateValue(10), CreateValue(20)) }),
+                From = { new CollectionSelector { CollectionId = "col" } }
+            };
+            Assert.Equal(expected, query.ToStructuredQuery());
+        }
+
+        [Fact]
+        public void WhereArrayContainsAny_FieldPath()
+        {
+            var query = GetEmptyQuery().WhereArrayContainsAny(new FieldPath("a", "b"), new[] { 10, 20 });
+            var expected = new StructuredQuery
+            {
+                Where = Filter(new FieldFilter { Field = Field("a.b"), Op = FieldFilter.Types.Operator.ArrayContainsAny, Value = CreateArray(CreateValue(10), CreateValue(20)) }),
+                From = { new CollectionSelector { CollectionId = "col" } }
+            };
+            Assert.Equal(expected, query.ToStructuredQuery());
+        }
+
+        [Fact]
+        public void Where_FiltersThatProhibitNullValue()
+        {
+            // Just for operations which prohibit them
+            var query = GetEmptyQuery();
+            Assert.ThrowsAny<ArgumentException>(() => query.WhereLessThan("a.b", null));
+            Assert.ThrowsAny<ArgumentException>(() => query.WhereLessThanOrEqualTo("a.b", null));
+            Assert.ThrowsAny<ArgumentException>(() => query.WhereGreaterThan("a.b", null));
+            Assert.ThrowsAny<ArgumentException>(() => query.WhereGreaterThanOrEqualTo("a.b", null));
+            Assert.ThrowsAny<ArgumentException>(() => query.WhereArrayContains("a.b", null));
+            Assert.ThrowsAny<ArgumentException>(() => query.WhereIn("a.b", null));
+            Assert.ThrowsAny<ArgumentException>(() => query.WhereArrayContainsAny("a.b", null));
+
+            var fieldPath = new FieldPath("a", "b");
+            Assert.ThrowsAny<ArgumentException>(() => query.WhereLessThan(fieldPath, null));
+            Assert.ThrowsAny<ArgumentException>(() => query.WhereLessThanOrEqualTo(fieldPath, null));
+            Assert.ThrowsAny<ArgumentException>(() => query.WhereGreaterThan(fieldPath, null));
+            Assert.ThrowsAny<ArgumentException>(() => query.WhereGreaterThanOrEqualTo(fieldPath, null));
+            Assert.ThrowsAny<ArgumentException>(() => query.WhereArrayContains(fieldPath, null));
+            Assert.ThrowsAny<ArgumentException>(() => query.WhereIn(fieldPath, null));
+            Assert.ThrowsAny<ArgumentException>(() => query.WhereArrayContainsAny(fieldPath, null));
+        }
 
         // Test for methods which replace previous values
         [Fact]

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Query.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Query.cs
@@ -17,6 +17,7 @@ using Google.Api.Gax.Grpc;
 using Google.Cloud.Firestore.V1;
 using Google.Protobuf;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -297,6 +298,59 @@ namespace Google.Cloud.Firestore
         /// <returns>A new query based on the current one, but with the additional specified filter applied.</returns>
         public Query WhereArrayContains(FieldPath fieldPath, object value) =>
             Where(fieldPath, FieldOp.ArrayContains, value);
+
+
+        /// <summary>
+        /// Returns a query with a filter specifying that <paramref name="fieldPath"/> must be
+        /// a field present in the document, with a value which is an array containing at least one value in <paramref name="values"/>.
+        /// </summary>
+        /// <remarks>
+        /// This call adds additional filters to any previously-specified ones.
+        /// </remarks>
+        /// <param name="fieldPath">The dot-separated field path to filter on. Must not be null or empty.</param>
+        /// <param name="values">The values to compare in the filter. Must not be null.</param>
+        /// <returns>A new query based on the current one, but with the additional specified filter applied.</returns>
+        public Query WhereArrayContainsAny(string fieldPath, IEnumerable values) =>
+            Where(fieldPath, FieldOp.ArrayContainsAny, values);
+
+        /// <summary>
+        /// Returns a query with a filter specifying that <paramref name="fieldPath"/> must be
+        /// a field present in the document, with a value which is an array containing at least one value in <paramref name="values"/>.
+        /// </summary>
+        /// <remarks>
+        /// This call adds additional filters to any previously-specified ones.
+        /// </remarks>
+        /// <param name="fieldPath">The field path to filter on. Must not be null.</param>
+        /// <param name="values">The values to compare in the filter. Must not be null.</param>
+        /// <returns>A new query based on the current one, but with the additional specified filter applied.</returns>
+        public Query WhereArrayContainsAny(FieldPath fieldPath, IEnumerable values) =>
+            Where(fieldPath, FieldOp.ArrayContainsAny, values);
+
+        /// <summary>
+        /// Returns a query with a filter specifying that <paramref name="fieldPath"/> must be
+        /// a field present in the document, with a value which is one of the values <paramref name="values"/>.
+        /// </summary>
+        /// <remarks>
+        /// This call adds additional filters to any previously-specified ones.
+        /// </remarks>
+        /// <param name="fieldPath">The dot-separated field path to filter on. Must not be null or empty.</param>
+        /// <param name="values">The values to compare in the filter. Must not be null.</param>
+        /// <returns>A new query based on the current one, but with the additional specified filter applied.</returns>
+        public Query WhereIn(string fieldPath, IEnumerable values) =>
+            Where(fieldPath, FieldOp.In, values);
+
+        /// <summary>
+        /// Returns a query with a filter specifying that <paramref name="fieldPath"/> must be
+        /// a field present in the document, with a value which is one of the values <paramref name="values"/>.
+        /// </summary>
+        /// <remarks>
+        /// This call adds additional filters to any previously-specified ones.
+        /// </remarks>
+        /// <param name="fieldPath">The field path to filter on. Must not be null.</param>
+        /// <param name="values">The values to compare in the filter. Must not be null.</param>
+        /// <returns>A new query based on the current one, but with the additional specified filter applied.</returns>
+        public Query WhereIn(FieldPath fieldPath, IEnumerable values) =>
+            Where(fieldPath, FieldOp.In, values);
 
         // Note: the two general Where methods were originally public, accepting a public QueryOperator enum.
         // If we ever want to make them public again, we should reinstate the QueryOperator enum to avoid an API


### PR DESCRIPTION
Fixes #3783.

Note that this does *not* validate some extra constraints on the query:

- The inability to mix cursors these filters
- The inability to mix WhereArrayContainsAny and WhereArrayContains or WhereIn

I'm currently assuming it's fine for those to be validated server-side.