### PR TITLE
Release Google.Cloud.Trace (V1 and V2) version 2.0.0-beta01

### DIFF
--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.csproj
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha00</Version>
+    <Version>2.0.0-beta01</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.Trace.V1/docs/history.md
+++ b/apis/Google.Cloud.Trace.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+# Version 2.0.0-beta01, released 2020-02-19
+
+This is the first prerelease targeting GAX v3. Please see the [breaking changes
+guide](https://googleapis.github.io/google-cloud-dotnet/docs/guides/breaking-gax2.html)
+for details of changes to both GAX and code generation.
+
 # Version 1.2.0, released 2019-12-09
 
 - [Commit 1ad0290](https://github.com/googleapis/google-cloud-dotnet/commit/1ad0290): Some retry settings are now obsolete, and will be removed from the next major version

--- a/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.csproj
+++ b/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha00</Version>
+    <Version>2.0.0-beta01</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.Trace.V2/docs/history.md
+++ b/apis/Google.Cloud.Trace.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+# Version 2.0.0-beta01, released 2020-02-19
+
+This is the first prerelease targeting GAX v3. Please see the [breaking changes
+guide](https://googleapis.github.io/google-cloud-dotnet/docs/guides/breaking-gax2.html)
+for details of changes to both GAX and code generation.
+
 # Version 1.1.0, released 2019-12-09
 
 - [Commit 8f268e0](https://github.com/googleapis/google-cloud-dotnet/commit/8f268e0): Some retry settings are now obsolete, and will be removed from the next major version

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1181,7 +1181,7 @@
     "protoPath": "google/devtools/cloudtrace/v1",
     "productName": "Stackdriver Trace",
     "productUrl": "https://cloud.google.com/trace/",
-    "version": "2.0.0-alpha00",
+    "version": "2.0.0-beta01",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Trace API, which sends and retrieves trace data from Google Cloud Trace. Data is generated and available by default for all App Engine applications. Data from other applications can be written to Cloud Trace for display, reporting, and analysis.",
     "dependencies": {
@@ -1199,7 +1199,7 @@
     "protoPath": "google/devtools/cloudtrace/v2",
     "productName": "Stackdriver Trace",
     "productUrl": "https://cloud.google.com/trace/",
-    "version": "2.0.0-alpha00",
+    "version": "2.0.0-beta01",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Trace V2 API, which sends and retrieves trace data from Google Cloud Trace. Data is generated and available by default for all App Engine applications. Data from other applications can be written to Cloud Trace for display, reporting, and analysis.",
     "dependencies": {


### PR DESCRIPTION
This is the first prerelease targeting GAX v3. Please see the [breaking changes guide](https://googleapis.github.io/google-cloud-dotnet/docs/guides/breaking-gax2.html) for details of changes to both GAX and code generation.