### PR TITLE
Release Google.Cloud.Billing.V1 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.Billing.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.Billing.V1/.repo-metadata.json
@@ -1,4 +1,4 @@
 {
   "distribution_name": "Google.Cloud.Billing.V1",
-  "release_level": "beta"
+  "release_level": "ga"
 }

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.csproj
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard1.5;netstandard2.0;net45</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.Billing.V1/docs/history.md
+++ b/apis/Google.Cloud.Billing.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+# Version 1.0.0, released 2020-02-11
+
+- [Commit 6308c12](https://github.com/googleapis/google-cloud-dotnet/commit/6308c12): Adds parameterless (aside from page token/size) list methods:
+  - ListBillingAccounts
+  - ListServices
+
 # Version 1.0.0-beta01, released 2020-01-15
 
 Initial beta release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -151,7 +151,7 @@
     "protoPath": "google/cloud/billing/v1",
     "productName": "Google Cloud Billing API",
     "productUrl": "https://cloud.google.com/billing/docs/",
-    "version": "1.0.0-beta01",
+    "version": "1.0.0",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Billing API, which allows you to define a budget plan and the rules to execute as spend is tracked against that plan.",
     "dependencies": {


### PR DESCRIPTION
Changes since 1.0.0-beta01:

- [Commit 6308c12](https://github.com/googleapis/google-cloud-dotnet/commit/6308c12): Adds parameterless (aside from page token/size) list methods:
  - ListBillingAccounts
  - ListServices