### PR TITLE
Release Google.Cloud.Tasks.V2 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.Snippets/coverage.xml
@@ -7,9 +7,6 @@
       <FilterEntry>
         <ModuleMask>Google.Cloud.Tasks.V2</ModuleMask>
       </FilterEntry>
-      <FilterEntry>
-        <ModuleMask>Google.Cloud.Iam.V1</ModuleMask>
-      </FilterEntry>
     </IncludeFilters>
   </Filters>
   <AttributeFilters>

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.Tests/coverage.xml
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.Tests/coverage.xml
@@ -7,9 +7,6 @@
       <FilterEntry>
         <ModuleMask>Google.Cloud.Tasks.V2</ModuleMask>
       </FilterEntry>
-      <FilterEntry>
-        <ModuleMask>Google.Cloud.Iam.V1</ModuleMask>
-      </FilterEntry>
     </IncludeFilters>
   </Filters>
   <AttributeFilters>

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.csproj
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0-beta02</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard1.5;netstandard2.0;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
@@ -24,7 +24,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="2.10.0" />
-    <ProjectReference Include="..\..\Google.Cloud.Iam.V1\Google.Cloud.Iam.V1\Google.Cloud.Iam.V1.csproj" />
+    <PackageReference Include="Google.Cloud.Iam.V1" Version="1.3.0" />
     <PackageReference Include="Grpc.Core" Version="1.22.1" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />

--- a/apis/Google.Cloud.Tasks.V2/docs/history.md
+++ b/apis/Google.Cloud.Tasks.V2/docs/history.md
@@ -1,0 +1,14 @@
+# Version history
+
+# Version 1.1.0, released 2019-12-09
+
+- [Commit dc37caa](https://github.com/googleapis/google-cloud-dotnet/commit/dc37caa): Retry settings are now obsolete and will be removed in the next major version
+- [Commit af47eb8](https://github.com/googleapis/google-cloud-dotnet/commit/af47eb8): Adds HttpRequest target
+- [Commit ee5c7dc](https://github.com/googleapis/google-cloud-dotnet/commit/ee5c7dc): Add client builders for simple configuration
+- [Commit 1424e89](https://github.com/googleapis/google-cloud-dotnet/commit/1424e89): Add string-accepting equivalents to all resource-name-accepting methods
+- Resource name types now have format methods
+
+# Version 1.0.0, released 2019-04-25
+
+Initial GA release.
+

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -901,12 +901,14 @@
     "protoPath": "google/cloud/tasks/v2",
     "productName": "Google Cloud Tasks",
     "productUrl": "https://cloud.google.com/tasks/",
-    "version": "1.1.0-beta02",
+    "version": "1.1.0",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Tasks API (v2), which manages the execution of large numbers of distributed requests.",
     "tags": [ "Tasks" ],
     "dependencies": {
-      "Google.Cloud.Iam.V1": "project"
+      "Google.Api.Gax.Grpc": "2.10.0",
+      "Google.Cloud.Iam.V1": "1.3.0",
+      "Grpc.Core": "1.22.1"
     }
   },
 


### PR DESCRIPTION
- [Commit dc37caa](https://github.com/googleapis/google-cloud-dotnet/commit/dc37caa): Retry settings are now obsolete and will be removed in the next major version
- [Commit af47eb8](https://github.com/googleapis/google-cloud-dotnet/commit/af47eb8): Adds HttpRequest target
- [Commit ee5c7dc](https://github.com/googleapis/google-cloud-dotnet/commit/ee5c7dc): Add client builders for simple configuration
- [Commit 1424e89](https://github.com/googleapis/google-cloud-dotnet/commit/1424e89): Add string-accepting equivalents to all resource-name-accepting methods
- Resource name types now have format methods