### PR TITLE
[BigQuery] Support for specifying specific fields when fetching a table or listing rows.

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/QueryTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/QueryTest.cs
@@ -727,19 +727,40 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             {
                 SelectedFields = "age,gender,children.gender,children.age"
             };
+
+            // Obtain the table's partial schema.
             var table = client.GetTable(datasetId, tableId, options);
-            // Making sure we grab a row of a person with children.
-            var row = client.ListRows(datasetId, tableId, table.Schema).First(row => ((Dictionary<string, object>[])row["children"]).Length > 0);
+            // Use the partial schema to obtain partial rows.
+            var rows = client.ListRows(datasetId, tableId, table.Schema);
+            // Make sure we grab a row of a person with children for testing fields that should be present.
+            var row = rows.First(row => ((Dictionary<string, object>[])row["children"])?.Length > 0);
+
             // These should be present
             Assert.NotNull(row["age"]);
             Assert.NotNull(row["gender"]);
-            var children = (Dictionary<string, object>[])row["children"];
+            var children = row["children"] as Dictionary<string, object>[];
             Assert.NotNull(children);
             Assert.NotNull(children[0]["gender"]);
             Assert.NotNull(children[0]["age"]);
             // These shouldn't
             Assert.Throws<KeyNotFoundException>(() => row["fullName"]);
             Assert.Throws<KeyNotFoundException>(() => children[0]["name"]);
+        }
+
+        [Fact]
+        public void ListRows_EmptySchema()
+        {
+            var client = BigQueryClient.Create(_fixture.ProjectId);
+            string datasetId = _fixture.DatasetId;
+            string tableId = _fixture.PeopleTableId;
+
+            // Use an empty schema to obtain the rows.
+            // We should get full rows.
+            var rows = client.ListRows(datasetId, tableId, new TableSchema()).ToList();
+
+            // The People table has 7 top level fields. We should have all fields.
+            object dummy;
+            Assert.All(rows, row => dummy = row[6]);
         }
 
         private class TitleComparer : IEqualityComparer<BigQueryRow>

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/TablesTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/TablesTest.cs
@@ -308,5 +308,86 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             Assert.Equal(totalCount - 2, remainder.Count);
         }
 
+        [Fact]
+        public void GetTable()
+        {
+            var client = BigQueryClient.Create(_fixture.ProjectId);
+            string datasetId = _fixture.DatasetId;
+            string tableId = _fixture.HighScoreExtendedTableId;
+
+            var table = client.GetTable(datasetId, tableId);
+
+            Assert.Equal(4, table.Schema.Fields.Count);
+            Assert.Equal("player", table.Schema.Fields[0].Name);
+            Assert.Equal("gameStarted", table.Schema.Fields[1].Name);
+            Assert.Equal("score", table.Schema.Fields[2].Name);
+            Assert.Equal("gameFinished", table.Schema.Fields[3].Name);
+        }
+
+        [Fact]
+        public void GetTable_PartialSchema_SimpleTypes()
+        {
+            var client = BigQueryClient.Create(_fixture.ProjectId);
+            string datasetId = _fixture.DatasetId;
+            string tableId = _fixture.HighScoreExtendedTableId;
+            var options = new GetTableOptions
+            {
+                SelectedFields = "player,score"
+            };
+            var table = client.GetTable(datasetId, tableId, options);
+
+            Assert.Equal(2, table.Schema.Fields.Count);
+            Assert.Equal("player", table.Schema.Fields[0].Name);
+            Assert.Equal("score", table.Schema.Fields[1].Name);
+        }
+
+        [Fact]
+        public void GetTable_PartialSchema_SimpleTypes_Ordered()
+        {
+            var client = BigQueryClient.Create(_fixture.ProjectId);
+            string datasetId = _fixture.DatasetId;
+            string tableId = _fixture.HighScoreExtendedTableId;
+            var options = new GetTableOptions
+            {
+                // Specify selected fields in a different order
+                // to the one they were created in.
+                SelectedFields = "score,player"
+            };
+            var table = client.GetTable(datasetId, tableId, options);
+
+            Assert.Equal(2, table.Schema.Fields.Count);
+            // The schema still contains the fields in the same order
+            // as the one they were created in.
+            Assert.Equal("player", table.Schema.Fields[0].Name);
+            Assert.Equal("score", table.Schema.Fields[1].Name);
+        }
+
+        [Fact]
+        public void GetTable_PartialSchema_ComplexTypes()
+        {
+            var client = BigQueryClient.Create(_fixture.ProjectId);
+            string datasetId = _fixture.DatasetId;
+            string tableId = _fixture.PeopleTableId;
+            var options = new GetTableOptions
+            {
+                SelectedFields = "age,gender,phoneNumber,children.gender,children.age"
+            };
+            var table = client.GetTable(datasetId, tableId, options);
+
+            Assert.Equal(4, table.Schema.Fields.Count);
+
+            Assert.Equal("age", table.Schema.Fields[0].Name);
+            Assert.Equal("gender", table.Schema.Fields[1].Name);
+
+            Assert.Equal("phoneNumber", table.Schema.Fields[2].Name);
+            Assert.Equal(2, table.Schema.Fields[2].Fields.Count);
+            Assert.Equal("areaCode", table.Schema.Fields[2].Fields[0].Name);
+            Assert.Equal("number", table.Schema.Fields[2].Fields[1].Name);
+
+            Assert.Equal("children", table.Schema.Fields[3].Name);
+            Assert.Equal(2, table.Schema.Fields[3].Fields.Count);
+            Assert.Equal("gender", table.Schema.Fields[3].Fields[0].Name);
+            Assert.Equal("age", table.Schema.Fields[3].Fields[1].Name);
+        }
     }
 }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/GetTableOptionsTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/GetTableOptionsTest.cs
@@ -19,13 +19,27 @@ namespace Google.Cloud.BigQuery.V2.Tests
 {
     public class GetTableOptionsTest
     {
-        // The test doesn't do anything yet... but neither does the code.
         [Fact]
         public void ModifyRequest_NoOp()
         {
             var request = new GetRequest(null, "project", "dataset", "table");
             var options = new GetTableOptions();
             options.ModifyRequest(request);
+
+            Assert.Null(request.SelectedFields);
+        }
+
+        [Fact]
+        public void ModifyRequest()
+        {
+            var request = new GetRequest(null, "project", "dataset", "table");
+            var options = new GetTableOptions
+            { 
+                SelectedFields = "a,b,c"
+            };
+            options.ModifyRequest(request);
+
+            Assert.Equal("a,b,c", request.SelectedFields);
         }
     }
 }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/TableSchemaExtensionsTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/TableSchemaExtensionsTest.cs
@@ -41,5 +41,82 @@ namespace Google.Cloud.BigQuery.V2.Tests
             var schema = new TableSchema();
             Assert.Empty(schema.IndexFieldNames());
         }
+
+        [Fact]
+        public void SelectedFields_EmptySchema()
+        {
+            var schema = new TableSchema();
+            Assert.Equal(string.Empty, schema.BuildSelectedFields());
+        }
+
+        [Fact]
+        public void SelectedFields_OneField()
+        {
+            var schema = new TableSchema
+            {
+                Fields = new List<TableFieldSchema>
+                {
+                    new TableFieldSchema { Name = "foo" },
+                }
+            };
+
+            Assert.Equal("foo", schema.BuildSelectedFields());
+        }
+
+        [Fact]
+        public void SelectedFields_OneLevel()
+        {
+            var schema = new TableSchema
+            {
+                Fields = new List<TableFieldSchema>
+                {
+                    new TableFieldSchema { Name = "foo" },
+                    new TableFieldSchema { Name = "bar" },
+                }
+            };
+
+            Assert.Equal("foo,bar", schema.BuildSelectedFields());
+        }
+
+        [Fact]
+        public void SelectedFields_Nested()
+        {
+            var schema = new TableSchema
+            {
+                Fields = new List<TableFieldSchema>
+                {
+                    new TableFieldSchema
+                    {
+                        Name = "l0_f0",
+                        Fields = new List<TableFieldSchema>
+                        {
+                            new TableFieldSchema { Name = "l1_f0"},
+                            new TableFieldSchema
+                            {
+                                Name = "l1_f1",
+                                Fields = new List<TableFieldSchema>
+                                {
+                                    new TableFieldSchema { Name = "l2_f0" },
+                                    new TableFieldSchema { Name = "l2_f1" }
+                                }
+                            }
+                        }
+                    },
+                    new TableFieldSchema { Name = "l0_f1" },
+                    new TableFieldSchema
+                    {
+                        Name = "l0_f2",
+                        Fields = new List<TableFieldSchema>
+                        {
+                            new TableFieldSchema { Name = "l1_f2"},
+                            new TableFieldSchema { Name = "l1_f3"}
+                        }
+                    },
+
+                }
+            };
+
+            Assert.Equal("l0_f0.l1_f0,l0_f0.l1_f1.l2_f0,l0_f0.l1_f1.l2_f1,l0_f1,l0_f2.l1_f2,l0_f2.l1_f3", schema.BuildSelectedFields());
+        }
     }
 }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/TableSchemaExtensionsTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/TableSchemaExtensionsTest.cs
@@ -43,14 +43,21 @@ namespace Google.Cloud.BigQuery.V2.Tests
         }
 
         [Fact]
-        public void SelectedFields_EmptySchema()
+        public void BuildSelectedFields_NullSchema()
+        {
+            TableSchema schema = null;
+            Assert.Null(schema.BuildSelectedFields());
+        }
+
+        [Fact]
+        public void BuildSelectedFields_EmptySchema()
         {
             var schema = new TableSchema();
             Assert.Equal(string.Empty, schema.BuildSelectedFields());
         }
 
         [Fact]
-        public void SelectedFields_OneField()
+        public void BuildSelectedFields_OneField()
         {
             var schema = new TableSchema
             {
@@ -64,7 +71,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
         }
 
         [Fact]
-        public void SelectedFields_OneLevel()
+        public void BuildSelectedFields_OneLevel()
         {
             var schema = new TableSchema
             {
@@ -79,7 +86,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
         }
 
         [Fact]
-        public void SelectedFields_Nested()
+        public void BuildSelectedFields_Nested()
         {
             var schema = new TableSchema
             {

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClient.Queries.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClient.Queries.cs
@@ -226,7 +226,9 @@ namespace Google.Cloud.BigQuery.V2
         /// </remarks>
         /// <param name="datasetId">The dataset ID. Must not be null.</param>
         /// <param name="tableId">The table ID. Must not be null.</param>
-        /// <param name="schema">The schema to use when interpreting results. This may be null, in which case it will be fetched from
+        /// <param name="schema">The schema to use when interpreting results. If this is a partial schema, then partial rows
+        /// will be fetched. See <see cref="GetTableOptions.SelectedFields"/> for how to obtain a table's partial schema.
+        /// This may be null or empty (i.e. <see cref="TableSchema.Fields"/> null or empty), in which case it will be fetched from
         /// the table first.</param>
         /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
         /// <returns>The results of listing the rows within the table.</returns>
@@ -243,7 +245,9 @@ namespace Google.Cloud.BigQuery.V2
         /// or service failures can cause exceptions even after the first results have been returned.
         /// </remarks>
         /// <param name="tableReference">A fully-qualified identifier for the table. Must not be null.</param>
-        /// <param name="schema">The schema to use when interpreting results. This may be null, in which case it will be fetched from
+        /// <param name="schema">The schema to use when interpreting results. If this is a partial schema, then partial rows
+        /// will be fetched. See <see cref="GetTableOptions.SelectedFields"/> for how to obtain a table's partial schema.
+        /// This may be null or empty (i.e. <see cref="TableSchema.Fields"/> null or empty), in which case it will be fetched from
         /// the table first.</param>
         /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
         /// <returns>The results of listing the rows within the table.</returns>

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.Queries.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.Queries.cs
@@ -128,7 +128,9 @@ namespace Google.Cloud.BigQuery.V2
         public override PagedEnumerable<TableDataList, BigQueryRow> ListRows(TableReference tableReference, TableSchema schema = null, ListRowsOptions options = null)
         {
             GaxPreconditions.CheckNotNull(tableReference, nameof(tableReference));
-            var resultSchema = schema ?? GetSchema(tableReference);
+            // There's no way to specify fetching rows with no fields (that looks more like a dry run anyways).
+            // So, if the schema is empty, the whole rows will be fetch, so we need to get the whole schema.
+            var resultSchema = schema?.Fields?.Count > 0 ? schema : GetSchema(tableReference);
 
             var pageManager = new TableRowPageManager(resultSchema);
             return new RestPagedEnumerable<TabledataResource.ListRequest, TableDataList, BigQueryRow>(
@@ -143,7 +145,9 @@ namespace Google.Cloud.BigQuery.V2
             GaxPreconditions.CheckNotNull(tableReference, nameof(tableReference));
             // TODO: This is a synchronous call. We can't easily make this part asynchronous - we don't have a cancellation token, and we're returning
             // a non-task value. We could defer until the first MoveNext call, but that's tricky.
-            var resultSchema = schema ?? GetSchema(tableReference);
+            // There's no way to specify fetching rows with no fields (that looks more like a dry run anyways).
+            // So, if the schema is empty, the whole rows will be fetch, so we need to get the whole schema.
+            var resultSchema = schema?.Fields?.Count > 0 ? schema : GetSchema(tableReference);
 
             var pageManager = new TableRowPageManager(schema);
             return new RestPagedAsyncEnumerable<TabledataResource.ListRequest, TableDataList, BigQueryRow>(
@@ -188,10 +192,9 @@ namespace Google.Cloud.BigQuery.V2
         {
             var request = Service.Tabledata.List(tableReference.ProjectId, tableReference.DatasetId, tableReference.TableId);
             options?.ModifyRequest(request);
-            if (schema != null)
-            {
-                request.SelectedFields = schema.BuildSelectedFields();
-            }
+            // null and empty schemas are handled by BuildSelectedFields,
+            // but both values mean the same, and that is to return whole rows.
+            request.SelectedFields = schema.BuildSelectedFields();
             RetryHandler.MarkAsRetriable(request);
             return request;
         }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/GetTableOptions.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/GetTableOptions.cs
@@ -17,15 +17,14 @@ using static Google.Apis.Bigquery.v2.TablesResource;
 namespace Google.Cloud.BigQuery.V2
 {
     /// <summary>
-    /// Options for <c>GetTable</c> operations. Currently no options are
-    /// available, but this class exists to provide consistency and extensibility.
+    /// Options for <c>GetTable</c> operations.
     /// </summary>
     public sealed class GetTableOptions
     {
         /// <summary>
         /// Comma separated list of schema fields to return.
         /// When set allows to obtain a partial table schema.
-        /// If not set, all fields, that is, the full table schema, will be returned.
+        /// When this property is null or empty the full table schema is returned.
         /// </summary>
         public string SelectedFields { get; set; }
 

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/GetTableOptions.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/GetTableOptions.cs
@@ -22,8 +22,19 @@ namespace Google.Cloud.BigQuery.V2
     /// </summary>
     public sealed class GetTableOptions
     {
+        /// <summary>
+        /// Comma separated list of schema fields to return.
+        /// When set allows to obtain a partial table schema.
+        /// If not set, all fields, that is, the full table schema, will be returned.
+        /// </summary>
+        public string SelectedFields { get; set; }
+
         internal void ModifyRequest(GetRequest request)
         {
+            if (SelectedFields != null)
+            {
+                request.SelectedFields = SelectedFields;
+            }
         }
     }
 }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/TableSchemaExtensions.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/TableSchemaExtensions.cs
@@ -40,5 +40,38 @@ namespace Google.Cloud.BigQuery.V2
             }
             return ret;
         }
+
+        internal static string BuildSelectedFields(this TableSchema schema)
+        {
+            if (!(schema?.Fields?.Count > 0))
+            {
+                return string.Empty;
+            }
+
+            var built = new List<string>();
+            var currentField = new List<string>();
+            BuildSelectedFields(schema.Fields, currentField, built);
+            return string.Join(",", built);
+        }
+
+        private static void BuildSelectedFields(IList<TableFieldSchema> fieldSchemas, IList<string> currentField, IList<string> built)
+        {
+            // Whatever we have in currentField is terminal.
+            // Build that an we are done.
+            if (!(fieldSchemas?.Count > 0))
+            {
+                built.Add(string.Join(".", currentField));
+            }
+            else
+            {
+                int removeAtIndex = currentField.Count;
+                foreach(var field in fieldSchemas)
+                {
+                    currentField.Add(field.Name);
+                    BuildSelectedFields(field.Fields, currentField, built);
+                    currentField.RemoveAt(removeAtIndex);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Partially addresses #3749 

First commit adds support for partial table schema retrieval.
Second commit adds support for partial row (data) retrieval. Semantic breaking change here, so pushing into next major version branch.

