### PR TITLE
Release Google.Cloud.Speech.V1 version 1.3.0

### DIFF
--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.csproj
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.3.0-beta03</Version>
+    <Version>1.3.0</Version>
     <TargetFrameworks>netstandard1.5;netstandard2.0;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.Speech.V1/docs/history.md
+++ b/apis/Google.Cloud.Speech.V1/docs/history.md
@@ -1,0 +1,32 @@
+# Version history
+
+# Version 1.3.0, released 2019-12-09
+
+- [Commit bdb68ed](https://github.com/googleapis/google-cloud-dotnet/commit/bdb68ed): SpeakerDiarizationConfig.SpeakerTag is now obsolete.
+- [Commit 0537e3c](https://github.com/googleapis/google-cloud-dotnet/commit/0537e3c): Introduces WordInfo.SpeakerTag
+- [Commit f481c88](https://github.com/googleapis/google-cloud-dotnet/commit/f481c88): Makes some retry settings obsolete; these will be removed in the next major version
+- [Commit 648fabe](https://github.com/googleapis/google-cloud-dotnet/commit/648fabe): Adds speaker diarization configuration
+- [Commit 8777ebb](https://github.com/googleapis/google-cloud-dotnet/commit/8777ebb): Regenerate language codes
+
+# Version 1.2.0, released 2019-07-10
+
+- [Commit ee5c7dc](https://github.com/googleapis/google-cloud-dotnet/commit/ee5c7dc): Introduce ClientBuilders for simplified configuration
+- [Commit 51b3107](https://github.com/googleapis/google-cloud-dotnet/commit/51b3107): Regenerate Cloud Speech: adds RecognitionMetadata
+
+# Version 1.1.0, released 2019-02-05
+
+- [Commit fb6f9ea](https://github.com/googleapis/google-cloud-dotnet/commit/fb6f9ea): Adds RecognitionConfig.AudioChannelCount
+- [Commit 2171f4a](https://github.com/googleapis/google-cloud-dotnet/commit/2171f4a): Adds the ability to recognize on each channel separately
+- [Commit 1143b43](https://github.com/googleapis/google-cloud-dotnet/commit/1143b43): New features:
+  - Automatic punctuation
+  - Model configuration
+  - Enhanced models
+- [Commit a4b3499](https://github.com/googleapis/google-cloud-dotnet/commit/a4b3499): Regenerate language codes
+
+# Version 1.0.1, released 2018-01-25
+
+- [Commit a02e785](https://github.com/googleapis/google-cloud-dotnet/commit/a02e785): Updated timeouts
+
+# Version 1.0.0, released 2017-09-19
+
+Initial GA release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -832,12 +832,14 @@
     "protoPath": "google/cloud/speech/v1",
     "productName": "Google Cloud Speech",
     "productUrl": "https://cloud.google.com/speech",
-    "version": "1.3.0-beta03",
+    "version": "1.3.0",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Speech API, which performs speech recognition.",
     "tags": [ "Speech" ],
     "dependencies": {
-      "Google.LongRunning": "1.1.0"
+      "Google.Api.Gax.Grpc": "2.10.0",
+      "Google.LongRunning": "1.1.0",
+      "Grpc.Core": "1.22.1"
     }
   },
 


### PR DESCRIPTION
Changes from 1.2.0:

- [Commit bdb68ed](https://github.com/googleapis/google-cloud-dotnet/commit/bdb68ed): SpeakerDiarizationConfig.SpeakerTag is now obsolete.
- [Commit 0537e3c](https://github.com/googleapis/google-cloud-dotnet/commit/0537e3c): Introduces WordInfo.SpeakerTag
- [Commit f481c88](https://github.com/googleapis/google-cloud-dotnet/commit/f481c88): Makes some retry settings obsolete; these will be removed in the next major version
- [Commit 648fabe](https://github.com/googleapis/google-cloud-dotnet/commit/648fabe): Adds speaker diarization configuration
- [Commit 8777ebb](https://github.com/googleapis/google-cloud-dotnet/commit/8777ebb): Regenerate language codes