### PR TITLE
Release Google.Cloud.Language.V1 version 1.4.0

### DIFF
--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/Google.Cloud.Language.V1.csproj
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/Google.Cloud.Language.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.4.0-beta00</Version>
+    <Version>1.4.0</Version>
     <TargetFrameworks>netstandard1.5;netstandard2.0;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.Language.V1/docs/history.md
+++ b/apis/Google.Cloud.Language.V1/docs/history.md
@@ -1,0 +1,24 @@
+# Version history
+
+# Version 1.4.0, released 2019-12-09
+
+- [Commit 699db57](https://github.com/googleapis/google-cloud-dotnet/commit/699db57): Some retry settings are now obsolete, and will be removed in the next major version
+- Methods accepting `Nullable<EncodingType>` parameters are now obsolete, and will be removed in the next major version.
+  (Equivalent methods with non-nullable parameters have been added.)
+
+# Version 1.3.0, released 2019-07-10
+
+- More entity `Type` enum values
+- Added more sentiment analysis method overloads
+
+# Version 1.2.0, released 2019-02-05
+
+- Added async methods that accept requests (as well as the other signatures)
+
+# Version 1.1.0, released 2017-11-14
+
+- New feature: text classification
+
+# Version 1.0.0, released 2017-09-19
+
+Initial GA release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -469,10 +469,12 @@
     "protoPath": "google/cloud/language/v1",
     "productName": "Google Cloud Natural Language",
     "productUrl": "https://cloud.google.com/natural-language",
-    "version": "1.4.0-beta00",
+    "version": "1.4.0",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Natural Language API, which provides natural language understanding technologies to developers. Examples include sentiment analysis, entity recognition, and text annotations.",
     "dependencies": {
+      "Google.Api.Gax.Grpc": "2.10.0",
+      "Grpc.Core": "1.22.1"
     },
     "tags": [ "Language" ]
   },


### PR DESCRIPTION
Changes since 1.3.0:

- [Commit 699db57](https://github.com/googleapis/google-cloud-dotnet/commit/699db57): Some retry settings are now obsolete, and will be removed in the next major version
- Methods accepting `Nullable<EncodingType>` parameters are now obsolete, and will be removed in the next major version.
  (Equivalent methods with non-nullable parameters have been added.)