### PR TITLE
Fix fetch-latest-gax script to account for SDK differences

### DIFF
--- a/fetch-latest-gax.sh
+++ b/fetch-latest-gax.sh
@@ -3,4 +3,4 @@
 echo "Fetching and building GAX"
 
 git clone -q https://github.com/googleapis/gax-dotnet.git
-dotnet pack -v quiet -c Release -o $PWD/gax-dotnet/nuget gax-dotnet/Gax.sln
+(cd gax-dotnet && dotnet pack -v quiet -c Release -o $PWD/nuget Gax.sln)


### PR DESCRIPTION
We need to run "dotnet pack" in the GAX working directory to pick up SDK 3.1, otherwise GAX doesn't build.