### PR TITLE
Release Google.Cloud.Logging.NLog version 3.0.0-beta01

### DIFF
--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.IntegrationTests/coverage.xml
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.IntegrationTests/coverage.xml
@@ -8,9 +8,6 @@
         <ModuleMask>Google.Cloud.Logging.NLog</ModuleMask>
       </FilterEntry>
       <FilterEntry>
-        <ModuleMask>Google.Cloud.Logging.V2</ModuleMask>
-      </FilterEntry>
-      <FilterEntry>
         <ModuleMask>Google.Cloud.DevTools.Common</ModuleMask>
       </FilterEntry>
     </IncludeFilters>

--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.Snippets/coverage.xml
@@ -8,9 +8,6 @@
         <ModuleMask>Google.Cloud.Logging.NLog</ModuleMask>
       </FilterEntry>
       <FilterEntry>
-        <ModuleMask>Google.Cloud.Logging.V2</ModuleMask>
-      </FilterEntry>
-      <FilterEntry>
         <ModuleMask>Google.Cloud.DevTools.Common</ModuleMask>
       </FilterEntry>
     </IncludeFilters>

--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.Tests/coverage.xml
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.Tests/coverage.xml
@@ -8,9 +8,6 @@
         <ModuleMask>Google.Cloud.Logging.NLog</ModuleMask>
       </FilterEntry>
       <FilterEntry>
-        <ModuleMask>Google.Cloud.Logging.V2</ModuleMask>
-      </FilterEntry>
-      <FilterEntry>
         <ModuleMask>Google.Cloud.DevTools.Common</ModuleMask>
       </FilterEntry>
     </IncludeFilters>

--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.csproj
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0-alpha00</Version>
+    <Version>3.0.0-beta01</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
@@ -25,7 +25,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="3.0.0-beta01" />
     <ProjectReference Include="..\..\Google.Cloud.DevTools.Common\Google.Cloud.DevTools.Common\Google.Cloud.DevTools.Common.csproj" />
-    <ProjectReference Include="..\..\Google.Cloud.Logging.V2\Google.Cloud.Logging.V2\Google.Cloud.Logging.V2.csproj" />
+    <PackageReference Include="Google.Cloud.Logging.V2" Version="3.0.0-beta01" />
     <PackageReference Include="Grpc.Core" Version="2.27.0" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="NLog" Version="4.5.11" />

--- a/apis/Google.Cloud.Logging.NLog/docs/history.md
+++ b/apis/Google.Cloud.Logging.NLog/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+# Version 3.0.0-beta01, released 2020-02-18
+
+This is the first prerelease targeting GAX v3. Please see the [breaking changes
+guide](https://googleapis.github.io/google-cloud-dotnet/docs/guides/breaking-gax2.html)
+for details of changes to both GAX and code generation.
+
+This package has not taken any direct breaking changes, but has a major version number change due to its dependencies.
+
 # Version 2.2.0, released 2019-12-10
 
 - [Commit e708f35](https://github.com/googleapis/google-cloud-dotnet/commit/e708f35): Improve handling of dangerous object properties that throws exceptions during Json.Net serialization. ([issue 3668](https://github.com/googleapis/google-cloud-dotnet/issues/3668))

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -599,7 +599,7 @@
   },
   {
     "id": "Google.Cloud.Logging.NLog",
-    "version": "3.0.0-alpha00",
+    "version": "3.0.0-beta01",
     "type": "other",
     "targetFrameworks": "netstandard2.0;net461",
     "testTargetFrameworks": "netcoreapp2.1;net461",
@@ -612,7 +612,7 @@
     "dependencies": {
       "NLog": "4.5.11",
       "Google.Api.Gax.Grpc.GrpcCore": "3.0.0-beta01",
-      "Google.Cloud.Logging.V2": "project",
+      "Google.Cloud.Logging.V2": "3.0.0-beta01",
       "Google.Cloud.DevTools.Common": "project",
       "Grpc.Core": "2.27.0"
     },


### PR DESCRIPTION
This is the first prerelease targeting GAX v3. Please see the [breaking changes guide](https://googleapis.github.io/google-cloud-dotnet/docs/guides/breaking-gax2.html) for details of changes to both GAX and code generation.

This package has not taken any direct breaking changes, but has a major version number change due to its dependencies.