### PR TITLE
Make sure we have local tags before updating release notes

### DIFF
--- a/prepare-release.sh
+++ b/prepare-release.sh
@@ -8,6 +8,9 @@ then
   exit 1
 fi
 
+# Make sure we have all the tags locally.
+git fetch --all --tags -f -q
+
 echo "Building $1"
 ./build.sh $1 --notests
 echo ""


### PR DESCRIPTION
Without this, the release note updater may not find the latest version as a tag, but will see it in the release notes, and then insert all the older tag versions.