### PR TITLE
Release Google.Cloud.Logging.Type version 3.0.0-beta01

### DIFF
--- a/apis/Google.Cloud.Logging.Type/Google.Cloud.Logging.Type/Google.Cloud.Logging.Type.csproj
+++ b/apis/Google.Cloud.Logging.Type/Google.Cloud.Logging.Type/Google.Cloud.Logging.Type.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0-alpha00</Version>
+    <Version>3.0.0-beta01</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.Logging.Type/docs/history.md
+++ b/apis/Google.Cloud.Logging.Type/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 3.0.0-beta01, released 2020-02-18
+
+No significant changes since 2.1.0, other than depending on a new major version of Google.Api.CommonProtos.
+
 # Version 2.1.0, released 2019-12-10
 
 - Added HttpRequest.Protocol property

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -624,7 +624,7 @@
     "id": "Google.Cloud.Logging.Type",
     "generator": "proto",
     "protoPath": "google/logging/type",
-    "version": "3.0.0-alpha00",
+    "version": "3.0.0-beta01",
     "type": "other",
     "targetFrameworks": "netstandard2.0;net461",
     "description": "Version-agnostic types for the Google Stackdriver Logging API.",


### PR DESCRIPTION
No significant changes since 2.1.0, other than depending on a new major version of Google.Api.CommonProtos.