### PR TITLE
Release Google.Cloud.Redis.V1 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.csproj
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0-beta00</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard1.5;netstandard2.0;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.Redis.V1/docs/history.md
+++ b/apis/Google.Cloud.Redis.V1/docs/history.md
@@ -1,0 +1,11 @@
+# Version history
+
+# Version 1.1.0, released 2019-12-09
+
+- [Commit 95691ca](https://github.com/googleapis/google-cloud-dotnet/commit/95691ca): Retry settings are now obsolete, and will be removed from the next major version
+- Async RPC methods now always have overloads accepting request objects
+- Resource name classes now have format methods
+
+# Version 1.0.0, released 2019-07-10
+
+Initial GA release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -671,11 +671,13 @@
     "protoPath": "google/cloud/redis/v1",
     "productName": "Google Cloud Memorystore for Redis",
     "productUrl": "https://cloud.google.com/memorystore/",
-    "version": "1.1.0-beta00",
+    "version": "1.1.0",
     "type": "grpc",
     "description": "Recommended Google client library to administer Cloud Memorystore for Redis.",
     "dependencies": {
-      "Google.LongRunning": "1.1.0"
+      "Google.Api.Gax.Grpc": "2.10.0",
+      "Google.LongRunning": "1.1.0",
+      "Grpc.Core": "1.22.1"
     },
     "tags": [ "Redis", "Memorystore" ]
   },


### PR DESCRIPTION
Changes since 1.0.0:

- [Commit 95691ca](https://github.com/googleapis/google-cloud-dotnet/commit/95691ca): Retry settings are now obsolete, and will be removed from the next major version
- Async RPC methods now always have overloads accepting request objects
- Resource name classes now have format methods