### PR TITLE
Fixes issue introduced in #4073.

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/QueryTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/QueryTest.cs
@@ -717,52 +717,6 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             Assert.Equal(DateTime.MinValue, (DateTime) row["x"]);
         }
 
-        [Fact]
-        public void ListRows_PartialSchema()
-        {
-            var client = BigQueryClient.Create(_fixture.ProjectId);
-            string datasetId = _fixture.DatasetId;
-            string tableId = _fixture.PeopleTableId;
-            var options = new GetTableOptions
-            {
-                SelectedFields = "age,gender,children.gender,children.age"
-            };
-
-            // Obtain the table's partial schema.
-            var table = client.GetTable(datasetId, tableId, options);
-            // Use the partial schema to obtain partial rows.
-            var rows = client.ListRows(datasetId, tableId, table.Schema);
-            // Make sure we grab a row of a person with children for testing fields that should be present.
-            var row = rows.First(row => ((Dictionary<string, object>[])row["children"])?.Length > 0);
-
-            // These should be present
-            Assert.NotNull(row["age"]);
-            Assert.NotNull(row["gender"]);
-            var children = row["children"] as Dictionary<string, object>[];
-            Assert.NotNull(children);
-            Assert.NotNull(children[0]["gender"]);
-            Assert.NotNull(children[0]["age"]);
-            // These shouldn't
-            Assert.Throws<KeyNotFoundException>(() => row["fullName"]);
-            Assert.Throws<KeyNotFoundException>(() => children[0]["name"]);
-        }
-
-        [Fact]
-        public void ListRows_EmptySchema()
-        {
-            var client = BigQueryClient.Create(_fixture.ProjectId);
-            string datasetId = _fixture.DatasetId;
-            string tableId = _fixture.PeopleTableId;
-
-            // Use an empty schema to obtain the rows.
-            // We should get full rows.
-            var rows = client.ListRows(datasetId, tableId, new TableSchema()).ToList();
-
-            // The People table has 7 top level fields. We should have all fields.
-            object dummy;
-            Assert.All(rows, row => dummy = row[6]);
-        }
-
         private class TitleComparer : IEqualityComparer<BigQueryRow>
         {
             public bool Equals(BigQueryRow x, BigQueryRow y) => (string)x["title"] == (string)y["title"];

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.Queries.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.Queries.cs
@@ -149,7 +149,7 @@ namespace Google.Cloud.BigQuery.V2
             // So, if the schema is empty, the whole rows will be fetch, so we need to get the whole schema.
             var resultSchema = schema?.Fields?.Count > 0 ? schema : GetSchema(tableReference);
 
-            var pageManager = new TableRowPageManager(schema);
+            var pageManager = new TableRowPageManager(resultSchema);
             return new RestPagedAsyncEnumerable<TabledataResource.ListRequest, TableDataList, BigQueryRow>(
                 // Pass the original schema, if it was null then the whole table will be fetch and we don't need to
                 // specify selected fields.


### PR DESCRIPTION
In #4073 listing partial rows was introduced if a table's partial schema was passed as a parameter to the ListRow methods. If no schema is passed we fetch the table's full schema. In this case, we were incorrectly using the null parameter instead of the fetched table's schema, but only in the Async versions of the method. 
Also in this PR:
  * Moves ListRows tests to correct files.
  * Adds testing for ListRowsAsync.