### PR TITLE
Release Google.Cloud.Speech.V1 version 1.3.1

### DIFF
--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.csproj
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.3.0</Version>
+    <Version>1.3.1</Version>
     <TargetFrameworks>netstandard1.5;netstandard2.0;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.Speech.V1/docs/history.md
+++ b/apis/Google.Cloud.Speech.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.3.1, released 2019-12-16
+
+- [Commit 3ac2779](https://github.com/googleapis/google-cloud-dotnet/commit/3ac2779): Regenerate without retry for streaming calls. Fixes [issue 3902](https://github.com/googleapis/google-cloud-dotnet/issues/3902).
+
 # Version 1.3.0, released 2019-12-09
 
 - [Commit bdb68ed](https://github.com/googleapis/google-cloud-dotnet/commit/bdb68ed): SpeakerDiarizationConfig.SpeakerTag is now obsolete.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -874,7 +874,7 @@
     "protoPath": "google/cloud/speech/v1",
     "productName": "Google Cloud Speech",
     "productUrl": "https://cloud.google.com/speech",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Speech API, which performs speech recognition.",
     "tags": [ "Speech" ],


### PR DESCRIPTION
This contains no API surface changes, just a fix to not attempt to retry streaming calls (which isn't supported).