### PR TITLE
Speed up autosynth by using a cache directory

### DIFF
--- a/apis/Google.Cloud.AutoML.V1/postgeneration.sh
+++ b/apis/Google.Cloud.AutoML.V1/postgeneration.sh
@@ -3,4 +3,4 @@
 set -e
 
 # Undo the changes made in pregeneration.sh and pregeneration.patch
-git -C ../../googleapis checkout google/cloud/automl
+git -C $GOOGLEAPIS checkout google/cloud/automl

--- a/apis/Google.Cloud.AutoML.V1/pregeneration.patch
+++ b/apis/Google.Cloud.AutoML.V1/pregeneration.patch
@@ -1,5 +1,5 @@
---- a/googleapis/google/cloud/automl/v1/prediction_service.proto
-+++ b/googleapis/google/cloud/automl/v1/prediction_service.proto
+--- a/google/cloud/automl/v1/prediction_service.proto
++++ b/google/cloud/automl/v1/prediction_service.proto
 @@ -82,6 +82,10 @@ service PredictionService {
        post: "/v1/{name=projects/*/locations/*/models/*}:batchPredict"
        body: "*"
@@ -11,8 +11,8 @@
    }
  }
  
---- a/googleapis/google/cloud/automl/v1/service.proto
-+++ b/googleapis/google/cloud/automl/v1/service.proto
+--- a/google/cloud/automl/v1/service.proto
++++ b/google/cloud/automl/v1/service.proto
 @@ -65,6 +65,10 @@ service AutoMl {
        post: "/v1/{parent=projects/*/locations/*}/datasets"
        body: "dataset"

--- a/apis/Google.Cloud.AutoML.V1/pregeneration.sh
+++ b/apis/Google.Cloud.AutoML.V1/pregeneration.sh
@@ -2,6 +2,8 @@
 
 set -e
 
-# The patch file is relative to the root; it looks like patch files don't like to specify
+OLDPWD=$PWD
+
+# The patch file is relative to googleapis; it looks like patch files don't like to specify
 # parent directories.
-(cd ../..; git apply apis/Google.Cloud.AutoML.V1/pregeneration.patch)
+(cd $GOOGLEAPIS; git apply $OLDPWD/pregeneration.patch)

--- a/apis/Google.Cloud.Bigtable.V2/midmicrogeneration.sh
+++ b/apis/Google.Cloud.Bigtable.V2/midmicrogeneration.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 # Rename the service to BigtableServiceApi
-sed -i 's/service Bigtable/service BigtableServiceApi/g' ../../googleapis/google/bigtable/v2/bigtable.proto
-sed -i 's/v2.Bigtable/v2.BigtableServiceApi/g' ../../googleapis/google/bigtable/v2/bigtable_grpc_service_config.json
+sed -i 's/service Bigtable/service BigtableServiceApi/g' $GOOGLEAPIS/google/bigtable/v2/bigtable.proto
+sed -i 's/v2.Bigtable/v2.BigtableServiceApi/g' $GOOGLEAPIS/google/bigtable/v2/bigtable_grpc_service_config.json

--- a/apis/Google.Cloud.Bigtable.V2/postgeneration.sh
+++ b/apis/Google.Cloud.Bigtable.V2/postgeneration.sh
@@ -4,8 +4,8 @@ set -e
 
 # Undo the changes in googleapis
 # (Do this first so that if we have any failures in the remaining steps)
-git -C ../../googleapis checkout google/bigtable/v2/bigtable.proto
-git -C ../../googleapis checkout google/bigtable/v2/bigtable_grpc_service_config.json
+git -C $GOOGLEAPIS checkout google/bigtable/v2/bigtable.proto
+git -C $GOOGLEAPIS checkout google/bigtable/v2/bigtable_grpc_service_config.json
 
 # Fix up the generated client for using Grpc.Gcp and other tweaks
 sed -i -r -f BigtableServiceApiClient.sed Google.Cloud.Bigtable.V2/BigtableServiceApiClient.g.cs

--- a/apis/Google.Cloud.Container.V1/postgeneration.sh
+++ b/apis/Google.Cloud.Container.V1/postgeneration.sh
@@ -3,4 +3,4 @@
 set -e
 
 # Undo the changes made in pregeneration.sh
-git -C ../../googleapis checkout google/container/v1
+git -C $GOOGLEAPIS checkout google/container/v1

--- a/apis/Google.Cloud.Container.V1/pregeneration.sh
+++ b/apis/Google.Cloud.Container.V1/pregeneration.sh
@@ -3,4 +3,4 @@
 # Fix links such as [zones](/compute/docs/zones) to include the full URL
 # Note: using | instead of / to avoid worrying about escaping.
 
-sed -i 's|](/|](https://cloud.google.com/|g' ../../googleapis/google/container/v1/*.proto
+sed -i 's|](/|](https://cloud.google.com/|g' $GOOGLEAPIS/google/container/v1/*.proto

--- a/apis/Google.Cloud.PubSub.V1/midmicrogeneration.sh
+++ b/apis/Google.Cloud.PubSub.V1/midmicrogeneration.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Rename the services to {Publisher/Subscriber}ServiceApi
-sed -i 's/service Publisher/service PublisherServiceApi/g' ../../googleapis/google/pubsub/v1/pubsub.proto
-sed -i 's/v1.Publisher/v2.PublisherServiceApi/g' ../../googleapis/google/pubsub/v1/pubsub_grpc_service_config.json
+sed -i 's/service Publisher/service PublisherServiceApi/g' $GOOGLEAPIS/google/pubsub/v1/pubsub.proto
+sed -i 's/v1.Publisher/v2.PublisherServiceApi/g' $GOOGLEAPIS/google/pubsub/v1/pubsub_grpc_service_config.json
 
-sed -i 's/service Subscriber/service SubscriberServiceApi/g' ../../googleapis/google/pubsub/v1/pubsub.proto
-sed -i 's/v1.Subscriber/v2.SubscriberServiceApi/g' ../../googleapis/google/pubsub/v1/pubsub_grpc_service_config.json
+sed -i 's/service Subscriber/service SubscriberServiceApi/g' $GOOGLEAPIS/google/pubsub/v1/pubsub.proto
+sed -i 's/v1.Subscriber/v2.SubscriberServiceApi/g' $GOOGLEAPIS/google/pubsub/v1/pubsub_grpc_service_config.json

--- a/apis/Google.Cloud.PubSub.V1/postgeneration.sh
+++ b/apis/Google.Cloud.PubSub.V1/postgeneration.sh
@@ -3,8 +3,8 @@
 set -e
 
 # Undo the changes in googleapis
-git -C ../../googleapis checkout google/pubsub/v1/pubsub.proto
-git -C ../../googleapis checkout google/pubsub/v1/pubsub_grpc_service_config.json
+git -C $GOOGLEAPIS checkout google/pubsub/v1/pubsub.proto
+git -C $GOOGLEAPIS checkout google/pubsub/v1/pubsub_grpc_service_config.json
 
 # Fix up the generated client to use the right gRPC types
 sed -i s/PublisherServiceApi.PublisherServiceApiClient/Publisher.PublisherClient/g Google.Cloud.PubSub.V1/PublisherServiceApiClient.g.cs

--- a/apis/Google.LongRunning/postgeneration.sh
+++ b/apis/Google.LongRunning/postgeneration.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -e
-
-# Undo the changes made in pregeneration.sh
-git -C ../../googleapis checkout google/longrunning

--- a/apis/Google.LongRunning/pregeneration.sh
+++ b/apis/Google.LongRunning/pregeneration.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-set -e
-
-# The LongRunning API code is under the Apache licence for C#, but BSD for other languages.
-sed -i \
-  s/license-header-bsd-3-clause.txt/license-header-apache-2.0.txt/g \
-  ../../googleapis/google/longrunning/longrunning_gapic.yaml

--- a/generateapis.sh
+++ b/generateapis.sh
@@ -22,20 +22,26 @@ OUTDIR=tmp
 if [[ "$SYNTHTOOL_GOOGLEAPIS" != "" ]]
 then
   declare -r GOOGLEAPIS="$SYNTHTOOL_GOOGLEAPIS"
+elif [[ "$SYNTHTOOL_CACHE" != "" ]]
+then
+  declare -r GOOGLEAPIS="$SYNTHTOOL_CACHE/googleapis"
 else
   declare -r GOOGLEAPIS=googleapis
 fi
 
+# Allow pre/post-generation scripts to know where to find the repo
+export GOOGLEAPIS
+
 fetch_github_repos() {
   if [[ "$SYNTHTOOL_GOOGLEAPIS" == "" ]]
   then
-    if [ -d "googleapis" ]
+    if [ -d "$GOOGLEAPIS" ]
     then
-      git -C googleapis pull -q
+      git -C $GOOGLEAPIS pull -q
     else
       # Auto-detect whether we're cloning the public or private googleapis repo.
       git remote -v | grep -q google-cloud-dotnet-private && repo=googleapis-private || repo=googleapis
-      git clone https://github.com/googleapis/${repo} googleapis --depth 1
+      git clone https://github.com/googleapis/${repo} $GOOGLEAPIS --depth 1
     fi
   fi
 }


### PR DESCRIPTION
This requires fixing up some per-API scripts to use $GOOGLEAPIS

The Google.LongRunning scripts are no longer useful; I need to check whether we need a separate equivalent though.