### PR TITLE
[BigQuery] Proposal: Have insert methods return an insert response wrapper.

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.GenerateOverloads/Methods/InsertData.xml
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.GenerateOverloads/Methods/InsertData.xml
@@ -133,7 +133,7 @@
   <Method Name="InsertRows"
       RegionLabel="InsertRows(sequence)"
       TargetType="Table"
-      ReturnType="void">
+      ReturnType="BigQueryInsertResults">
 
     <Options Type="InsertOptions" />
     <AdditionalParameters>
@@ -144,6 +144,7 @@
       <summary>
         Inserts all the given rows of data into {target}.
       </summary>
+      <returns>An insert result object which contains information on insert errors if any.</returns>
     </Comments>
   </Method>
 </File>

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/BigQueryFixture.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/BigQueryFixture.cs
@@ -263,15 +263,17 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             InsertAndWait(table, () => table.InsertRow(ExhaustiveTypesTest.GetSampleRow()), 1);
         }
 
-        internal void InsertAndWait(BigQueryTable table, Action insertAction, int expectedRowCountChange)
+        internal BigQueryInsertResults InsertAndWait(BigQueryTable table, Func<BigQueryInsertResults> insertAction, int expectedRowCountChange)
         {
             var countBefore = table.ListRows().Count();
             var expectedCount = countBefore + expectedRowCountChange;
-            insertAction();
+            var results = insertAction();
             // Wait until there are *at least* enough rows
             int actualCount = table.PollUntilRowCountIsAtLeast(expectedCount);
             // Now check it's *exactly* the right number of rows.
             Assert.Equal(expectedCount, actualCount);
+
+            return results;
         }
 
         internal List<string> LoadTextResource(string relativeName)

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryClientTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryClientTest.cs
@@ -584,7 +584,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
             var options = new InsertOptions();
             var stream = new MemoryStream();
             var row = new BigQueryInsertRow();
-            VerifyEquivalent(
+            VerifyEquivalent(new BigQueryInsertResults(new DerivedBigQueryClient(), options, Enumerable.Repeat(row, 1).ToList(), new TableDataInsertAllResponse()),
                 client => client.InsertRows(MatchesWhenSerialized(reference), new[] { row }, options),
                 client => client.InsertRow(datasetId, tableId, row, options),
                 client => client.InsertRow(ProjectId, datasetId, tableId, row, options),
@@ -601,7 +601,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
             var options = new InsertOptions();
             var stream = new MemoryStream();
             var rows = new[] { new BigQueryInsertRow(), new BigQueryInsertRow() };
-            VerifyEquivalent(
+            VerifyEquivalent(new BigQueryInsertResults(new DerivedBigQueryClient(), options, rows, new TableDataInsertAllResponse()),
                 client => client.InsertRows(MatchesWhenSerialized(reference), rows, options),
                 client => client.InsertRows(datasetId, tableId, rows, options),
                 client => client.InsertRows(ProjectId, datasetId, tableId, rows, options),
@@ -618,7 +618,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
             var options = new InsertOptions();
             var stream = new MemoryStream();
             var rows = new[] { new BigQueryInsertRow(), new BigQueryInsertRow() };
-            VerifyEquivalent(
+            VerifyEquivalent(new BigQueryInsertResults(new DerivedBigQueryClient(), options, rows, new TableDataInsertAllResponse()),
                 client => client.InsertRows(MatchesWhenSerialized(reference), rows, null),
                 client => client.InsertRows(datasetId, tableId, rows[0], rows[1]),
                 client => client.InsertRows(ProjectId, datasetId, tableId, rows[0], rows[1]),
@@ -1132,7 +1132,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
             var token = new CancellationTokenSource().Token;
             var stream = new MemoryStream();
             var row = new BigQueryInsertRow();
-            VerifyEquivalentAsync(
+            VerifyEquivalentAsync(new BigQueryInsertResults(new DerivedBigQueryClient(), options, Enumerable.Repeat(row, 1).ToList(), new TableDataInsertAllResponse()),
                 client => client.InsertRowsAsync(MatchesWhenSerialized(reference), new[] { row }, options, token),
                 client => client.InsertRowAsync(datasetId, tableId, row, options, token),
                 client => client.InsertRowAsync(ProjectId, datasetId, tableId, row, options, token),
@@ -1150,7 +1150,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
             var token = new CancellationTokenSource().Token;
             var stream = new MemoryStream();
             var rows = new[] { new BigQueryInsertRow(), new BigQueryInsertRow() };
-            VerifyEquivalentAsync(
+            VerifyEquivalentAsync(new BigQueryInsertResults(new DerivedBigQueryClient(), options, rows, new TableDataInsertAllResponse()),
                 client => client.InsertRowsAsync(MatchesWhenSerialized(reference), rows, options, token),
                 client => client.InsertRowsAsync(datasetId, tableId, rows, options, token),
                 client => client.InsertRowsAsync(ProjectId, datasetId, tableId, rows, options, token),
@@ -1168,7 +1168,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
             var token = new CancellationTokenSource().Token;
             var stream = new MemoryStream();
             var rows = new[] { new BigQueryInsertRow(), new BigQueryInsertRow() };
-            VerifyEquivalentAsync(
+            VerifyEquivalentAsync(new BigQueryInsertResults(new DerivedBigQueryClient(), options, rows, new TableDataInsertAllResponse()),
                 client => client.InsertRowsAsync(MatchesWhenSerialized(reference), rows, null, default),
                 client => client.InsertRowsAsync(datasetId, tableId, rows[0], rows[1]),
                 client => client.InsertRowsAsync(ProjectId, datasetId, tableId, rows[0], rows[1]),

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryInsertResultsTests.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryInsertResultsTests.cs
@@ -1,0 +1,352 @@
+﻿// Copyright 2020 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Bigquery.v2;
+using Google.Apis.Bigquery.v2.Data;
+using Google.Apis.Requests;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using static Google.Apis.Bigquery.v2.Data.TableDataInsertAllResponse;
+
+namespace Google.Cloud.BigQuery.V2.Tests
+{
+    public class BigQueryInsertResultsTests
+    {
+        private readonly BigQueryClient _client;
+
+        public BigQueryInsertResultsTests()
+        {
+            _client = new DerivedBigQueryClient();
+        }
+
+        public static IEnumerable<object[]> NotNullableConstructorParametersData
+        {
+            get
+            {
+                yield return new object[] { null, new InsertOptions(), new List<BigQueryInsertRow>().AsReadOnly(), new TableDataInsertAllResponse() };
+                yield return new object[] { new DerivedBigQueryClient(), new InsertOptions(), null, new TableDataInsertAllResponse() };
+                yield return new object[] { new DerivedBigQueryClient(), new InsertOptions(), new List<BigQueryInsertRow>().AsReadOnly(), null };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(NotNullableConstructorParametersData))]
+        public void Constructor_NullParameters_Fail(
+            BigQueryClient client, InsertOptions options, IReadOnlyList<BigQueryInsertRow> rows, TableDataInsertAllResponse response) =>
+            Assert.Throws<ArgumentNullException>(() => new BigQueryInsertResults(client, options, rows, response));
+
+        [Fact]
+        public void Constructor_NullOptions() =>
+            Assert.NotNull(new BigQueryInsertResults(_client, null, new List<BigQueryInsertRow>(), new TableDataInsertAllResponse()));
+
+        public static IEnumerable<object[]> NoErrorsData
+        {
+            get
+            {
+                yield return new object[] { new TableDataInsertAllResponse() };
+                yield return new object[] { new TableDataInsertAllResponse { InsertErrors = new List<InsertErrorsData>() } };
+                yield return new object[] { new TableDataInsertAllResponse { InsertErrors = new List<InsertErrorsData> { null, null, null } } };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(NoErrorsData))]
+        public void AllRowsInserted(TableDataInsertAllResponse response)
+        {
+            BigQueryInsertResults results = new BigQueryInsertResults(
+                _client, 
+                new InsertOptions(), 
+                new List<BigQueryInsertRow> { new BigQueryInsertRow() },
+                response);
+
+            Assert.Equal(BigQueryInsertStatus.AllRowsInserted, results.Status);
+            Assert.Equal(0, results.OriginalRowsWithErrors);
+            Assert.Equal(1, results.InsertAttemptRowCount);
+            Assert.Empty(results.Errors);
+            Assert.Same(results, results.ThrowOnNoneInserted());
+            Assert.Same(results, results.ThrowOnNotAllInserted());
+            Assert.Same(results, results.ThrowOnAnyError());
+        }
+
+        [Fact]
+        public void SomeRowsInserted()
+        {
+            ErrorProto row1Error1 = new ErrorProto { Location = "field_1", Reason = "reason_1", Message = "message_1" };
+            ErrorProto row1Error2 = new ErrorProto { Location = "field_2", Message = "message_2" };
+            InsertErrorsData row1List1 = new InsertErrorsData { Index = 1, Errors = new List<ErrorProto> { row1Error1, row1Error2 } };
+
+            ErrorProto row5Error1 = new ErrorProto { Location = "field_3", Reason = "reason_3" };
+            InsertErrorsData row5List1 = new InsertErrorsData { Index = 5, Errors = new List<ErrorProto> { row5Error1 } };
+
+            InsertErrorsData row6List1 = new InsertErrorsData { Index = 6 };
+
+            ErrorProto row1Error3 = new ErrorProto { Location = "field_4", Reason = "reason_4", Message = "message_4" };
+            InsertErrorsData row1List2 = new InsertErrorsData { Index = 1, Errors = new List<ErrorProto> { row1Error3 } };
+
+            TableDataInsertAllResponse response = new TableDataInsertAllResponse
+            {
+                InsertErrors = new List<InsertErrorsData>
+                {
+                    row1List1,
+                    row5List1,
+                    row6List1,
+                    row1List2
+                }
+            };
+
+            IReadOnlyList<BigQueryInsertRow> rows = Enumerable.Range(0, 8).Select(_ => new BigQueryInsertRow()).ToList().AsReadOnly();
+
+            List<BigQueryInsertRowErrors> expectedInsertRowErrors = new List<BigQueryInsertRowErrors>
+            {
+                new BigQueryInsertRowErrors(rows[1], new List<InsertErrorsData> { row1List1, row1List2 }),
+                new BigQueryInsertRowErrors(rows[5], new List<InsertErrorsData> { row5List1 }),
+                new BigQueryInsertRowErrors(rows[6], new List<InsertErrorsData> { row6List1 }),
+            };
+            List<SingleError> expectedSingleErrors = expectedInsertRowErrors.SelectMany(rowError => rowError).ToList();
+
+            BigQueryInsertResults results = new BigQueryInsertResults(
+                _client,
+                new InsertOptions { SkipInvalidRows = true },
+                rows,
+                response);
+
+            Assert.Equal(BigQueryInsertStatus.SomeRowsInserted, results.Status);
+            Assert.Equal(3, results.OriginalRowsWithErrors);
+            Assert.Equal(8, results.InsertAttemptRowCount);
+            Assert.Equal(expectedInsertRowErrors, results.Errors.ToList(), new BigQueryInsertRowErrorEqualityComparer());
+            Assert.Same(results, results.ThrowOnNoneInserted());
+            AssertException(results.ThrowOnNotAllInserted, expectedSingleErrors, BigQueryInsertStatus.SomeRowsInserted);
+            AssertException(results.ThrowOnAnyError, expectedSingleErrors, BigQueryInsertStatus.SomeRowsInserted);
+        }
+
+        [Fact]
+        public void NoRowsInserted_NoSkip()
+        {
+            ErrorProto row1Error1 = new ErrorProto { Location = "field_1", Reason = "reason_1", Message = "message_1" };
+            ErrorProto row1Error2 = new ErrorProto { Location = "field_2", Message = "message_2" };
+            InsertErrorsData row1List1 = new InsertErrorsData { Index = 1, Errors = new List<ErrorProto> { row1Error1, row1Error2 } };
+
+            ErrorProto row5Error1 = new ErrorProto { Location = "field_3", Reason = "reason_3" };
+            InsertErrorsData row5List1 = new InsertErrorsData { Index = 5, Errors = new List<ErrorProto> { row5Error1 } };
+
+            InsertErrorsData row6List1 = new InsertErrorsData { Index = 6 };
+
+            ErrorProto row1Error3 = new ErrorProto { Location = "field_4", Reason = "reason_4", Message = "message_4" };
+            InsertErrorsData row1List2 = new InsertErrorsData { Index = 1, Errors = new List<ErrorProto> { row1Error3 } };
+
+            TableDataInsertAllResponse response = new TableDataInsertAllResponse
+            {
+                InsertErrors = new List<InsertErrorsData>
+                {
+                    row1List1,
+                    row5List1,
+                    row6List1,
+                    row1List2
+                }
+            };
+
+            IReadOnlyList<BigQueryInsertRow> rows = Enumerable.Range(0, 8).Select(_ => new BigQueryInsertRow()).ToList().AsReadOnly();
+
+            // We don't need to have errors for all rows to know that no rows were inserted.
+            // If SkipInvalidRows is not set to true, then even if only one row has errors, no rows are inserted.
+            List<BigQueryInsertRowErrors> expectedInsertRowErrors = new List<BigQueryInsertRowErrors>
+            {
+                new BigQueryInsertRowErrors(rows[1], new List<InsertErrorsData> { row1List1, row1List2 }),
+                new BigQueryInsertRowErrors(rows[5], new List<InsertErrorsData> { row5List1 }),
+                new BigQueryInsertRowErrors(rows[6], new List<InsertErrorsData> { row6List1 }),
+            };
+            List<SingleError> expectedSingleErrors = expectedInsertRowErrors.SelectMany(rowError => rowError).ToList();
+
+            BigQueryInsertResults results = new BigQueryInsertResults(
+                _client,
+                new InsertOptions(),
+                rows,
+                response);
+
+            Assert.Equal(BigQueryInsertStatus.NoRowsInserted, results.Status);
+            Assert.Equal(3, results.OriginalRowsWithErrors);
+            Assert.Equal(8, results.InsertAttemptRowCount);
+            Assert.Equal(expectedInsertRowErrors, results.Errors.ToList(), new BigQueryInsertRowErrorEqualityComparer());
+            AssertException(results.ThrowOnNoneInserted, expectedSingleErrors, BigQueryInsertStatus.NoRowsInserted);
+            AssertException(results.ThrowOnNotAllInserted, expectedSingleErrors, BigQueryInsertStatus.NoRowsInserted);
+            AssertException(results.ThrowOnAnyError, expectedSingleErrors, BigQueryInsertStatus.NoRowsInserted);
+        }
+
+        [Fact]
+        public void NoRowsInserted_AllInvalid()
+        {
+            ErrorProto row0Error1 = new ErrorProto { Location = "field_1", Reason = "reason_1", Message = "message_1" };
+            ErrorProto row0Error2 = new ErrorProto { Location = "field_2", Message = "message_2" };
+            InsertErrorsData row0List1 = new InsertErrorsData { Index = 0, Errors = new List<ErrorProto> { row0Error1, row0Error2 } };
+
+            ErrorProto row1Error1 = new ErrorProto { Location = "field_3", Reason = "reason_3" };
+            InsertErrorsData row1List1 = new InsertErrorsData { Index = 1, Errors = new List<ErrorProto> { row1Error1 } };
+
+            InsertErrorsData row2List1 = new InsertErrorsData { Index = 2 };
+
+            ErrorProto row0Error3 = new ErrorProto { Location = "field_4", Reason = "reason_4", Message = "message_4" };
+            InsertErrorsData row0List2 = new InsertErrorsData { Index = 0, Errors = new List<ErrorProto> { row0Error3 } };
+
+            TableDataInsertAllResponse response = new TableDataInsertAllResponse
+            {
+                InsertErrors = new List<InsertErrorsData>
+                {
+                    row0List1,
+                    row1List1,
+                    row2List1,
+                    row0List2
+                }
+            };
+
+            IReadOnlyList<BigQueryInsertRow> rows = Enumerable.Range(0, 3).Select(_ => new BigQueryInsertRow()).ToList().AsReadOnly();
+
+            List<BigQueryInsertRowErrors> expectedInsertRowErrors = new List<BigQueryInsertRowErrors>
+            {
+                new BigQueryInsertRowErrors(rows[0], new List<InsertErrorsData> { row0List1, row0List2 }),
+                new BigQueryInsertRowErrors(rows[1], new List<InsertErrorsData> { row1List1 }),
+                new BigQueryInsertRowErrors(rows[2], new List<InsertErrorsData> { row2List1 }),
+            };
+            List<SingleError> expectedSingleErrors = expectedInsertRowErrors.SelectMany(rowError => rowError).ToList();
+
+            BigQueryInsertResults results = new BigQueryInsertResults(
+                _client,
+                new InsertOptions { SkipInvalidRows = true },
+                rows,
+                response);
+
+            Assert.Equal(BigQueryInsertStatus.NoRowsInserted, results.Status);
+            Assert.Equal(3, results.OriginalRowsWithErrors);
+            Assert.Equal(3, results.InsertAttemptRowCount);
+            Assert.Equal(expectedInsertRowErrors, results.Errors.ToList(), new BigQueryInsertRowErrorEqualityComparer());
+            AssertException(results.ThrowOnNoneInserted, expectedSingleErrors, BigQueryInsertStatus.NoRowsInserted);
+            AssertException(results.ThrowOnNotAllInserted, expectedSingleErrors, BigQueryInsertStatus.NoRowsInserted);
+            AssertException(results.ThrowOnAnyError, expectedSingleErrors, BigQueryInsertStatus.NoRowsInserted);
+        }
+
+        [Fact]
+        public void UnexpectedResponse()
+        {
+            ErrorProto row1Error1 = new ErrorProto { Location = "field_1", Reason = "reason_1", Message = "message_1" };
+            ErrorProto row1Error2 = new ErrorProto { Location = "field_2", Message = "message_2" };
+            InsertErrorsData row1List1 = new InsertErrorsData { Index = 1, Errors = new List<ErrorProto> { row1Error1, row1Error2 } };
+
+            ErrorProto row5Error1 = new ErrorProto { Location = "field_3", Reason = "reason_3" };
+            InsertErrorsData row5List1 = new InsertErrorsData { Index = 5, Errors = new List<ErrorProto> { row5Error1 } };
+
+            InsertErrorsData row6List1 = new InsertErrorsData { Index = 6 };
+
+            ErrorProto row1Error3 = new ErrorProto { Location = "field_4", Reason = "reason_4", Message = "message_4" };
+            InsertErrorsData row1List2 = new InsertErrorsData { Index = 1, Errors = new List<ErrorProto> { row1Error3 } };
+
+            // Row 11, which we don't have
+            ErrorProto row11Error1 = new ErrorProto { Location = "field_5", Reason = "reason_5", Message = "message_5" };
+            InsertErrorsData row11List1 = new InsertErrorsData { Index = 11, Errors = new List<ErrorProto> { row11Error1 } };
+
+            // No row index specified
+            ErrorProto rowNullError1 = new ErrorProto { Location = "field_6", Reason = "reason_6", Message = "message_6" };
+            InsertErrorsData rowNullList1 = new InsertErrorsData { Index = null, Errors = new List<ErrorProto> { rowNullError1 } };
+
+            TableDataInsertAllResponse response = new TableDataInsertAllResponse
+            {
+                InsertErrors = new List<InsertErrorsData>
+                {
+                    row1List1,
+                    row5List1,
+                    null, // Ignored
+                    row6List1,
+                    row11List1,
+                    row1List2,
+                    rowNullList1
+                }
+            };
+
+            IReadOnlyList<BigQueryInsertRow> rows = Enumerable.Range(0, 8).Select(_ => new BigQueryInsertRow()).ToList().AsReadOnly();
+
+            List<BigQueryInsertRowErrors> expectedInsertRowErrors = new List<BigQueryInsertRowErrors>
+            {
+                new BigQueryInsertRowErrors(rows[1], new List<InsertErrorsData> { row1List1, row1List2 }),
+                new BigQueryInsertRowErrors(rows[5], new List<InsertErrorsData> { row5List1 }),
+                new BigQueryInsertRowErrors(rows[6], new List<InsertErrorsData> { row6List1 }),
+                new BigQueryInsertRowErrors(null, new List<InsertErrorsData> { row11List1 }),
+                new BigQueryInsertRowErrors(null, new List<InsertErrorsData> { rowNullList1 }),
+            };
+            List<SingleError> expectedSingleErrors = expectedInsertRowErrors.SelectMany(rowError => rowError).ToList();
+
+            BigQueryInsertResults results = new BigQueryInsertResults(
+                _client,
+                new InsertOptions { SkipInvalidRows = true },
+                rows,
+                response);
+
+            Assert.Equal(BigQueryInsertStatus.SomeRowsInserted, results.Status);
+            Assert.Equal(3, results.OriginalRowsWithErrors);
+            Assert.Equal(8, results.InsertAttemptRowCount);
+            Assert.Equal(expectedInsertRowErrors, results.Errors.ToList(), new BigQueryInsertRowErrorEqualityComparer());
+            Assert.Same(results, results.ThrowOnNoneInserted());
+            AssertException(results.ThrowOnNotAllInserted, expectedSingleErrors, BigQueryInsertStatus.SomeRowsInserted);
+            AssertException(results.ThrowOnAnyError, expectedSingleErrors, BigQueryInsertStatus.SomeRowsInserted);
+        }
+
+        private void AssertException(Func<BigQueryInsertResults> throwing, List<SingleError> expectedErrors, BigQueryInsertStatus expectedStatus)
+        {
+            GoogleApiException exception = Assert.Throws<GoogleApiException>(throwing);
+            Assert.Equal("fake_service_name", exception.ServiceName);
+            Assert.Contains(expectedStatus.ToString(), exception.Message);
+            Assert.Equal(expectedErrors, exception.Error.Errors, new SingleErrorEqualityComparer());
+        }
+
+        public class DerivedBigQueryClient : BigQueryClient
+        {
+            private readonly BigqueryService _service = new DerivedBigQueryService();
+            public override BigqueryService Service => _service;
+        }
+
+        public class DerivedBigQueryService : BigqueryService
+        {
+            public override string Name => "fake_service_name";
+        }
+
+        public class BigQueryInsertRowErrorEqualityComparer : IEqualityComparer<BigQueryInsertRowErrors>
+        {
+            public bool Equals(BigQueryInsertRowErrors x, BigQueryInsertRowErrors y)
+            {
+                if (x == y)
+                {
+                    return true;
+                }
+                if (x == null || y == null)
+                {
+                    return false;
+                }
+
+                return x.OriginalRowIndex == y.OriginalRowIndex &&
+                    // This is good enough for the purposes of this test.
+                    x.OriginalRow == y.OriginalRow &&
+                    x.SequenceEqual(y, new SingleErrorEqualityComparer());
+            }
+
+            public int GetHashCode(BigQueryInsertRowErrors obj) => throw new NotImplementedException();
+        }
+
+        public class SingleErrorEqualityComparer : IEqualityComparer<SingleError>
+        {
+            public bool Equals(SingleError x, SingleError y) =>
+                string.Equals(x?.ToString(), y?.ToString(), StringComparison.InvariantCulture);
+
+            public int GetHashCode(SingleError obj) => throw new NotImplementedException();
+        }
+    }
+}

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryInsertRowErrorsTests.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryInsertRowErrorsTests.cs
@@ -1,0 +1,206 @@
+﻿// Copyright 2020 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Bigquery.v2.Data;
+using Google.Apis.Requests;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using static Google.Apis.Bigquery.v2.Data.TableDataInsertAllResponse;
+using static Google.Cloud.BigQuery.V2.Tests.BigQueryInsertResultsTests;
+
+namespace Google.Cloud.BigQuery.V2.Tests
+{
+    public class BigQueryInsertRowErrorsTests
+    {
+        [Fact]
+        public void Constructor_NullErrors()
+        {
+            Assert.Throws<ArgumentException>(() => new BigQueryInsertRowErrors(new BigQueryInsertRow(), null));
+        }
+
+        [Fact]
+        public void Constructor_EmptyErrors()
+        {
+            Assert.Throws<ArgumentException>(() => new BigQueryInsertRowErrors(
+                new BigQueryInsertRow(),
+                new List<InsertErrorsData>()));
+        }
+
+        [Fact]
+        public void Constructor_NullRow_NoErrorDetail()
+        {
+            List<InsertErrorsData> errors = new List<InsertErrorsData>
+            {
+                new InsertErrorsData { }
+            };
+
+            SingleError expected = new SingleError
+            {
+                Message = "Error in row unknown."
+            };
+
+            // This is allowed in case there's no information (index)
+            // to associate errors to a row.
+            BigQueryInsertRowErrors insertRowErrors = new BigQueryInsertRowErrors(null, errors);
+            Assert.Single(insertRowErrors);
+            Assert.Contains(expected, insertRowErrors, new SingleErrorEqualityComparer());
+            Assert.Null(insertRowErrors.OriginalRow);
+            Assert.Null(insertRowErrors.OriginalRowIndex);
+        }
+
+        [Fact]
+        public void Constructor_NullRow_ErrorDetail()
+        {
+            List<InsertErrorsData> errors = new List<InsertErrorsData>
+            {
+                new InsertErrorsData
+                {
+                    Index = null,
+                    Errors = new List<ErrorProto>
+                    {
+                        new ErrorProto
+                        {
+                            Reason = "Very bad reason",
+                            Message = "A very bad error occurred"
+                        }
+                    }
+                }
+            };
+
+            SingleError expected = new SingleError
+            {
+                Reason = "Very bad reason",
+                Message = "Error in row unknown. A very bad error occurred"
+            };
+
+            // This is allowed in case there's no information (index)
+            // to associate errors to a row.
+            BigQueryInsertRowErrors insertRowErrors = new BigQueryInsertRowErrors(null, errors);
+            Assert.Single(insertRowErrors);
+            Assert.Contains(expected, insertRowErrors, new SingleErrorEqualityComparer());
+            Assert.Null(insertRowErrors.OriginalRow);
+            Assert.Null(insertRowErrors.OriginalRowIndex);
+        }
+
+        [Fact]
+        public void OriginalRow()
+        {
+            List<InsertErrorsData> errors = new List<InsertErrorsData>
+            {
+                new InsertErrorsData
+                {
+                    Index = 1,
+                    Errors = new List<ErrorProto>
+                    {
+                        new ErrorProto
+                        {
+                            Reason = "Reason 1",
+                            Message = "A very bad error 1 occurred",
+                            Location = "field_1"
+                        },
+                    }
+                },
+            };
+
+            IList<SingleError> expected = new List<SingleError>
+            {
+                new SingleError
+                {
+                    Reason = "Reason 1",
+                    Message = "Error in row 1. A very bad error 1 occurred",
+                    Location = "field_1"
+                },
+            };
+
+            BigQueryInsertRow row = new BigQueryInsertRow();
+
+            BigQueryInsertRowErrors insertRowErrors = new BigQueryInsertRowErrors(row, errors);
+            Assert.Equal(expected, insertRowErrors.ToList(), new SingleErrorEqualityComparer());
+            Assert.Same(row, insertRowErrors.OriginalRow);
+            Assert.Equal(1, insertRowErrors.OriginalRowIndex);
+        }
+
+        [Fact]
+        public void GetEnumerator()
+        {
+            List<InsertErrorsData> errors = new List<InsertErrorsData>
+            {
+                new InsertErrorsData
+                {
+                    Index = 1,
+                    Errors = new List<ErrorProto>
+                    {
+                        new ErrorProto
+                        {
+                            Reason = "Reason 1",
+                            Message = "A very bad error 1 occurred",
+                            Location = "field_1"
+                        },
+                        new ErrorProto
+                        {
+                            Reason = "Reason 2",
+                            Location = "field_2"
+                        }
+                    }
+                },
+                new InsertErrorsData { },
+                new InsertErrorsData
+                {
+                    Index = 1,
+                    Errors = new List<ErrorProto>
+                    {
+                        new ErrorProto
+                        {
+                            Reason = "Reason 3",
+                            Message = "A very bad error 3 occurred",
+                            Location = "field_3"
+                        }
+                    }
+                },
+                null
+            };
+
+            IList<SingleError> expected = new List<SingleError>
+            {
+                new SingleError
+                {
+                    Reason = "Reason 1",
+                    Message = "Error in row 1. A very bad error 1 occurred",
+                    Location = "field_1"
+                },
+                new SingleError
+                {
+                    Reason = "Reason 2",
+                    Message = "Error in row 1. ",
+                    Location = "field_2"
+                },
+                new SingleError
+                {
+                    Reason = "Reason 3",
+                    Message = "Error in row 1. A very bad error 3 occurred",
+                    Location = "field_3"
+                }
+            };
+
+            // This is allowed in case there's no information (index)
+            // to associate errors to a row or the index obtained in the response is out of range (unlikely).
+            BigQueryInsertRowErrors insertRowErrors = new BigQueryInsertRowErrors(null, errors);
+            Assert.Equal(expected, insertRowErrors.ToList(), new SingleErrorEqualityComparer());
+            Assert.Null(insertRowErrors.OriginalRow);
+            Assert.Equal(1, insertRowErrors.OriginalRowIndex);
+        }
+    }
+}

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClient.InsertData.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClient.InsertData.cs
@@ -546,7 +546,7 @@ namespace Google.Cloud.BigQuery.V2
         /// <returns>A data upload job.</returns>
         public virtual BigQueryJob UploadParquet(string datasetId, string tableId, Stream input, UploadParquetOptions options = null) =>
             UploadParquet(GetTableReference(datasetId, tableId), input, options);
-
+        
         /// <summary>
         /// Uploads a stream of Parquet data to the specified table.
         /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="UploadParquet(TableReference, Stream, UploadParquetOptions)"/>.
@@ -559,7 +559,7 @@ namespace Google.Cloud.BigQuery.V2
         /// <returns>A data upload job.</returns>
         public virtual BigQueryJob UploadParquet(string projectId, string datasetId, string tableId, Stream input, UploadParquetOptions options = null) =>
             UploadParquet(GetTableReference(projectId, datasetId, tableId), input, options);
-
+        
         /// <summary>
         /// Uploads a stream of Parquet data to the specified table.
         /// </summary>
@@ -569,7 +569,7 @@ namespace Google.Cloud.BigQuery.V2
         /// <returns>A data upload job.</returns>
         public virtual BigQueryJob UploadParquet(TableReference tableReference, Stream input, UploadParquetOptions options = null) =>
             throw new NotImplementedException();
-
+        
         /// <summary>
         /// Asynchronously uploads a stream of Parquet data to the specified table within this client's project.
         /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="UploadParquetAsync(TableReference, Stream, UploadParquetOptions, CancellationToken)"/>.
@@ -583,7 +583,7 @@ namespace Google.Cloud.BigQuery.V2
         /// a data upload job.</returns>
         public virtual Task<BigQueryJob> UploadParquetAsync(string datasetId, string tableId, Stream input, UploadParquetOptions options = null, CancellationToken cancellationToken = default) =>
             UploadParquetAsync(GetTableReference(datasetId, tableId), input, options, cancellationToken);
-
+        
         /// <summary>
         /// Asynchronously uploads a stream of Parquet data to the specified table.
         /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="UploadParquetAsync(TableReference, Stream, UploadParquetOptions, CancellationToken)"/>.
@@ -598,7 +598,7 @@ namespace Google.Cloud.BigQuery.V2
         /// a data upload job.</returns>
         public virtual Task<BigQueryJob> UploadParquetAsync(string projectId, string datasetId, string tableId, Stream input, UploadParquetOptions options = null, CancellationToken cancellationToken = default) =>
             UploadParquetAsync(GetTableReference(projectId, datasetId, tableId), input, options, cancellationToken);
-
+        
         /// <summary>
         /// Asynchronously uploads a stream of Parquet data to the specified table.
         /// </summary>
@@ -622,7 +622,8 @@ namespace Google.Cloud.BigQuery.V2
         /// <param name="tableId">The table ID. Must not be null.</param>
         /// <param name="row">The data to insert. Must not be null.</param>
         /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
-        public virtual void InsertRow(string projectId, string datasetId, string tableId, BigQueryInsertRow row, InsertOptions options = null) =>
+        /// <returns>An insert result object which contains information on insert errors if any.</returns>
+        public virtual BigQueryInsertResults InsertRow(string projectId, string datasetId, string tableId, BigQueryInsertRow row, InsertOptions options = null) =>
             InsertRow(GetTableReference(projectId, datasetId, tableId), row, options);
 
         /// <summary>
@@ -633,7 +634,8 @@ namespace Google.Cloud.BigQuery.V2
         /// <param name="tableId">The table ID. Must not be null.</param>
         /// <param name="row">The data to insert. Must not be null.</param>
         /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
-        public virtual void InsertRow(string datasetId, string tableId, BigQueryInsertRow row, InsertOptions options = null) =>
+        /// <returns>An insert result object which contains information on insert errors if any.</returns>
+        public virtual BigQueryInsertResults InsertRow(string datasetId, string tableId, BigQueryInsertRow row, InsertOptions options = null) =>
             InsertRow(GetTableReference(datasetId, tableId), row, options);
 
         /// <summary>
@@ -643,7 +645,8 @@ namespace Google.Cloud.BigQuery.V2
         /// <param name="tableReference">A fully-qualified identifier for the table. Must not be null.</param>
         /// <param name="row">The data to insert. Must not be null.</param>
         /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
-        public virtual void InsertRow(TableReference tableReference, BigQueryInsertRow row, InsertOptions options = null) =>
+        /// <returns>An insert result object which contains information on insert errors if any.</returns>
+        public virtual BigQueryInsertResults InsertRow(TableReference tableReference, BigQueryInsertRow row, InsertOptions options = null) =>
             InsertRows(tableReference, new[] { GaxPreconditions.CheckNotNull(row, nameof(row)) }, options);
 
         /// <summary>
@@ -656,8 +659,9 @@ namespace Google.Cloud.BigQuery.V2
         /// <param name="row">The data to insert. Must not be null.</param>
         /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        /// <returns>A task representing the asynchronous operation.</returns>
-        public virtual Task InsertRowAsync(string projectId, string datasetId, string tableId, BigQueryInsertRow row, InsertOptions options = null, CancellationToken cancellationToken = default) =>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is
+        /// an insert result object which contains information on insert errors if any.</returns>
+        public virtual Task<BigQueryInsertResults> InsertRowAsync(string projectId, string datasetId, string tableId, BigQueryInsertRow row, InsertOptions options = null, CancellationToken cancellationToken = default) =>
             InsertRowAsync(GetTableReference(projectId, datasetId, tableId), row, options, cancellationToken);
 
         /// <summary>
@@ -669,8 +673,9 @@ namespace Google.Cloud.BigQuery.V2
         /// <param name="row">The data to insert. Must not be null.</param>
         /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        /// <returns>A task representing the asynchronous operation.</returns>
-        public virtual Task InsertRowAsync(string datasetId, string tableId, BigQueryInsertRow row, InsertOptions options = null, CancellationToken cancellationToken = default) =>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is
+        /// an insert result object which contains information on insert errors if any.</returns>
+        public virtual Task<BigQueryInsertResults> InsertRowAsync(string datasetId, string tableId, BigQueryInsertRow row, InsertOptions options = null, CancellationToken cancellationToken = default) =>
             InsertRowAsync(GetTableReference(datasetId, tableId), row, options, cancellationToken);
 
         /// <summary>
@@ -681,8 +686,9 @@ namespace Google.Cloud.BigQuery.V2
         /// <param name="row">The data to insert. Must not be null.</param>
         /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        /// <returns>A task representing the asynchronous operation.</returns>
-        public virtual Task InsertRowAsync(TableReference tableReference, BigQueryInsertRow row, InsertOptions options = null, CancellationToken cancellationToken = default) =>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is
+        /// an insert result object which contains information on insert errors if any.</returns>
+        public virtual Task<BigQueryInsertResults> InsertRowAsync(TableReference tableReference, BigQueryInsertRow row, InsertOptions options = null, CancellationToken cancellationToken = default) =>
             InsertRowsAsync(tableReference, new[] { GaxPreconditions.CheckNotNull(row, nameof(row)) }, options, cancellationToken);
         #endregion
 
@@ -699,7 +705,8 @@ namespace Google.Cloud.BigQuery.V2
         /// <param name="datasetId">The dataset ID. Must not be null.</param>
         /// <param name="tableId">The table ID. Must not be null.</param>
         /// <param name="rows">The rows to insert. Must not be null, or contain null elements.</param>
-        public virtual void InsertRows(string projectId, string datasetId, string tableId, params BigQueryInsertRow[] rows) =>
+        /// <returns>An insert result object which contains information on insert errors if any.</returns>
+        public virtual BigQueryInsertResults InsertRows(string projectId, string datasetId, string tableId, params BigQueryInsertRow[] rows) =>
             InsertRows(GetTableReference(projectId, datasetId, tableId), rows, null);
 
         /// <summary>
@@ -713,7 +720,8 @@ namespace Google.Cloud.BigQuery.V2
         /// <param name="datasetId">The dataset ID. Must not be null.</param>
         /// <param name="tableId">The table ID. Must not be null.</param>
         /// <param name="rows">The rows to insert. Must not be null, or contain null elements.</param>
-        public virtual void InsertRows(string datasetId, string tableId, params BigQueryInsertRow[] rows) =>
+        /// <returns>An insert result object which contains information on insert errors if any.</returns>
+        public virtual BigQueryInsertResults InsertRows(string datasetId, string tableId, params BigQueryInsertRow[] rows) =>
             InsertRows(GetTableReference(datasetId, tableId), rows, null);
 
         /// <summary>
@@ -726,7 +734,8 @@ namespace Google.Cloud.BigQuery.V2
         /// </remarks>
         /// <param name="tableReference">A fully-qualified identifier for the table. Must not be null.</param>
         /// <param name="rows">The rows to insert. Must not be null, or contain null elements.</param>
-        public virtual void InsertRows(TableReference tableReference, params BigQueryInsertRow[] rows) =>
+        /// <returns>An insert result object which contains information on insert errors if any.</returns>
+        public virtual BigQueryInsertResults InsertRows(TableReference tableReference, params BigQueryInsertRow[] rows) =>
             InsertRows(tableReference, rows, null);
 
         /// <summary>
@@ -741,8 +750,9 @@ namespace Google.Cloud.BigQuery.V2
         /// <param name="datasetId">The dataset ID. Must not be null.</param>
         /// <param name="tableId">The table ID. Must not be null.</param>
         /// <param name="rows">The rows to insert. Must not be null, or contain null elements.</param>
-        /// <returns>A task representing the asynchronous operation.</returns>
-        public virtual Task InsertRowsAsync(string projectId, string datasetId, string tableId, params BigQueryInsertRow[] rows) =>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is
+        /// an insert result object which contains information on insert errors if any.</returns>
+        public virtual Task<BigQueryInsertResults> InsertRowsAsync(string projectId, string datasetId, string tableId, params BigQueryInsertRow[] rows) =>
             InsertRowsAsync(GetTableReference(projectId, datasetId, tableId), rows, null);
 
         /// <summary>
@@ -756,8 +766,9 @@ namespace Google.Cloud.BigQuery.V2
         /// <param name="datasetId">The dataset ID. Must not be null.</param>
         /// <param name="tableId">The table ID. Must not be null.</param>
         /// <param name="rows">The rows to insert. Must not be null, or contain null elements.</param>
-        /// <returns>A task representing the asynchronous operation.</returns>
-        public virtual Task InsertRowsAsync(string datasetId, string tableId, params BigQueryInsertRow[] rows) =>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is
+        /// an insert result object which contains information on insert errors if any.</returns>
+        public virtual Task<BigQueryInsertResults> InsertRowsAsync(string datasetId, string tableId, params BigQueryInsertRow[] rows) =>
             InsertRowsAsync(GetTableReference(datasetId, tableId), rows, null, CancellationToken.None);
 
         /// <summary>
@@ -770,8 +781,9 @@ namespace Google.Cloud.BigQuery.V2
         /// </remarks>
         /// <param name="tableReference">A fully-qualified identifier for the table. Must not be null.</param>
         /// <param name="rows">The rows to insert. Must not be null, or contain null elements.</param>
-        /// <returns>A task representing the asynchronous operation.</returns>
-        public virtual Task InsertRowsAsync(TableReference tableReference, params BigQueryInsertRow[] rows) =>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is
+        /// an insert result object which contains information on insert errors if any.</returns>
+        public virtual Task<BigQueryInsertResults> InsertRowsAsync(TableReference tableReference, params BigQueryInsertRow[] rows) =>
             InsertRowsAsync(tableReference, rows, null, CancellationToken.None);
         #endregion
 
@@ -784,7 +796,8 @@ namespace Google.Cloud.BigQuery.V2
         /// <param name="tableId">The table ID. Must not be null.</param>
         /// <param name="rows">The data to insert. Must not be null, or contain null entries.</param>
         /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
-        public virtual void InsertRows(string datasetId, string tableId, IEnumerable<BigQueryInsertRow> rows, InsertOptions options = null) =>
+        /// <returns>An insert result object which contains information on insert errors if any.</returns>
+        public virtual BigQueryInsertResults InsertRows(string datasetId, string tableId, IEnumerable<BigQueryInsertRow> rows, InsertOptions options = null) =>
             InsertRows(GetTableReference(datasetId, tableId), rows, options);
         
         /// <summary>
@@ -796,7 +809,8 @@ namespace Google.Cloud.BigQuery.V2
         /// <param name="tableId">The table ID. Must not be null.</param>
         /// <param name="rows">The data to insert. Must not be null, or contain null entries.</param>
         /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
-        public virtual void InsertRows(string projectId, string datasetId, string tableId, IEnumerable<BigQueryInsertRow> rows, InsertOptions options = null) =>
+        /// <returns>An insert result object which contains information on insert errors if any.</returns>
+        public virtual BigQueryInsertResults InsertRows(string projectId, string datasetId, string tableId, IEnumerable<BigQueryInsertRow> rows, InsertOptions options = null) =>
             InsertRows(GetTableReference(projectId, datasetId, tableId), rows, options);
         
         /// <summary>
@@ -805,7 +819,8 @@ namespace Google.Cloud.BigQuery.V2
         /// <param name="tableReference">A fully-qualified identifier for the table. Must not be null.</param>
         /// <param name="rows">The data to insert. Must not be null, or contain null entries.</param>
         /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
-        public virtual void InsertRows(TableReference tableReference, IEnumerable<BigQueryInsertRow> rows, InsertOptions options = null) =>
+        /// <returns>An insert result object which contains information on insert errors if any.</returns>
+        public virtual BigQueryInsertResults InsertRows(TableReference tableReference, IEnumerable<BigQueryInsertRow> rows, InsertOptions options = null) =>
             throw new NotImplementedException();
         
         /// <summary>
@@ -817,8 +832,9 @@ namespace Google.Cloud.BigQuery.V2
         /// <param name="rows">The data to insert. Must not be null, or contain null entries.</param>
         /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        /// <returns>A task representing the asynchronous operation.</returns>
-        public virtual Task InsertRowsAsync(string datasetId, string tableId, IEnumerable<BigQueryInsertRow> rows, InsertOptions options = null, CancellationToken cancellationToken = default) =>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is
+        /// an insert result object which contains information on insert errors if any.</returns>
+        public virtual Task<BigQueryInsertResults> InsertRowsAsync(string datasetId, string tableId, IEnumerable<BigQueryInsertRow> rows, InsertOptions options = null, CancellationToken cancellationToken = default) =>
             InsertRowsAsync(GetTableReference(datasetId, tableId), rows, options, cancellationToken);
         
         /// <summary>
@@ -831,8 +847,9 @@ namespace Google.Cloud.BigQuery.V2
         /// <param name="rows">The data to insert. Must not be null, or contain null entries.</param>
         /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        /// <returns>A task representing the asynchronous operation.</returns>
-        public virtual Task InsertRowsAsync(string projectId, string datasetId, string tableId, IEnumerable<BigQueryInsertRow> rows, InsertOptions options = null, CancellationToken cancellationToken = default) =>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is
+        /// an insert result object which contains information on insert errors if any.</returns>
+        public virtual Task<BigQueryInsertResults> InsertRowsAsync(string projectId, string datasetId, string tableId, IEnumerable<BigQueryInsertRow> rows, InsertOptions options = null, CancellationToken cancellationToken = default) =>
             InsertRowsAsync(GetTableReference(projectId, datasetId, tableId), rows, options, cancellationToken);
         
         /// <summary>
@@ -842,8 +859,9 @@ namespace Google.Cloud.BigQuery.V2
         /// <param name="rows">The data to insert. Must not be null, or contain null entries.</param>
         /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        /// <returns>A task representing the asynchronous operation.</returns>
-        public virtual Task InsertRowsAsync(TableReference tableReference, IEnumerable<BigQueryInsertRow> rows, InsertOptions options = null, CancellationToken cancellationToken = default) =>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is
+        /// an insert result object which contains information on insert errors if any.</returns>
+        public virtual Task<BigQueryInsertResults> InsertRowsAsync(TableReference tableReference, IEnumerable<BigQueryInsertRow> rows, InsertOptions options = null, CancellationToken cancellationToken = default) =>
             throw new NotImplementedException();
         #endregion
 

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryInsertResults.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryInsertResults.cs
@@ -1,0 +1,151 @@
+﻿// Copyright 2020 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using Google.Apis.Bigquery.v2.Data;
+using Google.Apis.Requests;
+using System.Collections.Generic;
+using System.Linq;
+using static Google.Apis.Bigquery.v2.Data.TableDataInsertAllResponse;
+
+namespace Google.Cloud.BigQuery.V2
+{
+    /// <summary>
+    /// The results obtained after an insertion attempt.
+    /// This will contain information on invalid rows if any.
+    /// </summary>
+    public sealed class BigQueryInsertResults
+    {
+        private readonly BigQueryClient _client;
+        private readonly InsertOptions _options;
+        private IReadOnlyList<BigQueryInsertRowErrors> _errors;
+
+        /// <summary>
+        /// Status of the insert request.
+        /// See <see cref="BigQueryInsertStatus"/> for a detailed explanation.
+        /// </summary>
+        public BigQueryInsertStatus Status
+        {
+            get
+            {
+                if (_errors.Count == 0)
+                {
+                    return BigQueryInsertStatus.AllRowsInserted;
+                }
+                if (OriginalRowsWithErrors >= InsertAttemptRowCount || _options?.SkipInvalidRows != true)
+                {
+                    return BigQueryInsertStatus.NoRowsInserted;
+                }
+
+                return BigQueryInsertStatus.SomeRowsInserted;
+            }
+        }
+
+        /// <summary>
+        /// Returns a sequence over rows with insert errors.
+        /// Each element represents a row with possibly multiple errors associated to it.
+        /// </summary>
+        /// <returns>A sequence over rows with insert errors. Will never be null.</returns>
+        public IEnumerable<BigQueryInsertRowErrors> Errors => _errors;
+
+        /// <summary>
+        /// The amount of rows that were attempted in the insert operation.
+        /// </summary>
+        public int InsertAttemptRowCount { get; }
+
+        /// <summary>
+        /// The number of rows with reported errors in <see cref="Errors"/>.
+        /// Note that it's possible that some errors are not associated to 
+        /// any particular row so this number might be smaller than the number
+        /// of elements in <see cref="Errors"/>.
+        /// </summary>
+        public int OriginalRowsWithErrors { get; }
+
+        /// <summary>
+        /// Constructs a new set of insert results.
+        /// </summary>
+        /// <param name="client">The client used for the insert request. Must not be null.</param>
+        /// <param name="options">The options used for the insert request. May be null.</param>
+        /// <param name="originalRows">The rows whose insert was attempted. Must not be null.</param>
+        /// <param name="insertResponse">The response obtained after attempting the insert. Must not be null.</param>
+        public BigQueryInsertResults(BigQueryClient client, InsertOptions options, IReadOnlyList<BigQueryInsertRow> originalRows, TableDataInsertAllResponse insertResponse)
+        {
+            GaxPreconditions.CheckNotNull(insertResponse, nameof(insertResponse));
+            _client = GaxPreconditions.CheckNotNull(client, nameof(client));
+            GaxPreconditions.CheckNotNull(originalRows, nameof(originalRows));
+            InsertAttemptRowCount = originalRows.Count;
+            _options = options;
+
+            var errorsByRow = insertResponse.InsertErrors
+                ?.Where(error => error != null)
+                .GroupBy(error => error.Index) ?? Enumerable.Empty<IGrouping<long?, InsertErrorsData>>();
+
+            int originalRowsWithErrors = 0;
+            _errors = errorsByRow
+                .Select(rowErrors => new BigQueryInsertRowErrors(GetRow(rowErrors.Key), rowErrors.ToList().AsReadOnly()))
+                .ToList().AsReadOnly();
+
+            OriginalRowsWithErrors = originalRowsWithErrors;
+
+            BigQueryInsertRow GetRow(long? index)
+            {
+                if (index.HasValue && index.Value >= 0 && index.Value < InsertAttemptRowCount)
+                {
+                    originalRowsWithErrors++;
+                    return originalRows[(int)index.Value];
+                }
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Throws <see cref="GoogleApiException"/> if not all rows were inserted.
+        /// </summary>
+        /// <exception cref="GoogleApiException">Not all rows were inserted.</exception>
+        public BigQueryInsertResults ThrowOnNotAllInserted() =>
+            Status == BigQueryInsertStatus.AllRowsInserted ? this : ThrowOnAnyError();
+
+        /// <summary>
+        /// Throws <see cref="GoogleApiException"/> if no row was inserted.
+        /// </summary>
+        /// <exception cref="GoogleApiException">No row was inserted.</exception>
+        public BigQueryInsertResults ThrowOnNoneInserted() =>
+            Status == BigQueryInsertStatus.NoRowsInserted ? ThrowOnAnyError() : this;
+
+        /// <summary>
+        /// Throws <see cref="GoogleApiException"/> if there were insert errors.
+        /// The excetpion will contain details of these errors.
+        /// </summary>
+        /// <exception cref="GoogleApiException">There were insert errors.</exception>
+        public BigQueryInsertResults ThrowOnAnyError()
+        {
+            if (_errors.Count == 0)
+            {
+                return this;
+            }
+
+            var exception = new GoogleApiException(_client.Service.Name, $"Error inserting data. Status: {Status}")
+            {
+                Error = new RequestError
+                {
+                    Errors = Errors.SelectMany(rowErrors => rowErrors).ToList()
+                }
+            };
+            throw exception;
+        }
+
+        internal BigQueryInsertResults ThrowIfNotSuppressing(bool? suppressInsertErrors) =>
+            suppressInsertErrors == true ? this : ThrowOnAnyError();
+    }
+}

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryInsertRowErrors.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryInsertRowErrors.cs
@@ -1,0 +1,91 @@
+﻿// Copyright 2020 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using Google.Apis.Requests;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using static Google.Apis.Bigquery.v2.Data.TableDataInsertAllResponse;
+
+namespace Google.Cloud.BigQuery.V2
+{
+    /// <summary>
+    /// Represents insert errors related to one row.
+    /// </summary>
+    public sealed class BigQueryInsertRowErrors : IEnumerable<SingleError>
+    {
+        private readonly IReadOnlyList<InsertErrorsData> _errors;
+
+        /// <summary>
+        /// The original row to which these errors are related to.
+        /// </summary>
+        /// <remarks>
+        /// Some errors obtained after an insert request might not contain enough
+        /// information so as to associate them with one row.
+        /// In such cases this may be null.
+        /// </remarks>
+        public BigQueryInsertRow OriginalRow { get; }
+
+        /// <summary>
+        /// The index of the row these errors relate to in the original
+        /// inser request. Might be unknown.
+        /// </summary>
+        public long? OriginalRowIndex => _errors[0].Index;
+
+        /// <summary>
+        /// Returns an iterator over the insert errors.
+        /// </summary>
+        /// <returns>An iterator over the insert errors.</returns>
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        /// <summary>
+        /// Constructs a new set of insert errors related to one insert row.
+        /// </summary>
+        /// <param name="originalRow">The original row to which these errors are related to if known. May be null.</param>
+        /// <param name="errors">The errors information.</param>
+        public BigQueryInsertRowErrors(BigQueryInsertRow originalRow, IReadOnlyList<InsertErrorsData> errors)
+        {
+            GaxPreconditions.CheckArgument(errors?.Count > 0, nameof(errors), "Can't be null or empty");
+            _errors = errors;
+            OriginalRow = originalRow;
+        }
+
+        /// <summary>
+        /// Returns an interator over the insert errors.
+        /// </summary>
+        /// <returns>An iterator over the insert errors.</returns>
+        public IEnumerator<SingleError> GetEnumerator()
+        {
+            string messagePrefix = $"Error in row {OriginalRowIndex?.ToString() ?? "unknown"}.";
+
+            IEnumerable<SingleError> singleErrors = from error in _errors
+                                                    where error?.Errors != null
+                                                    from detail in error.Errors
+                                                    where detail != null
+                                                    select new SingleError
+                                                    {
+                                                        Location = detail.Location,
+                                                        Reason = detail.Reason,
+                                                        Message = $"{messagePrefix} {detail.Message ?? string.Empty}"
+                                                    };
+            if (!singleErrors.Any())
+            {
+                // No error details, just unknown errors potentially associated to a row.
+                return Enumerable.Repeat(new SingleError { Message = messagePrefix }, 1).GetEnumerator();
+            }
+            return singleErrors.GetEnumerator();
+        }
+    }
+}

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryInsertStatus.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryInsertStatus.cs
@@ -1,0 +1,55 @@
+﻿// Copyright 2020 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Google.Cloud.BigQuery.V2
+{
+    /// <summary>
+    /// Specifies the status of an insert attempt depending on the validity of the rows.
+    /// Note that the validity of a row is determined by whether <see cref="InsertOptions.AllowUnknownFields"/>
+    /// is set to true or not.
+    /// If <see cref="InsertOptions.AllowUnknownFields"/> is set to true, then rows containing fields
+    /// that do not match any on the destination table will, otherwise, be considered valid rows.
+    /// All matching fields in these rows will be inserted, while unmatching fields will be silently skipped.
+    /// If <see cref="InsertOptions.AllowUnknownFields"/> is not set to true, then rows containing fields
+    /// that do not match any on the destination table will be considered invalid and won't be inserted.
+    /// </summary>
+    public enum BigQueryInsertStatus
+    {
+        /// <summary>
+        /// All rows were inserted successfully.
+        /// This only happens if all rows are valid rows.
+        /// </summary>
+        AllRowsInserted,
+
+        /// <summary>
+        /// Some rows were inserted but not others. In that case the <see cref="BigQueryInsertResults"/>
+        /// returned by the insert operation will contain error information about the rows that were not inserted.
+        /// This happens only when <see cref="InsertOptions.SkipInvalidRows"/> is set to true and some, 
+        /// but not all of the rows, are invalid.
+        /// </summary>
+        SomeRowsInserted,
+
+        /// <summary>
+        /// No rows were inserted. In that case the <see cref="BigQueryInsertResults"/>
+        /// returned by the insert operation will contain error information about the invalid rows.
+        /// This can happen when:
+        /// <list type="bullet">
+        /// <item> No rows are valid.</item>
+        /// <item> <see cref="InsertOptions.SkipInvalidRows"/> is not set to true and at least
+        /// one row is invalid.</item>
+        /// </list>
+        /// </summary>
+        NoRowsInserted
+    }
+}

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryTable.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryTable.cs
@@ -158,7 +158,8 @@ namespace Google.Cloud.BigQuery.V2
         /// </summary>
         /// <param name="row">The data to insert. Must not be null.</param>
         /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
-        public void InsertRow(BigQueryInsertRow row, InsertOptions options = null) =>
+        /// <returns>An insert result object which contains information on insert errors if any.</returns>
+        public BigQueryInsertResults InsertRow(BigQueryInsertRow row, InsertOptions options = null) =>
             _client.InsertRow(Reference, row, options);
 
         /// <summary>
@@ -167,7 +168,8 @@ namespace Google.Cloud.BigQuery.V2
         /// </summary>
         /// <param name="rows">The rows to insert. Must not be null or contain null entries.</param>
         /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
-        public void InsertRows(IEnumerable<BigQueryInsertRow> rows, InsertOptions options = null) =>
+        /// <returns>An insert result object which contains information on insert errors if any.</returns>
+        public BigQueryInsertResults InsertRows(IEnumerable<BigQueryInsertRow> rows, InsertOptions options = null) =>
             _client.InsertRows(Reference, rows, options);
 
         /// <summary>
@@ -175,7 +177,8 @@ namespace Google.Cloud.BigQuery.V2
         /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="BigQueryClient.InsertRows(TableReference, BigQueryInsertRow[])"/>.
         /// </summary>
         /// <param name="rows">The rows to insert. Must not be null or contain null entries.</param>
-        public void InsertRows(params BigQueryInsertRow[] rows) =>
+        /// <returns>An insert result object which contains information on insert errors if any.</returns>
+        public BigQueryInsertResults InsertRows(params BigQueryInsertRow[] rows) =>
             _client.InsertRows(Reference, rows);
 
         /// <summary>
@@ -358,8 +361,9 @@ namespace Google.Cloud.BigQuery.V2
         /// <param name="row">The data to insert. Must not be null.</param>
         /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        /// <returns>A task representing the asynchronous operation.</returns>
-        public Task InsertRowAsync(BigQueryInsertRow row, InsertOptions options = null, CancellationToken cancellationToken = default) =>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is
+        /// an insert result object which contains information on insert errors if any.</returns>
+        public Task<BigQueryInsertResults> InsertRowAsync(BigQueryInsertRow row, InsertOptions options = null, CancellationToken cancellationToken = default) =>
             _client.InsertRowAsync(Reference, row, options, cancellationToken);
 
         /// <summary>
@@ -369,8 +373,9 @@ namespace Google.Cloud.BigQuery.V2
         /// <param name="rows">The rows to insert. Must not be null or contain null entries.</param>
         /// <param name="options">The options for the operation. May be null, in which case defaults will be supplied.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        /// <returns>A task representing the asynchronous operation.</returns>
-        public Task InsertRowsAsync(IEnumerable<BigQueryInsertRow> rows, InsertOptions options = null, CancellationToken cancellationToken = default) =>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is
+        /// an insert result object which contains information on insert errors if any.</returns>
+        public Task<BigQueryInsertResults> InsertRowsAsync(IEnumerable<BigQueryInsertRow> rows, InsertOptions options = null, CancellationToken cancellationToken = default) =>
             _client.InsertRowsAsync(Reference, rows, options, cancellationToken);
 
         /// <summary>
@@ -378,8 +383,9 @@ namespace Google.Cloud.BigQuery.V2
         /// This method just creates a <see cref="TableReference"/> and delegates to <see cref="BigQueryClient.InsertRowsAsync(TableReference, BigQueryInsertRow[])"/>.
         /// </summary>
         /// <param name="rows">The rows to insert. Must not be null or contain null entries.</param>
-        /// <returns>A task representing the asynchronous operation.</returns>
-        public Task InsertRowsAsync(params BigQueryInsertRow[] rows) =>
+        /// <returns>A task representing the asynchronous operation. When complete, the result is
+        /// an insert result object which contains information on insert errors if any.</returns>
+        public Task<BigQueryInsertResults> InsertRowsAsync(params BigQueryInsertRow[] rows) =>
             _client.InsertRowsAsync(Reference, rows);
 
         /// <summary>


### PR DESCRIPTION
The API insert operation returns a response object with information about the rows that contained errors, if any, which is specially relevant if the option SkipInvalidRows is set to true. In that case the insert operation is partially successful and the response contains information about the rows that were not inserted and why.
The client library insert operations were, until now, void. The only way to obtain part of the information contained in the reponse object has been trough an exception that was thrown depending on another option SuppressInsertErrors. Even then, the information contained in the exception was less machine readable than the information in the response, for instance, in the exception, the index of each of the erred rows is part of a message and cannot be accessed by itself.

In this proposal the BigQueryInsertResults wraps the response object. I believe this wrapper is in line with more or less everything in the library but I also understand that it is more code for us to maintain so I'd be fine with simple returning the response object or a simpler wrapper.

In this proposal the SuppressInsertErrors options has been, that is, unless it is set to true, insert methods will throw unless **all** rows are inserted. Even if SkipInvalidRows is set to true, if some rows were skipped, the methods would throw. For a discussion around this see #4199 .