### PR TITLE
Release Google.Cloud.Debugger.V2 version 2.0.0-beta01

### DIFF
--- a/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2.Snippets/coverage.xml
@@ -7,9 +7,6 @@
       <FilterEntry>
         <ModuleMask>Google.Cloud.Debugger.V2</ModuleMask>
       </FilterEntry>
-      <FilterEntry>
-        <ModuleMask>Google.Cloud.DevTools.Common</ModuleMask>
-      </FilterEntry>
     </IncludeFilters>
   </Filters>
   <AttributeFilters>

--- a/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2.Tests/coverage.xml
+++ b/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2.Tests/coverage.xml
@@ -7,9 +7,6 @@
       <FilterEntry>
         <ModuleMask>Google.Cloud.Debugger.V2</ModuleMask>
       </FilterEntry>
-      <FilterEntry>
-        <ModuleMask>Google.Cloud.DevTools.Common</ModuleMask>
-      </FilterEntry>
     </IncludeFilters>
   </Filters>
   <AttributeFilters>

--- a/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2.csproj
+++ b/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha00</Version>
+    <Version>2.0.0-beta01</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
@@ -24,7 +24,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="3.0.0-beta01" />
-    <ProjectReference Include="..\..\Google.Cloud.DevTools.Common\Google.Cloud.DevTools.Common\Google.Cloud.DevTools.Common.csproj" />
+    <PackageReference Include="Google.Cloud.DevTools.Common" Version="2.0.0-beta01" />
     <PackageReference Include="Grpc.Core" Version="2.27.0" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />

--- a/apis/Google.Cloud.Debugger.V2/docs/history.md
+++ b/apis/Google.Cloud.Debugger.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+# Version 2.0.0-beta01, released 2020-02-18
+
+This is the first prerelease targeting GAX v3. Please see the [breaking changes
+guide](https://googleapis.github.io/google-cloud-dotnet/docs/guides/breaking-gax2.html)
+for details of changes to both GAX and code generation.
+
 # Version 1.1.0, released 2019-12-09
 
 - [Commit f3c6a75](https://github.com/googleapis/google-cloud-dotnet/commit/f3c6a75): Some retry settings are now obsolete, and will be removed from the next major version.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -232,7 +232,7 @@
     "protoPath": "google/devtools/clouddebugger/v2",
     "productName": "Stackdriver Debugger",
     "productUrl": "https://cloud.google.com/debugger/",
-    "version": "2.0.0-alpha00",
+    "version": "2.0.0-beta01",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Debugger API.",
     "tags": [
@@ -243,7 +243,7 @@
     ],
     "dependencies": {
       "Google.Api.Gax.Grpc.GrpcCore": "3.0.0-beta01",
-      "Google.Cloud.DevTools.Common": "project",
+      "Google.Cloud.DevTools.Common": "2.0.0-beta01",
       "Grpc.Core": "2.27.0"
     }
   },


### PR DESCRIPTION
This is the first prerelease targeting GAX v3. Please see the [breaking changes guide](https://googleapis.github.io/google-cloud-dotnet/docs/guides/breaking-gax2.html) for details of changes to both GAX and code generation.