### PR TITLE
Release Google.Cloud.Logging.Log4Net version 3.0.0-beta01

### DIFF
--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.IntegrationTests/coverage.xml
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.IntegrationTests/coverage.xml
@@ -7,12 +7,6 @@
       <FilterEntry>
         <ModuleMask>Google.Cloud.Logging.Log4Net</ModuleMask>
       </FilterEntry>
-      <FilterEntry>
-        <ModuleMask>Google.Cloud.Logging.V2</ModuleMask>
-      </FilterEntry>
-      <FilterEntry>
-        <ModuleMask>Google.Cloud.DevTools.Common</ModuleMask>
-      </FilterEntry>
     </IncludeFilters>
   </Filters>
   <AttributeFilters>

--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Snippets/coverage.xml
@@ -7,12 +7,6 @@
       <FilterEntry>
         <ModuleMask>Google.Cloud.Logging.Log4Net</ModuleMask>
       </FilterEntry>
-      <FilterEntry>
-        <ModuleMask>Google.Cloud.Logging.V2</ModuleMask>
-      </FilterEntry>
-      <FilterEntry>
-        <ModuleMask>Google.Cloud.DevTools.Common</ModuleMask>
-      </FilterEntry>
     </IncludeFilters>
   </Filters>
   <AttributeFilters>

--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Tests/coverage.xml
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Tests/coverage.xml
@@ -7,12 +7,6 @@
       <FilterEntry>
         <ModuleMask>Google.Cloud.Logging.Log4Net</ModuleMask>
       </FilterEntry>
-      <FilterEntry>
-        <ModuleMask>Google.Cloud.Logging.V2</ModuleMask>
-      </FilterEntry>
-      <FilterEntry>
-        <ModuleMask>Google.Cloud.DevTools.Common</ModuleMask>
-      </FilterEntry>
     </IncludeFilters>
   </Filters>
   <AttributeFilters>

--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.csproj
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0-alpha00</Version>
+    <Version>3.0.0-beta01</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
@@ -24,8 +24,8 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="3.0.0-beta01" />
-    <ProjectReference Include="..\..\Google.Cloud.DevTools.Common\Google.Cloud.DevTools.Common\Google.Cloud.DevTools.Common.csproj" />
-    <ProjectReference Include="..\..\Google.Cloud.Logging.V2\Google.Cloud.Logging.V2\Google.Cloud.Logging.V2.csproj" />
+    <PackageReference Include="Google.Cloud.DevTools.Common" Version="2.0.0-beta01" />
+    <PackageReference Include="Google.Cloud.Logging.V2" Version="3.0.0-beta01" />
     <PackageReference Include="Grpc.Core" Version="2.27.0" PrivateAssets="None" />
     <PackageReference Include="log4net" Version="2.0.8" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.Logging.Log4Net/docs/history.md
+++ b/apis/Google.Cloud.Logging.Log4Net/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+# Version 3.0.0-beta01, released 2020-02-18
+
+This is the first prerelease targeting GAX v3. Please see the [breaking changes guide](https://googleapis.github.io/google-cloud-dotnet/docs/guides/breaking-gax2.html) for details of changes to both GAX and code generation.
+
+This package has not taken any direct breaking changes, but has a major version number change due to its dependencies.
+
 # Version 2.5.0, released 2019-12-10
 
 No API surface change - just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -576,7 +576,7 @@
   },
   {
     "id": "Google.Cloud.Logging.Log4Net",
-    "version": "3.0.0-alpha00",
+    "version": "3.0.0-beta01",
     "type": "other",
     "targetFrameworks": "netstandard2.0;net461",
     "testTargetFrameworks": "netcoreapp2.1;net461",
@@ -589,8 +589,8 @@
     "dependencies": {
       "log4net": "2.0.8",
       "Google.Api.Gax.Grpc.GrpcCore": "3.0.0-beta01",
-      "Google.Cloud.Logging.V2": "project",
-      "Google.Cloud.DevTools.Common": "project",
+      "Google.Cloud.Logging.V2": "3.0.0-beta01",
+      "Google.Cloud.DevTools.Common": "2.0.0-beta01",
       "Grpc.Core": "2.27.0"
     },
     "testDependencies": {


### PR DESCRIPTION
This is the first prerelease targeting GAX v3. Please see the [breaking changes guide](https://googleapis.github.io/google-cloud-dotnet/docs/guides/breaking-gax2.html) for details of changes to both GAX and code generation.

This package has not taken any direct breaking changes, but has a major version number change due to its dependencies.