### PR TITLE
Release Google.Cloud.Iam.V1 version 1.3.0

### DIFF
--- a/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.csproj
+++ b/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.3.0-beta00</Version>
+    <Version>1.3.0</Version>
     <TargetFrameworks>netstandard1.5;netstandard2.0;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.Iam.V1/docs/history.md
+++ b/apis/Google.Cloud.Iam.V1/docs/history.md
@@ -1,0 +1,21 @@
+# Version history
+
+# Version 1.3.0, released 2019-12-09
+
+- [Commit f8f09a8](https://github.com/googleapis/google-cloud-dotnet/commit/f8f09a8): Update IAM helper methods to protect against IAM conditions. The methods throw an exception if:
+  - The policy version is greater than 1
+  - Any bindings have conditions
+- [Commit ab0fe73](https://github.com/googleapis/google-cloud-dotnet/commit/ab0fe73): Added GetPolicyOptions
+- [Commit 65376a1](https://github.com/googleapis/google-cloud-dotnet/commit/65376a1): Introduces IAM conditions
+
+# Version 1.2.0, released 2019-02-20
+
+(No visible API changes; could have been released as a patch to 1.1.0.)
+
+# Version 1.1.0, released 2018-06-28
+
+- [Commit 74a5ba8](https://github.com/googleapis/google-cloud-dotnet/commit/74a5ba8): Add resource name properties to IAM requests
+
+# Version 1.0.0, released 2017-12-05
+
+Initial GA release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -427,10 +427,14 @@
     "id": "Google.Cloud.Iam.V1",
     "generator": "protogrpc",
     "protoPath": "google/iam/v1",
-    "version": "1.3.0-beta00",
+    "version": "1.3.0",
     "type": "grpc",
     "description": "gRPC services for the Google Identity and Access Management API. This library is typically used as a dependency for other API client libraries.",
-    "tags": [ "IAM", "Identity", "Access" ]
+    "tags": [ "IAM", "Identity", "Access" ],
+    "dependencies": {
+      "Google.Api.Gax.Grpc": "2.10.0",
+      "Grpc.Core": "1.22.1"
+    }
   },
 
   {


### PR DESCRIPTION
This introduces IAM conditions. The helper methods for policy manipulation are too simplistic to use when conditions are in use, so these methods now throw exceptions if they detect conditions anywhere in the policy.