### PR TITLE
Release Google.Cloud.DevTools.Common version 2.0.0-beta01

### DIFF
--- a/apis/Google.Cloud.DevTools.Common/Google.Cloud.DevTools.Common/Google.Cloud.DevTools.Common.csproj
+++ b/apis/Google.Cloud.DevTools.Common/Google.Cloud.DevTools.Common/Google.Cloud.DevTools.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha00</Version>
+    <Version>2.0.0-beta01</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.DevTools.Common/docs/history.md
+++ b/apis/Google.Cloud.DevTools.Common/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 2.0.0-beta01, released 2020-02-18
+
+No significant changes since 1.1.0, other than depending on a new major version of Google.Api.CommonProtos.
+
 # Version 1.1.0, released 2019-12-09
 
 - [Commit 518728a](https://github.com/googleapis/google-cloud-dotnet/commit/518728a): A few minor tidy-ups of comments

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -249,7 +249,7 @@
   },
   {
     "id": "Google.Cloud.DevTools.Common",
-    "version": "2.0.0-alpha00",
+    "version": "2.0.0-beta01",
     "type": "other",
     "targetFrameworks": "netstandard2.0;net461",
     "testTargetFrameworks": "netcoreapp2.1;net461",


### PR DESCRIPTION
No significant changes since 1.1.0, other than depending on a new major version of Google.Api.CommonProtos.