### PR TITLE
Release Google.Cloud.Billing.V1 version 2.0.0-beta01

### DIFF
--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.csproj
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha00</Version>
+    <Version>2.0.0-beta01</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.Billing.V1/docs/history.md
+++ b/apis/Google.Cloud.Billing.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+# Version 2.0.0-beta01, released 2020-02-18
+
+This is the first prerelease targeting GAX v3. Please see the [breaking changes
+guide](https://googleapis.github.io/google-cloud-dotnet/docs/guides/breaking-gax2.html)
+for details of changes to both GAX and code generation.
+
 # Version 1.0.0, released 2020-02-11
 
 - [Commit 6308c12](https://github.com/googleapis/google-cloud-dotnet/commit/6308c12): Adds parameterless (aside from page token/size) list methods:

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -157,7 +157,7 @@
     "protoPath": "google/cloud/billing/v1",
     "productName": "Google Cloud Billing API",
     "productUrl": "https://cloud.google.com/billing/docs/",
-    "version": "2.0.0-alpha00",
+    "version": "2.0.0-beta01",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Billing API, which allows you to define a budget plan and the rules to execute as spend is tracked against that plan.",
     "dependencies": {


### PR DESCRIPTION
This is the first prerelease targeting GAX v3. Please see the [breaking changes guide](https://googleapis.github.io/google-cloud-dotnet/docs/guides/breaking-gax2.html) for details of changes to both GAX and code generation.