### PR TITLE
Release Google.Cloud.Diagnostics.AspNetCore.Analyzers version 1.0.0

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore.Analyzers/.repo-metadata.json
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore.Analyzers/.repo-metadata.json
@@ -1,4 +1,4 @@
 {
   "distribution_name": "Google.Cloud.Diagnostics.AspNetCore.Analyzers",
-  "release_level": "beta"
+  "release_level": "ga"
 }

--- a/apis/Google.Cloud.Diagnostics.AspNetCore.Analyzers/Google.Cloud.Diagnostics.AspNetCore.Analyzers/Google.Cloud.Diagnostics.AspNetCore.Analyzers.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore.Analyzers/Google.Cloud.Diagnostics.AspNetCore.Analyzers/Google.Cloud.Diagnostics.AspNetCore.Analyzers.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard1.3</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.3</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore.Analyzers/docs/history.md
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore.Analyzers/docs/history.md
@@ -1,5 +1,5 @@
 # Version history
 
-# Version 1.0.0-beta02, released 2018-05-08
+# Version 1.0.0, released 2019-12-12
 
-(No release history recorded.)
+Initial GA release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -301,7 +301,7 @@
 
   {
     "id": "Google.Cloud.Diagnostics.AspNetCore.Analyzers",
-    "version": "1.0.0-beta02",
+    "version": "1.0.0",
     "type": "analyzers",
     "targetFrameworks": "netstandard1.3",
     "testTargetFrameworks": "netcoreapp2.0",


### PR DESCRIPTION
(This needs to be GA so that the other diagnostics libraries can go GA.)