### PR TITLE
Release Google.Cloud.Monitoring.V3 version 1.2.0

### DIFF
--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.csproj
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.2.0-beta01</Version>
+    <Version>1.2.0</Version>
     <TargetFrameworks>netstandard1.5;netstandard2.0;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.Monitoring.V3/docs/history.md
+++ b/apis/Google.Cloud.Monitoring.V3/docs/history.md
@@ -1,0 +1,32 @@
+# Version history
+
+# Version 1.2.0, released 2019-12-10
+
+- [Commit 1258244](https://github.com/googleapis/google-cloud-dotnet/commit/1258244): Multiple new features, including a new service (ServiceMonitoringService).
+- [Commit 84915b4](https://github.com/googleapis/google-cloud-dotnet/commit/84915b4): Additions:
+  - AlertPolicy.Validity
+  - DeleteGroupRequest.Recursive
+  - GroupServiceClient.ListGroups
+  - GroupServiceClient.ListGroupsAsync
+  - InternalChecker.Types.State
+  - UptimeCheckConfig.Types.ContentMatcher
+  - UptimeCheckConfig.Types.HttpCheck
+  - UptimeCheckConfig.IsInternal is now deprecated.
+- [Commit e5b2e69](https://github.com/googleapis/google-cloud-dotnet/commit/e5b2e69): Adds support for verifying notification channels
+- [Commit 50658e2](https://github.com/googleapis/google-cloud-dotnet/commit/50658e2): Add format methods for all resource name types
+
+# Version 1.1.0, released 2019-07-10
+
+New RPCs, with supporting classes and properties:
+
+- Create/Delete/Get/List/Update for alert policies
+- Create/Delete/Get/List/Update for notification channels
+- Create/Delete/Get/List/Update for uptime check configs
+- ListUptimeCheckIps
+- ListNotificationChannelDescriptors
+
+Additionally, there are new overloads due to code generator updates.
+
+# Version 1.0.0, released 2017-09-22
+
+Initial GA release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -579,11 +579,13 @@
     "serviceYaml": "monitoring.yaml",
     "productName": "Stackdriver Monitoring",
     "productUrl": "https://cloud.google.com/monitoring/api/v3/",
-    "version": "1.2.0-beta01",
+    "version": "1.2.0",
     "type": "grpc",
     "description": "Recommended Google client library to access the Stackdriver Monitoring API, which manages your Stackdriver Monitoring data and configurations. Most projects must be associated with a Stackdriver account, with a few exceptions as noted on the individual method pages.",
     "tags": [ "Monitoring", "Stackdriver" ],
     "dependencies": {
+      "Google.Api.Gax.Grpc": "2.10.0",
+      "Grpc.Core": "1.22.1"
     }
   },
 


### PR DESCRIPTION
New features since 1.1.0:

- [Commit 1258244](https://github.com/googleapis/google-cloud-dotnet/commit/1258244): Multiple new features, including a new service (ServiceMonitoringService).
- [Commit 84915b4](https://github.com/googleapis/google-cloud-dotnet/commit/84915b4): Additions:
  - AlertPolicy.Validity
  - DeleteGroupRequest.Recursive
  - GroupServiceClient.ListGroups
  - GroupServiceClient.ListGroupsAsync
  - InternalChecker.Types.State
  - UptimeCheckConfig.Types.ContentMatcher
  - UptimeCheckConfig.Types.HttpCheck
  - UptimeCheckConfig.IsInternal is now deprecated.
- [Commit e5b2e69](https://github.com/googleapis/google-cloud-dotnet/commit/e5b2e69): Adds support for verifying notification channels
- [Commit 50658e2](https://github.com/googleapis/google-cloud-dotnet/commit/50658e2): Add format methods for all resource name types