### PR TITLE
Release Google.Cloud.BigQuery.V2 version 1.4.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.4.0-beta07</Version>
+    <Version>1.4.0</Version>
     <TargetFrameworks>netstandard1.3;netstandard2.0;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.3;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Rest" Version="2.10.0" />
-    <PackageReference Include="Google.Apis.Bigquery.v2" Version="1.41.1.1697" />
+    <PackageReference Include="Google.Apis.Bigquery.v2" Version="1.42.0.1795" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.BigQuery.V2/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.V2/docs/history.md
@@ -1,16 +1,17 @@
 # Version history
 
-# Version 1.4.0-beta07, released 2019-11-19
+# Version 1.4.0, released 2019-12-16
 
-Changes since 1.3.0:
+New features since 1.3.0:
 
+- [Commit 1074e9f](https://github.com/googleapis/google-cloud-dotnet/commit/1074e9f): Support for empty InsertIds when inserting rows.
 - Add TemplateSuffix, SkipInvalidRows and SuppressInsertErrors to InsertOptions.
 - Add DefaultPartitionExpiration and DefaultEncryptionConfiguration to CreateDatasetOptions.
 - Add table CreationTime, ExpirationTime and Clustering info to ListTables output.
 - Loosen the restriction on JobConfigurationQuery.DestinationTable not being null.
 - Provide option for using Avro logical types for load/extract.
 - Adds creation time filtering to BigQuery job listing.
-- Client builder.
+- New type BigQueryClientBuilder to simplify configuration.
 - Implement support for BigQuery GEOGRAPHY type.
 - netstandard2.0 target
 - Reimplemented query handling using GetQueryResults RPC instead of ListRows,

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -74,11 +74,12 @@
     "id": "Google.Cloud.BigQuery.V2",
     "productName": "Google BigQuery",
     "productUrl": "https://cloud.google.com/bigquery/",
-    "version": "1.4.0-beta07",
+    "version": "1.4.0",
     "type": "rest",
     "description": "Recommended Google client library to access the BigQuery API. It wraps the Google.Apis.Bigquery.v2 client library, making common operations simpler in client code. BigQuery is a data platform for customers to create, manage, share and query data.",
     "dependencies": {
-      "Google.Apis.Bigquery.v2": "1.41.1.1697"
+      "Google.Api.Gax.Rest": "2.10.0",
+      "Google.Apis.Bigquery.v2": "1.42.0.1795"
     },
     "testDependencies": {
       "Google.Cloud.Storage.V1": "project"


### PR DESCRIPTION
New features since 1.3.0:

- [Commit 1074e9f](https://github.com/googleapis/google-cloud-dotnet/commit/1074e9f): Support for empty InsertIds when inserting rows.
- Add TemplateSuffix, SkipInvalidRows and SuppressInsertErrors to InsertOptions.
- Add DefaultPartitionExpiration and DefaultEncryptionConfiguration to CreateDatasetOptions.
- Add table CreationTime, ExpirationTime and Clustering info to ListTables output.
- Loosen the restriction on JobConfigurationQuery.DestinationTable not being null.
- Provide option for using Avro logical types for load/extract.
- Adds creation time filtering to BigQuery job listing.
- New type BigQueryClientBuilder to simplify configuration.
- Implement support for BigQuery GEOGRAPHY type.
- netstandard2.0 target
- Reimplemented query handling using GetQueryResults RPC instead of ListRows,
  resulting in a performance improvement