### PR TITLE
Add Fields parameters to ListObjectsOptions and ListBucketsOptions

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/ListBucketsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/ListBucketsTest.cs
@@ -59,6 +59,22 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
             await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await task);
         }
 
+        [Fact]
+        public void PartialResponses()
+        {
+            var options = new ListBucketsOptions { Fields = "items(name,location),nextPageToken" };
+            var buckets = _fixture.Client.ListBuckets(_fixture.ProjectId, options).ToList();
+            foreach (var bucket in buckets)
+            {
+                // These fields are requested
+                Assert.NotNull(bucket.Name);
+                Assert.NotNull(bucket.Location);
+                // These are not
+                Assert.Null(bucket.LocationType);
+                Assert.Null(bucket.ETag);
+            }
+        }
+
         // Fetches buckets using the given options in each possible way, validating that the expected bucket names are returned.
         private async Task AssertBuckets(ListBucketsOptions options, params string[] expectedBucketNames)
         {

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/ListObjectsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/ListObjectsTest.cs
@@ -94,6 +94,22 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
             await AssertObjects(name, null, name);
         }
 
+        [Fact]
+        public void PartialResponses()
+        {
+            var options = new ListObjectsOptions { Fields = "items(name,contentType),nextPageToken" };
+            var objects = _fixture.Client.ListObjects(_fixture.ReadBucket, options: options).ToList();
+            foreach (var obj in objects)
+            {
+                // These fields are requested
+                Assert.NotNull(obj.Name);
+                Assert.NotNull(obj.ContentType);
+                // These are not
+                Assert.Null(obj.ContentEncoding);
+                Assert.Null(obj.ContentDisposition);
+            }
+        }
+
         private async Task AssertObjects(string prefix, ListObjectsOptions options, params string[] expectedNames)
         {
             IEnumerable<Object> actual = _fixture.Client.ListObjects(_fixture.ReadBucket, prefix, options);

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/ListBucketsOptionsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/ListBucketsOptionsTest.cs
@@ -41,13 +41,15 @@ namespace Google.Cloud.Storage.V1.Tests
                 PageSize = 10,
                 Prefix = "prefix",
                 Projection = Projection.Full,
-                PageToken = "nextpage"
+                PageToken = "nextpage",
+                Fields = "items(name),nextPageToken"
             };
             options.ModifyRequest(request);
             Assert.Equal(10, request.MaxResults);
             Assert.Equal("prefix", request.Prefix);
             Assert.Equal(ProjectionEnum.Full, request.Projection);
             Assert.Equal("nextpage", request.PageToken);
+            Assert.Equal("items(name),nextPageToken", request.Fields);
         }
     }
 }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/ListObjectsOptionsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/ListObjectsOptionsTest.cs
@@ -48,6 +48,7 @@ namespace Google.Cloud.Storage.V1.Tests
                 Versions = true,
                 UserProject = "proj",
                 PageToken = "nextpage",
+                Fields = "items(name),nextPageToken"
             };
             options.ModifyRequest(request);
             Assert.Equal(10, request.MaxResults);
@@ -57,6 +58,7 @@ namespace Google.Cloud.Storage.V1.Tests
             Assert.True(request.Versions);
             Assert.Equal("proj", request.UserProject);
             Assert.Equal("nextpage", request.PageToken);
+            Assert.Equal("items(name),nextPageToken", request.Fields);
         }
     }
 }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/ListBucketsOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/ListBucketsOptions.cs
@@ -47,6 +47,17 @@ namespace Google.Cloud.Storage.V1
         public string PageToken { get; set; }
 
         /// <summary>
+        /// If set, this specifies the fields to fetch in the result to obtain partial responses,
+        /// usually to improve performance.
+        /// For example, to fetch just the name and location of each bucket, set this property to
+        /// "items(name,location),nextPageToken". The "nextPageToken" field is required in order to
+        /// fetch multiple pages; the library does not add this automatically.
+        /// See https://cloud.google.com/storage/docs/json_api/v1/how-tos/performance#partial for more details
+        /// on specifying fields for partial responses.
+        /// </summary>
+        public string Fields { get; set; }
+
+        /// <summary>
         /// Modifies the specified request for all non-null properties of this options object.
         /// </summary>
         /// <param name="request">The request to modify</param>
@@ -67,6 +78,10 @@ namespace Google.Cloud.Storage.V1
             if (PageToken != null)
             {
                 request.PageToken = PageToken;
+            }
+            if (Fields != null)
+            {
+                request.Fields = Fields;
             }
         }
     }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/ListObjectsOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/ListObjectsOptions.cs
@@ -70,6 +70,17 @@ namespace Google.Cloud.Storage.V1
         public string PageToken { get; set; }
 
         /// <summary>
+        /// If set, this specifies the fields to fetch in the result to obtain partial responses,
+        /// usually to improve performance.
+        /// For example, to fetch just the name and content type of each object, set this property to
+        /// "items(name,contentType),nextPageToken". The "nextPageToken" field is required in order to
+        /// fetch multiple pages; the library does not add this automatically.
+        /// See https://cloud.google.com/storage/docs/json_api/v1/how-tos/performance#partial for more details
+        /// on specifying fields for partial responses.
+        /// </summary>
+        public string Fields { get; set; }
+
+        /// <summary>
         /// Modifies the specified request for all non-null properties of this options object.
         /// </summary>
         /// <param name="request">The request to modify</param>
@@ -102,6 +113,10 @@ namespace Google.Cloud.Storage.V1
             if (PageToken != null)
             {
                 request.PageToken = PageToken;
+            }
+            if (Fields != null)
+            {
+                request.Fields = Fields;
             }
         }
     }


### PR DESCRIPTION
An alternative design would be to accept a collection of strings, and perform the join ourselves - possibly adding "nextPageToken" implicitly.

This design is closer to a "raw" approach for fullest control.

Fixes #4019.