### PR TITLE
Release Google.Cloud.Debugger.V2 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2.csproj
+++ b/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0-beta00</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard1.5;netstandard2.0;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
@@ -24,7 +24,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="2.10.0" />
-    <PackageReference Include="Google.Cloud.DevTools.Common" Version="1.0.0" />
+    <PackageReference Include="Google.Cloud.DevTools.Common" Version="1.1.0" />
     <PackageReference Include="Grpc.Core" Version="1.22.1" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />

--- a/apis/Google.Cloud.Debugger.V2/docs/history.md
+++ b/apis/Google.Cloud.Debugger.V2/docs/history.md
@@ -1,0 +1,10 @@
+# Version history
+
+# Version 1.1.0, released 2019-12-09
+
+- [Commit f3c6a75](https://github.com/googleapis/google-cloud-dotnet/commit/f3c6a75): Some retry settings are now obsolete, and will be removed from the next major version.
+- Comment changes and dependency updates.
+
+# Version 1.0.0, released 2019-07-10
+
+Initial GA release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -195,12 +195,14 @@
     "protoPath": "google/devtools/clouddebugger/v2",
     "productName": "Stackdriver Debugger",
     "productUrl": "https://cloud.google.com/debugger/",
-    "version": "1.1.0-beta00",
+    "version": "1.1.0",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Debugger API.",
     "tags": [ "Debug", "Debugger", "Debugging", "Stackdriver"],
     "dependencies": {
-      "Google.Cloud.DevTools.Common": "1.0.0"
+      "Google.Api.Gax.Grpc": "2.10.0",
+      "Google.Cloud.DevTools.Common": "1.1.0",
+      "Grpc.Core": "1.22.1"
     }
   },
 


### PR DESCRIPTION
Changes since 1.0.0:

- [Commit f3c6a75](https://github.com/googleapis/google-cloud-dotnet/commit/f3c6a75): Some retry settings are now obsolete, and will be removed from the next major version.
- Comment changes and dependency updates.