### PR TITLE
Release Google.Cloud.Storage.V1 version 2.4.0

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/Google.Cloud.Storage.V1.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/Google.Cloud.Storage.V1.IntegrationTests.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Google.Api.Gax.Testing" Version="2.10.0" />
-    <PackageReference Include="Google.Apis.Iam.v1" Version="1.41.1.1709" />
+    <PackageReference Include="Google.Apis.Iam.v1" Version="1.42.0.1779" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="1.2.0" />
     <ProjectReference Include="..\..\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1.csproj" />

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Snippets/Google.Cloud.Storage.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Snippets/Google.Cloud.Storage.V1.Snippets.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Google.Api.Gax.Testing" Version="2.10.0" />
-    <PackageReference Include="Google.Apis.Iam.v1" Version="1.41.1.1709" />
+    <PackageReference Include="Google.Apis.Iam.v1" Version="1.42.0.1779" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="1.2.0" />
     <ProjectReference Include="..\..\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1.csproj" />

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/Google.Cloud.Storage.V1.Tests.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/Google.Cloud.Storage.V1.Tests.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Google.Api.Gax.Testing" Version="2.10.0" />
-    <PackageReference Include="Google.Apis.Iam.v1" Version="1.41.1.1709" />
+    <PackageReference Include="Google.Apis.Iam.v1" Version="1.42.0.1779" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="1.2.0" />
     <ProjectReference Include="..\..\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1.csproj" />

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.4.0-beta04</Version>
+    <Version>2.4.0</Version>
     <TargetFrameworks>netstandard1.3;netstandard2.0;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.3;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Rest" Version="2.10.0" />
-    <PackageReference Include="Google.Apis.Storage.v1" Version="1.41.1.1744" />
+    <PackageReference Include="Google.Apis.Storage.v1" Version="1.42.0.1744" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Storage.V1/docs/history.md
+++ b/apis/Google.Cloud.Storage.V1/docs/history.md
@@ -1,11 +1,15 @@
 # Version history
 
-# Version 2.4.0-beta01, released 2019-04-08
+# Version 2.4.0, released 2019-12-10
 
 New features since 2.3.0:
 
-- Beta support for V4 signing URLs
+- Opt-in support for V4 signing URLs
 - Add `IncludeTrailingDelimiter` to `ListObjectsOptions`
+- Default endpoint is now storage.googleapis.com
+- Added GetBucketIamPolicyOptions.RequestedPolicyVersion in anticipation of IAM conditions
+- Added StorageClientBuilder for simplified configuration
+- Added support for HMAC keys associated with service accounts in GCS
 
 # Version 2.3.0, released 2019-02-11
 

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -872,17 +872,18 @@
     "id": "Google.Cloud.Storage.V1",
     "productName": "Google Cloud Storage",
     "productUrl": "https://cloud.google.com/storage/",
-    "version": "2.4.0-beta04",
+    "version": "2.4.0",
     "type": "rest",
     "description": "Recommended Google client library to access the Google Cloud Storage API. It wraps the Google.Apis.Storage.v1 client library, making common operations simpler in client code. Google Cloud Storage stores and retrieves potentially large, immutable data objects.",
     "dependencies": {
-      "Google.Apis.Storage.v1": "1.41.1.1744"
+      "Google.Apis.Storage.v1": "1.42.0.1744",
+      "Google.Api.Gax.Rest": "2.10.0"
     },
     "testDependencies": {
       "Google.Cloud.Iam.V1": "1.2.0",
       "Google.Cloud.PubSub.V1": "project",
-      "Google.Api.Gax.Testing": "default",
-      "Google.Apis.Iam.v1": "1.41.1.1709"
+      "Google.Api.Gax.Testing": "2.10.0",
+      "Google.Apis.Iam.v1": "1.42.0.1779"
     },
     "tags": [ "Storage" ]
   },


### PR DESCRIPTION
New features since 2.3.0:

- Opt-in support for V4 signing URLs
- Add `IncludeTrailingDelimiter` to `ListObjectsOptions`
- Default endpoint is now storage.googleapis.com
- Added GetBucketIamPolicyOptions.RequestedPolicyVersion in anticipation of IAM conditions
- Added StorageClientBuilder for simplified configuration
- Added support for HMAC keys associated with service accounts in GCS