### PR TITLE
Re-disable deprecation warnings

### DIFF
--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.Tests/ClusterManagerClientTest.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.Tests/ClusterManagerClientTest.g.cs
@@ -14,6 +14,12 @@
 
 // Generated code. DO NOT EDIT!
 
+// Ignore obsolete members within this file.
+// This is currently a hand-written addition to the generated file, until the
+// generator includes it automatically.
+// See https://github.com/googleapis/gapic-generator-csharp/issues/220
+#pragma warning disable CS0612 // Type or member is obsolete
+
 using gaxgrpc = Google.Api.Gax.Grpc;
 using wkt = Google.Protobuf.WellKnownTypes;
 using grpccore = Grpc.Core;

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/ClusterManagerClient.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/ClusterManagerClient.g.cs
@@ -14,6 +14,12 @@
 
 // Generated code. DO NOT EDIT!
 
+// Ignore obsolete members within this file.
+// This is currently a hand-written addition to the generated file, until the
+// generator includes it automatically.
+// See https://github.com/googleapis/gapic-generator-csharp/issues/220
+#pragma warning disable CS0612 // Type or member is obsolete
+
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
 using gaxgrpccore = Google.Api.Gax.Grpc.GrpcCore;


### PR DESCRIPTION
We have method signatures that use deprecated fields; we need the generator to add pragmas to remove deprecation warnings on those messages.

I haven't included a patch file for this, as I want to just fix it in the generator ASAP.
(It's filed as https://github.com/googleapis/gapic-generator-csharp/issues/220)