### PR TITLE
Release Google.Cloud.Recommender.V1 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.Recommender.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.Recommender.V1/.repo-metadata.json
@@ -1,4 +1,4 @@
 {
   "distribution_name": "Google.Cloud.Recommender.V1",
-  "release_level": "beta"
+  "release_level": "ga"
 }

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.csproj
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard1.5;netstandard2.0;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.Recommender.V1/docs/history.md
+++ b/apis/Google.Cloud.Recommender.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.0.0, released 2020-02-11
+
+GA release, with no API surface changes compared with 1.0.0-beta01.
+
 # Version 1.0.0-beta01, released 2020-01-15
 
 Initial beta release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -745,7 +745,7 @@
     "protoPath": "google/cloud/recommender/v1",
     "productName": "Google Cloud Recommender",
     "productUrl": "https://cloud.google.com/recommender/",
-    "version": "1.0.0-beta01",
+    "version": "1.0.0",
     "type": "grpc",
     "description": "Recommended Google client library for the Recommender API, which provides usage recommendations for Cloud products and services.",
     "dependencies": {


### PR DESCRIPTION
This has no API surface changes compared with 1.0.0-beta01.