### PR TITLE
Release Google.Cloud.Datastore.V1 version 2.2.0

### DIFF
--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.2.0-beta02</Version>
+    <Version>2.2.0</Version>
     <TargetFrameworks>netstandard1.5;netstandard2.0;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.Datastore.V1/docs/history.md
+++ b/apis/Google.Cloud.Datastore.V1/docs/history.md
@@ -1,0 +1,22 @@
+# Version history
+
+# Version 2.2.0, released 2019-12-09
+
+- Implement DatastoreDbBuilder for easy configuration, including emulator support
+- Multiple code generation improvements
+- Some retry-based settings are now obsolete, and will be removed in the next major release
+
+# Version 2.1.0, released 2018-02-01
+
+- [Commit 3730474](https://github.com/googleapis/google-cloud-dotnet/commit/3730474): Implement Datastore transaction options in DatastoreDb.
+- [Commit 6287f81](https://github.com/googleapis/google-cloud-dotnet/commit/6287f81): Added transaction options to underlying API
+
+# Version 2.0.0, released 2017-06-22
+
+- [Commit 04c3fdc](https://github.com/googleapis/google-cloud-dotnet/commit/04c3fdc): Retry setting changes
+- [Commit 49e0362](https://github.com/googleapis/google-cloud-dotnet/commit/49e0362): ConfigureAwait fixes
+- Dependency on GAX updated to v2
+
+# Version 1.0.0, released 2017-03-30
+
+Initial GA release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -176,12 +176,16 @@
     "protoPath": "google/datastore/v1",
     "productName": "Google Cloud Datastore",
     "productUrl": "https://cloud.google.com/datastore/docs/concepts/overview",
-    "version": "2.2.0-beta02",
+    "version": "2.2.0",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Datastore API, which accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.",
     "tags": [ "Datastore" ],
+    "dependencies": {
+      "Google.Api.Gax.Grpc": "2.10.0",
+      "Grpc.Core": "1.22.1"
+    },
     "testDependencies": {
-      "Google.Api.Gax.Grpc.Testing": "default"
+      "Google.Api.Gax.Grpc.Testing": "2.10.0"
     }
   },
 


### PR DESCRIPTION
Most important changes since 2.1.0:

- Implement DatastoreDbBuilder for easy configuration, including emulator support
- Multiple code generation improvements
- Some retry-based settings are now obsolete, and will be removed in the next major release