### PR TITLE
Release Google.Cloud.Vision.V1 version 1.7.0

### DIFF
--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.csproj
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.7.0-beta00</Version>
+    <Version>1.7.0</Version>
     <TargetFrameworks>netstandard1.5;netstandard2.0;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.Vision.V1/docs/history.md
+++ b/apis/Google.Cloud.Vision.V1/docs/history.md
@@ -1,0 +1,46 @@
+# Version history
+
+# Version 1.7.0, released 2019-12-09
+
+
+- [Commit c56e9ee](https://github.com/googleapis/google-cloud-dotnet/commit/c56e9ee): Some retry settings are now obsolete and will be removed in the next major version
+- [Commit b4a35c8](https://github.com/googleapis/google-cloud-dotnet/commit/b4a35c8): Added category-specific confidence properties to SafeSearchAnnotation
+
+# Version 1.6.0, released 2019-08-13
+
+- [Commit 3028526](https://github.com/googleapis/google-cloud-dotnet/commit/3028526): New features:
+  - New error field on responses
+  - PurgeProducts long-running RPC
+  - Object annotations in products
+- [Commit 50658e2](https://github.com/googleapis/google-cloud-dotnet/commit/50658e2): Added resource name format methods
+
+# Version 1.5.0, released 2019-07-10
+
+- [Commit ee5c7dc](https://github.com/googleapis/google-cloud-dotnet/commit/ee5c7dc):- Introduce ClientBuilders for simplified client configuration
+
+# Version 1.4.0, released 2019-06-05
+
+- [Commit 1424e89](https://github.com/googleapis/google-cloud-dotnet/commit/1424e89): Add string-based overloads for methods accepting resource names. This fixes [issue 2442](https://github.com/googleapis/google-cloud-dotnet/issues/2442).
+- [Commit 9031a3d](https://github.com/googleapis/google-cloud-dotnet/commit/9031a3d): New features:
+  - BatchAnnotateFiles method
+  - AsyncBatchAnnotateImages method
+
+# Version 1.3.0, released 2019-02-05
+
+- Added ProductSearchClient
+- Added ImageAnnotatorClient.DetectSimilarProducts
+- Added ImageAnnotatorClient.DetectLocalizedObjects
+
+# Version 1.2.0, released 2018-05-23
+
+- Added AsyncAnnotateFile methods
+- Added AsyncBatchAnnotateFiles methods
+
+# Version 1.1.0, released 2018-01-30
+
+- Web detection
+- Additional details on result properties (e.g. confidence)
+
+# Version 1.0.0, released 2017-09-19
+
+Initial GA release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1016,12 +1016,14 @@
     "protoPath": "google/cloud/vision/v1",
     "productName": "Google Cloud Vision",
     "productUrl": "https://cloud.google.com/vision",
-    "version": "1.7.0-beta00",
+    "version": "1.7.0",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Vision API, which integrates Google Vision features, including image labeling, face, logo, and landmark detection, optical character recognition (OCR), and detection of explicit content, into applications.",
     "tags": [ "Vision" ],
     "dependencies": {
-      "Google.LongRunning": "1.1.0"
+      "Google.Api.Gax.Grpc": "2.10.0",
+      "Google.LongRunning": "1.1.0",
+      "Grpc.Core": "1.22.1"
     }
   },
 


### PR DESCRIPTION
- [Commit c56e9ee](https://github.com/googleapis/google-cloud-dotnet/commit/c56e9ee): Some retry settings are now obsolete and will be removed in the next major version
- [Commit b4a35c8](https://github.com/googleapis/google-cloud-dotnet/commit/b4a35c8): Added category-specific confidence properties to SafeSearchAnnotation
