### PR TITLE
Release Google.Cloud.Logging.NLog version 2.2.0

### DIFF
--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.csproj
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.2.0-beta01</Version>
+    <Version>2.2.0</Version>
     <TargetFrameworks>netstandard1.5;netstandard2.0;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
@@ -25,7 +25,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="2.10.0" />
     <PackageReference Include="Google.Cloud.DevTools.Common" Version="1.0.0" />
-    <PackageReference Include="Google.Cloud.Logging.V2" Version="2.2.0" />
+    <PackageReference Include="Google.Cloud.Logging.V2" Version="2.3.0" />
     <PackageReference Include="Grpc.Core" Version="1.22.1" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="NLog" Version="4.5.11" />

--- a/apis/Google.Cloud.Logging.NLog/docs/history.md
+++ b/apis/Google.Cloud.Logging.NLog/docs/history.md
@@ -1,0 +1,15 @@
+# Version history
+
+# Version 2.2.0, released 2019-12-10
+
+- [Commit e708f35](https://github.com/googleapis/google-cloud-dotnet/commit/e708f35): Improve handling of dangerous object properties that throws exceptions during Json.Net serialization. ([issue 3668](https://github.com/googleapis/google-cloud-dotnet/issues/3668))
+
+# Version 2.1.0, released 2019-07-10
+
+- [Commit 4cb5765](https://github.com/googleapis/google-cloud-dotnet/commit/4cb5765): Include ServiceContext to allow errors to be forwarded (docs) ([issue 3125](https://github.com/googleapis/google-cloud-dotnet/issues/3125))
+- [Commit dac0dbd](https://github.com/googleapis/google-cloud-dotnet/commit/dac0dbd): Include ServiceContext to allow errors to be forwarded ([issue 3115](https://github.com/googleapis/google-cloud-dotnet/issues/3115))
+- [Commit d007553](https://github.com/googleapis/google-cloud-dotnet/commit/d007553): Avoid InvalidCastException for custom IConvertible that returns TypeCode.Boolean ([issue 3088](https://github.com/googleapis/google-cloud-dotnet/issues/3088))
+
+# Version 2.0.0, released 2019-02-26
+
+Initial GA release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -505,7 +505,7 @@
 
   {
     "id": "Google.Cloud.Logging.NLog",
-    "version": "2.2.0-beta01",
+    "version": "2.2.0",
     "type": "other",
     "targetFrameworks": "netstandard1.5;netstandard2.0;net45",
     "testTargetFrameworks": "netcoreapp2.1;net452",
@@ -514,7 +514,7 @@
     "dependencies": {
       "NLog": "4.5.11",
       "Google.Api.Gax.Grpc": "2.10.0",
-      "Google.Cloud.Logging.V2": "2.2.0",
+      "Google.Cloud.Logging.V2": "2.3.0",
       "Google.Cloud.DevTools.Common": "1.0.0",
       "Grpc.Core": "1.22.1"
     },


### PR DESCRIPTION
Changes since 2.1.0:

- [Commit e708f35](https://github.com/googleapis/google-cloud-dotnet/commit/e708f35): Improve handling of dangerous object properties that throws exceptions during Json.Net serialization. ([issue 3668](https://github.com/googleapis/google-cloud-dotnet/issues/3668))