### PR TITLE
Release Google.Cloud.Container.V1 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0-beta00</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard1.5;netstandard2.0;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.Container.V1/docs/history.md
+++ b/apis/Google.Cloud.Container.V1/docs/history.md
@@ -1,0 +1,11 @@
+# Version history
+
+# Version 1.1.0, released 2019-12-09
+
+- Some retry settings are now obsolete, and will be removed in the next major version
+- Added support for many cluster options
+- Added ListUsableSubnetworks methods
+
+# Version 1.0.0, released 2019-07-10
+
+Initial GA release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -142,10 +142,12 @@
     "protoPath": "google/container/v1",
     "productName": "Google Kubernetes Engine API",
     "productUrl": "https://cloud.google.com/kubernetes-engine/docs/reference/rest/",
-    "version": "1.1.0-beta00",
+    "version": "1.1.0",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.",
     "dependencies": {
+      "Google.Api.Gax.Grpc": "2.10.0",
+      "Grpc.Core": "1.22.1"
     },
     "tags": [ "Kubernetes" ]
   },


### PR DESCRIPTION
Changes since 1.0.0:

- Some retry settings are now obsolete, and will be removed in the next major version
- Added support for many cluster options
- Added ListUsableSubnetworks methods