### PR TITLE
Release Google.Cloud.Firestore 1.1.0

### DIFF
--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.csproj
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0-beta02</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Google.Cloud.Firestore.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Google.Cloud.Firestore.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0-beta02</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -381,7 +381,7 @@
     "id": "Google.Cloud.Firestore",
     "productName": "Firestore",
     "productUrl": "https://firebase.google.com/docs/firestore/",
-    "version": "1.1.0-beta02",
+    "version": "1.1.0",
     "type": "other",
     "targetFrameworks": "netstandard2.0;net45",
     "testTargetFrameworks": "netcoreapp2.1;net452",
@@ -389,11 +389,11 @@
     "tags": [ "firestore", "firebase" ],
     "dependencies": {
       "Google.Cloud.Firestore.V1": "project",
-      "Grpc.Core": "default"
+      "Grpc.Core": "1.22.1"
     },
     "testDependencies": {
-      "Google.Api.Gax.Testing": "default",
-      "Grpc.Core.Testing": "default",
+      "Google.Api.Gax.Testing": "2.10.0",
+      "Grpc.Core.Testing": "1.22.1",
       "System.ValueTuple": "4.5.0",
       "Xunit.Combinatorial": "1.2.7"
     }
@@ -406,14 +406,16 @@
     "serviceYaml": "firestore_v1.yaml",
     "productName": "Firestore",
     "productUrl": "https://firebase.google.com",
-    "version": "1.1.0-beta02",
+    "version": "1.1.0",
     "type": "grpc",
     "targetFrameworks": "netstandard2.0;net45",
     "testTargetFrameworks": "netcoreapp2.1;net452",
     "description": "Low-level Google client library to access the Firestore API. Users are recommended to use the Google.Cloud.Firestore package instead.",
     "tags": [ "firestore", "firebase" ],
     "dependencies": {
-      "Google.LongRunning": "1.1.0"
+      "Google.LongRunning": "1.1.0",
+      "Google.Api.Gax.Grpc": "2.10.0",
+      "Grpc.Core": "1.22.1"
     }
   },
 


### PR DESCRIPTION
Changes since 1.0.0
---

- Support for In and ArrayContainsAny queries (#3783)
- Firestore emulator support (#3397)
- Conversion support for named value tuples (#2787)
- FirestoreDbBuilder for simplified configuration beyond defaults
- Per-FirestoreDb converter customization (#3255)
- Public FirestoreEnumNameConverter type (#2842)
- Document snapshot timestamp propagation attributes (#2830)

Changes since 1.1.0-beta02
---

- Support for In and ArrayContainsAny queries