### PR TITLE
Release Google.Cloud.TextToSpeech.V1 version 2.0.0-beta01

### DIFF
--- a/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.csproj
+++ b/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha00</Version>
+    <Version>2.0.0-beta01</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.TextToSpeech.V1/docs/history.md
+++ b/apis/Google.Cloud.TextToSpeech.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+# Version 2.0.0-beta01, released 2020-02-19
+
+This is the first prerelease targeting GAX v3. Please see the [breaking changes
+guide](https://googleapis.github.io/google-cloud-dotnet/docs/guides/breaking-gax2.html)
+for details of changes to both GAX and code generation.
+
 # Version 1.1.0, released 2019-12-09
 
 - [Commit bf4d39c](https://github.com/googleapis/google-cloud-dotnet/commit/bf4d39c): Some settings are now obsolete, and will be removed in the next major version.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1163,7 +1163,7 @@
     "protoPath": "google/cloud/texttospeech/v1",
     "productName": "Google Cloud Text-to-Speech",
     "productUrl": "https://cloud.google.com/text-to-speech",
-    "version": "2.0.0-alpha00",
+    "version": "2.0.0-beta01",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Text-to-Speech API, synthesizes natural-sounding speech by applying powerful neural network models.",
     "dependencies": {


### PR DESCRIPTION
This is the first prerelease targeting GAX v3. Please see the [breaking changes guide](https://googleapis.github.io/google-cloud-dotnet/docs/guides/breaking-gax2.html) for details of changes to both GAX and code generation.