### PR TITLE
Release Google.Cloud.PubSub.V1 version 2.0.0-beta01

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha00</Version>
+    <Version>2.0.0-beta01</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.PubSub.V1/docs/history.md
+++ b/apis/Google.Cloud.PubSub.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+# Version 2.0.0-beta01, released 2020-02-18
+
+This is the first prerelease targeting GAX v3. Please see the [breaking changes
+guide](https://googleapis.github.io/google-cloud-dotnet/docs/guides/breaking-gax2.html)
+for details of changes to both GAX and code generation.
+
+Additional significant changes in this release:
+
+- [Commit 173b019](https://github.com/googleapis/google-cloud-dotnet/commit/173b019): Dead-letter queue support in subscriber client
+
 # Version 1.2.0-beta01, released 2020-01-06
 
 - [Commit d859592](https://github.com/googleapis/google-cloud-dotnet/commit/d859592): Fully enable ordering-keys ([issue 3921](https://github.com/googleapis/google-cloud-dotnet/issues/3921))

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -796,7 +796,7 @@
     "protoPath": "google/pubsub/v1",
     "productName": "Cloud Pub/Sub",
     "productUrl": "https://cloud.google.com/pubsub/",
-    "version": "2.0.0-alpha00",
+    "version": "2.0.0-beta01",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.",
     "dependencies": {


### PR DESCRIPTION
This is the first prerelease targeting GAX v3. Please see the [breaking changes guide](https://googleapis.github.io/google-cloud-dotnet/docs/guides/breaking-gax2.html) for details of changes to both GAX and code generation.

Additional significant changes in this release:

- [Commit 173b019](https://github.com/googleapis/google-cloud-dotnet/commit/173b019): Dead-letter queue support in subscriber client