### PR TITLE
Release Google.Cloud.DevTools.Common version 1.1.0

### DIFF
--- a/apis/Google.Cloud.DevTools.Common/Google.Cloud.DevTools.Common/Google.Cloud.DevTools.Common.csproj
+++ b/apis/Google.Cloud.DevTools.Common/Google.Cloud.DevTools.Common/Google.Cloud.DevTools.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0-beta00</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard1.3;netstandard2.0;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.3;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
@@ -22,7 +22,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.CommonProtos" Version="1.6.0" />
+    <PackageReference Include="Google.Api.CommonProtos" Version="1.7.0" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.DevTools.Common/docs/history.md
+++ b/apis/Google.Cloud.DevTools.Common/docs/history.md
@@ -1,0 +1,10 @@
+# Version history
+
+# Version 1.1.0, released 2019-12-09
+
+- [Commit 518728a](https://github.com/googleapis/google-cloud-dotnet/commit/518728a): A few minor tidy-ups of comments
+- Dependency updates
+
+# Version 1.0.0, released 2017-08-01
+
+Initial GA release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -202,14 +202,14 @@
 
   {
     "id": "Google.Cloud.DevTools.Common",
-    "version": "1.1.0-beta00",
+    "version": "1.1.0",
     "type": "other",
     "targetFrameworks": "netstandard1.3;netstandard2.0;net45",
     "testTargetFrameworks": "netcoreapp2.1;net452",
     "description": "Common Protocol Buffer messages for Google Cloud Developer Tools APIs.",
     "tags": [ "Tools" ],
     "dependencies": {
-      "Google.Api.CommonProtos": "1.6.0"
+      "Google.Api.CommonProtos": "1.7.0"
     }
   },
 


### PR DESCRIPTION
Aside from updated comments, this is just a dependency update.