### PR TITLE
Release Google.Cloud.Translation.V2 version 1.2.0

### DIFF
--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.csproj
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.2.0-beta02</Version>
+    <Version>1.2.0</Version>
     <TargetFrameworks>netstandard1.3;netstandard2.0;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.3;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Rest" Version="2.10.0" />
-    <PackageReference Include="Google.Apis.Translate.v2" Version="1.41.1.875" />
+    <PackageReference Include="Google.Apis.Translate.v2" Version="1.42.0.875" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Translation.V2/docs/history.md
+++ b/apis/Google.Cloud.Translation.V2/docs/history.md
@@ -1,0 +1,17 @@
+# Version history
+
+# Version 1.2.0, released 2019-12-09
+
+- [Commit 5c5afff](https://github.com/googleapis/google-cloud-dotnet/commit/5c5afff): Added client builders for simplified configuration
+- [Commit 4c1905b](https://github.com/googleapis/google-cloud-dotnet/commit/4c1905b): Use Translate method instead of List method, to avoid URI construction limits. Fixes [issue 2957](https://github.com/googleapis/google-cloud-dotnet/issues/2957) as far as we can.
+
+# Version 1.1.0, released 2018-08-07
+
+- [Commit 9f2bde3](https://github.com/googleapis/google-cloud-dotnet/commit/9f2bde3): Implement IDisposable on clients ([issue 1624](https://github.com/googleapis/google-cloud-dotnet/issues/1624)). Fixes [issue 407](https://github.com/googleapis/google-cloud-dotnet/issues/407)
+- [Commit 1630044](https://github.com/googleapis/google-cloud-dotnet/commit/1630044): Cleanup default expressions ([issue 1388](https://github.com/googleapis/google-cloud-dotnet/issues/1388))
+- [Commit 048afaa](https://github.com/googleapis/google-cloud-dotnet/commit/048afaa): Add AdvancedTranslationClient for custom model scenarios
+- [Commit bcf665c](https://github.com/googleapis/google-cloud-dotnet/commit/bcf665c): Fix the TranslationResult.Model property not being populated.
+
+# Version 1.0.0, released 2017-06-28
+
+Initial GA release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -982,11 +982,12 @@
     "id": "Google.Cloud.Translation.V2",
     "productName": "Google Cloud Translation",
     "productUrl": "https://cloud.google.com/translate/",
-    "version": "1.2.0-beta02",
+    "version": "1.2.0",
     "type": "rest",
     "description": "Recommended Google client library to access the Translate v2 API. It wraps the Google.Apis.Translate.v2 client library, making common operations simpler in client code. The Translate API translates text from one language to another.",
     "dependencies": {
-      "Google.Apis.Translate.v2": "1.41.1.875"
+      "Google.Apis.Translate.v2": "1.42.0.875",
+      "Google.Api.Gax.Rest": "2.10.0"
     },
     "tags": [ "Translate", "Translation" ]
   },


### PR DESCRIPTION
Changes since 1.1.0:

- [Commit 5c5afff](https://github.com/googleapis/google-cloud-dotnet/commit/5c5afff): Added client builders for simplified configuration
- [Commit 4c1905b](https://github.com/googleapis/google-cloud-dotnet/commit/4c1905b): Use Translate method instead of List method, to avoid URI construction limits. Fixes [issue 2957](https://github.com/googleapis/google-cloud-dotnet/issues/2957) as far as we can.