### PR TITLE
Migrate projects from .NET Core 2.2 to 3.1

### DIFF
--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationBenchmarks/Google.Cloud.Firestore.IntegrationBenchmarks.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationBenchmarks/Google.Cloud.Firestore.IntegrationBenchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>False</IsPackable>
   </PropertyGroup>
 

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.OrderingKeyTester/Google.Cloud.PubSub.V1.OrderingKeyTester.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.OrderingKeyTester/Google.Cloud.PubSub.V1.OrderingKeyTester.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>False</IsPackable>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/tools/Google.Cloud.Tools.CompareVersions/Google.Cloud.Tools.CompareVersions.csproj
+++ b/tools/Google.Cloud.Tools.CompareVersions/Google.Cloud.Tools.CompareVersions.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/tools/Google.Cloud.Tools.VersionCompat.Tests/Google.Cloud.Tools.VersionCompat.Tests.csproj
+++ b/tools/Google.Cloud.Tools.VersionCompat.Tests/Google.Cloud.Tools.VersionCompat.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
These aren't test projects, so we might as well move them to 3.1 rather than down to 2.1.