### PR TITLE
Release Google.Cloud.VideoIntelligence.V1 version 1.3.0

### DIFF
--- a/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1.csproj
+++ b/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.3.0-beta00</Version>
+    <Version>1.3.0</Version>
     <TargetFrameworks>netstandard1.5;netstandard2.0;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.VideoIntelligence.V1/docs/history.md
+++ b/apis/Google.Cloud.VideoIntelligence.V1/docs/history.md
@@ -1,0 +1,21 @@
+# Version history
+
+# Version 1.3.0, released 2019-12-09
+
+- [Commit cf20a0e](https://github.com/googleapis/google-cloud-dotnet/commit/cf20a0e): Retry settings are now obsolete, and will be removed in the next major version.
+
+# Version 1.2.0, released 2019-08-13
+
+- [Commit e24d5be](https://github.com/googleapis/google-cloud-dotnet/commit/e24d5be): Adds support for segment and shot presence
+- [Commit abbbf43](https://github.com/googleapis/google-cloud-dotnet/commit/abbbf43): Provides segment and feature tracking in results
+
+# Version 1.1.0, released 2019-07-10
+
+- Expose AnnotateVideoException
+- Added object tracking
+- Added text detection
+- Added speech transcription
+
+# Version 1.0.0, released 2017-11-15
+
+Initial GA release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1010,12 +1010,14 @@
     "protoPath": "google/cloud/videointelligence/v1",
     "productName": "Google Cloud Video Intelligence",
     "productUrl": "https://cloud.google.com/video-intelligence",
-    "version": "1.3.0-beta00",
+    "version": "1.3.0",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Video Intelligence API.",
     "tags": [ "VideoIntelligence" ],
     "dependencies": {
-      "Google.LongRunning": "1.1.0"
+      "Google.Api.Gax.Grpc": "2.10.0",
+      "Google.LongRunning": "1.1.0",
+      "Grpc.Core": "1.22.1"
     }
   },
 


### PR DESCRIPTION
Changes since 1.2.0:

- [Commit cf20a0e](https://github.com/googleapis/google-cloud-dotnet/commit/cf20a0e): Retry settings are now obsolete, and will be removed in the next major version.