### PR TITLE
Release Google.LongRunning version 2.0.0-beta01

### DIFF
--- a/apis/Google.LongRunning/Google.LongRunning/Google.LongRunning.csproj
+++ b/apis/Google.LongRunning/Google.LongRunning/Google.LongRunning.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha00</Version>
+    <Version>2.0.0-beta01</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.LongRunning/docs/history.md
+++ b/apis/Google.LongRunning/docs/history.md
@@ -1,5 +1,29 @@
 # Version history
 
+# Version 2.0.0-beta01, released 2020-02-17
+
+This is the first prerelease targeting GAX v3. Please see the [breaking changes
+guide](https://googleapis.github.io/google-cloud-dotnet/docs/guides/breaking-gax2.html)
+for details of changes to both GAX and code generation.
+
+# Version 1.2.0-beta01, released 2019-06-10
+
+- [Commit ee5c7dc](https://github.com/googleapis/google-cloud-dotnet/commit/ee5c7dc):
+  - Introduce ClientBuilders for all APIs (except Grafeas)
+  - (We need to work out what to do about Grafeas separately. Next commit will be code to remove the new builder which is generated for Grafeas.)
+- [Commit 0cb5661](https://github.com/googleapis/google-cloud-dotnet/commit/0cb5661):
+  - Revert "Regenerate all clients, without retrying on DeadlineExceeded"
+  - This reverts commit 877f04bb6a47d51399d2e4945e60f05a2b9097d0.
+- [Commit 877f04b](https://github.com/googleapis/google-cloud-dotnet/commit/877f04b): Regenerate all clients, without retrying on DeadlineExceeded
+- [Commit 34507ab](https://github.com/googleapis/google-cloud-dotnet/commit/34507ab): Use effective settings for PollUntilCompleted more carefully. Fixes [issue 3029](https://github.com/googleapis/google-cloud-dotnet/issues/3029).
+- [Commit a1a01f9](https://github.com/googleapis/google-cloud-dotnet/commit/a1a01f9):
+  - Regenerate all APIs with updated generator
+  - This populates x-goog-request-params on all requests
+- [Commit 45cd32e](https://github.com/googleapis/google-cloud-dotnet/commit/45cd32e):
+  - Regenerate Long Running Operations API
+  - This introduces a new WaitOperation call, along with comment changes
+- [Commit e539ddc](https://github.com/googleapis/google-cloud-dotnet/commit/e539ddc): Regenerate LRO API: comment changes only
+
 # Version 1.1.0, released 2019-02-19
 
 Added async RPC methods accepting full request objects.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1305,7 +1305,7 @@
     "id": "Google.LongRunning",
     "generator": "micro",
     "protoPath": "google/longrunning",
-    "version": "2.0.0-alpha00",
+    "version": "2.0.0-beta01",
     "type": "grpc",
     "description": "gRPC services for the Google Long Running Operations API. This library is typically used as a dependency for other API client libraries.",
     "tags": [


### PR DESCRIPTION
This is the first prerelease targeting GAX v3. Please see the [breaking changes
guide](https://googleapis.github.io/google-cloud-dotnet/docs/guides/breaking-gax2.html)
for details of changes to both GAX and code generation.