### PR TITLE
Release Google.Cloud.Trace.V1 version 1.2.0

### DIFF
--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.csproj
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.2.0-beta01</Version>
+    <Version>1.2.0</Version>
     <TargetFrameworks>netstandard1.5;netstandard2.0;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.Trace.V1/docs/history.md
+++ b/apis/Google.Cloud.Trace.V1/docs/history.md
@@ -1,0 +1,14 @@
+# Version history
+
+# Version 1.2.0, released 2019-12-09
+
+- [Commit 1ad0290](https://github.com/googleapis/google-cloud-dotnet/commit/1ad0290): Some retry settings are now obsolete, and will be removed from the next major version
+
+# Version 1.1.0, released 2019-07-10
+
+- [Commit ee5c7dc](https://github.com/googleapis/google-cloud-dotnet/commit/ee5c7dc): Introduce ClientBuilders for simpler client configuration
+- Many code generation changes
+
+# Version 1.0.0, released 2017-08-07
+
+Initial GA release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -943,10 +943,12 @@
     "protoPath": "google/devtools/cloudtrace/v1",
     "productName": "Stackdriver Trace",
     "productUrl": "https://cloud.google.com/trace/",
-    "version": "1.2.0-beta01",
+    "version": "1.2.0",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Trace API, which sends and retrieves trace data from Google Cloud Trace. Data is generated and available by default for all App Engine applications. Data from other applications can be written to Cloud Trace for display, reporting, and analysis.",
     "dependencies": {
+      "Google.Api.Gax.Grpc": "2.10.0",
+      "Grpc.Core": "1.22.1"
     },
     "tags": [ "Tracing", "Trace" ]
   },


### PR DESCRIPTION
Changes since 1.1.0:

- [Commit 1ad0290](https://github.com/googleapis/google-cloud-dotnet/commit/1ad0290): Some retry settings are now obsolete, and will be removed from the next major version