### PR TITLE
Make builds quieter

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -112,7 +112,7 @@ fi
 log_build_action "(Start) build.sh"
 log_build_action "Building analyzers"
 
-dotnet publish -c Release -f netstandard1.3 tools/Google.Cloud.Tools.Analyzers
+dotnet publish -nologo -clp:NoSummary -v quiet -c Release -f netstandard1.3 tools/Google.Cloud.Tools.Analyzers
 
 # Then build the requested APIs, working out the test projects as we go.
 > AllTests.txt
@@ -127,7 +127,7 @@ do
   fi
 
   log_build_action "Building $apidir"
-  dotnet build -c Release $apidir
+  dotnet build -nologo -clp:NoSummary -v quiet -c Release $apidir
 
   # On Linux, we don't have desktop .NET, so any projects which only
   # support desktop .NET are going to be broken. Just don't add them.
@@ -153,7 +153,7 @@ then
       echo "(Running with coverage)"
       (cd "$testdir"; $DOTCOVER cover "coverage.xml" -ReturnTargetExitCode)
     else
-      dotnet test -c Release --no-build $testproject
+      dotnet test -nologo -c Release --no-build $testproject
     fi
   done < AllTests.txt
 fi

--- a/docs/builddocs.sh
+++ b/docs/builddocs.sh
@@ -67,8 +67,8 @@ mkdir output
 mkdir output/assembled
 
 # Build the tools once, then we can run them without restoring/building each time
-dotnet build ../tools/Google.Cloud.Tools.GenerateDocfxSources -v quiet
-dotnet build ../tools/Google.Cloud.Tools.GenerateSnippetMarkdown -v quiet
+dotnet build ../tools/Google.Cloud.Tools.GenerateDocfxSources -v quiet -nologo -clp:NoSummary
+dotnet build ../tools/Google.Cloud.Tools.GenerateSnippetMarkdown -v quiet -nologo -clp:NoSummary
 
 apis=$@
 if [ -z "$apis" ]

--- a/runintegrationtests.sh
+++ b/runintegrationtests.sh
@@ -106,7 +106,7 @@ do
   then
     (cd $testdir; $DOTCOVER cover "coverage.xml" -ReturnTargetExitCode || echo "$testdir" >> $FAILURE_TEMP_FILE)
   else
-    (cd $testdir; dotnet test -c Release --no-build || echo "$testdir" >> $FAILURE_TEMP_FILE)
+    (cd $testdir; dotnet test -nologo -c Release --no-build || echo "$testdir" >> $FAILURE_TEMP_FILE)
   fi
 done
 log_build_action "(End) Integration tests"


### PR DESCRIPTION
We really don't need to see the compiler version hundreds of times