### PR TITLE
Release Google.Cloud.AutoML.V1 version 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The following libraries are available at a [GA](#versioning) quality level:
 * [Google Cloud Asset Inventory](https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview) - [V1 API docs](http://googleapis.github.io/google-cloud-dotnet/docs/Google.Cloud.Asset.V1) (GA)
   * Additionally, the following library is available for access to beta API functionality:
   * [V1Beta1 API docs](http://googleapis.github.io/google-cloud-dotnet/docs/Google.Cloud.Asset.V1Beta1/) (beta)
+* [Google Cloud AutoML](https://cloud.google.com/automl/) - [API docs](http://googleapis.github.io/google-cloud-dotnet/docs/Google.AutoML.V1/) (GA)
 * [Google BigQuery Data Transfer](https://cloud.google.com/bigquery/transfer/) - [API docs](http://googleapis.github.io/google-cloud-dotnet/docs/Google.Cloud.BigQuery.DataTransfer.V1/) (GA)
 * [Google BigQuery](https://cloud.google.com/bigquery/) - [API docs](http://googleapis.github.io/google-cloud-dotnet/docs/Google.Cloud.BigQuery.V2/) (GA)
 * [Google Cloud Bigtable](https://cloud.google.com/bigtable/) - [API docs](http://googleapis.github.io/google-cloud-dotnet/docs/Google.Cloud.Bigtable.V2/) (GA)

--- a/apis/Google.Cloud.AutoML.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.AutoML.V1/.repo-metadata.json
@@ -1,4 +1,4 @@
 {
   "distribution_name": "Google.Cloud.AutoML.V1",
-  "release_level": "beta"
+  "release_level": "ga"
 }

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.csproj
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta03</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard1.5;netstandard2.0;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.AutoML.V1/docs/history.md
+++ b/apis/Google.Cloud.AutoML.V1/docs/history.md
@@ -1,0 +1,24 @@
+# Version history
+
+# Version 1.0.0, released 2019-12-10
+
+First GA release. No API surface changes since 1.0.0-beta03.
+
+# Version 1.0.0-beta03, released 2019-11-07
+
+- [Commit 1c275a8](https://github.com/googleapis/google-cloud-dotnet/commit/1c275a8): Removed ImageInputConfig
+- [Commit fda30ff](https://github.com/googleapis/google-cloud-dotnet/commit/fda30ff): New RPCs, with supporting classes and properties:
+  - GetAnnotationSpec
+  - DeployModel
+  - ExportModel
+  - UndeployModel
+  - BatchPredict
+
+# Version 1.0.0-beta02, released 2019-10-08
+
+- [Commit fb2b456](https://github.com/googleapis/google-cloud-dotnet/commit/fb2b456): Modifies long-running operations to give them response/metadata types
+
+# Version 1.0.0-beta01, released 2019-09-24
+
+- [Commit ba7dfdd](https://github.com/googleapis/google-cloud-dotnet/commit/ba7dfdd): First generation of AutoML
+

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -42,11 +42,13 @@
     "serviceYaml": "automl_v1.yaml",
     "productName": "Google AutoML",
     "productUrl": "https://cloud.google.com/automl/",
-    "version": "1.0.0-beta03",
+    "version": "1.0.0",
     "type": "grpc",
     "description": "Recommended Google client library to access the AutoML API, which allows you to train high-quality custom machine learning models with minimal effort and machine learning expertise.",
     "dependencies": {
-      "Google.LongRunning": "1.1.0"
+      "Google.Api.Gax.Grpc": "2.10.0",
+      "Google.LongRunning": "1.1.0",
+      "Grpc.Core": "1.22.1"
     },
     "tags": [ "automl", "ml" ]
   },

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -17,6 +17,7 @@ supported here.
 GA:
 
 - [Google.Cloud.Asset.V1](Google.Cloud.Asset.V1/index.html)
+- [Google.Cloud.AutoML.V1](Google.Cloud.AutoML.V1/index.html)
 - [Google.Cloud.BigQuery.DataTransfer.V1](Google.Cloud.BigQuery.DataTransfer.V1/index.html)
 - [Google.Cloud.BigQuery.V2](Google.Cloud.BigQuery.V2/index.html)
 - [Google.Cloud.Bigtable.V2](Google.Cloud.Bigtable.V2/index.html)


### PR DESCRIPTION
There are no API surface changes in 1.0.0-beta03.