### PR TITLE
Release Google.Cloud.Asset.V1 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.csproj
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0-beta00</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard1.5;netstandard2.0;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.Asset.V1/docs/history.md
+++ b/apis/Google.Cloud.Asset.V1/docs/history.md
@@ -1,0 +1,13 @@
+# Version history
+
+# Version 1.1.0, released 2019-12-09
+
+- [Commit 4f2ccbe](https://github.com/googleapis/google-cloud-dotnet/commit/4f2ccbe): Real-time feed support
+- [Commit f4e3eaf](https://github.com/googleapis/google-cloud-dotnet/commit/f4e3eaf):
+  - BigQuery output support
+  - Storage URI prefix support
+  - Added ContentType.OrgPolicy and ContentType.AccessPolicy
+
+# Version 1.0.0, released 2019-07-10
+
+Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -6,12 +6,14 @@
     "serviceYaml": "cloudasset_v1.yaml",
     "productName": "Google Cloud Asset Inventory",
     "productUrl": "https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview",
-    "version": "1.1.0-beta00",
+    "version": "1.1.0",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Asset Inventory API (v1).",
     "dependencies": {
       "Google.LongRunning": "1.1.0",
-      "Google.Cloud.Iam.V1": "1.2.0"
+      "Google.Cloud.Iam.V1": "1.2.0",
+      "Google.Api.Gax.Grpc": "2.10.0",
+      "Grpc.Core": "1.22.1"
     },
     "tags": [ "asset", "inventory", "assets" ]
   },


### PR DESCRIPTION
New features since 1.0.0:

- Real-time feed support
- BigQuery output support
- Storage URI prefix support
- Added ContentType.OrgPolicy and ContentType.AccessPolicy