### PR TITLE
Add release notes for remaining APIs

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore.Analyzers/docs/history.md
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore.Analyzers/docs/history.md
@@ -1,0 +1,5 @@
+# Version history
+
+# Version 1.0.0-beta02, released 2018-05-08
+
+(No release history recorded.)

--- a/apis/Google.Cloud.Diagnostics.Common/docs/history.md
+++ b/apis/Google.Cloud.Diagnostics.Common/docs/history.md
@@ -1,0 +1,8 @@
+# Version history
+
+This package is not usually intended for direct consumption; it's a
+dependency of other packages. The release histories of those
+higher-level packages are more useful:
+
+- [Google.Cloud.Diagnostics.AspNetCore](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.AspNetCore/latest/history.html)
+- [Google.Cloud.Diagnostics.AspNet](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.AspNet/latest/history.html)

--- a/apis/Google.Cloud.Dlp.V2/docs/history.md
+++ b/apis/Google.Cloud.Dlp.V2/docs/history.md
@@ -1,0 +1,11 @@
+# Version history
+
+# Version 1.1.0, released 2019-12-11
+
+- [Commit 484e335](https://github.com/googleapis/google-cloud-dotnet/commit/484e335): Adds LocationId to multiple messages in preparation for regionalization
+- [Commit 8dd3a37](https://github.com/googleapis/google-cloud-dotnet/commit/8dd3a37): Added "publish to Stackdriver" functionality.
+- [Commit 50658e2](https://github.com/googleapis/google-cloud-dotnet/commit/50658e2): Added Format method to all resource name classes
+
+# Version 1.0.0, released 2019-07-10
+
+Initial GA release.

--- a/apis/Google.Cloud.Firestore.V1/docs/history.md
+++ b/apis/Google.Cloud.Firestore.V1/docs/history.md
@@ -1,0 +1,5 @@
+# Version history
+
+This package is primarily a dependency of Google.Cloud.Firestore. See the
+[Google.Cloud.Firestore version history](https://googleapis.dev/dotnet/Google.Cloud.Firestore/latest/history.html)
+for more details.

--- a/apis/Google.Cloud.Firestore/docs/history.md
+++ b/apis/Google.Cloud.Firestore/docs/history.md
@@ -1,0 +1,15 @@
+# Version history
+
+# Version 1.1.0, released 2019-12-03
+
+- Support for In and ArrayContainsAny queries ([issue 3783](https://github.com/googleapis/google-cloud-dotnet/issues/3783))
+- Firestore emulator support ([issue 3397](https://github.com/googleapis/google-cloud-dotnet/issues/3397))
+- Conversion support for named value tuples ([issue 2787](https://github.com/googleapis/google-cloud-dotnet/issues/2787))
+- FirestoreDbBuilder for simplified configuration beyond defaults
+- Per-FirestoreDb converter customization ([issue 3255](https://github.com/googleapis/google-cloud-dotnet/issues/3255))
+- Public FirestoreEnumNameConverter type ([issue 2842](https://github.com/googleapis/google-cloud-dotnet/issues/2842))
+- Document snapshot timestamp propagation attributes ([issue 2830](https://github.com/googleapis/google-cloud-dotnet/issues/2830))
+
+# Version 1.0.0, released 2019-07-16
+
+Initial GA release.

--- a/apis/Google.Cloud.Metadata.V1/docs/history.md
+++ b/apis/Google.Cloud.Metadata.V1/docs/history.md
@@ -1,0 +1,3 @@
+# Version history
+
+(No version history yet; only alpha releases.)

--- a/apis/Google.Cloud.OsLogin.Common/docs/history.md
+++ b/apis/Google.Cloud.OsLogin.Common/docs/history.md
@@ -1,0 +1,3 @@
+# Version history
+
+(No version history; this package is primarily a dependency.)

--- a/apis/Google.Cloud.OsLogin.V1/docs/history.md
+++ b/apis/Google.Cloud.OsLogin.V1/docs/history.md
@@ -1,0 +1,5 @@
+# Version history
+
+# Version 1.0.0, released 2019-07-10
+
+Initial GA release.

--- a/apis/Google.Cloud.OsLogin.V1Beta/docs/history.md
+++ b/apis/Google.Cloud.OsLogin.V1Beta/docs/history.md
@@ -1,0 +1,9 @@
+# Version history
+
+(No detailed release history yet. More details will be produced for later releases.)
+
+# Version 1.0.0-beta02, released 2019-12-11
+
+# Version 1.0.0-beta01, released 2017-12-22
+
+Initial beta release.

--- a/apis/Google.Cloud.PhishingProtection.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.PhishingProtection.V1Beta1/docs/history.md
@@ -1,0 +1,3 @@
+# Version history
+
+(No releases yet.)

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/docs/history.md
@@ -1,0 +1,3 @@
+# Version history
+
+(No releases yet.)

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/docs/history.md
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/docs/history.md
@@ -1,0 +1,5 @@
+# Version history
+
+This package is primarily intended as a dependency of Google.Cloud.Spanner.Data. See the
+[Google.Cloud.Spanner.Data version history](https://googleapis.dev/dotnet/Google.Cloud.Spanner.Data/latest/history.html)
+for more details.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/docs/history.md
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/docs/history.md
@@ -1,0 +1,5 @@
+# Version history
+
+This package is primarily intended as a dependency of Google.Cloud.Spanner.Data. See the
+[Google.Cloud.Spanner.Data version history](https://googleapis.dev/dotnet/Google.Cloud.Spanner.Data/latest/history.html)
+for more details.

--- a/apis/Google.Cloud.Spanner.V1/docs/history.md
+++ b/apis/Google.Cloud.Spanner.V1/docs/history.md
@@ -1,0 +1,5 @@
+# Version history
+
+This package is primarily intended as a dependency of Google.Cloud.Spanner.Data. See the
+[Google.Cloud.Spanner.Data version history](https://googleapis.dev/dotnet/Google.Cloud.Spanner.Data/latest/history.html)
+for more details.

--- a/apis/Google.Cloud.Translate.V3/docs/history.md
+++ b/apis/Google.Cloud.Translate.V3/docs/history.md
@@ -1,0 +1,5 @@
+# Version history
+
+# Version 1.0.0, released 2019-12-11
+
+Initial GA release.

--- a/apis/Google.LongRunning/docs/history.md
+++ b/apis/Google.LongRunning/docs/history.md
@@ -1,0 +1,9 @@
+# Version history
+
+# Version 1.1.0, released 2019-02-19
+
+Added async RPC methods accepting full request objects.
+
+# Version 1.0.0, released 2017-09-19
+
+Initial GA release.


### PR DESCRIPTION
Many of these are just links to other packages. For the Spanner admin APIs we *may* want to add more detailed histories at some point, but it's better to have something than nothing.