### PR TITLE
Parse timestamp JSON values as decimal instead of double

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryRowTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryRowTest.cs
@@ -173,6 +173,25 @@ namespace Google.Cloud.BigQuery.V2.Tests
             Assert.Throws<InvalidOperationException>(() => row["struct"]);
         }
 
+        [Fact]
+        public void TimestampRounding()
+        {
+            var schema = new TableSchemaBuilder
+            {
+                { "timestamp", BigQueryDbType.Timestamp },
+            }.Build();
+            var rawRow = new TableRow
+            {
+                F = new[]
+                {
+                    new TableCell { V = "1.090855528173333E9" },
+                }
+            };
+            var row = new BigQueryRow(rawRow, schema);
+            var expected = new DateTime(2004, 7, 26, 15, 25, 28, DateTimeKind.Utc).AddTicks(1733330);
+            Assert.Equal(expected, (DateTime) row["timestamp"]);
+        }
+
         private JArray CreateArray(params string[] values) => new JArray(values.Select(CreateObject));
 
         private JObject CreateObject(string value) => new JObject { ["v"] = value };

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryRow.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryRow.cs
@@ -65,8 +65,8 @@ namespace Google.Cloud.BigQuery.V2
         // Instead, we work out the number of ticks and add that.
         private static readonly Func<string, DateTime> TimestampConverter = v =>
         {
-            double seconds = DoubleConverter(v);
-            long microseconds = (long) (seconds * 1e6);
+            decimal seconds = decimal.Parse(v, NumberStyles.AllowDecimalPoint | NumberStyles.AllowExponent, CultureInfo.InvariantCulture);
+            long microseconds = (long) (seconds * 1e6m);
             long ticks = microseconds * 10;
             return new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddTicks(ticks);
         };


### PR DESCRIPTION
This avoids losing precision.

Fixes #4031.