### PR TITLE
Release Google.Cloud.Datastore.V1 version 3.0.0-beta01

### DIFF
--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0-alpha00</Version>
+    <Version>3.0.0-beta01</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.Datastore.V1/docs/history.md
+++ b/apis/Google.Cloud.Datastore.V1/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+# Version 3.0.0-beta01, released 2020-02-18
+
+This is the first prerelease targeting GAX v3. Please see the [breaking changes
+guide](https://googleapis.github.io/google-cloud-dotnet/docs/guides/breaking-gax2.html)
+for details of changes to both GAX and code generation.
+
+Additional breaking changes not covered in the guide:
+
+- The `EmulatorDetection` enum is now in the `Google.Api.Gax`
+  namespace, and the previous `ProductionOrEmulator` value within
+  it has been renamed to `EmulatorOrProduction`.
+
 # Version 2.2.0, released 2019-12-09
 
 - Implement DatastoreDbBuilder for easy configuration, including emulator support

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -211,7 +211,7 @@
     "protoPath": "google/datastore/v1",
     "productName": "Google Cloud Datastore",
     "productUrl": "https://cloud.google.com/datastore/docs/concepts/overview",
-    "version": "3.0.0-alpha00",
+    "version": "3.0.0-beta01",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Datastore API, which accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.",
     "tags": [


### PR DESCRIPTION
This is the first prerelease targeting GAX v3. Please see the [breaking changes guide](https://googleapis.github.io/google-cloud-dotnet/docs/guides/breaking-gax2.html) for details of changes to both GAX and code generation.

Additional breaking changes not covered in the guide:

- The `EmulatorDetection` enum is now in the `Google.Api.Gax` namespace, and the previous `ProductionOrEmulator` value within it has been renamed to `EmulatorOrProduction`