### PR TITLE
Reformat the API catalog as part of project generation

### DIFF
--- a/apis/apis.json
+++ b/apis/apis.json
@@ -15,9 +15,12 @@
       "Google.Cloud.Iam.V1": "project",
       "Grpc.Core": "2.25.0"
     },
-    "tags": [ "asset", "inventory", "assets" ]
+    "tags": [
+      "asset",
+      "inventory",
+      "assets"
+    ]
   },
-
   {
     "id": "Google.Cloud.Asset.V1Beta1",
     "generator": "gapic",
@@ -33,9 +36,12 @@
       "Google.LongRunning": "project",
       "Google.Cloud.Iam.V1": "project"
     },
-    "tags": [ "asset", "inventory", "assets" ]
+    "tags": [
+      "asset",
+      "inventory",
+      "assets"
+    ]
   },
-
   {
     "id": "Google.Cloud.AutoML.V1",
     "generator": "gapic",
@@ -51,9 +57,11 @@
       "Google.LongRunning": "project",
       "Grpc.Core": "2.25.0"
     },
-    "tags": [ "automl", "ml" ]
+    "tags": [
+      "automl",
+      "ml"
+    ]
   },
-  
   {
     "id": "Google.Cloud.BigQuery.DataTransfer.V1",
     "generator": "gapic",
@@ -68,9 +76,11 @@
       "Google.Api.Gax.Grpc": "3.0.0-alpha00",
       "Grpc.Core": "2.25.0"
     },
-    "tags": [ "BigQuery", "DataTransfer" ]
+    "tags": [
+      "BigQuery",
+      "DataTransfer"
+    ]
   },
-
   {
     "id": "Google.Cloud.BigQuery.V2",
     "productName": "Google BigQuery",
@@ -84,9 +94,10 @@
     "testDependencies": {
       "Google.Cloud.Storage.V1": "project"
     },
-    "tags": [ "BigQuery" ]
+    "tags": [
+      "BigQuery"
+    ]
   },
-
   {
     "id": "Google.Cloud.Bigtable.Admin.V2",
     "generator": "gapic",
@@ -97,7 +108,9 @@
     "version": "2.0.0-alpha00",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Bigtable Instance and Table Admin APIs.",
-    "tags": [ "Bigtable" ],
+    "tags": [
+      "Bigtable"
+    ],
     "dependencies": {
       "Google.Api.Gax.Grpc": "3.0.0-alpha00",
       "Google.LongRunning": "project",
@@ -109,20 +122,20 @@
       "Google.Api.Gax.Grpc.Testing": "3.0.0-alpha00"
     }
   },
-
   {
     "id": "Google.Cloud.Bigtable.Common.V2",
     "type": "other",
     "targetFrameworks": "netstandard2.0;net461",
     "version": "2.0.0-alpha00",
     "description": "Common code used by Bigtable V2 APIs",
-    "tags": [ "Bigtable" ],
+    "tags": [
+      "Bigtable"
+    ],
     "dependencies": {
       "Google.Api.Gax": "3.0.0-alpha00",
       "Google.Protobuf": "3.8.0"
     }
   },
-  
   {
     "id": "Google.Cloud.Bigtable.V2",
     "generator": "micro",
@@ -132,7 +145,9 @@
     "version": "2.0.0-alpha00",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Bigtable API.",
-    "tags": [ "Bigtable" ],
+    "tags": [
+      "Bigtable"
+    ],
     "dependencies": {
       "Google.Api.Gax.Grpc": "3.0.0-alpha00",
       "Google.Api.Gax.Grpc.Gcp": "3.0.0-alpha00",
@@ -144,7 +159,6 @@
       "Google.Cloud.Bigtable.Admin.V2": "project"
     }
   },
-
   {
     "id": "Google.Cloud.Container.V1",
     "generator": "micro",
@@ -158,9 +172,10 @@
       "Google.Api.Gax.Grpc": "3.0.0-alpha00",
       "Grpc.Core": "2.25.0"
     },
-    "tags": [ "Kubernetes" ]
+    "tags": [
+      "Kubernetes"
+    ]
   },
-
   {
     "id": "Google.Cloud.Dataproc.V1",
     "generator": "gapic",
@@ -171,14 +186,16 @@
     "version": "2.0.0-alpha00",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Dataproc API, which manages Hadoop-based clusters and jobs on Google Cloud Platform.",
-    "tags": [ "Dataproc", "Hadoop" ],
+    "tags": [
+      "Dataproc",
+      "Hadoop"
+    ],
     "dependencies": {
       "Google.LongRunning": "project",
       "Google.Api.Gax.Grpc": "3.0.0-alpha00",
       "Grpc.Core": "2.25.0"
     }
   },
-
   {
     "id": "Google.Cloud.Datastore.V1",
     "generator": "micro",
@@ -188,7 +205,9 @@
     "version": "3.0.0-alpha00",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Datastore API, which accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.",
-    "tags": [ "Datastore" ],
+    "tags": [
+      "Datastore"
+    ],
     "dependencies": {
       "Google.Api.Gax.Grpc": "3.0.0-alpha00",
       "Grpc.Core": "2.25.0",
@@ -198,7 +217,6 @@
       "Google.Api.Gax.Grpc.Testing": "3.0.0-alpha00"
     }
   },
-
   {
     "id": "Google.Cloud.Debugger.V2",
     "generator": "micro",
@@ -208,14 +226,18 @@
     "version": "2.0.0-alpha00",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Debugger API.",
-    "tags": [ "Debug", "Debugger", "Debugging", "Stackdriver"],
+    "tags": [
+      "Debug",
+      "Debugger",
+      "Debugging",
+      "Stackdriver"
+    ],
     "dependencies": {
       "Google.Api.Gax.Grpc": "3.0.0-alpha00",
       "Google.Cloud.DevTools.Common": "project",
       "Grpc.Core": "2.25.0"
     }
   },
-
   {
     "id": "Google.Cloud.DevTools.Common",
     "version": "2.0.0-alpha00",
@@ -223,12 +245,13 @@
     "targetFrameworks": "netstandard2.0;net461",
     "testTargetFrameworks": "netcoreapp2.1;net461",
     "description": "Common Protocol Buffer messages for Google Cloud Developer Tools APIs.",
-    "tags": [ "Tools" ],
+    "tags": [
+      "Tools"
+    ],
     "dependencies": {
       "Google.Api.CommonProtos": "2.0.0-alpha00"
     }
   },
-
   {
     "id": "Google.Cloud.DevTools.ContainerAnalysis.V1",
     "generator": "gapic",
@@ -239,7 +262,12 @@
     "version": "2.0.0-alpha00",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Container Analysis API.",
-    "tags": [ "analysis", "artifact", "metadata", "grafeas" ],
+    "tags": [
+      "analysis",
+      "artifact",
+      "metadata",
+      "grafeas"
+    ],
     "dependencies": {
       "Google.Api.Gax.Grpc": "3.0.0-alpha00",
       "Google.Cloud.Iam.V1": "project",
@@ -247,7 +275,6 @@
       "Grpc.Core": "2.25.0"
     }
   },
-  
   {
     "id": "Google.Cloud.Diagnostics.AspNet",
     "version": "4.0.0-alpha00",
@@ -255,7 +282,14 @@
     "targetFrameworks": "net461",
     "testTargetFrameworks": "net461",
     "description": "Google Stackdriver Instrumentation Libraries for ASP.NET.",
-    "tags": [ "Error", "Reporting", "Stackdriver", "ExceptionLogger", "Trace", "Diagnostics" ],
+    "tags": [
+      "Error",
+      "Reporting",
+      "Stackdriver",
+      "ExceptionLogger",
+      "Trace",
+      "Diagnostics"
+    ],
     "dependencies": {
       "Google.Cloud.Diagnostics.Common": "project",
       "Microsoft.AspNet.WebApi.Core": "5.2.7",
@@ -269,7 +303,6 @@
       "Microsoft.AspNet.Http": "1.0.0-rc1-final"
     }
   },
-
   {
     "id": "Google.Cloud.Diagnostics.AspNetCore",
     "version": "4.0.0-alpha00",
@@ -277,7 +310,14 @@
     "targetFrameworks": "netstandard2.0",
     "testTargetFrameworks": "netcoreapp2.1;net461",
     "description": "Google Stackdriver Instrumentation Libraries for ASP.NET Core.",
-    "tags": [ "Error", "Reporting", "Stackdriver", "ExceptionLogger", "Trace", "Diagnostics" ],
+    "tags": [
+      "Error",
+      "Reporting",
+      "Stackdriver",
+      "ExceptionLogger",
+      "Trace",
+      "Diagnostics"
+    ],
     "dependencies": {
       "Google.Cloud.Diagnostics.Common": "project",
       "Google.Cloud.Diagnostics.AspNetCore.Analyzers": "project",
@@ -300,7 +340,6 @@
       "Microsoft.AspNetCore.Routing": "1.0.4"
     }
   },
-
   {
     "id": "Google.Cloud.Diagnostics.AspNetCore.Analyzers",
     "version": "2.0.0-alpha00",
@@ -308,13 +347,16 @@
     "targetFrameworks": "netstandard1.3",
     "testTargetFrameworks": "netcoreapp2.0",
     "description": "Guidelines for using Google Stackdriver Instrumentation Libraries for ASP.NET Core.",
-    "tags": [ "CodeAnalysis", "Analyzers", "CSharp" ],
+    "tags": [
+      "CodeAnalysis",
+      "Analyzers",
+      "CSharp"
+    ],
     "testDependencies": {
       "Microsoft.AspNetCore.Mvc.Core": "1.0.4",
       "Microsoft.AspNetCore.Routing": "1.0.4"
     }
   },
-
   {
     "id": "Google.Cloud.Diagnostics.Common",
     "version": "4.0.0-alpha00",
@@ -322,7 +364,14 @@
     "targetFrameworks": "netstandard2.0",
     "testTargetFrameworks": "netcoreapp2.1;net461",
     "description": "Google Stackdriver Instrumentation Libraries Common Components.",
-    "tags": [ "Error", "Reporting", "Stackdriver", "ExceptionLogger", "Trace", "Diagnostics" ],
+    "tags": [
+      "Error",
+      "Reporting",
+      "Stackdriver",
+      "ExceptionLogger",
+      "Trace",
+      "Diagnostics"
+    ],
     "dependencies": {
       "Google.Api.Gax.Grpc": "default",
       "Google.Cloud.Logging.V2": "project",
@@ -336,7 +385,6 @@
       "Microsoft.AspNetCore.Http": "2.1.1"
     }
   },
-  
   {
     "id": "Google.Cloud.Dialogflow.V2",
     "generator": "gapic",
@@ -347,7 +395,10 @@
     "version": "2.0.0-alpha00",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Dialogflow API.",
-    "tags": [ "dialogflow", "iot" ],
+    "tags": [
+      "dialogflow",
+      "iot"
+    ],
     "dependencies": {
       "Google.Api.Gax.Grpc": "3.0.0-alpha00",
       "Google.LongRunning": "project",
@@ -357,7 +408,6 @@
       "Microsoft.AspNetCore.Mvc.Core": "1.0.4"
     }
   },
-
   {
     "id": "Google.Cloud.Dlp.V2",
     "generator": "gapic",
@@ -372,9 +422,13 @@
       "Google.Api.Gax.Grpc": "3.0.0-alpha00",
       "Grpc.Core": "2.25.0"
     },
-    "tags": [ "DLP", "data loss prevention", "privacy", "pii" ]
+    "tags": [
+      "DLP",
+      "data loss prevention",
+      "privacy",
+      "pii"
+    ]
   },
-
   {
     "id": "Google.Cloud.ErrorReporting.V1Beta1",
     "generator": "micro",
@@ -385,9 +439,11 @@
     "releaseLevelOverride": "beta",
     "type": "grpc",
     "description": "Recommended Google client library to access the Stackdriver Error Reporting API, which groups and counts similar errors from cloud services. The Stackdriver Error Reporting API provides a way to report new errors and read access to error groups and their associated errors.",
-    "tags": [ "ErrorReporting", "Stackdriver" ]
+    "tags": [
+      "ErrorReporting",
+      "Stackdriver"
+    ]
   },
-
   {
     "id": "Google.Cloud.Firestore.Admin.V1",
     "generator": "gapic",
@@ -400,14 +456,17 @@
     "version": "2.0.0-alpha00",
     "type": "grpc",
     "description": "Recommended Google client library to access the Firestore Admin API.",
-    "tags": [ "firestore", "firebase", "admin" ],
+    "tags": [
+      "firestore",
+      "firebase",
+      "admin"
+    ],
     "dependencies": {
       "Google.Api.Gax.Grpc": "3.0.0-alpha00",
       "Google.LongRunning": "project",
       "Grpc.Core": "2.25.0"
     }
   },
-  
   {
     "id": "Google.Cloud.Firestore",
     "productName": "Firestore",
@@ -417,7 +476,10 @@
     "targetFrameworks": "netstandard2.0;net461",
     "testTargetFrameworks": "netcoreapp2.1;net461",
     "description": "Recommended Google client library to access the Firestore API.",
-    "tags": [ "firestore", "firebase" ],
+    "tags": [
+      "firestore",
+      "firebase"
+    ],
     "dependencies": {
       "Google.Cloud.Firestore.V1": "project",
       "Grpc.Core": "2.25.0",
@@ -431,7 +493,6 @@
       "Xunit.Combinatorial": "1.2.7"
     }
   },
-
   {
     "id": "Google.Cloud.Firestore.V1",
     "generator": "gapic",
@@ -444,14 +505,16 @@
     "targetFrameworks": "netstandard2.0;net461",
     "testTargetFrameworks": "netcoreapp2.1;net461",
     "description": "Low-level Google client library to access the Firestore API. Users are recommended to use the Google.Cloud.Firestore package instead.",
-    "tags": [ "firestore", "firebase" ],
+    "tags": [
+      "firestore",
+      "firebase"
+    ],
     "dependencies": {
       "Google.LongRunning": "project",
       "Google.Api.Gax.Grpc": "3.0.0-alpha00",
       "Grpc.Core": "2.25.0"
     }
   },
-
   {
     "id": "Google.Cloud.Iam.V1",
     "generator": "protogrpc",
@@ -459,13 +522,16 @@
     "version": "2.0.0-alpha00",
     "type": "grpc",
     "description": "gRPC services for the Google Identity and Access Management API. This library is typically used as a dependency for other API client libraries.",
-    "tags": [ "IAM", "Identity", "Access" ],
+    "tags": [
+      "IAM",
+      "Identity",
+      "Access"
+    ],
     "dependencies": {
       "Google.Api.Gax.Grpc": "3.0.0-alpha00",
       "Grpc.Core": "2.25.0"
     }
   },
-
   {
     "id": "Google.Cloud.Kms.V1",
     "generator": "gapic",
@@ -476,14 +542,18 @@
     "version": "2.0.0-alpha00",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Key Management Service API, which manages encryption for your cloud services the same way you do on-premises. You can generate, use, rotate, and destroy AES256 encryption keys.",
-    "tags": [ "kms", "keys", "security", "encryption" ],
+    "tags": [
+      "kms",
+      "keys",
+      "security",
+      "encryption"
+    ],
     "dependencies": {
       "Google.Api.Gax.Grpc": "3.0.0-alpha00",
       "Google.Cloud.Iam.V1": "project",
       "Grpc.Core": "2.25.0"
     }
   },
-
   {
     "id": "Google.Cloud.Language.V1",
     "generator": "micro",
@@ -497,9 +567,10 @@
       "Google.Api.Gax.Grpc": "3.0.0-alpha00",
       "Grpc.Core": "2.25.0"
     },
-    "tags": [ "Language" ]
+    "tags": [
+      "Language"
+    ]
   },
-
   {
     "id": "Google.Cloud.Logging.Log4Net",
     "version": "3.0.0-alpha00",
@@ -507,7 +578,11 @@
     "targetFrameworks": "netstandard2.0;net461",
     "testTargetFrameworks": "netcoreapp2.1;net461",
     "description": "Log4Net client library for the Google Stackdriver Logging API.",
-    "tags": [ "Log4Net", "Logging", "Stackdriver" ],
+    "tags": [
+      "Log4Net",
+      "Logging",
+      "Stackdriver"
+    ],
     "dependencies": {
       "log4net": "2.0.8",
       "Google.Api.Gax.Grpc": "3.0.0-alpha00",
@@ -519,7 +594,6 @@
       "Google.Api.Gax.Testing": "3.0.0-alpha00"
     }
   },
-
   {
     "id": "Google.Cloud.Logging.NLog",
     "version": "3.0.0-alpha00",
@@ -527,7 +601,11 @@
     "targetFrameworks": "netstandard2.0;net461",
     "testTargetFrameworks": "netcoreapp2.1;net461",
     "description": "NLog target for the Google Stackdriver Logging API.",
-    "tags": [ "NLog", "Logging", "Stackdriver" ],
+    "tags": [
+      "NLog",
+      "Logging",
+      "Stackdriver"
+    ],
     "dependencies": {
       "NLog": "4.5.11",
       "Google.Api.Gax.Grpc": "3.0.0-alpha00",
@@ -539,7 +617,6 @@
       "Google.Api.Gax.Testing": "3.0.0-alpha00"
     }
   },
-
   {
     "id": "Google.Cloud.Logging.Type",
     "generator": "proto",
@@ -548,12 +625,14 @@
     "type": "other",
     "targetFrameworks": "netstandard2.0;net461",
     "description": "Version-agnostic types for the Google Stackdriver Logging API.",
-    "tags": [ "Logging", "Stackdriver" ],
+    "tags": [
+      "Logging",
+      "Stackdriver"
+    ],
     "dependencies": {
       "Google.Api.CommonProtos": "2.0.0-alpha00"
     }
   },
-
   {
     "id": "Google.Cloud.Logging.V2",
     "generator": "gapic",
@@ -564,14 +643,16 @@
     "version": "3.0.0-alpha00",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Stackdriver Logging API, which writes log entries and manages your logs, log sinks, and logs-based metrics.",
-    "tags": [ "Logging", "Stackdriver" ],
+    "tags": [
+      "Logging",
+      "Stackdriver"
+    ],
     "dependencies": {
       "Google.Api.Gax.Grpc": "3.0.0-alpha00",
       "Google.Cloud.Logging.Type": "project",
       "Grpc.Core": "2.25.0"
     }
   },
-
   {
     "id": "Google.Cloud.Metadata.V1",
     "productName": "Google Compute Engine Metadata Server",
@@ -580,12 +661,13 @@
     "releaseLevelOverride": "alpha",
     "type": "rest",
     "description": "Google Compute Engine Metadata v1 client library",
-    "tags": [ "Metadata" ],
+    "tags": [
+      "Metadata"
+    ],
     "dependencies": {
       "Google.Apis.Compute.v1": "1.41.1.1687"
     }
   },
-
   {
     "id": "Google.Cloud.Monitoring.V3",
     "generator": "gapic",
@@ -596,13 +678,15 @@
     "version": "2.0.0-alpha00",
     "type": "grpc",
     "description": "Recommended Google client library to access the Stackdriver Monitoring API, which manages your Stackdriver Monitoring data and configurations. Most projects must be associated with a Stackdriver account, with a few exceptions as noted on the individual method pages.",
-    "tags": [ "Monitoring", "Stackdriver" ],
+    "tags": [
+      "Monitoring",
+      "Stackdriver"
+    ],
     "dependencies": {
       "Google.Api.Gax.Grpc": "3.0.0-alpha00",
       "Grpc.Core": "2.25.0"
     }
   },
-
   {
     "id": "Google.Cloud.OsLogin.Common",
     "generator": "micro",
@@ -611,13 +695,15 @@
     "type": "other",
     "targetFrameworks": "netstandard2.0;net461",
     "description": "Version-agnostic types for the Google OS Login API.",
-    "tags": [ "OsLogin", "Login" ],
+    "tags": [
+      "OsLogin",
+      "Login"
+    ],
     "dependencies": {
       "Google.Api.CommonProtos": "2.0.0-alpha00",
       "Google.Api.Gax": "default"
     }
   },
-
   {
     "id": "Google.Cloud.OsLogin.V1",
     "generator": "micro",
@@ -628,12 +714,14 @@
     "version": "2.0.0-alpha00",
     "type": "grpc",
     "description": "Recommended Google client library to manage OS login configuration for Google account users.",
-    "tags": [ "OsLogin", "Login" ],
+    "tags": [
+      "OsLogin",
+      "Login"
+    ],
     "dependencies": {
       "Google.Cloud.OsLogin.Common": "project"
     }
   },
-
   {
     "id": "Google.Cloud.OsLogin.V1Beta",
     "generator": "micro",
@@ -645,12 +733,14 @@
     "releaseLevelOverride": "beta",
     "type": "grpc",
     "description": "Recommended Google client library to manages OS login configuration for Google account users.",
-    "tags": [ "OsLogin", "Login" ],
+    "tags": [
+      "OsLogin",
+      "Login"
+    ],
     "dependencies": {
       "Google.Cloud.OsLogin.Common": "project"
     }
   },
-
   {
     "id": "Google.Cloud.PhishingProtection.V1Beta1",
     "generator": "micro",
@@ -661,9 +751,11 @@
     "releaseLevelOverride": "none",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Phishing Protection API.",
-    "tags": [ "Phishing", "Security" ]
+    "tags": [
+      "Phishing",
+      "Security"
+    ]
   },
-  
   {
     "id": "Google.Cloud.PubSub.V1",
     "generator": "gapic",
@@ -682,9 +774,10 @@
     "testDependencies": {
       "System.ValueTuple": "4.4.0"
     },
-    "tags": [ "PubSub" ]
+    "tags": [
+      "PubSub"
+    ]
   },
-
   {
     "id": "Google.Cloud.RecaptchaEnterprise.V1Beta1",
     "generator": "micro",
@@ -695,9 +788,10 @@
     "releaseLevelOverride": "none",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud reCAPTCHA for Enterprise API.",
-    "tags": [ "reCAPTCHA" ]
+    "tags": [
+      "reCAPTCHA"
+    ]
   },
-
   {
     "id": "Google.Cloud.Redis.V1",
     "generator": "micro",
@@ -712,9 +806,11 @@
       "Google.LongRunning": "project",
       "Grpc.Core": "2.25.0"
     },
-    "tags": [ "Redis", "Memorystore" ]
+    "tags": [
+      "Redis",
+      "Memorystore"
+    ]
   },
-
   {
     "id": "Google.Cloud.Redis.V1Beta1",
     "generator": "micro",
@@ -728,9 +824,11 @@
     "dependencies": {
       "Google.LongRunning": "project"
     },
-    "tags": [ "Redis", "Memorystore" ]
+    "tags": [
+      "Redis",
+      "Memorystore"
+    ]
   },
-
   {
     "id": "Google.Cloud.Scheduler.V1",
     "generator": "micro",
@@ -740,13 +838,15 @@
     "version": "2.0.0-alpha00",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Scheduler API (v1), which creates and manages jobs run on a regular recurring schedule.",
-    "tags": [ "scheduler", "cron" ],
+    "tags": [
+      "scheduler",
+      "cron"
+    ],
     "dependencies": {
       "Google.Api.Gax.Grpc": "3.0.0-alpha00",
       "Grpc.Core": "2.25.0"
     }
   },
-
   {
     "id": "Google.Cloud.SecretManager.V1Beta1",
     "generator": "micro",
@@ -761,9 +861,12 @@
     "dependencies": {
       "Google.Cloud.Iam.V1": "project"
     },
-    "tags": [ "secret", "secrets", "security" ]
+    "tags": [
+      "secret",
+      "secrets",
+      "security"
+    ]
   },
-
   {
     "id": "Google.Cloud.SecurityCenter.V1",
     "generator": "micro",
@@ -779,9 +882,11 @@
       "Google.LongRunning": "project",
       "Grpc.Core": "2.25.0"
     },
-    "tags": [ "security", "data risk" ]
+    "tags": [
+      "security",
+      "data risk"
+    ]
   },
-
   {
     "id": "Google.Cloud.Spanner.Admin.Database.V1",
     "generator": "micro",
@@ -793,14 +898,15 @@
     "version": "3.0.0-alpha00",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Spanner Database Admin API.",
-    "tags": [ "Spanner" ],
+    "tags": [
+      "Spanner"
+    ],
     "dependencies": {
       "Google.LongRunning": "project",
       "Google.Cloud.Iam.V1": "project",
       "Google.Cloud.Spanner.Common.V1": "project"
     }
   },
-
   {
     "id": "Google.Cloud.Spanner.Admin.Instance.V1",
     "generator": "micro",
@@ -812,14 +918,15 @@
     "version": "3.0.0-alpha00",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Spanner Instance Admin API.",
-    "tags": [ "Spanner" ],
+    "tags": [
+      "Spanner"
+    ],
     "dependencies": {
       "Google.LongRunning": "project",
       "Google.Cloud.Iam.V1": "project",
       "Google.Cloud.Spanner.Common.V1": "project"
     }
   },
-
   {
     "id": "Google.Cloud.Spanner.Data",
     "targetFrameworks": "netstandard2.0;net461",
@@ -827,7 +934,10 @@
     "version": "3.0.0-alpha00",
     "type": "other",
     "description": "Google ADO.NET Provider for Google Cloud Spanner.",
-    "tags": [ "Spanner", "ADO" ],
+    "tags": [
+      "Spanner",
+      "ADO"
+    ],
     "dependencies": {
       "Google.Cloud.Spanner.V1": "project",
       "Google.Cloud.Spanner.Admin.Database.V1": "project",
@@ -840,19 +950,19 @@
       "Google.Api.Gax.Grpc.Testing": "default"
     }
   },
-
   {
     "id": "Google.Cloud.Spanner.Common.V1",
     "type": "other",
     "targetFrameworks": "netstandard2.0;net461",
     "version": "3.0.0-alpha00",
     "description": "Common resource names used by all Spanner V1 APIs",
-    "tags": [ "Spanner" ],
+    "tags": [
+      "Spanner"
+    ],
     "dependencies": {
       "Google.Api.Gax": "3.0.0-alpha00"
     }
   },
-  
   {
     "id": "Google.Cloud.Spanner.V1",
     "generator": "micro",
@@ -864,12 +974,13 @@
     "version": "3.0.0-alpha00",
     "type": "grpc",
     "description": "Low-level Google client library to access the Google Cloud Spanner API. The ADO.NET provider (Google.Cloud.Spanner.Data) which depends on this package is generally preferred for Spanner access.",
-    "tags": [ "Spanner" ],
+    "tags": [
+      "Spanner"
+    ],
     "dependencies": {
       "Google.Cloud.Spanner.Common.V1": "project"
     }
   },
-
   {
     "id": "Google.Cloud.Speech.V1",
     "generator": "micro",
@@ -879,14 +990,15 @@
     "version": "2.0.0-alpha00",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Speech API, which performs speech recognition.",
-    "tags": [ "Speech" ],
+    "tags": [
+      "Speech"
+    ],
     "dependencies": {
       "Google.Api.Gax.Grpc": "3.0.0-alpha00",
       "Google.LongRunning": "project",
       "Grpc.Core": "2.25.0"
     }
   },
-
   {
     "id": "Google.Cloud.Speech.V1P1Beta1",
     "generator": "micro",
@@ -897,12 +1009,13 @@
     "releaseLevelOverride": "beta",
     "type": "grpc",
     "description": "Google client library to access the Google Cloud Speech API version v1p1beta1 with upcoming features.",
-    "tags": [ "Speech" ],
+    "tags": [
+      "Speech"
+    ],
     "dependencies": {
       "Google.LongRunning": "project"
     }
   },
-
   {
     "id": "Google.Cloud.Storage.V1",
     "productName": "Google Cloud Storage",
@@ -919,9 +1032,10 @@
       "Google.Api.Gax.Testing": "3.0.0-alpha00",
       "Google.Apis.Iam.v1": "1.42.0.1779"
     },
-    "tags": [ "Storage" ]
+    "tags": [
+      "Storage"
+    ]
   },
-
   {
     "id": "Google.Cloud.Talent.V4Beta1",
     "generator": "gapic",
@@ -933,12 +1047,14 @@
     "releaseLevelOverride": "beta",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Talent solution API which provides the capability to create, read, update, and delete job postings, as well as search jobs based on keywords and filters.",
-    "tags": [ "Talent", "Jobs" ],
+    "tags": [
+      "Talent",
+      "Jobs"
+    ],
     "dependencies": {
       "Google.LongRunning": "project"
     }
   },
-
   {
     "id": "Google.Cloud.Tasks.V2",
     "generator": "micro",
@@ -948,14 +1064,15 @@
     "version": "2.0.0-alpha00",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Tasks API (v2), which manages the execution of large numbers of distributed requests.",
-    "tags": [ "Tasks" ],
+    "tags": [
+      "Tasks"
+    ],
     "dependencies": {
       "Google.Api.Gax.Grpc": "3.0.0-alpha00",
       "Google.Cloud.Iam.V1": "project",
       "Grpc.Core": "2.25.0"
     }
   },
-
   {
     "id": "Google.Cloud.Tasks.V2Beta3",
     "generator": "micro",
@@ -966,12 +1083,13 @@
     "releaseLevelOverride": "beta",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Tasks API (v2beta3), which manages the execution of large numbers of distributed requests.",
-    "tags": [ "Tasks" ],
+    "tags": [
+      "Tasks"
+    ],
     "dependencies": {
       "Google.Cloud.Iam.V1": "project"
     }
   },
-
   {
     "id": "Google.Cloud.TextToSpeech.V1",
     "generator": "micro",
@@ -985,9 +1103,11 @@
       "Google.Api.Gax.Grpc": "3.0.0-alpha00",
       "Grpc.Core": "2.25.0"
     },
-    "tags": [ "Speech", "Text-to-speech" ]
+    "tags": [
+      "Speech",
+      "Text-to-speech"
+    ]
   },
-
   {
     "id": "Google.Cloud.Trace.V1",
     "generator": "micro",
@@ -1001,9 +1121,11 @@
       "Google.Api.Gax.Grpc": "3.0.0-alpha00",
       "Grpc.Core": "2.25.0"
     },
-    "tags": [ "Tracing", "Trace" ]
+    "tags": [
+      "Tracing",
+      "Trace"
+    ]
   },
-
   {
     "id": "Google.Cloud.Trace.V2",
     "generator": "micro",
@@ -1017,9 +1139,11 @@
       "Google.Api.Gax.Grpc": "3.0.0-alpha00",
       "Grpc.Core": "2.25.0"
     },
-    "tags": [ "Tracing", "Trace" ]
+    "tags": [
+      "Tracing",
+      "Trace"
+    ]
   },
-
   {
     "id": "Google.Cloud.Translate.V3",
     "productName": "Google Cloud Translation",
@@ -1034,9 +1158,11 @@
       "Google.LongRunning": "project",
       "Grpc.Core": "2.25.0"
     },
-    "tags": [ "Translate", "Translation" ]
+    "tags": [
+      "Translate",
+      "Translation"
+    ]
   },
-
   {
     "id": "Google.Cloud.Translation.V2",
     "productName": "Google Cloud Translation",
@@ -1048,9 +1174,11 @@
       "Google.Apis.Translate.v2": "1.42.0.875",
       "Google.Api.Gax.Rest": "3.0.0-alpha00"
     },
-    "tags": [ "Translate", "Translation" ]
+    "tags": [
+      "Translate",
+      "Translation"
+    ]
   },
-
   {
     "id": "Google.Cloud.VideoIntelligence.V1",
     "generator": "micro",
@@ -1060,14 +1188,15 @@
     "version": "2.0.0-alpha00",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Video Intelligence API.",
-    "tags": [ "VideoIntelligence" ],
+    "tags": [
+      "VideoIntelligence"
+    ],
     "dependencies": {
       "Google.Api.Gax.Grpc": "3.0.0-alpha00",
       "Google.LongRunning": "project",
       "Grpc.Core": "2.25.0"
     }
   },
-
   {
     "id": "Google.Cloud.Vision.V1",
     "generator": "micro",
@@ -1077,14 +1206,15 @@
     "version": "2.0.0-alpha00",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Vision API, which integrates Google Vision features, including image labeling, face, logo, and landmark detection, optical character recognition (OCR), and detection of explicit content, into applications.",
-    "tags": [ "Vision" ],
+    "tags": [
+      "Vision"
+    ],
     "dependencies": {
       "Google.Api.Gax.Grpc": "3.0.0-alpha00",
       "Google.LongRunning": "project",
       "Grpc.Core": "2.25.0"
     }
   },
-
   {
     "id": "Google.Cloud.WebRisk.V1Beta1",
     "generator": "micro",
@@ -1095,9 +1225,15 @@
     "releaseLevelOverride": "beta",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Web Risk API, which lets client applications check URLs against Google's constantly updated lists of unsafe web resources.",
-    "tags": [ "security", "phishing", "malware", "safety", "risk", "url" ]
+    "tags": [
+      "security",
+      "phishing",
+      "malware",
+      "safety",
+      "risk",
+      "url"
+    ]
   },
-  
   {
     "id": "Google.LongRunning",
     "generator": "micro",
@@ -1105,14 +1241,14 @@
     "version": "2.0.0-alpha00",
     "type": "grpc",
     "description": "gRPC services for the Google Long Running Operations API. This library is typically used as a dependency for other API client libraries.",
-    "tags": [ "LongRunning" ],
-    "dependencies": {
-    },
+    "tags": [
+      "LongRunning"
+    ],
+    "dependencies": {},
     "testDependencies": {
       "Google.Api.Gax.Testing": "3.0.0-alpha00"
     }
   },
-
   {
     "id": "Grafeas.V1",
     "generator": "gapic",
@@ -1123,7 +1259,12 @@
     "version": "2.0.0-alpha00",
     "type": "grpc",
     "description": "Recommended client library to access Grafeas, an open artifact metadata API to audit and govern your software supply chain.",
-    "tags": [ "audit", "metadata", "artifact", "grafeas" ],
+    "tags": [
+      "audit",
+      "metadata",
+      "artifact",
+      "grafeas"
+    ],
     "dependencies": {
       "Google.Api.Gax.Grpc": "3.0.0-alpha00",
       "Grpc.Core": "2.25.0"

--- a/tools/Google.Cloud.Tools.Common/ApiMetadata.cs
+++ b/tools/Google.Cloud.Tools.Common/ApiMetadata.cs
@@ -70,6 +70,11 @@ namespace Google.Cloud.Tools.Common
         public StructuredVersion StructuredVersion => new StructuredVersion(Version);
 
         /// <summary>
+        /// The path to the API catalog (apis.json).
+        /// </summary>
+        public static string CatalogPath => Path.Combine(DirectoryLayout.DetermineRootDirectory(), "apis", "apis.json");
+
+        /// <summary>
         /// The release level to record in .repo-metadata.json, if this differs from the one
         /// inferred from the JSON. (For example, we will have 2.0.0-alpha00 versions that didn't
         /// have a 1.0.0.)
@@ -95,7 +100,7 @@ namespace Google.Cloud.Tools.Common
         {
             var root = DirectoryLayout.DetermineRootDirectory();
 
-            var json = File.ReadAllText(Path.Combine(root, "apis", "apis.json"));
+            var json = File.ReadAllText(CatalogPath);
             return JsonConvert.DeserializeObject<List<ApiMetadata>>(json);
         }
     }

--- a/tools/Google.Cloud.Tools.ProjectGenerator/Program.cs
+++ b/tools/Google.Cloud.Tools.ProjectGenerator/Program.cs
@@ -14,6 +14,7 @@
 
 using Google.Cloud.Tools.Common;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -126,6 +127,8 @@ namespace Google.Cloud.Tools.ProjectGenerator
                 var root = DirectoryLayout.DetermineRootDirectory();
                 var apis = ApiMetadata.LoadApis();
                 Console.WriteLine($"API catalog contains {apis.Count} entries");
+                // Now we know we can parse the API catalog, let's reformat it.
+                ReformatApiCatalog();
                 HashSet<string> apiNames = new HashSet<string>(apis.Select(api => api.Id));
 
                 foreach (var api in apis)
@@ -148,6 +151,19 @@ namespace Google.Cloud.Tools.ProjectGenerator
             {
                 Console.WriteLine($"Failed: {e}");
                 return 1;
+            }
+        }
+
+        static void ReformatApiCatalog()
+        {
+            string path = ApiMetadata.CatalogPath;
+            string existing = File.ReadAllText(path);
+            JToken parsed = JToken.Parse(existing);
+            string formatted = parsed.ToString(Formatting.Indented);
+            if (existing != formatted)
+            {
+                File.WriteAllText(path, formatted);
+                Console.WriteLine("Reformatted apis.json");
             }
         }
 

--- a/tools/Google.Cloud.Tools.sln
+++ b/tools/Google.Cloud.Tools.sln
@@ -32,8 +32,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.AnalyzersTesti
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Tools.ProcessBuildTimingLog", "Google.Cloud.Tools.ProcessBuildTimingLog\Google.Cloud.Tools.ProcessBuildTimingLog.csproj", "{E47C244F-96BC-4753-BFE1-7A54A3C3AA3E}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Tools.GeneratePublicApi", "Google.Cloud.Tools.GeneratePublicApi\Google.Cloud.Tools.GeneratePublicApi.csproj", "{6C268EFF-E10A-458E-8CDB-060F5381238A}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Tools.ShowReleaseStatus", "Google.Cloud.Tools.ShowReleaseStatus\Google.Cloud.Tools.ShowReleaseStatus.csproj", "{1EAFDF69-BBF8-450F-8B73-BAED481378F3}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Tools.VersionCompat", "Google.Cloud.Tools.VersionCompat\Google.Cloud.Tools.VersionCompat.csproj", "{1D31D545-9008-44BB-894F-11A84CDA8BDC}"
@@ -50,7 +48,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Tools.CheckVer
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Tools.UpdateReleaseNotes", "Google.Cloud.Tools.UpdateReleaseNotes\Google.Cloud.Tools.UpdateReleaseNotes.csproj", "{E66FC669-1F15-4158-8980-4958565F84EE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Tools.CompareVersions", "Google.Cloud.Tools.CompareVersions\Google.Cloud.Tools.CompareVersions.csproj", "{BC2FA087-5154-49BF-AEE1-5B50305BAAAD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Tools.CompareVersions", "Google.Cloud.Tools.CompareVersions\Google.Cloud.Tools.CompareVersions.csproj", "{BC2FA087-5154-49BF-AEE1-5B50305BAAAD}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.LongRunning", "..\apis\Google.LongRunning\Google.LongRunning\Google.LongRunning.csproj", "{342C4A65-EA46-44CE-9986-1570EF96A6C9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -242,18 +242,6 @@ Global
 		{E47C244F-96BC-4753-BFE1-7A54A3C3AA3E}.Release|x64.Build.0 = Release|Any CPU
 		{E47C244F-96BC-4753-BFE1-7A54A3C3AA3E}.Release|x86.ActiveCfg = Release|Any CPU
 		{E47C244F-96BC-4753-BFE1-7A54A3C3AA3E}.Release|x86.Build.0 = Release|Any CPU
-		{6C268EFF-E10A-458E-8CDB-060F5381238A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6C268EFF-E10A-458E-8CDB-060F5381238A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6C268EFF-E10A-458E-8CDB-060F5381238A}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{6C268EFF-E10A-458E-8CDB-060F5381238A}.Debug|x64.Build.0 = Debug|Any CPU
-		{6C268EFF-E10A-458E-8CDB-060F5381238A}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{6C268EFF-E10A-458E-8CDB-060F5381238A}.Debug|x86.Build.0 = Debug|Any CPU
-		{6C268EFF-E10A-458E-8CDB-060F5381238A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6C268EFF-E10A-458E-8CDB-060F5381238A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{6C268EFF-E10A-458E-8CDB-060F5381238A}.Release|x64.ActiveCfg = Release|Any CPU
-		{6C268EFF-E10A-458E-8CDB-060F5381238A}.Release|x64.Build.0 = Release|Any CPU
-		{6C268EFF-E10A-458E-8CDB-060F5381238A}.Release|x86.ActiveCfg = Release|Any CPU
-		{6C268EFF-E10A-458E-8CDB-060F5381238A}.Release|x86.Build.0 = Release|Any CPU
 		{1EAFDF69-BBF8-450F-8B73-BAED481378F3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1EAFDF69-BBF8-450F-8B73-BAED481378F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1EAFDF69-BBF8-450F-8B73-BAED481378F3}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -362,6 +350,18 @@ Global
 		{BC2FA087-5154-49BF-AEE1-5B50305BAAAD}.Release|x64.Build.0 = Release|Any CPU
 		{BC2FA087-5154-49BF-AEE1-5B50305BAAAD}.Release|x86.ActiveCfg = Release|Any CPU
 		{BC2FA087-5154-49BF-AEE1-5B50305BAAAD}.Release|x86.Build.0 = Release|Any CPU
+		{342C4A65-EA46-44CE-9986-1570EF96A6C9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{342C4A65-EA46-44CE-9986-1570EF96A6C9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{342C4A65-EA46-44CE-9986-1570EF96A6C9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{342C4A65-EA46-44CE-9986-1570EF96A6C9}.Debug|x64.Build.0 = Debug|Any CPU
+		{342C4A65-EA46-44CE-9986-1570EF96A6C9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{342C4A65-EA46-44CE-9986-1570EF96A6C9}.Debug|x86.Build.0 = Debug|Any CPU
+		{342C4A65-EA46-44CE-9986-1570EF96A6C9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{342C4A65-EA46-44CE-9986-1570EF96A6C9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{342C4A65-EA46-44CE-9986-1570EF96A6C9}.Release|x64.ActiveCfg = Release|Any CPU
+		{342C4A65-EA46-44CE-9986-1570EF96A6C9}.Release|x64.Build.0 = Release|Any CPU
+		{342C4A65-EA46-44CE-9986-1570EF96A6C9}.Release|x86.ActiveCfg = Release|Any CPU
+		{342C4A65-EA46-44CE-9986-1570EF96A6C9}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This has two benefits:

- If it's always auto-formatted, we can automate modifications without creating unexpected changes.
- We never end up with a trailing comma or other invalid-but-accepted-by-Json.NET bits of JSON

It turns out our file was very nearly auto-formatted already. There are three kinds of changes:

- We don't have a blank line between each API
- Tag lists are "one tag per line"
- Empty dependency maps now contain a line break