### PR TITLE
Only expand {{client-classes}} when necessary.

### DIFF
--- a/tools/Google.Cloud.Tools.GenerateDocfxSources/Program.cs
+++ b/tools/Google.Cloud.Tools.GenerateDocfxSources/Program.cs
@@ -212,7 +212,8 @@ The credentials will automatically be used to authenticate. See the [Getting Sta
 Authentication](https://cloud.google.com/docs/authentication/getting-started) guide for more details.";
 
             var clients = GetClientClasses(api);
-            string clientClasses = CreateClientClassesDocumentation(api, clients);
+            string clientClasses = text.Contains("{{client-classes}}") ?
+                CreateClientClassesDocumentation(api, clients) : "no client classes needed";
 
             var exampleClient = clients.FirstOrDefault();
             string clientConstruction =


### PR DESCRIPTION
It's okay not to be able to find any generated client classes if the docs don't need them.