### PR TITLE
Release Google.Cloud.SecurityCenter (V1 and V1P1Beta1) version 2.0.0-beta01

### DIFF
--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.csproj
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha00</Version>
+    <Version>2.0.0-beta01</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.SecurityCenter.V1/docs/history.md
+++ b/apis/Google.Cloud.SecurityCenter.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+# Version 2.0.0-beta01, released 2020-02-18
+
+This is the first prerelease targeting GAX v3. Please see the [breaking changes
+guide](https://googleapis.github.io/google-cloud-dotnet/docs/guides/breaking-gax2.html)
+for details of changes to both GAX and code generation.
+
 # Version 1.1.0, released 2019-12-10
 
 - [Commit 50658e2](https://github.com/googleapis/google-cloud-dotnet/commit/50658e2): Add format methods to all resource name types

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.csproj
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha00</Version>
+    <Version>2.0.0-beta01</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/docs/history.md
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
-# 1.0.0-beta01
+# Version 2.0.0-beta01, released 2020-02-18
+
+This is the first prerelease targeting GAX v3. Please see the [breaking changes
+guide](https://googleapis.github.io/google-cloud-dotnet/docs/guides/breaking-gax2.html)
+for details of changes to both GAX and code generation.
+
+# Version 1.0.0-beta01, released 2020-02-07
 
 Initial beta release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -921,7 +921,7 @@
     "protoPath": "google/cloud/securitycenter/v1",
     "productName": "Google Cloud Security Command Center",
     "productUrl": "https://cloud.google.com/security-command-center/",
-    "version": "2.0.0-alpha00",
+    "version": "2.0.0-beta01",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Security Command Center API, which helps security teams gather data, identify threats, and act on them before they result in business damage or loss.",
     "dependencies": {
@@ -941,7 +941,7 @@
     "protoPath": "google/cloud/securitycenter/v1p1beta1",
     "productName": "Google Cloud Security Command Center",
     "productUrl": "https://cloud.google.com/security-command-center/",
-    "version": "2.0.0-alpha00",
+    "version": "2.0.0-beta01",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Security Command Center API version v1p1beta1, which helps security teams gather data, identify threats, and act on them before they result in business damage or loss.",
     "dependencies": {


### PR DESCRIPTION
This is the first prerelease targeting GAX v3. Please see the [breaking changes guide](https://googleapis.github.io/google-cloud-dotnet/docs/guides/breaking-gax2.html) for details of changes to both GAX and code generation.