### PR TITLE
Release Google.Cloud.Kms.V1 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.csproj
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0-beta01</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard1.5;netstandard2.0;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
@@ -24,7 +24,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="2.10.0" />
-    <PackageReference Include="Google.Cloud.Iam.V1" Version="1.1.0" />
+    <PackageReference Include="Google.Cloud.Iam.V1" Version="1.3.0" />
     <PackageReference Include="Grpc.Core" Version="1.22.1" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />

--- a/apis/Google.Cloud.Kms.V1/docs/history.md
+++ b/apis/Google.Cloud.Kms.V1/docs/history.md
@@ -1,0 +1,18 @@
+# Version history
+
+# Version 1.1.0, released 2019-12-10
+
+New features:
+
+- RPCs for CreateImportJob, GetImportJob, ImportCryptoKeVersion, ListImportJobs
+- Added filtering and ordering when listing crypto keys
+- Added filtering and ordering when listing keyrings
+- Added Format methods to all resource names
+- Added method overloads accepting requests for RPCs that didn't already have them
+- Added CryptoKeyVersion properties ImportTime, ImportFailureReason, ImportJob
+- Added new CryptoKeyVersionAlgorithm enum values
+- Added KeyManagementServiceClientBuilder for simpler configuration
+
+# Version 1.0.0, released 2019-01-24
+
+Initial GA release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -458,12 +458,14 @@
     "serviceYaml": "cloudkms.yaml",
     "productName": "Google Cloud Key Management Service",
     "productUrl": "https://cloud.google.com/kms/",
-    "version": "1.1.0-beta01",
+    "version": "1.1.0",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Key Management Service API, which manages encryption for your cloud services the same way you do on-premises. You can generate, use, rotate, and destroy AES256 encryption keys.",
     "tags": [ "kms", "keys", "security", "encryption" ],
     "dependencies": {
-      "Google.Cloud.Iam.V1": "1.1.0"
+      "Google.Api.Gax.Grpc": "2.10.0",
+      "Google.Cloud.Iam.V1": "1.3.0",
+      "Grpc.Core": "1.22.1"
     }
   },
 


### PR DESCRIPTION
New features since 1.0.0:

- RPCs for CreateImportJob, GetImportJob, ImportCryptoKeVersion, ListImportJobs
- Added filtering and ordering when listing crypto keys
- Added filtering and ordering when listing keyrings
- Added Format methods to all resource names
- Added method overloads accepting requests for RPCs that didn't already have them
- Added CryptoKeyVersion properties ImportTime, ImportFailureReason, ImportJob
- Added new CryptoKeyVersionAlgorithm enum values
- Added KeyManagementServiceClientBuilder for simpler configuration