### PR TITLE
Release Google.Cloud.Bigtable.Common.V2 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.Bigtable.Common.V2/Google.Cloud.Bigtable.Common.V2/Google.Cloud.Bigtable.Common.V2.csproj
+++ b/apis/Google.Cloud.Bigtable.Common.V2/Google.Cloud.Bigtable.Common.V2/Google.Cloud.Bigtable.Common.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0-beta01</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard1.5;netstandard2.0;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.Bigtable.Common.V2/docs/history.md
+++ b/apis/Google.Cloud.Bigtable.Common.V2/docs/history.md
@@ -1,0 +1,9 @@
+# Version history
+
+# Version 1.1.0, released 2019-12-10
+
+- [Commit d29c61b](https://github.com/googleapis/google-cloud-dotnet/commit/d29c61b): Add resource name format methods to resource name classes
+
+# Version 1.0.0, released 2019-05-23
+
+Initial GA release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -107,7 +107,7 @@
     "id": "Google.Cloud.Bigtable.Common.V2",
     "type": "other",
     "targetFrameworks": "netstandard1.5;netstandard2.0;net45",
-    "version": "1.1.0-beta01",
+    "version": "1.1.0",
     "description": "Common code used by Bigtable V2 APIs",
     "tags": [ "Bigtable" ],
     "dependencies": {


### PR DESCRIPTION
Changes since 1.0.0:

- Resource name types have Format methods