### PR TITLE
Make the gax-v2 branch capable of supporting CI builds and releases

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,7 +19,7 @@ shopt -s nullglob
 # of this script, or under apis.
 # Additional arguments:
 # --notests: Just build, don't run the tests
-# --diff: Detect which APIs to build based on a diff to the master branch
+# --diff: Detect which APIs to build based on a diff to the gax-v2 branch
 # --regex regex: Only build APIs that match the given regex
 # --nobuild: Just list which APIs would be built; don't run the build
 # --coverage: Run tests with coverage enabled
@@ -34,7 +34,7 @@ while (( "$#" )); do
     runtests=false
   elif [[ "$1" == "--diff" ]]
   then
-    apis+=($(git diff master --name-only | grep -e 'apis/.*/' | cut -d/ -f 2 | uniq))
+    apis+=($(git diff gax-v2 --name-only | grep -e 'apis/.*/' | cut -d/ -f 2 | uniq))
   elif [[ "$1" == "--regex" ]]
   then
     shift

--- a/detect-pr-changes.sh
+++ b/detect-pr-changes.sh
@@ -2,9 +2,9 @@
 
 set -e
 
-apis=$(git diff master --name-only | grep -e 'apis/.*/' | cut -d/ -f 2 | uniq)
+apis=$(git diff gax-v2 --name-only | grep -e 'apis/.*/' | cut -d/ -f 2 | uniq)
 
-git clone . tmpgit --no-local -b master --depth 1
+git clone . tmpgit --no-local -b gax-v2 --depth 1
 
 mkdir tmpgit/old
 mkdir tmpgit/new

--- a/tools/Google.Cloud.Tools.GenerateReleaseNotes/Program.cs
+++ b/tools/Google.Cloud.Tools.GenerateReleaseNotes/Program.cs
@@ -84,7 +84,7 @@ namespace Google.Cloud.Tools.GenerateReleaseNotes
                     .ToList();
                 var idToTagName = apiTags.ToDictionary(tag => tag.Target.Id, tag => tag.FriendlyName.Substring(tagPrefix.Length));
 
-                foreach (var commit in repo.Branches["master"].Commits)
+                foreach (var commit in repo.Branches["gax-v2"].Commits)
                 {
                     if (idToTagName.TryGetValue(commit.Id, out string version))
                     {

--- a/tools/Google.Cloud.Tools.TagReleases/Program.cs
+++ b/tools/Google.Cloud.Tools.TagReleases/Program.cs
@@ -28,7 +28,7 @@ namespace Google.Cloud.Tools.TagReleases
     /// 
     /// Steps taken:
     /// 
-    /// - Find the current head of the master branch on github
+    /// - Find the current head of the gax-v2 branch on github
     /// - Check that the local repo is at the same commit
     /// - Check that the local repo has no pending changes to apis.json
     /// - Work out which packages would need to be tagged
@@ -40,7 +40,7 @@ namespace Google.Cloud.Tools.TagReleases
     {
         private const string RepositoryOwner = "googleapis";
         private const string RepositoryName = "google-cloud-dotnet";
-        private const string TargetBranch = "master";
+        private const string TargetBranch = "gax-v2";
         private const string ApplicationName = "google-cloud-dotnet-tagreleases";
 
         private static int Main(string[] args)

--- a/tools/Google.Cloud.Tools.UpdateReleaseNotes/Program.cs
+++ b/tools/Google.Cloud.Tools.UpdateReleaseNotes/Program.cs
@@ -94,7 +94,7 @@ namespace Google.Cloud.Tools.UpdateReleaseNotes
                 .Where(tag => tag.FriendlyName.StartsWith(tagPrefix))
                 .ToDictionary(tag => tag.Target.Id, tag => tag.FriendlyName.Substring(tagPrefix.Length));
 
-            foreach (var commit in repo.Branches["master"].Commits)
+            foreach (var commit in repo.Branches["gax-v2"].Commits)
             {
                 if (CommitContainsApi(commit))
                 {


### PR DESCRIPTION
(There may be other occurrences, but this is a reasonable first pass. We can do more when we first need to do a release from the gax-v2 branch.)