### PR TITLE
Release Google.Cloud.Scheduler.V1 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.csproj
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0-beta01</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard1.5;netstandard2.0;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.Scheduler.V1/docs/history.md
+++ b/apis/Google.Cloud.Scheduler.V1/docs/history.md
@@ -1,0 +1,12 @@
+# Version history
+
+# Version 1.1.0, released 2019-12-09
+
+- [Commit ab7762c](https://github.com/googleapis/google-cloud-dotnet/commit/ab7762c): Retry settings are now obsolete, and will be removed from the next major version
+- Method overloads with resource name parameters now have corresponding string-accepting overloads
+- Added HttpTarget OIDC support
+- Resource names now have format methods
+
+# Version 1.0.0, released 2019-04-25
+
+Initial GA release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -701,10 +701,14 @@
     "protoPath": "google/cloud/scheduler/v1",
     "productName": "Google Cloud Scheduler",
     "productUrl": "https://cloud.google.com/scheduler/",
-    "version": "1.1.0-beta01",
+    "version": "1.1.0",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Scheduler API (v1), which creates and manages jobs run on a regular recurring schedule.",
-    "tags": [ "scheduler", "cron" ]
+    "tags": [ "scheduler", "cron" ],
+    "dependencies": {
+      "Google.Api.Gax.Grpc": "2.10.0",
+      "Grpc.Core": "1.22.1"
+    }
   },
 
   {


### PR DESCRIPTION
Changes since 1.0.0:

- [Commit ab7762c](https://github.com/googleapis/google-cloud-dotnet/commit/ab7762c): Retry settings are now obsolete, and will be removed from the next major version
- Method overloads with resource name parameters now have corresponding string-accepting overloads
- Added HttpTarget OIDC support
- Resource names now have format methods