### PR TITLE
Release Google.Cloud.BigQuery.V2 version 3.0.0-beta01

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha00</Version>
+    <Version>3.0.0-beta01</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>

--- a/apis/Google.Cloud.BigQuery.V2/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.V2/docs/history.md
@@ -1,5 +1,37 @@
 # Version history
 
+# Version 3.0.0-beta01, released 2020-02-20
+
+Breaking changes:
+
+- Updated to GAX v3, which has breaking changes, particularly around async pagination
+- Removed obsolete BigQueryResults constructor
+- Insert operations now return a BigQueryInsertResults instead of void
+
+Further breaking changes are being considered before the 3.0.0
+release, specifically around BigQueryResults.SafeTotalRows and
+options to create resources (tables, datasets etc).
+
+New features:
+
+- Introduced BigQueryInsertResults as a cleaner way of handling insert errors
+- Retrieval of partial results via GetTableOptions.SelectedFields
+- Support for ParentJobId filtering when listing jobs
+- CRUD support for models
+
+Specific commits:
+
+- [Commit 3c900ed](https://github.com/googleapis/google-cloud-dotnet/commit/3c900ed): Remove obsolete BigQueryResults constructor
+- [Commit 21117b7](https://github.com/googleapis/google-cloud-dotnet/commit/21117b7): Fixes issue introduced in [issue 4073](https://github.com/googleapis/google-cloud-dotnet/issues/4073).
+- [Commit 3cadc8e](https://github.com/googleapis/google-cloud-dotnet/commit/3cadc8e): Modifies insert methods to return BigQueryInsertResults.
+- [Commit 9a2f966](https://github.com/googleapis/google-cloud-dotnet/commit/9a2f966): Adds BigQueryInsertResults which wraps the response obtained from insert attempts.
+- [Commit a849e5c](https://github.com/googleapis/google-cloud-dotnet/commit/a849e5c): Supports listing partial rows by specifying a partial table schema.
+- [Commit a820034](https://github.com/googleapis/google-cloud-dotnet/commit/a820034): Supports fetching a partial table schema when getting a table.
+- [Commit 06e0d6e](https://github.com/googleapis/google-cloud-dotnet/commit/06e0d6e): Adds Model CRUD operations wrappers to BigQueryDataset and BigQueryModel.
+- [Commit 38e755a](https://github.com/googleapis/google-cloud-dotnet/commit/38e755a): Adds some Model CRUD operations and supporting types.
+- [Commit ade13ba](https://github.com/googleapis/google-cloud-dotnet/commit/ade13ba): Support ParentJobId filtering when listing Jobs.
+- [Commit ebeece5](https://github.com/googleapis/google-cloud-dotnet/commit/ebeece5): Parse timestamp JSON values as decimal instead of double. Fixes [issue 4031](https://github.com/googleapis/google-cloud-dotnet/issues/4031).
+
 # Version 1.4.0, released 2019-12-16
 
 New features since 1.3.0:

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -61,7 +61,7 @@
     "id": "Google.Cloud.BigQuery.V2",
     "productName": "Google BigQuery",
     "productUrl": "https://cloud.google.com/bigquery/",
-    "version": "2.0.0-alpha00",
+    "version": "3.0.0-beta01",
     "type": "rest",
     "description": "Recommended Google client library to access the BigQuery API. It wraps the Google.Apis.Bigquery.v2 client library, making common operations simpler in client code. BigQuery is a data platform for customers to create, manage, share and query data.",
     "dependencies": {


### PR DESCRIPTION
Breaking changes:

- Updated to GAX v3, which has breaking changes, particularly around async pagination
- Removed obsolete BigQueryResults constructor
- Insert operations now return a BigQueryInsertResults instead of void

Further breaking changes are being considered before the 3.0.0
release, specifically around BigQueryResults.SafeTotalRows and
options to create resources (tables, datasets etc).

New features:

- Introduced BigQueryInsertResults as a cleaner way of handling insert errors
- Retrieval of partial results via GetTableOptions.SelectedFields
- Support for ParentJobId filtering when listing jobs
- CRUD support for models

Specific commits:

- [Commit 3c900ed](https://github.com/googleapis/google-cloud-dotnet/commit/3c900ed): Remove obsolete BigQueryResults constructor
- [Commit 21117b7](https://github.com/googleapis/google-cloud-dotnet/commit/21117b7): Fixes issue introduced in [issue 4073](https://github.com/googleapis/google-cloud-dotnet/issues/4073).
- [Commit 3cadc8e](https://github.com/googleapis/google-cloud-dotnet/commit/3cadc8e): Modifies insert methods to return BigQueryInsertResults.
- [Commit 9a2f966](https://github.com/googleapis/google-cloud-dotnet/commit/9a2f966): Adds BigQueryInsertResults which wraps the response obtained from insert attempts.
- [Commit a849e5c](https://github.com/googleapis/google-cloud-dotnet/commit/a849e5c): Supports listing partial rows by specifying a partial table schema.
- [Commit a820034](https://github.com/googleapis/google-cloud-dotnet/commit/a820034): Supports fetching a partial table schema when getting a table.
- [Commit 06e0d6e](https://github.com/googleapis/google-cloud-dotnet/commit/06e0d6e): Adds Model CRUD operations wrappers to BigQueryDataset and BigQueryModel.
- [Commit 38e755a](https://github.com/googleapis/google-cloud-dotnet/commit/38e755a): Adds some Model CRUD operations and supporting types.
- [Commit ade13ba](https://github.com/googleapis/google-cloud-dotnet/commit/ade13ba): Support ParentJobId filtering when listing Jobs.
- [Commit ebeece5](https://github.com/googleapis/google-cloud-dotnet/commit/ebeece5): Parse timestamp JSON values as decimal instead of double. Fixes [issue 4031](https://github.com/googleapis/google-cloud-dotnet/issues/4031).