### PR TITLE
Release Google.Cloud.Storage.V1 version 3.0.0-beta01

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0-alpha00</Version>
+    <Version>3.0.0-beta01</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.Storage.V1/docs/history.md
+++ b/apis/Google.Cloud.Storage.V1/docs/history.md
@@ -1,5 +1,14 @@
 # Version history
 
+# Version 3.0.0-beta01, released 2020-02-20
+
+Upgrade dependencies to GAX v3. Currently there are no direct
+surface changes, but breaking changes in GAX may affect users, for
+example in terms of async pagination.
+
+More direct breaking changes are expected in this package before
+3.0.0 is released, specifically around signed URLs.
+
 # Version 2.5.0, released 2020-01-06
 
 - [Commit f556739](https://github.com/googleapis/google-cloud-dotnet/commit/f556739): Add Fields parameters to ListObjectsOptions and ListBucketsOptions

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1043,7 +1043,7 @@
     "id": "Google.Cloud.Storage.V1",
     "productName": "Google Cloud Storage",
     "productUrl": "https://cloud.google.com/storage/",
-    "version": "3.0.0-alpha00",
+    "version": "3.0.0-beta01",
     "type": "rest",
     "description": "Recommended Google client library to access the Google Cloud Storage API. It wraps the Google.Apis.Storage.v1 client library, making common operations simpler in client code. Google Cloud Storage stores and retrieves potentially large, immutable data objects.",
     "dependencies": {


### PR DESCRIPTION
Upgrade dependencies to GAX v3. Currently there are no direct
surface changes, but breaking changes in GAX may affect users, for
example in terms of async pagination.

More direct breaking changes are expected in this package before
3.0.0 is released, specifically around signed URLs.