### PR TITLE
Release Google.Cloud.BigQuery.DataTransfer.V1 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0-beta00</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard1.5;netstandard2.0;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/docs/history.md
@@ -1,0 +1,11 @@
+# Version history
+
+# Version 1.1.0, released 2019-12-10
+
+- [Commit c0001b5](https://github.com/googleapis/google-cloud-dotnet/commit/c0001b5): Adds service account, email and PubSub options.
+- [Commit cc6ec31](https://github.com/googleapis/google-cloud-dotnet/commit/cc6ec31): Introduces a oneof for TransferConfig.Destination and TransferRun.Destingation.
+- [Commit 50658e2](https://github.com/googleapis/google-cloud-dotnet/commit/50658e2): Adds a Format method for all resource name classes
+
+# Version 1.0.0, released 2019-07-10
+
+Initial GA release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -60,10 +60,12 @@
     "serviceYaml": "bigquerydatatransfer_v1.yaml",
     "productName": "Google BigQuery Data Transfer",
     "productUrl": "https://cloud.google.com/bigquery/transfer/",
-    "version": "1.1.0-beta00",
+    "version": "1.1.0",
     "type": "grpc",
     "description": "Recommended Google client library to access the BigQuery Data Transfer API, which transfers data from partner SaaS applications to Google BigQuery on a scheduled, managed basis.",
     "dependencies": {
+      "Google.Api.Gax.Grpc": "2.10.0",
+      "Grpc.Core": "1.22.1"
     },
     "tags": [ "BigQuery", "DataTransfer" ]
   },


### PR DESCRIPTION
Changes since 1.0.0:

- [Commit c0001b5](https://github.com/googleapis/google-cloud-dotnet/commit/c0001b5): Adds service account, email and PubSub options.
- [Commit cc6ec31](https://github.com/googleapis/google-cloud-dotnet/commit/cc6ec31): Introduces a oneof for TransferConfig.Destination and TransferRun.Destingation.
- [Commit 50658e2](https://github.com/googleapis/google-cloud-dotnet/commit/50658e2): Adds a Format method for all resource name classes