### PR TITLE
Fix Bigtable to work with changes in retry handling

### DIFF
--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.sln
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.sln
@@ -1,6 +1,7 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2020
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29613.14
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Bigtable.V2", "Google.Cloud.Bigtable.V2\Google.Cloud.Bigtable.V2.csproj", "{4D4B5FB5-FC91-4E89-9A6F-4577671BE53E}"
 EndProject
@@ -18,9 +19,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Bigtable.V2.Ge
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Bigtable.Common.V2", "..\Google.Cloud.Bigtable.Common.V2\Google.Cloud.Bigtable.Common.V2\Google.Cloud.Bigtable.Common.V2.csproj", "{FD3A1128-0981-460C-86F2-621CA0A4799D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Tools.SourceManipulation", "..\..\tools\Google.Cloud.Tools.SourceManipulation\Google.Cloud.Tools.SourceManipulation.csproj", "{9FC53511-2F0C-4099-B53F-7FD2863D2880}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Tools.SourceManipulation", "..\..\tools\Google.Cloud.Tools.SourceManipulation\Google.Cloud.Tools.SourceManipulation.csproj", "{9FC53511-2F0C-4099-B53F-7FD2863D2880}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Tools.Common", "..\..\tools\Google.Cloud.Tools.Common\Google.Cloud.Tools.Common.csproj", "{C81D237A-B51E-44B6-B413-6C02EDB2C084}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Tools.Common", "..\..\tools\Google.Cloud.Tools.Common\Google.Cloud.Tools.Common.csproj", "{C81D237A-B51E-44B6-B413-6C02EDB2C084}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Iam.V1", "..\Google.Cloud.Iam.V1\Google.Cloud.Iam.V1\Google.Cloud.Iam.V1.csproj", "{7865F184-8894-488E-9990-247B6ECB1F7A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.LongRunning", "..\Google.LongRunning\Google.LongRunning\Google.LongRunning.csproj", "{A4948C2D-A6D7-4EF3-9230-ACCD2B029075}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -151,6 +156,30 @@ Global
 		{C81D237A-B51E-44B6-B413-6C02EDB2C084}.Release|x64.Build.0 = Release|Any CPU
 		{C81D237A-B51E-44B6-B413-6C02EDB2C084}.Release|x86.ActiveCfg = Release|Any CPU
 		{C81D237A-B51E-44B6-B413-6C02EDB2C084}.Release|x86.Build.0 = Release|Any CPU
+		{7865F184-8894-488E-9990-247B6ECB1F7A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7865F184-8894-488E-9990-247B6ECB1F7A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7865F184-8894-488E-9990-247B6ECB1F7A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7865F184-8894-488E-9990-247B6ECB1F7A}.Debug|x64.Build.0 = Debug|Any CPU
+		{7865F184-8894-488E-9990-247B6ECB1F7A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7865F184-8894-488E-9990-247B6ECB1F7A}.Debug|x86.Build.0 = Debug|Any CPU
+		{7865F184-8894-488E-9990-247B6ECB1F7A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7865F184-8894-488E-9990-247B6ECB1F7A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7865F184-8894-488E-9990-247B6ECB1F7A}.Release|x64.ActiveCfg = Release|Any CPU
+		{7865F184-8894-488E-9990-247B6ECB1F7A}.Release|x64.Build.0 = Release|Any CPU
+		{7865F184-8894-488E-9990-247B6ECB1F7A}.Release|x86.ActiveCfg = Release|Any CPU
+		{7865F184-8894-488E-9990-247B6ECB1F7A}.Release|x86.Build.0 = Release|Any CPU
+		{A4948C2D-A6D7-4EF3-9230-ACCD2B029075}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A4948C2D-A6D7-4EF3-9230-ACCD2B029075}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A4948C2D-A6D7-4EF3-9230-ACCD2B029075}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A4948C2D-A6D7-4EF3-9230-ACCD2B029075}.Debug|x64.Build.0 = Debug|Any CPU
+		{A4948C2D-A6D7-4EF3-9230-ACCD2B029075}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A4948C2D-A6D7-4EF3-9230-ACCD2B029075}.Debug|x86.Build.0 = Debug|Any CPU
+		{A4948C2D-A6D7-4EF3-9230-ACCD2B029075}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A4948C2D-A6D7-4EF3-9230-ACCD2B029075}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A4948C2D-A6D7-4EF3-9230-ACCD2B029075}.Release|x64.ActiveCfg = Release|Any CPU
+		{A4948C2D-A6D7-4EF3-9230-ACCD2B029075}.Release|x64.Build.0 = Release|Any CPU
+		{A4948C2D-A6D7-4EF3-9230-ACCD2B029075}.Release|x86.ActiveCfg = Release|Any CPU
+		{A4948C2D-A6D7-4EF3-9230-ACCD2B029075}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableClientBuilder.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableClientBuilder.cs
@@ -50,7 +50,7 @@ namespace Google.Cloud.Bigtable.V2
         protected override ChannelPool GetChannelPool() => throw new NotImplementedException();
 
         /// <inheritdoc />
-        protected override ServiceEndpoint GetDefaultEndpoint() => throw new NotImplementedException();
+        protected override string GetDefaultEndpoint() => throw new NotImplementedException();
 
         /// <inheritdoc />
         protected override IReadOnlyList<string> GetDefaultScopes() => throw new NotImplementedException();

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableClientPartial.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableClientPartial.cs
@@ -36,29 +36,18 @@ namespace Google.Cloud.Bigtable.V2
         // TODO: Auto-generate these if possible/easy after multi-channel support is added.
 
         /// <summary>
-        /// Asynchronously creates a <see cref="BigtableClient"/>, applying defaults for all unspecified settings,
-        /// and creating channels connecting to the given endpoint with application default credentials where
-        /// necessary.
+        /// Asynchronously creates a <see cref="BigtableClient"/> using the default credentials, endpoint and
+        /// settings. To specify custom credentials or other settings, use <see cref="BigtableClientBuilder"/>.
         /// </summary>
-        /// <param name="endpoint">Optional <see cref="ServiceEndpoint"/> to use when connecting to Bigtable.</param>
-        /// <param name="settings">Optional <see cref="BigtableServiceApiSettings"/> to control API requests.</param>
-        /// <returns>The task representing the created <see cref="BigtableClient"/>.</returns>
-        public static async Task<BigtableClient> CreateAsync(ServiceEndpoint endpoint = null, BigtableServiceApiSettings settings = null)
-        {
-            var client = await BigtableServiceApiClient.CreateAsync(endpoint, settings).ConfigureAwait(false);
-            return new BigtableClientImpl(client);
-        }
+        /// <returns>The created <see cref="BigtableServiceApiClient"/>.</returns>
+        public static Task<BigtableClient> CreateAsync() => new BigtableClientBuilder().BuildAsync();
 
         /// <summary>
-        /// Synchronously creates a <see cref="BigtableClient"/>, applying defaults for all unspecified settings,
-        /// and creating channels connecting to the given endpoint with application default credentials where
-        /// necessary.
+        /// Synchronously creates a <see cref="BigtableClient"/> using the default credentials, endpoint and
+        /// settings. To specify custom credentials or other settings, use <see cref="BigtableClientBuilder"/>.
         /// </summary>
-        /// <param name="endpoint">Optional <see cref="ServiceEndpoint"/> to use when connecting to Bigtable.</param>
-        /// <param name="settings">Optional <see cref="BigtableServiceApiSettings"/> to control API requests.</param>
-        /// <returns>The created <see cref="BigtableClient"/>.</returns>
-        public static BigtableClient Create(ServiceEndpoint endpoint = null, BigtableServiceApiSettings settings = null) =>
-            Task.Run(() => CreateAsync(endpoint, settings)).ResultWithUnwrappedExceptions();
+        /// <returns>The created <see cref="BigtableServiceApiClient"/>.</returns>
+        public static BigtableClient Create() => new BigtableClientBuilder().Build();
 
         /// <summary>
         /// Synchronously creates a <see cref="BigtableClient"/> from a pre-existing API client.
@@ -1012,9 +1001,9 @@ namespace Google.Cloud.Bigtable.V2
             var requestManager = new BigtableMutateRowsRequestManager(retryStatuses, request);
 
             await Utilities.RetryOperationUntilCompleted(
-                async () =>
+                async thisCallSettings =>
                 {
-                    var currentStream = _client.MutateRows(requestManager.NextRequest, callSettings);
+                    var currentStream = _client.MutateRows(requestManager.NextRequest, thisCallSettings);
                     return await ProcessCurrentStream(currentStream).ConfigureAwait(false) != ProcessingStatus.Retryable;
                 },
                 Clock,

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableClientPartial.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableClientPartial.cs
@@ -60,16 +60,6 @@ namespace Google.Cloud.Bigtable.V2
             new BigtableClientImpl(GaxPreconditions.CheckNotNull(client, nameof(client)));
 
         /// <summary>
-        /// Synchronously creates a <see cref="BigtableClient"/>, applying defaults for all unspecified settings,
-        /// using the specified <see cref="CallInvoker"/> for API requests.
-        /// </summary>
-        /// <param name="callInvoker">The <see cref="CallInvoker"/> which performs API requests. Must not be null.</param>
-        /// <param name="settings">Optional <see cref="BigtableServiceApiSettings"/> to control API requests.</param>
-        /// <returns>The created <see cref="BigtableClient"/>.</returns>
-        public static BigtableClient Create(CallInvoker callInvoker, BigtableServiceApiSettings settings = null) =>
-            Create(BigtableServiceApiClient.Create(GaxPreconditions.CheckNotNull(callInvoker, nameof(callInvoker)), settings));
-
-        /// <summary>
         /// Gets the value which specifies routing for replication.
         /// If null or empty, the "default" application profile will be used by the server.
         /// </summary>

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableServiceApiClientPartial.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableServiceApiClientPartial.cs
@@ -36,29 +36,26 @@ namespace Google.Cloud.Bigtable.V2
         /// The default <c>BigtableClient.MutateRows</c> and <c>BigtableClient.MutateRowsAsync</c>
         /// <see cref="RetrySettings"/> are:
         /// <list type="bullet">
+        /// <item><description>Max attempts: 5</description></item>
         /// <item><description>Initial retry delay: 10 milliseconds</description></item>
         /// <item><description>Retry delay multiplier: 2.0</description></item>
         /// <item><description>Retry maximum delay: 60000 milliseconds</description></item>
-        /// <item><description>Initial timeout: 20000 milliseconds</description></item>
-        /// <item><description>Timeout multiplier: 1.0</description></item>
-        /// <item><description>Timeout maximum delay: 20000 milliseconds</description></item>
         /// </list>
         /// Retry will be attempted on the following response status codes on individual mutations:
         /// <list>
         /// <item><description><see cref="StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="StatusCode.Unavailable"/></description></item>
         /// </list>
-        /// Default RPC expiration is 600000 milliseconds.
         /// </remarks>
         /// <seealso cref="MutateRowsSettings"/>
         public RetrySettings MutateRowsRetrySettings { get; set; } =
-            new RetrySettings(
-                retryBackoff: new BackoffSettings(delay: TimeSpan.FromMilliseconds(10), maxDelay: TimeSpan.FromMilliseconds(60000), delayMultiplier: 2.0),
-                timeoutBackoff: new BackoffSettings(delay: TimeSpan.FromMilliseconds(20000), maxDelay: TimeSpan.FromMilliseconds(20000), delayMultiplier: 1.0),
-                totalExpiration: Expiration.FromTimeout(TimeSpan.FromMilliseconds(600000)),
-                retryFilter: RetrySettings.FilterForStatusCodes(StatusCode.DeadlineExceeded, StatusCode.Unavailable)
-            );
-        
+            RetrySettings.FromExponentialBackoff(
+                maxAttempts: 5,
+                initialBackoff: TimeSpan.FromMilliseconds(10),
+                maxBackoff: TimeSpan.FromMinutes(1),
+                backoffMultiplier: 2,
+                retryFilter: RetrySettings.FilterForStatusCodes(StatusCode.DeadlineExceeded, StatusCode.Unavailable));
+
         /// <summary>
         /// <see cref="RetrySettings"/> for calls to <c>BigtableClient.ReadRows</c> when the stream
         /// of results ends prematurely.
@@ -66,28 +63,25 @@ namespace Google.Cloud.Bigtable.V2
         /// <remarks>
         /// The default <c>BigtableClient.ReadRows</c> <see cref="RetrySettings"/> are:
         /// <list type="bullet">
+        /// <item><description>Max attempts: 5</description></item>
         /// <item><description>Initial retry delay: 10 milliseconds</description></item>
         /// <item><description>Retry delay multiplier: 2.0</description></item>
         /// <item><description>Retry maximum delay: 60000 milliseconds</description></item>
-        /// <item><description>Initial timeout: 20000 milliseconds</description></item>
-        /// <item><description>Timeout multiplier: 1.0</description></item>
-        /// <item><description>Timeout maximum delay: 20000 milliseconds</description></item>
         /// </list>
         /// Retry will be attempted on the following response status codes on individual mutations:
         /// <list>
         /// <item><description><see cref="StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="StatusCode.Unavailable"/></description></item>
         /// </list>
-        /// Default RPC expiration is 600000 milliseconds.
         /// </remarks>
         /// <seealso cref="ReadRowsSettings"/>
         public RetrySettings ReadRowsRetrySettings { get; set; } =
-            new RetrySettings(
-                retryBackoff: new BackoffSettings(delay: TimeSpan.FromMilliseconds(10), maxDelay: TimeSpan.FromMilliseconds(60000), delayMultiplier: 2.0),
-                timeoutBackoff: new BackoffSettings(delay: TimeSpan.FromMilliseconds(20000), maxDelay: TimeSpan.FromMilliseconds(20000), delayMultiplier: 1.0),
-                totalExpiration: Expiration.FromTimeout(TimeSpan.FromMilliseconds(600000)),
-                retryFilter: RetrySettings.FilterForStatusCodes(StatusCode.DeadlineExceeded, StatusCode.Unavailable)
-            );
+            RetrySettings.FromExponentialBackoff(
+                maxAttempts: 5,
+                initialBackoff: TimeSpan.FromMilliseconds(10),
+                maxBackoff: TimeSpan.FromMinutes(1),
+                backoffMultiplier: 2,
+                retryFilter: RetrySettings.FilterForStatusCodes(StatusCode.DeadlineExceeded, StatusCode.Unavailable));
 
         /// <summary>
         /// This value specifies routing for replication. If not specified, the

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/RowAsyncEnumerator.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/RowAsyncEnumerator.cs
@@ -137,9 +137,9 @@ namespace Google.Cloud.Bigtable.V2
 
             Task EstablishStream(ReadRowsRequest request)  =>
                 Utilities.RetryOperationUntilCompleted(
-                    () =>
+                    thisCallSettings =>
                     {
-                        _stream = _client.ReadRowsInternal(request, _callSettings);
+                        _stream = _client.ReadRowsInternal(request, thisCallSettings);
                         return Task.FromResult(true);
                     },
                     _client.Clock,

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Utilities.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Utilities.cs
@@ -115,49 +115,51 @@ namespace Google.Cloud.Bigtable.V2
         }
 
         internal static async Task RetryOperationUntilCompleted(
-            Func<Task<bool>> fn,
+            Func<CallSettings, Task<bool>> fn,
             IClock clock,
             IScheduler scheduler,
             CallSettings callSettings,
             RetrySettings retrySettings)
         {
-            DateTime? overallDeadline = retrySettings.TotalExpiration.CalculateDeadline(clock);
-            TimeSpan retryDelay = retrySettings.RetryBackoff.Delay;
-            TimeSpan callTimeout = retrySettings.TimeoutBackoff.Delay;
+            DateTime? overallDeadline = callSettings.Expiration.CalculateDeadline(clock);
+            TimeSpan retryBackoff = retrySettings.InitialBackoff;
+            // Every attempt should use the same deadline, calculated from the start of the call.
+            if (callSettings.Expiration?.Type == ExpirationType.Timeout)
+            {
+                callSettings = callSettings.WithDeadline(overallDeadline.Value);
+            }
+            int attempt = 0;
             while (true)
             {
-                DateTime attemptDeadline = clock.GetCurrentDateTimeUtc() + callTimeout;
-                // Note: this handles a null total deadline due to "<" returning false if overallDeadline is null.
-                DateTime combinedDeadline = overallDeadline < attemptDeadline ? overallDeadline.Value : attemptDeadline;
-                CallSettings attemptCallSettings = callSettings.WithCallTiming(CallTiming.FromDeadline(combinedDeadline));
-                TimeSpan actualDelay = retrySettings.DelayJitter.GetDelay(retryDelay);
                 DateTime expectedRetryTime;
+                TimeSpan actualBackoff = retrySettings.BackoffJitter.GetDelay(retryBackoff);
                 try
                 {
-                    bool isResponseOk = await fn().ConfigureAwait(false);
+                    attempt++;
+
+                    bool isResponseOk = await fn(callSettings).ConfigureAwait(false);
                     if (isResponseOk)
                     {
                         return;
                     }
 
-                    expectedRetryTime = clock.GetCurrentDateTimeUtc() + actualDelay;
+                    expectedRetryTime = clock.GetCurrentDateTimeUtc() + actualBackoff;
                     if (expectedRetryTime > overallDeadline)
                     {
                         // TODO: Can we get this string from somewhere?
                         throw new RpcException(new Status(StatusCode.DeadlineExceeded, "Deadline Exceeded"));
                     }
                 }
-                catch (RpcException e) when (retrySettings.RetryFilter(e))
+                catch (RpcException e) when (attempt < retrySettings.MaxAttempts && retrySettings.RetryFilter(e))
                 {
-                    expectedRetryTime = clock.GetCurrentDateTimeUtc() + actualDelay;
+                    expectedRetryTime = clock.GetCurrentDateTimeUtc() + actualBackoff;
                     if (expectedRetryTime > overallDeadline)
                     {
                         throw;
                     }
                 }
-                await scheduler.Delay(actualDelay, callSettings.CancellationToken.GetValueOrDefault()).ConfigureAwait(false);
-                retryDelay = retrySettings.RetryBackoff.NextDelay(retryDelay);
-                callTimeout = retrySettings.TimeoutBackoff.NextDelay(callTimeout);
+                await scheduler.Delay(actualBackoff, callSettings.CancellationToken.GetValueOrDefault()).ConfigureAwait(false);
+                retryBackoff = retrySettings.NextBackoff(retryBackoff);
             }
         }
 


### PR DESCRIPTION
Note that the utility retry method now accepts a function which is passed a CallSettings, so that multiple retries can use the same overall deadline.

(The solution file change is just to get the relevant projects in. Nothing serious there.)

Note that we no longer have per-RPC timeouts, which simplifies things in some ways - although `attemptCallSettings` in the original code was never used.