### PR TITLE
Remove "Not running tests..." message from build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -31,7 +31,6 @@ nobuild=false
 while (( "$#" )); do
   if [[ "$1" == "--notests" ]]
   then 
-    echo "Not running tests..."
     runtests=false
   elif [[ "$1" == "--diff" ]]
   then


### PR DESCRIPTION
I suspect this was accidentally added while diagnosing issues.