### PR TITLE
Release Google.Cloud.Diagnostics.AspNetCore 4.0.0-beta01

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore.Analyzers/Google.Cloud.Diagnostics.AspNetCore.Analyzers/Google.Cloud.Diagnostics.AspNetCore.Analyzers.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore.Analyzers/Google.Cloud.Diagnostics.AspNetCore.Analyzers/Google.Cloud.Diagnostics.AspNetCore.Analyzers.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha00</Version>
+    <Version>2.0.0-beta01</Version>
     <TargetFrameworks>netstandard1.3</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.3</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore.Analyzers/docs/history.md
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore.Analyzers/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+# Version 2.0.0-beta01, released 2020-02-19
+
+First beta of next major version. In theory this package does not
+need a new major version, but it's simplest to rev it at the same
+time as all the others.
+
 # Version 1.0.0, released 2019-12-12
 
 Initial GA release.

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.0.0-alpha00</Version>
+    <Version>4.0.0-beta01</Version>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/docs/history.md
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/docs/history.md
@@ -1,5 +1,14 @@
 # Version history
 
+# Version 4.0.0-beta01, released 2020-02-19
+
+This is the first prerelease targeting GAX v3. Please see the [breaking changes
+guide](https://googleapis.github.io/google-cloud-dotnet/docs/guides/breaking-gax2.html)
+for details of changes to both GAX and code generation.
+
+There are no direct API surface changes in *this* package, but the
+changes in dependencies can still cause breaking changes.
+
 # Version 3.0.0, released 2019-12-16
 
 This is the last version of this package to depend on GAX 2.x and

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.0.0-alpha00</Version>
+    <Version>4.0.0-beta01</Version>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -313,7 +313,7 @@
   },
   {
     "id": "Google.Cloud.Diagnostics.AspNetCore",
-    "version": "4.0.0-alpha00",
+    "version": "4.0.0-beta01",
     "type": "other",
     "targetFrameworks": "netstandard2.0",
     "testTargetFrameworks": "netcoreapp2.1;net461",
@@ -350,7 +350,7 @@
   },
   {
     "id": "Google.Cloud.Diagnostics.AspNetCore.Analyzers",
-    "version": "2.0.0-alpha00",
+    "version": "2.0.0-beta01",
     "type": "analyzers",
     "targetFrameworks": "netstandard1.3",
     "testTargetFrameworks": "netcoreapp2.0",
@@ -367,7 +367,7 @@
   },
   {
     "id": "Google.Cloud.Diagnostics.Common",
-    "version": "4.0.0-alpha00",
+    "version": "4.0.0-beta01",
     "type": "other",
     "targetFrameworks": "netstandard2.0",
     "testTargetFrameworks": "netcoreapp2.1;net461",


### PR DESCRIPTION
(Also the common and analyzer libraries.)

This is the first prerelease targeting GAX v3. Please see the [breaking changes guide](https://googleapis.github.io/google-cloud-dotnet/docs/guides/breaking-gax2.html) for details of changes to both GAX and code generation.

There are no direct API surface changes in *this* package, but the changes in dependencies can still cause breaking changes.