### PR TITLE
Release Google.Cloud.Trace.V2 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.csproj
+++ b/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0-beta00</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard1.5;netstandard2.0;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.Trace.V2/docs/history.md
+++ b/apis/Google.Cloud.Trace.V2/docs/history.md
@@ -1,0 +1,10 @@
+# Version history
+
+# Version 1.1.0, released 2019-12-09
+
+- [Commit 8f268e0](https://github.com/googleapis/google-cloud-dotnet/commit/8f268e0): Some retry settings are now obsolete, and will be removed from the next major version
+- [Commit 50658e2](https://github.com/googleapis/google-cloud-dotnet/commit/50658e2): Adds resource name Format methods
+
+# Version 1.0.0, released 2019-07-10
+
+Initial GA release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -957,10 +957,12 @@
     "protoPath": "google/devtools/cloudtrace/v2",
     "productName": "Stackdriver Trace",
     "productUrl": "https://cloud.google.com/trace/",
-    "version": "1.1.0-beta00",
+    "version": "1.1.0",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Trace V2 API, which sends and retrieves trace data from Google Cloud Trace. Data is generated and available by default for all App Engine applications. Data from other applications can be written to Cloud Trace for display, reporting, and analysis.",
     "dependencies": {
+      "Google.Api.Gax.Grpc": "2.10.0",
+      "Grpc.Core": "1.22.1"
     },
     "tags": [ "Tracing", "Trace" ]
   },


### PR DESCRIPTION
Changes since 1.0.0:

- [Commit 8f268e0](https://github.com/googleapis/google-cloud-dotnet/commit/8f268e0): Some retry settings are now obsolete, and will be removed from the next major version
- [Commit 50658e2](https://github.com/googleapis/google-cloud-dotnet/commit/50658e2): Adds resource name Format methods