### PR TITLE
Introduce a "release manager" to make our lives easier

### DIFF
--- a/prepare-release.sh
+++ b/prepare-release.sh
@@ -2,23 +2,4 @@
 
 set -e
 
-if [ -z "$1" ]
-then
-  echo "Please specify the API you're releasing, e.g. Google.Cloud.Storage.V1"
-  exit 1
-fi
-
-# Make sure we have all the tags locally.
-git fetch --tags -f -q upstream master
-
-echo "Building $1"
-./build.sh $1 --notests
-echo ""
-
-echo "Updating release notes at:"
-echo "apis/$1/docs/history.md"
-dotnet run -p tools/Google.Cloud.Tools.UpdateReleaseNotes -- $1
-echo ""
-
-echo "Checking version compatibility"
-dotnet run -p tools/Google.Cloud.Tools.CheckVersionCompatibility -- $1
+dotnet run -p tools/Google.Cloud.Tools.ReleaseManager -- $*

--- a/tools/Google.Cloud.Tools.CheckVersionCompatibility/Google.Cloud.Tools.CheckVersionCompatibility.csproj
+++ b/tools/Google.Cloud.Tools.CheckVersionCompatibility/Google.Cloud.Tools.CheckVersionCompatibility.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/Google.Cloud.Tools.CheckVersionCompatibility/Program.cs
+++ b/tools/Google.Cloud.Tools.CheckVersionCompatibility/Program.cs
@@ -23,7 +23,7 @@ using Mono.Cecil;
 
 namespace Google.Cloud.Tools.CheckVersionCompatibility
 {
-    class Program
+    public class Program
     {
         // These APIs don't build for netstandard2.0, so for now we ignore them.
         // We could potentially detect the right TFM, but that's more work than it's probably worth.
@@ -33,7 +33,7 @@ namespace Google.Cloud.Tools.CheckVersionCompatibility
             "Google.Cloud.Diagnostics.AspNetCore.Analyzers"
         }.ToList();
 
-        static int Main(string[] args)
+        public static int Main(string[] args)
         {
             var root = DirectoryLayout.DetermineRootDirectory();
             var apis = ApiMetadata.LoadApis();

--- a/tools/Google.Cloud.Tools.Common/ApiMetadata.cs
+++ b/tools/Google.Cloud.Tools.Common/ApiMetadata.cs
@@ -98,8 +98,6 @@ namespace Google.Cloud.Tools.Common
 
         public static List<ApiMetadata> LoadApis()
         {
-            var root = DirectoryLayout.DetermineRootDirectory();
-
             var json = File.ReadAllText(CatalogPath);
             return JsonConvert.DeserializeObject<List<ApiMetadata>>(json);
         }

--- a/tools/Google.Cloud.Tools.ProjectGenerator/Program.cs
+++ b/tools/Google.Cloud.Tools.ProjectGenerator/Program.cs
@@ -17,7 +17,6 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
@@ -168,7 +167,7 @@ namespace Google.Cloud.Tools.ProjectGenerator
             }
         }
 
-        static void GenerateProjects(string apiRoot, ApiMetadata api, HashSet<string> apiNames)
+        public static void GenerateProjects(string apiRoot, ApiMetadata api, HashSet<string> apiNames)
         {
             if (api.Type == ApiType.Analyzers)
             {
@@ -346,7 +345,7 @@ shell.run(
         /// Generates a metadata file (currently .repo-metadata.json; may change name later) with
         /// all the information that language-agnostic tools require.
         /// </summary>
-        private static void GenerateMetadataFile(string apiRoot, ApiMetadata api)
+        public static void GenerateMetadataFile(string apiRoot, ApiMetadata api)
         {
             var version = api.StructuredVersion;
             string versionBasedReleaseLevel = 
@@ -369,7 +368,6 @@ shell.run(
             };
             string json = JsonConvert.SerializeObject(metadata, Formatting.Indented);
             File.WriteAllText(Path.Combine(apiRoot, ".repo-metadata.json"), json);
-
         }
 
         private static void GenerateMainProject(ApiMetadata api, string directory, HashSet<string> apiNames)

--- a/tools/Google.Cloud.Tools.ReleaseManager/ApiVersionPair.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/ApiVersionPair.cs
@@ -1,0 +1,41 @@
+﻿// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Google.Cloud.Tools.ReleaseManager
+{
+    internal sealed class ApiVersionPair
+    {
+        /// <summary>
+        /// The API ID, e.g. "Google.Cloud.Storage.V1"
+        /// </summary>
+        public string Id { get; }
+
+        /// <summary>
+        /// The old version, i.e. the version on the logical master branch,
+        /// or null if the API does not exist in the master branch.
+        /// </summary>
+        public string OldVersion { get; }
+
+        /// <summary>
+        /// The new version, i.e. the version in the working directory, or null if
+        /// the API does not exist in the working directory.
+        /// </summary>
+        public string NewVersion { get; }
+
+        internal ApiVersionPair(string id, string oldVersion, string newVersion) =>
+            (Id, OldVersion, NewVersion) = (id, oldVersion, newVersion);
+
+        public override string ToString() => $"{Id}: {OldVersion ?? "(None)"} => {NewVersion ?? "(None)"}";
+    }
+}

--- a/tools/Google.Cloud.Tools.ReleaseManager/Google.Cloud.Tools.ReleaseManager.csproj
+++ b/tools/Google.Cloud.Tools.ReleaseManager/Google.Cloud.Tools.ReleaseManager.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Google.Cloud.Tools.ProjectGenerator\Google.Cloud.Tools.ProjectGenerator.csproj" />
+    <ProjectReference Include="..\Google.Cloud.Tools.UpdateReleaseNotes\Google.Cloud.Tools.UpdateReleaseNotes.csproj" />
+    <ProjectReference Include="..\Google.Cloud.Tools.CheckVersionCompatibility\Google.Cloud.Tools.CheckVersionCompatibility.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tools/Google.Cloud.Tools.ReleaseManager/Program.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/Program.cs
@@ -1,0 +1,282 @@
+﻿// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Tools.Common;
+using Google.Cloud.Tools.UpdateReleaseNotes;
+using LibGit2Sharp;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Google.Cloud.Tools.ReleaseManager
+{
+    /// <summary>
+    /// Release management tool, providing a single entry point to multiple common tasks
+    /// when releasing  libraries.
+    /// </summary>
+    internal sealed class Program
+    {
+        // The branch we're thinking of as master. It may actually be some other branch for occasional
+        // releases, but fundamentally it's "the current source of truth we're basing this release on".
+        private const string MasterBranch = "master";
+
+        private const string SetVersionCommand = "set-version";
+        private const string ShowCommand = "show";
+        private const string CompareCommand = "compare";
+        private const string UpdateHistoryCommand = "update-history";
+        private const string CommitCommand = "commit";
+
+        private static int Main(string[] args)
+        {
+            try
+            {
+                if (args.Length == 0)
+                {
+                    ShowUsage();
+                    return 0;
+                }
+                var command = args[0];
+                var commandArgs = args.Skip(1).ToArray();
+                switch (command)
+                {
+                    case SetVersionCommand:
+                        SetVersion(commandArgs);
+                        break;
+                    case ShowCommand:
+                        ShowVersions(commandArgs);
+                        break;
+                    case CompareCommand:
+                        CompareVersions(commandArgs);
+                        break;
+                    case UpdateHistoryCommand:
+                        UpdateHistory(commandArgs);
+                        break;
+                    case CommitCommand:
+                        Commit(commandArgs);
+                        break;
+                    default:
+                        Console.WriteLine($"Unknown command: '{command}'");
+                        ShowUsage();
+                        return 1;
+                }
+                return 0;
+            }
+            catch (UserErrorException e)
+            {
+                Console.WriteLine($"Configuration error: {e.Message}");
+                return 1;
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine($"Failed: {e}");
+                return 1;
+            }
+        }
+
+        private static void ShowUsage()
+        {
+            Console.WriteLine($"{nameof(ReleaseManager)} commands:");
+            Console.WriteLine("");
+            Console.WriteLine($"{SetVersionCommand} <id> <new-version>: Set a version in apis.json and generate project files");
+            Console.WriteLine($"{ShowCommand}: Show the versions changes in the current PR");
+            Console.WriteLine($"{CompareCommand}: Compare each changed version with the previous release");
+            Console.WriteLine($"{UpdateHistoryCommand}: Update the release history file for each changed version");
+            Console.WriteLine($"{CommitCommand}: Commit the current set of changes with an appropriate commit message");
+        }
+
+        private static void SetVersion(string[] args)
+        {
+            if (args.Length != 2)
+            {
+                throw new UserErrorException($"{SetVersionCommand} requires two arguments: the package ID and the new version");
+            }
+            string id = args[0];
+            string version = args[1];
+            var catalog = ApiMetadata.LoadApis();
+
+            var api = catalog.FirstOrDefault(x => x.Id == id);
+            if (api == null)
+            {
+                throw new UserErrorException($"API '{id}' not found in API catalog.");
+            }
+            api.Version = version;
+            var layout = DirectoryLayout.ForApi(id);
+            var apiNames = new HashSet<string>(catalog.Select(x => x.Id));
+            ProjectGenerator.Program.GenerateMetadataFile(layout.SourceDirectory, api);
+            ProjectGenerator.Program.GenerateProjects(layout.SourceDirectory, api, apiNames);
+            
+            // This is somewhat annoying and ugly, but never mind.
+            // If we need similar code in other places, we should put it in ApiMetadata.
+            JToken parsed = JToken.Parse(File.ReadAllText(ApiMetadata.CatalogPath));
+            var apiObject = parsed
+                .Children()
+                .OfType<JObject>()
+                .FirstOrDefault(obj => obj.TryGetValue("id", out var idToken) && idToken.Value<string>() == id);
+            apiObject["version"] = version;
+            string formatted = parsed.ToString(Formatting.Indented);
+            File.WriteAllText(ApiMetadata.CatalogPath, formatted);
+            Console.WriteLine("Updated apis.json");
+        }
+
+        private static void ShowVersions(string[] args)
+        {
+            if (args.Length != 0)
+            {
+                throw new UserErrorException($"{ShowCommand} does not accept additional arguments");
+            }
+
+            foreach (var change in FindChangedVersions())
+            {
+                Console.WriteLine(change);
+            }
+        }
+
+        private static List<ApiVersionPair> FindChangedVersions()
+        {
+            var currentCatalog = ApiMetadata.LoadApis();
+            var masterCatalog = LoadMasterCatalog();
+            var currentVersions = currentCatalog.ToDictionary(api => api.Id, api => api.Version);
+            var masterVersions = masterCatalog.ToDictionary(api => api.Id, api => api.Version);
+            return currentVersions.Keys.Concat(masterVersions.Keys)
+                .Distinct()
+                .OrderBy(id => id)
+                .Select(id => new ApiVersionPair(id, masterVersions.GetValueOrDefault(id), currentVersions.GetValueOrDefault(id)))
+                .Where(v => v.NewVersion != v.OldVersion)
+                .ToList();
+        }
+
+        private static List<ApiMetadata> LoadMasterCatalog()
+        {
+            var root = DirectoryLayout.DetermineRootDirectory();
+            using (var repo = new Repository(root))
+            {
+                var master = repo.Branches.FirstOrDefault(b => b.FriendlyName == MasterBranch);
+                if (master == null)
+                {
+                    throw new UserErrorException($"Unable to find branch '{MasterBranch}'.");
+                }
+
+                var masterCatalogJson = master.Commits.First()["apis/apis.json"].Target.Peel<Blob>().GetContentText();
+                return JsonConvert.DeserializeObject<List<ApiMetadata>>(masterCatalogJson);
+            }
+        }
+
+        private static void CompareVersions(string[] args)
+        {
+            if (args.Length != 0)
+            {
+                throw new UserErrorException($"{CompareCommand} does not accept additional arguments");
+            }
+
+            var idsToCheck = new List<string>();
+            foreach (var diff in FindChangedVersions())
+            {
+                if (diff.OldVersion is null)
+                {
+                    Console.WriteLine($"{diff.Id} is new; no comparison required.");
+                }
+                else if (diff.NewVersion is null)
+                {
+                    Console.WriteLine($"{diff.Id} has been deleted; no comparison required.");
+                }
+                else
+                {
+                    idsToCheck.Add(diff.Id);
+                }
+            }
+            CheckVersionCompatibility.Program.Main(idsToCheck.ToArray());
+        }
+
+        private static void UpdateHistory(string[] args)
+        {
+            if (args.Length != 0)
+            {
+                throw new UserErrorException($"{UpdateHistoryCommand} does not accept additional arguments");
+            }
+
+            foreach (var diff in FindChangedVersions())
+            {
+                if (diff.NewVersion is null)
+                {
+                    Console.WriteLine($"{diff.Id} has been deleted; no history required.");
+                }
+                else
+                {
+                    UpdateReleaseNotes.Program.Execute(diff.Id);
+                }
+            }
+        }
+
+        private static void Commit(string[] args)
+        {
+            if (args.Length != 0)
+            {
+                throw new UserErrorException($"{CommitCommand} does not accept additional arguments");
+            }
+
+            var diffs = FindChangedVersions();
+            if (diffs.Count != 1)
+            {
+                throw new UserErrorException($"Can only automate a release commit with exactly 1 release. Found {diffs.Count}.");
+            }
+            var diff = diffs[0];
+            if (diff.NewVersion is null)
+            {
+                throw new UserErrorException($"Cannot automate a release commit for a deleted API.");
+            }
+
+            var historyFilePath = HistoryFile.GetPathForPackage(diff.Id);
+            if (!File.Exists(historyFilePath))
+            {
+                throw new UserErrorException($"Cannot automate a release commit without a version history file.");
+            }
+
+            var historyFile = HistoryFile.Load(historyFilePath);
+            var section = historyFile.Sections.FirstOrDefault(s  => s.Version?.ToString() == diff.NewVersion);
+            if (section is null)
+            {
+                throw new UserErrorException($"Version history Can only automate a release commit with exactly 1 release. Found {diffs.Count}.");
+            }
+
+            string header = $"Release {diff.Id} version {diff.NewVersion}";
+            var message = string.Join("\n", new[] { header, "", "Changes in this release:", "" }.Concat(section.Lines.Skip(2)));
+
+            var root = DirectoryLayout.DetermineRootDirectory();
+            using (var repo = new Repository(root))
+            {
+                RepositoryStatus status = repo.RetrieveStatus();
+                // TODO: Work out whether this is enough, and whether we actually need all of these.
+                // We basically want git add --all.
+                AddAll(status.Modified);
+                AddAll(status.Missing);
+                AddAll(status.Untracked);
+                repo.Index.Write();
+                var signature = repo.Config.BuildSignature(DateTimeOffset.UtcNow);
+                var commit = repo.Commit(message, signature, signature);
+                Console.WriteLine($"Created commit {commit.Sha}. Review the message and amend if necessary.");
+
+                void AddAll(IEnumerable<StatusEntry> entries)
+                {
+                    foreach (var entry in entries)
+                    {
+                        repo.Index.Add(entry.FilePath);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tools/Google.Cloud.Tools.UpdateReleaseNotes/Program.cs
+++ b/tools/Google.Cloud.Tools.UpdateReleaseNotes/Program.cs
@@ -26,7 +26,7 @@ namespace Google.Cloud.Tools.UpdateReleaseNotes
     /// This is similar to Google.Cloud.Tools.GenerateReleaseNotes, but that just spits all
     /// changes out onto the console.
     /// </summary>
-    class Program
+    public class Program
     {
         private const string MarkdownFile = "history.md";
 
@@ -54,11 +54,11 @@ namespace Google.Cloud.Tools.UpdateReleaseNotes
             }
         }
 
-        private static void Execute(string id)
+        public static void Execute(string id)
         {
             var catalog = ApiMetadata.LoadApis();
             var api = catalog.FirstOrDefault(x => x.Id == id) ?? throw new UserErrorException($"Unknown API: {id}");
-            string historyFilePath = Path.Combine(DirectoryLayout.ForApi(id).DocsSourceDirectory, MarkdownFile);
+            string historyFilePath = HistoryFile.GetPathForPackage(id);
 
             var root = DirectoryLayout.DetermineRootDirectory();
             using (var repo = new Repository(root))
@@ -72,6 +72,9 @@ namespace Google.Cloud.Tools.UpdateReleaseNotes
                 historyFile.MergeReleases(releases);
                 historyFile.Save(historyFilePath);
             }
+            var relativePath = Path.GetRelativePath(DirectoryLayout.DetermineRootDirectory(), historyFilePath)
+                .Replace('\\', '/');
+            Console.WriteLine($"Updated version history file: {relativePath}");
         }
 
         private static IEnumerable<Release> LoadReleases(Repository repo, ApiMetadata api)

--- a/tools/Google.Cloud.Tools.sln
+++ b/tools/Google.Cloud.Tools.sln
@@ -52,6 +52,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Tools.CompareV
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.LongRunning", "..\apis\Google.LongRunning\Google.LongRunning\Google.LongRunning.csproj", "{342C4A65-EA46-44CE-9986-1570EF96A6C9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Tools.ReleaseManager", "Google.Cloud.Tools.ReleaseManager\Google.Cloud.Tools.ReleaseManager.csproj", "{4171E471-ABAB-43B9-B759-6641BA6C4A4A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -362,6 +364,18 @@ Global
 		{342C4A65-EA46-44CE-9986-1570EF96A6C9}.Release|x64.Build.0 = Release|Any CPU
 		{342C4A65-EA46-44CE-9986-1570EF96A6C9}.Release|x86.ActiveCfg = Release|Any CPU
 		{342C4A65-EA46-44CE-9986-1570EF96A6C9}.Release|x86.Build.0 = Release|Any CPU
+		{4171E471-ABAB-43B9-B759-6641BA6C4A4A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4171E471-ABAB-43B9-B759-6641BA6C4A4A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4171E471-ABAB-43B9-B759-6641BA6C4A4A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4171E471-ABAB-43B9-B759-6641BA6C4A4A}.Debug|x64.Build.0 = Debug|Any CPU
+		{4171E471-ABAB-43B9-B759-6641BA6C4A4A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4171E471-ABAB-43B9-B759-6641BA6C4A4A}.Debug|x86.Build.0 = Debug|Any CPU
+		{4171E471-ABAB-43B9-B759-6641BA6C4A4A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4171E471-ABAB-43B9-B759-6641BA6C4A4A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4171E471-ABAB-43B9-B759-6641BA6C4A4A}.Release|x64.ActiveCfg = Release|Any CPU
+		{4171E471-ABAB-43B9-B759-6641BA6C4A4A}.Release|x64.Build.0 = Release|Any CPU
+		{4171E471-ABAB-43B9-B759-6641BA6C4A4A}.Release|x86.ActiveCfg = Release|Any CPU
+		{4171E471-ABAB-43B9-B759-6641BA6C4A4A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
(./prepare-release.sh is now just a simple way of invoking the release manager.)

The idea is to simplify the various steps involved in releasing,
without taking away any flexibility. ReleaseManager can do the
following things:

- Set the version of an API by editing apis.json and regenerating projects
- Show you which APIs have changed versions in the working directory
- Show you the changes (compatibility etc) for all changed APIs
- Update the version history for all changed APIs
- If you've only changed a single API (common case) create the git commit for it

So a common flow would be something like this:

- git checkout -b release-storage
- ./prepare-release.sh set-version Google.Cloud.Storage.V1 3.0.0-beta01
- ./prepare-release.sh show *(just to check we did the right thing)*
- ./prepare-release.sh update-history
- ./prepare-releases.sh compare
- Manually fix up the history file a bit (path is shown in update-history)
- ./prepare-releases.sh commit
- git push, after amending the commit if necessary
- Then create a PR etc as normal - this tooling doesn't affect that flow

Note that we've only had to type in the API ID and version once in that whole flow :)

Limitations:

- The tool doesn't update README.md or docs/root/index.md
- New APIs still require apis.json to be edited manually