### PR TITLE
feat: [Spanner] Add query options support

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/QueryOptionsTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/QueryOptionsTests.cs
@@ -1,0 +1,84 @@
+﻿// Copyright 2020 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Auth.OAuth2;
+using Google.Cloud.Spanner.Data.CommonTesting;
+using Google.Cloud.Spanner.V1;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Cloud.Spanner.Data.IntegrationTests
+{
+    [Collection(nameof(ReadTableFixture))]
+    [CommonTestDiagnostics]
+    public class QueryOptionsTests
+    {
+        private readonly ReadTableFixture _fixture;
+
+        public QueryOptionsTests(ReadTableFixture fixture) =>
+            _fixture = fixture;
+
+        private async Task<T> ExecuteAsync<T>(string sql)
+        {
+            using (var connection = _fixture.GetConnection())
+            {
+                var cmd = connection.CreateSelectCommand(sql);
+                var result = await cmd.ExecuteScalarAsync<T>();
+                return result;
+            }
+        }
+
+        // [START spanner_test_single_key_read_with_query_options]
+        [Fact]
+        public async Task PointReadWithConnectionLevelQueryOptions()
+        {
+            using (var connection = _fixture.GetConnection())
+            {
+                connection.QueryOptions = new QueryOptions().WithOptimizerVersion("1");
+                var cmd = connection.CreateSelectCommand($"SELECT * FROM {_fixture.TableName} WHERE Key = 'k1'");
+                using (var reader = await cmd.ExecuteReaderAsync())
+                {
+                    Assert.True(await reader.ReadAsync());
+                    Assert.Equal("k1", reader.GetString(0));
+                    Assert.Equal("v1", reader.GetString(1));
+
+                    Assert.False(await reader.ReadAsync());
+                }
+            }
+        }
+        // [END spanner_test_single_key_read_with_query_options]
+
+        // [START spanner_test_single_key_read_with_invalid_query_options]
+        [Fact]
+        public async Task PointReadWithInvalidConnectionLevelQueryOptions()
+        {
+            using (var connection = _fixture.GetConnection())
+            {
+                connection.QueryOptions = new QueryOptions().WithOptimizerVersion("invalid");
+                var cmd = connection.CreateSelectCommand($"SELECT * FROM {_fixture.TableName} WHERE Key = 'k1'");
+                using (var reader = await cmd.ExecuteReaderAsync())
+                {
+                    var e = await Assert.ThrowsAsync<SpannerException>(() => reader.ReadAsync());
+                    Assert.Equal(ErrorCode.InvalidArgument, e.ErrorCode);
+                    Assert.False(e.IsTransientSpannerFault());
+                }
+            }
+        }
+        // [END spanner_test_single_key_read_with_invalid_query_options]
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/QueryOptionsTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/QueryOptionsTests.cs
@@ -39,7 +39,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
         {
             using (var connection = _fixture.GetConnection())
             {
-                connection.QueryOptions = new QueryOptions().WithOptimizerVersion("1");
+                connection.QueryOptions = QueryOptions.Empty.WithOptimizerVersion("1");
                 var cmd = connection.CreateSelectCommand($"SELECT * FROM {_fixture.TableName} WHERE Key = 'k1'");
                 using (var reader = await cmd.ExecuteReaderAsync())
                 {
@@ -60,7 +60,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             using (var connection = _fixture.GetConnection())
             {
                 var cmd = connection.CreateSelectCommand($"SELECT * FROM {_fixture.TableName} WHERE Key = 'k1'");
-                cmd.QueryOptions = new QueryOptions().WithOptimizerVersion("1");
+                cmd.QueryOptions = QueryOptions.Empty.WithOptimizerVersion("1");
                 using (var reader = await cmd.ExecuteReaderAsync())
                 {
                     Assert.True(await reader.ReadAsync());
@@ -79,7 +79,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
         {
             using (var connection = _fixture.GetConnection())
             {
-                connection.QueryOptions = new QueryOptions().WithOptimizerVersion("invalid");
+                connection.QueryOptions = QueryOptions.Empty.WithOptimizerVersion("invalid");
                 var cmd = connection.CreateSelectCommand($"SELECT * FROM {_fixture.TableName} WHERE Key = 'k1'");
                 using (var reader = await cmd.ExecuteReaderAsync())
                 {

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/QueryOptionsTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/QueryOptionsTests.cs
@@ -1,0 +1,52 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Spanner.V1;
+using Xunit;
+
+namespace Google.Cloud.Spanner.Data.Tests
+{
+    public class QueryOptionsTests
+    {
+        [Fact]
+        public void FromProtoFromNullProto()
+        {
+            var queryOptions = QueryOptions.FromProto(null);
+            Assert.Null(queryOptions);
+        }
+
+        [Fact]
+        public void FromProtoFromEmptyProto()
+        {
+            var proto = new V1.ExecuteSqlRequest.Types.QueryOptions();
+            var queryOptions = QueryOptions.FromProto(proto);
+            Assert.Equal("", queryOptions.OptimizerVersion);
+        }
+
+        [Fact]
+        public void NoOptionsSet()
+        {
+            var queryOptions = new QueryOptions();
+            Assert.Equal("", queryOptions.OptimizerVersion);
+        }
+
+        [Fact]
+        public void SetAndGetOptimizerVersion()
+        {
+            var queryOptions = new QueryOptions();
+            queryOptions.OptimizerVersion = "latest";
+            Assert.Equal("latest", queryOptions.OptimizerVersion);
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/QueryOptionsTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/QueryOptionsTests.cs
@@ -31,14 +31,14 @@ namespace Google.Cloud.Spanner.Data.Tests
         [Fact]
         public void NoOptionsSet()
         {
-            var queryOptions = new QueryOptions();
+            var queryOptions = QueryOptions.Empty;
             Assert.Equal("", queryOptions.OptimizerVersion);
         }
 
         [Fact]
         public void SetAndGetOptimizerVersion()
         {
-            var queryOptions = new QueryOptions().WithOptimizerVersion("latest");
+            var queryOptions = QueryOptions.Empty.WithOptimizerVersion("latest");
             Assert.Equal("latest", queryOptions.OptimizerVersion);
         }
     }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/QueryOptionsTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/QueryOptionsTests.cs
@@ -13,19 +13,13 @@
 // limitations under the License.
 
 using Google.Cloud.Spanner.V1;
+using System;
 using Xunit;
 
 namespace Google.Cloud.Spanner.Data.Tests
 {
     public class QueryOptionsTests
     {
-        [Fact]
-        public void FromProtoFromNullProto()
-        {
-            var queryOptions = QueryOptions.FromProto(null);
-            Assert.Null(queryOptions);
-        }
-
         [Fact]
         public void FromProtoFromEmptyProto()
         {
@@ -44,8 +38,7 @@ namespace Google.Cloud.Spanner.Data.Tests
         [Fact]
         public void SetAndGetOptimizerVersion()
         {
-            var queryOptions = new QueryOptions();
-            queryOptions.OptimizerVersion = "latest";
+            var queryOptions = new QueryOptions().WithOptimizerVersion("latest");
             Assert.Equal("latest", queryOptions.OptimizerVersion);
         }
     }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerCommandTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerCommandTests.cs
@@ -113,7 +113,7 @@ namespace Google.Cloud.Spanner.Data.Tests
         public void CommandHasOptimizerVersionFromEnvironment()
         {
             // Save existing value of environment variable.
-            const string optimizerVersionVariable = "SPANNER_QUERY_OPTIMIZER_VERSION";
+            const string optimizerVersionVariable = "SPANNER_OPTIMIZER_VERSION";
             string savedOptimizerVersion = Environment.GetEnvironmentVariable(optimizerVersionVariable);
             const string envOptimizerVersion = "2";
             Environment.SetEnvironmentVariable(optimizerVersionVariable, envOptimizerVersion);
@@ -141,7 +141,7 @@ namespace Google.Cloud.Spanner.Data.Tests
         public void CommandHasOptimizerVersionSetOnCommand()
         {
             // Save existing value of environment variable.
-            const string optimizerVersionVariable = "SPANNER_QUERY_OPTIMIZER_VERSION";
+            const string optimizerVersionVariable = "SPANNER_OPTIMIZER_VERSION";
             string savedOptimizerVersion = Environment.GetEnvironmentVariable(optimizerVersionVariable);
             const string envOptimizerVersion = "2";
             Environment.SetEnvironmentVariable(optimizerVersionVariable, envOptimizerVersion);

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerCommandTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerCommandTests.cs
@@ -177,12 +177,7 @@ namespace Google.Cloud.Spanner.Data.Tests
                 .Setup(client => client.ExecuteStreamingSql(
                     It.Is<ExecuteSqlRequest>(request => request.QueryOptions.OptimizerVersion == optimizerVersion),
                     It.IsAny<CallSettings>()))
-                .Returns<ExecuteSqlRequest, CallSettings>((request, _) =>
-                {
-                    // Returning null since we can't return a SpannerClient.ExecuteStreamingSqlStream()
-                    // since it's an abstract class.
-                    return null;
-                });
+                .Returns<ExecuteSqlRequest, CallSettings>((request, _) => null);
             return spannerClientMock;
         }
 

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerCommandTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerCommandTests.cs
@@ -175,8 +175,7 @@ namespace Google.Cloud.Spanner.Data.Tests
             spannerClientMock
                 .SetupBatchCreateSessionsAsync()
                 .Setup(client => client.ExecuteStreamingSql(
-                    It.Is<ExecuteSqlRequest>(
-                        request => request.QueryOptions.OptimizerVersion == optimizerVersion),
+                    It.Is<ExecuteSqlRequest>(request => request.QueryOptions.OptimizerVersion == optimizerVersion),
                     It.IsAny<CallSettings>()))
                 .Returns<ExecuteSqlRequest, CallSettings>((request, _) =>
                 {

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerCommandTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerCommandTests.cs
@@ -113,7 +113,7 @@ namespace Google.Cloud.Spanner.Data.Tests
         public void CommandHasOptimizerVersionFromEnvironment()
         {
             // Save existing value of environment variable.
-            const string optimizerVersionVariable = "SPANNER_OPTIMIZER_VERSION";
+            const string optimizerVersionVariable = "SPANNER_QUERY_OPTIMIZER_VERSION";
             string savedOptimizerVersion = Environment.GetEnvironmentVariable(optimizerVersionVariable);
             const string envOptimizerVersion = "2";
             Environment.SetEnvironmentVariable(optimizerVersionVariable, envOptimizerVersion);
@@ -141,7 +141,7 @@ namespace Google.Cloud.Spanner.Data.Tests
         public void CommandHasOptimizerVersionSetOnCommand()
         {
             // Save existing value of environment variable.
-            const string optimizerVersionVariable = "SPANNER_OPTIMIZER_VERSION";
+            const string optimizerVersionVariable = "SPANNER_QUERY_OPTIMIZER_VERSION";
             string savedOptimizerVersion = Environment.GetEnvironmentVariable(optimizerVersionVariable);
             const string envOptimizerVersion = "2";
             Environment.SetEnvironmentVariable(optimizerVersionVariable, envOptimizerVersion);

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerCommandTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerCommandTests.cs
@@ -89,7 +89,7 @@ namespace Google.Cloud.Spanner.Data.Tests
         public void CommandHasConnectionQueryOptions()
         {
             var connection = new SpannerConnection("Data Source=projects/p/instances/i/databases/d");
-            var queryOptions = new QueryOptions{ OptimizerVersion = "1" };
+            var queryOptions = new QueryOptions().WithOptimizerVersion("1");
             connection.QueryOptions = queryOptions;
 
             var command = connection.CreateSelectCommand("SELECT * FROM FOO");
@@ -106,7 +106,7 @@ namespace Google.Cloud.Spanner.Data.Tests
             Environment.SetEnvironmentVariable(optimizerVersionVariable, envOptimizerVersion);
 
             var connection = new SpannerConnection("Data Source=projects/p/instances/i/databases/d");
-            connection.QueryOptions = new QueryOptions{ OptimizerVersion = "1" };
+            connection.QueryOptions = new QueryOptions().WithOptimizerVersion("1");
 
             var command = connection.CreateSelectCommand("SELECT * FROM FOO");
             // Optimizer version set through environment variable has higher
@@ -127,11 +127,11 @@ namespace Google.Cloud.Spanner.Data.Tests
             Environment.SetEnvironmentVariable(optimizerVersionVariable, envOptimizerVersion);
 
             var connection = new SpannerConnection("Data Source=projects/p/instances/i/databases/d");
-            connection.QueryOptions = new QueryOptions{ OptimizerVersion = "1" };
+            connection.QueryOptions = new QueryOptions().WithOptimizerVersion("1");
 
             var command = connection.CreateSelectCommand("SELECT * FROM FOO");
             var commandOptimizerVersion = "3";
-            command.QueryOptions = new QueryOptions{ OptimizerVersion = commandOptimizerVersion };
+            command.QueryOptions = new QueryOptions().WithOptimizerVersion("3");
             // Optimizer version set at a command level has higher precedence
             // than version set through the connection or the environment
             // variable.

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerCommandTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerCommandTests.cs
@@ -99,7 +99,7 @@ namespace Google.Cloud.Spanner.Data.Tests
             Mock<SpannerClient> spannerClientMock = SetupExecuteStreamingSql(connOptimizerVersion);
 
             SpannerConnection connection = BuildSpannerConnection(spannerClientMock);
-            var queryOptions = new QueryOptions().WithOptimizerVersion(connOptimizerVersion);
+            var queryOptions = QueryOptions.Empty.WithOptimizerVersion(connOptimizerVersion);
             connection.QueryOptions = queryOptions;
 
             var command = connection.CreateSelectCommand("SELECT * FROM FOO");
@@ -121,7 +121,7 @@ namespace Google.Cloud.Spanner.Data.Tests
 
                 const string connOptimizerVersion = "1";
                 SpannerConnection connection = BuildSpannerConnection(spannerClientMock);
-                var queryOptions = new QueryOptions().WithOptimizerVersion(connOptimizerVersion);
+                var queryOptions = QueryOptions.Empty.WithOptimizerVersion(connOptimizerVersion);
                 connection.QueryOptions = queryOptions;
 
                 var command = connection.CreateSelectCommand("SELECT * FROM FOO");
@@ -147,11 +147,11 @@ namespace Google.Cloud.Spanner.Data.Tests
 
                 const string connOptimizerVersion = "1";
                 SpannerConnection connection = BuildSpannerConnection(spannerClientMock);
-                var queryOptions = new QueryOptions().WithOptimizerVersion(connOptimizerVersion);
+                var queryOptions = QueryOptions.Empty.WithOptimizerVersion(connOptimizerVersion);
                 connection.QueryOptions = queryOptions;
 
                 var command = connection.CreateSelectCommand("SELECT * FROM FOO");
-                command.QueryOptions = new QueryOptions().WithOptimizerVersion(cmdOptimizerVersion);
+                command.QueryOptions = QueryOptions.Empty.WithOptimizerVersion(cmdOptimizerVersion);
                 using (var reader = command.ExecuteReader())
                 {
                     // Do nothing.

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerCommandTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerCommandTests.cs
@@ -93,6 +93,18 @@ namespace Google.Cloud.Spanner.Data.Tests
         }
 
         [Fact]
+        public void CloneWithQueryOptions()
+        {
+            var connection = new SpannerConnection("Data Source=projects/p/instances/i/databases/d");
+            var command = connection.CreateSelectCommand("SELECT * FROM FOO");
+            command.QueryOptions = QueryOptions.Empty.WithOptimizerVersion("1");
+            var command2 = (SpannerCommand)command.Clone();
+            Assert.Same(command.SpannerConnection, command2.SpannerConnection);
+            Assert.Equal(command.CommandText, command2.CommandText);
+            Assert.Equal(command.QueryOptions, command2.QueryOptions);
+        }
+
+        [Fact]
         public void CommandHasConnectionQueryOptions()
         {
             const string connOptimizerVersion = "1";

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/QueryOptions.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/QueryOptions.cs
@@ -1,0 +1,63 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Spanner.V1;
+
+namespace Google.Cloud.Spanner.Data
+{
+    /// <summary>
+    /// Immutable class representing query options.
+    /// </summary>
+    public sealed class QueryOptions
+    {
+        /// <summary>
+        /// An option to control the selection of optimizer version.
+        ///
+        /// This parameter allows individual queries to pick different query
+        /// optimizer versions.
+        ///
+        /// Specifying "latest" as a value instructs Cloud Spanner to use the
+        /// latest supported query optimizer version. If not specified, Cloud Spanner
+        /// uses optimizer version set at the database level options. Any other
+        /// positive integer (from the list of supported optimizer versions)
+        /// overrides the default optimizer version for query execution.
+        /// </summary>
+        public string OptimizerVersion
+        {
+            get { return Proto.OptimizerVersion; }
+            set { Proto.OptimizerVersion = value; }
+        }
+
+        /// <summary>
+        /// The proto representation of the query options. Must not be mutated
+        /// or exposed publicly.
+        /// </summary>
+        internal V1.ExecuteSqlRequest.Types.QueryOptions Proto { get; }
+
+        private QueryOptions(V1.ExecuteSqlRequest.Types.QueryOptions proto) => Proto = proto;
+
+        /// <summary>
+        /// Creates query options without specifying any options.
+        /// </summary>
+        public QueryOptions() : this(new V1.ExecuteSqlRequest.Types.QueryOptions())
+        {
+        }
+
+        /// <summary>
+        /// Set query options from the proto.
+        /// </summary>
+        public static QueryOptions FromProto(
+            V1.ExecuteSqlRequest.Types.QueryOptions proto) => proto == null ? null : new QueryOptions(proto);
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/QueryOptions.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/QueryOptions.cs
@@ -59,5 +59,13 @@ namespace Google.Cloud.Spanner.Data
         /// </summary>
         public static QueryOptions FromProto(
             V1.ExecuteSqlRequest.Types.QueryOptions proto) => proto == null ? null : new QueryOptions(proto);
+
+        /// <summary>
+        /// Get proto version of the query options.
+        /// </summary>
+        public V1.ExecuteSqlRequest.Types.QueryOptions ToProto()
+        {
+            return Proto.Clone();
+        }
     }
 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/QueryOptions.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/QueryOptions.cs
@@ -13,13 +13,14 @@
 // limitations under the License.
 
 using Google.Cloud.Spanner.V1;
+using System;
 
 namespace Google.Cloud.Spanner.Data
 {
     /// <summary>
     /// Immutable class representing query options.
     /// </summary>
-    public sealed class QueryOptions
+    public sealed class QueryOptions : IEquatable<QueryOptions>
     {
         /// <summary>
         /// An option to control the selection of optimizer version.
@@ -66,6 +67,32 @@ namespace Google.Cloud.Spanner.Data
         public V1.ExecuteSqlRequest.Types.QueryOptions ToProto()
         {
             return Proto.Clone();
+        }
+
+        /// <inheritdoc />
+        public bool Equals(QueryOptions other)
+        {
+            if (ReferenceEquals(null, other))
+            {
+                return false;
+            }
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+            return OptimizerVersion == other.OptimizerVersion;
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as QueryOptions);
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return OptimizerVersion.GetHashCode();
+            }
         }
     }
 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/QueryOptions.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/QueryOptions.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Api.Gax;
 using Google.Cloud.Spanner.V1;
 using System;
 
@@ -23,22 +24,36 @@ namespace Google.Cloud.Spanner.Data
     public sealed class QueryOptions : IEquatable<QueryOptions>
     {
         /// <summary>
-        /// An option to control the selection of optimizer version.
-        ///
-        /// This parameter allows individual queries to pick different query
-        /// optimizer versions.
-        ///
-        /// Specifying "latest" as a value instructs Cloud Spanner to use the
-        /// latest supported query optimizer version. If not specified, Cloud Spanner
-        /// uses optimizer version set at the database level options. Any other
-        /// positive integer (from the list of supported optimizer versions)
-        /// overrides the default optimizer version for query execution.
+        /// The query optimizer version configured in the options.
         /// </summary>
         public string OptimizerVersion
         {
-            get { return Proto.OptimizerVersion; }
-            set { Proto.OptimizerVersion = value; }
+            get => Proto.OptimizerVersion;
         }
+
+        /// <summary>
+        /// Clones the options and sets the optimizer version to the given value.
+        /// </summary>
+        /// <returns>
+        /// A clone of the options with the updated optimizer version.
+        /// </returns>
+        /// <remarks>
+        /// <para>The parameter allows individual queries to pick different query
+        /// optimizer versions.</para>
+        /// <para>Specifying "latest" as a value instructs Cloud Spanner to use the
+        /// latest supported query optimizer version. If not specified, Cloud Spanner
+        /// uses optimizer version set at the database level options. Any other
+        /// positive integer (from the list of supported optimizer versions)
+        /// overrides the default optimizer version for query execution.</para>
+        /// </remarks>
+        /// <param name="optimizerVersion">Optimizer version to set.</param>
+        public QueryOptions WithOptimizerVersion(string optimizerVersion)
+        {
+           var protoCopy = Proto.Clone();
+           protoCopy.OptimizerVersion = optimizerVersion;
+           return new QueryOptions(protoCopy);
+        }
+
 
         /// <summary>
         /// The proto representation of the query options. Must not be mutated
@@ -56,29 +71,30 @@ namespace Google.Cloud.Spanner.Data
         }
 
         /// <summary>
-        /// Set query options from the proto.
+        /// Set query options from the given proto.
         /// </summary>
+        /// <remarks>
+        /// The given proto should not be null. The given proto is cloned.
+        /// </remarks>
+        /// <param name="proto">The proto to construct <see cref="QueryOptions"/> from.</param>
         public static QueryOptions FromProto(
-            V1.ExecuteSqlRequest.Types.QueryOptions proto) => proto == null ? null : new QueryOptions(proto);
+            V1.ExecuteSqlRequest.Types.QueryOptions proto)
+        {
+            GaxPreconditions.CheckNotNull(proto, nameof(proto));
+            return new QueryOptions(proto.Clone());
+        }
 
         /// <summary>
         /// Get proto version of the query options.
         /// </summary>
-        public V1.ExecuteSqlRequest.Types.QueryOptions ToProto()
-        {
-            return Proto.Clone();
-        }
+        public V1.ExecuteSqlRequest.Types.QueryOptions ToProto() => Proto.Clone();
 
         /// <inheritdoc />
         public bool Equals(QueryOptions other)
         {
-            if (ReferenceEquals(null, other))
+            if (other is null)
             {
                 return false;
-            }
-            if (ReferenceEquals(this, other))
-            {
-                return true;
             }
             return OptimizerVersion == other.OptimizerVersion;
         }
@@ -87,12 +103,6 @@ namespace Google.Cloud.Spanner.Data
         public override bool Equals(object obj) => Equals(obj as QueryOptions);
 
         /// <inheritdoc />
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                return OptimizerVersion.GetHashCode();
-            }
-        }
+        public override int GetHashCode() => Proto.GetHashCode();
     }
 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/QueryOptions.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/QueryOptions.cs
@@ -86,14 +86,7 @@ namespace Google.Cloud.Spanner.Data
         public V1.ExecuteSqlRequest.Types.QueryOptions ToProto() => Proto.Clone();
 
         /// <inheritdoc />
-        public bool Equals(QueryOptions other)
-        {
-            if (other is null)
-            {
-                return false;
-            }
-            return OptimizerVersion == other.OptimizerVersion;
-        }
+        public bool Equals(QueryOptions other) => other is object && OptimizerVersion == other.OptimizerVersion;
 
         /// <inheritdoc />
         public override bool Equals(object obj) => Equals(obj as QueryOptions);

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/QueryOptions.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/QueryOptions.cs
@@ -51,7 +51,6 @@ namespace Google.Cloud.Spanner.Data
            return new QueryOptions(protoCopy);
         }
 
-
         /// <summary>
         /// The proto representation of the query options. Must not be mutated
         /// or exposed publicly.

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/QueryOptions.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/QueryOptions.cs
@@ -26,10 +26,7 @@ namespace Google.Cloud.Spanner.Data
         /// <summary>
         /// The query optimizer version configured in the options.
         /// </summary>
-        public string OptimizerVersion
-        {
-            get => Proto.OptimizerVersion;
-        }
+        public string OptimizerVersion { get => Proto.OptimizerVersion; }
 
         /// <summary>
         /// Clones the options and sets the optimizer version to the given value.
@@ -77,8 +74,7 @@ namespace Google.Cloud.Spanner.Data
         /// The given proto should not be null. The given proto is cloned.
         /// </remarks>
         /// <param name="proto">The proto to construct <see cref="QueryOptions"/> from.</param>
-        public static QueryOptions FromProto(
-            V1.ExecuteSqlRequest.Types.QueryOptions proto)
+        public static QueryOptions FromProto(V1.ExecuteSqlRequest.Types.QueryOptions proto)
         {
             GaxPreconditions.CheckNotNull(proto, nameof(proto));
             return new QueryOptions(proto.Clone());

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/QueryOptions.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/QueryOptions.cs
@@ -84,11 +84,6 @@ namespace Google.Cloud.Spanner.Data
             return new QueryOptions(proto.Clone());
         }
 
-        /// <summary>
-        /// Get proto version of the query options.
-        /// </summary>
-        public V1.ExecuteSqlRequest.Types.QueryOptions ToProto() => Proto.Clone();
-
         /// <inheritdoc />
         public bool Equals(QueryOptions other)
         {

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/QueryOptions.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/QueryOptions.cs
@@ -84,6 +84,11 @@ namespace Google.Cloud.Spanner.Data
             return new QueryOptions(proto.Clone());
         }
 
+        /// <summary>
+        /// Get proto version of the query options.
+        /// </summary>
+        public V1.ExecuteSqlRequest.Types.QueryOptions ToProto() => Proto.Clone();
+
         /// <inheritdoc />
         public bool Equals(QueryOptions other)
         {

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/QueryOptions.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/QueryOptions.cs
@@ -63,9 +63,7 @@ namespace Google.Cloud.Spanner.Data
         /// <summary>
         /// Creates query options without specifying any options.
         /// </summary>
-        public QueryOptions() : this(new V1.ExecuteSqlRequest.Types.QueryOptions())
-        {
-        }
+        public static QueryOptions Empty { get; } = new QueryOptions(new V1.ExecuteSqlRequest.Types.QueryOptions());
 
         /// <summary>
         /// Set query options from the given proto.

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.ExecutableCommand.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.ExecutableCommand.cs
@@ -379,10 +379,9 @@ namespace Google.Cloud.Spanner.Data
 
                 var request = new ExecuteSqlRequest
                 {
-                    Sql = CommandTextBuilder.ToString()
+                    Sql = CommandTextBuilder.ToString(),
+                    QueryOptions = GetEffectiveQueryOptions()
                 };
-
-                request.QueryOptions = GetEffectiveQueryOptions();
 
                 // See comment at the start of GetMutations.
                 SpannerConversionOptions options = null;

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.ExecutableCommand.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.ExecutableCommand.cs
@@ -53,7 +53,7 @@ namespace Google.Cloud.Spanner.Data
                 return settings;
             }
 
-            private const string SpannerOptimizerVersionVariable = "SPANNER_OPTIMIZER_VERSION";
+            private const string SpannerOptimizerVersionVariable = "SPANNER_QUERY_OPTIMIZER_VERSION";
 
             internal SpannerConnection Connection { get; }
             internal SpannerCommandTextBuilder CommandTextBuilder { get; }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.ExecutableCommand.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.ExecutableCommand.cs
@@ -53,7 +53,7 @@ namespace Google.Cloud.Spanner.Data
                 return settings;
             }
 
-            private const string SpannerOptimizerVersionVariable = "SPANNER_QUERY_OPTIMIZER_VERSION";
+            private const string SpannerOptimizerVersionVariable = "SPANNER_OPTIMIZER_VERSION";
 
             internal SpannerConnection Connection { get; }
             internal SpannerCommandTextBuilder CommandTextBuilder { get; }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.ExecutableCommand.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.ExecutableCommand.cs
@@ -59,6 +59,7 @@ namespace Google.Cloud.Spanner.Data
             internal SpannerTransaction Transaction { get; }
             internal CommandPartition Partition { get; }
             internal SpannerParameterCollection Parameters { get; }
+            internal QueryOptions QueryOptions { get; }
 
             public ExecutableCommand(SpannerCommand command)
             {
@@ -68,6 +69,7 @@ namespace Google.Cloud.Spanner.Data
                 Partition = command.Partition;
                 Parameters = command.Parameters;
                 Transaction = command._transaction;
+                QueryOptions = command.QueryOptions;
             }
 
             // ExecuteScalar is simply implemented in terms of ExecuteReader.
@@ -346,6 +348,11 @@ namespace Google.Cloud.Spanner.Data
                 {
                     Sql = CommandTextBuilder.ToString()
                 };
+
+                if (QueryOptions != null)
+                {
+                    request.QueryOptions = QueryOptions.ToProto();
+                }
 
                 // See comment at the start of GetMutations.
                 SpannerConversionOptions options = null;

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.cs
@@ -234,7 +234,7 @@ namespace Google.Cloud.Spanner.Data
                 _queryOptions = new QueryOptions();
             }
 
-            _queryOptions.OptimizerVersion = options.OptimizerVersion;
+            _queryOptions = _queryOptions.WithOptimizerVersion(options.OptimizerVersion);
         }
 
         /// <summary>

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.cs
@@ -41,7 +41,6 @@ namespace Google.Cloud.Spanner.Data
         private readonly CancellationTokenSource _synchronousCancellationTokenSource = new CancellationTokenSource();
         private int _commandTimeout;
         private SpannerTransaction _transaction;
-        private QueryOptions _queryOptions = null;
 
         /// <summary>
         /// Initializes a new instance of <see cref="SpannerCommand"/>, using a default command timeout.
@@ -223,11 +222,7 @@ namespace Google.Cloud.Spanner.Data
         /// <summary>
         /// Query options to use when running SQL and streaming SQL commands.
         /// </summary>
-        public QueryOptions QueryOptions
-        {
-            get => _queryOptions;
-            set => _queryOptions = (QueryOptions) value;
-        }
+        public QueryOptions QueryOptions { get; set; }
 
         /// <inheritdoc />
         protected override DbConnection DbConnection

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.cs
@@ -41,6 +41,7 @@ namespace Google.Cloud.Spanner.Data
         private readonly CancellationTokenSource _synchronousCancellationTokenSource = new CancellationTokenSource();
         private int _commandTimeout;
         private SpannerTransaction _transaction;
+        private QueryOptions _queryOptions = null;
 
         /// <summary>
         /// Initializes a new instance of <see cref="SpannerCommand"/>, using a default command timeout.
@@ -217,6 +218,34 @@ namespace Google.Cloud.Spanner.Data
                         + " Please use UUIDs instead of auto increment columns, which can be created on the client.");
                 }
             }
+        }
+
+        // When query options are set, merge the new set of options into the existing options.
+        private void MergeQueryOptions(QueryOptions options)
+        {
+            // Nothing to merge.
+            if (options == null || string.IsNullOrEmpty(options.OptimizerVersion))
+            {
+                return;
+            }
+
+            if (_queryOptions == null)
+            {
+                _queryOptions = new QueryOptions();
+            }
+
+            _queryOptions.OptimizerVersion = options.OptimizerVersion;
+        }
+
+        /// <summary>
+        /// Query options to use when running SQL and streaming SQL commands.
+        /// When a new set of options is set, the new fields will be merged
+        /// into the fields in the existing options.
+        /// </summary>
+        public QueryOptions QueryOptions
+        {
+            get => _queryOptions;
+            set => MergeQueryOptions(value);
         }
 
         /// <inheritdoc />

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.cs
@@ -261,7 +261,8 @@ namespace Google.Cloud.Spanner.Data
         {
             DesignTimeVisible = DesignTimeVisible,
             SpannerCommandTextBuilder = SpannerCommandTextBuilder,
-            CommandTimeout = CommandTimeout
+            CommandTimeout = CommandTimeout,
+            QueryOptions = QueryOptions
         };
 
         /// <inheritdoc />

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.cs
@@ -220,32 +220,13 @@ namespace Google.Cloud.Spanner.Data
             }
         }
 
-        // When query options are set, merge the new set of options into the existing options.
-        private void MergeQueryOptions(QueryOptions options)
-        {
-            // Nothing to merge.
-            if (options == null || string.IsNullOrEmpty(options.OptimizerVersion))
-            {
-                return;
-            }
-
-            if (_queryOptions == null)
-            {
-                _queryOptions = new QueryOptions();
-            }
-
-            _queryOptions = _queryOptions.WithOptimizerVersion(options.OptimizerVersion);
-        }
-
         /// <summary>
         /// Query options to use when running SQL and streaming SQL commands.
-        /// When a new set of options is set, the new fields will be merged
-        /// into the fields in the existing options.
         /// </summary>
         public QueryOptions QueryOptions
         {
             get => _queryOptions;
-            set => MergeQueryOptions(value);
+            set => _queryOptions = (QueryOptions) value;
         }
 
         /// <inheritdoc />

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnection.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnection.cs
@@ -110,6 +110,40 @@ namespace Google.Cloud.Spanner.Data
 
         internal bool IsOpen => (State & ConnectionState.Open) == ConnectionState.Open;
 
+        private QueryOptions _queryOptions = null;
+        private const string SpannerOptimizerVersionVariable = "SPANNER_OPTIMIZER_VERSION";
+
+        // Query options provided at a connection level will be overridden by query options
+        // set through environment variables.
+        private void ApplyQueryOptionsFromEnvironment()
+        {
+            string optimizerVersion = Environment.GetEnvironmentVariable(SpannerOptimizerVersionVariable)?.Trim() ?? "";
+            if (string.IsNullOrEmpty(optimizerVersion))
+            {
+                return;
+            }
+
+            if (_queryOptions == null)
+            {
+                _queryOptions = new QueryOptions();
+            }
+
+            _queryOptions.OptimizerVersion = optimizerVersion;
+        }
+
+        /// <summary>
+        /// Query options to use throughout the lifetime of the connection when
+        /// running SQL and streaming SQL requests.
+        /// </summary>
+        public QueryOptions QueryOptions
+        {
+            get => _queryOptions;
+            set {
+                _queryOptions = (QueryOptions) value;
+                ApplyQueryOptionsFromEnvironment();
+            }
+        }
+
         /// <summary>
         /// Creates a SpannerConnection with no datasource or credential specified.
         /// </summary>

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnection.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnection.cs
@@ -110,17 +110,11 @@ namespace Google.Cloud.Spanner.Data
 
         internal bool IsOpen => (State & ConnectionState.Open) == ConnectionState.Open;
 
-        private QueryOptions _queryOptions = null;
-
         /// <summary>
         /// Query options to use throughout the lifetime of the connection when
         /// running SQL and streaming SQL requests.
         /// </summary>
-        public QueryOptions QueryOptions
-        {
-            get => _queryOptions;
-            set => _queryOptions = (QueryOptions) value;
-        }
+        public QueryOptions QueryOptions { get; set; }
 
         /// <summary>
         /// Creates a SpannerConnection with no datasource or credential specified.

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnection.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnection.cs
@@ -128,7 +128,7 @@ namespace Google.Cloud.Spanner.Data
                 _queryOptions = new QueryOptions();
             }
 
-            _queryOptions.OptimizerVersion = optimizerVersion;
+            _queryOptions = _queryOptions.WithOptimizerVersion(optimizerVersion);
         }
 
         /// <summary>

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnection.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnection.cs
@@ -447,7 +447,7 @@ namespace Google.Cloud.Spanner.Data
             string databaseTable,
             SpannerParameterCollection primaryKeys = null) => new SpannerCommand(
             SpannerCommandTextBuilder.CreateDeleteTextBuilder(databaseTable), this, null,
-            primaryKeys);
+            primaryKeys) { QueryOptions = QueryOptions };
 
         /// <summary>
         /// Creates a new <see cref="SpannerCommand" /> to insert rows into a Spanner database table.
@@ -464,7 +464,7 @@ namespace Google.Cloud.Spanner.Data
             string databaseTable,
             SpannerParameterCollection insertedColumns = null) => new SpannerCommand(
             SpannerCommandTextBuilder.CreateInsertTextBuilder(databaseTable), this, null,
-            insertedColumns);
+            insertedColumns) { QueryOptions = QueryOptions };
 
         /// <summary>
         /// Creates a new <see cref="SpannerCommand" /> to insert or update rows into a Spanner database table.
@@ -481,7 +481,7 @@ namespace Google.Cloud.Spanner.Data
             string databaseTable,
             SpannerParameterCollection insertUpdateColumns = null) => new SpannerCommand(
             SpannerCommandTextBuilder.CreateInsertOrUpdateTextBuilder(databaseTable), this,
-            null, insertUpdateColumns);
+            null, insertUpdateColumns) { QueryOptions = QueryOptions };
 
         /// <summary>
         /// Creates a new <see cref="SpannerCommand" /> to select rows using a SQL query statement.
@@ -497,7 +497,7 @@ namespace Google.Cloud.Spanner.Data
         /// </param>
         /// <returns>A configured <see cref="SpannerCommand" /></returns>
         public SpannerCommand CreateSelectCommand(string sqlQueryStatement, SpannerParameterCollection selectParameters = null) =>
-            new SpannerCommand(SpannerCommandTextBuilder.CreateSelectTextBuilder(sqlQueryStatement), this, null, selectParameters);
+            new SpannerCommand(SpannerCommandTextBuilder.CreateSelectTextBuilder(sqlQueryStatement), this, null, selectParameters) { QueryOptions = QueryOptions };
 
         /// <summary>
         /// Creates a new <see cref="SpannerCommand" /> from a <see cref="CommandPartition"/>.
@@ -510,7 +510,7 @@ namespace Google.Cloud.Spanner.Data
         /// creating the <see cref="CommandPartition"/>.  See <see cref="SpannerConnection.BeginReadOnlyTransaction(TransactionId)"/>.</param>
         /// <returns>A configured <see cref="SpannerCommand" /></returns>
         public SpannerCommand CreateCommandWithPartition(CommandPartition partition, SpannerTransaction transaction) =>
-            new SpannerCommand(this, transaction, partition);
+            new SpannerCommand(this, transaction, partition) { QueryOptions = QueryOptions };
 
         /// <summary>
         /// Creates a new <see cref="SpannerCommand" /> to update rows in a Spanner database table.
@@ -525,7 +525,7 @@ namespace Google.Cloud.Spanner.Data
         /// </param>
         /// <returns>A configured <see cref="SpannerCommand" /></returns>
         public SpannerCommand CreateUpdateCommand(string databaseTable, SpannerParameterCollection updateColumns = null) =>
-            new SpannerCommand(SpannerCommandTextBuilder.CreateUpdateTextBuilder(databaseTable), this, null, updateColumns);
+            new SpannerCommand(SpannerCommandTextBuilder.CreateUpdateTextBuilder(databaseTable), this, null, updateColumns) { QueryOptions = QueryOptions };
 
         /// <summary>
         /// Creates a new <see cref="SpannerCommand" /> to execute a DDL (CREATE/DROP TABLE, etc) statement.
@@ -537,7 +537,7 @@ namespace Google.Cloud.Spanner.Data
         /// <returns>A configured <see cref="SpannerCommand" /></returns>
         public SpannerCommand CreateDdlCommand(
             string ddlStatement, params string[] extraDdlStatements) =>
-            new SpannerCommand(SpannerCommandTextBuilder.CreateDdlTextBuilder(ddlStatement, extraDdlStatements), this);
+            new SpannerCommand(SpannerCommandTextBuilder.CreateDdlTextBuilder(ddlStatement, extraDdlStatements), this) { QueryOptions = QueryOptions };
 
         /// <summary>
         /// Creates a new <see cref="SpannerCommand" /> to execute a general DML (UPDATE, INSERT, DELETE) statement.
@@ -555,7 +555,7 @@ namespace Google.Cloud.Spanner.Data
         /// </param>
         /// <returns>A configured <see cref="SpannerCommand" /></returns>
         public SpannerCommand CreateDmlCommand(string dmlStatement, SpannerParameterCollection dmlParameters = null) =>
-            new SpannerCommand(SpannerCommandTextBuilder.CreateDmlTextBuilder(dmlStatement), this, null, dmlParameters);
+            new SpannerCommand(SpannerCommandTextBuilder.CreateDmlTextBuilder(dmlStatement), this, null, dmlParameters) { QueryOptions = QueryOptions };
 
         /// <summary>
         /// Creates a new <see cref="SpannerBatchCommand"/> to execute batched DML statements with this connection, without using a transaction.

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnection.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnection.cs
@@ -111,25 +111,6 @@ namespace Google.Cloud.Spanner.Data
         internal bool IsOpen => (State & ConnectionState.Open) == ConnectionState.Open;
 
         private QueryOptions _queryOptions = null;
-        private const string SpannerOptimizerVersionVariable = "SPANNER_OPTIMIZER_VERSION";
-
-        // Query options provided at a connection level will be overridden by query options
-        // set through environment variables.
-        private void ApplyQueryOptionsFromEnvironment()
-        {
-            string optimizerVersion = Environment.GetEnvironmentVariable(SpannerOptimizerVersionVariable)?.Trim() ?? "";
-            if (string.IsNullOrEmpty(optimizerVersion))
-            {
-                return;
-            }
-
-            if (_queryOptions == null)
-            {
-                _queryOptions = new QueryOptions();
-            }
-
-            _queryOptions = _queryOptions.WithOptimizerVersion(optimizerVersion);
-        }
 
         /// <summary>
         /// Query options to use throughout the lifetime of the connection when
@@ -138,10 +119,7 @@ namespace Google.Cloud.Spanner.Data
         public QueryOptions QueryOptions
         {
             get => _queryOptions;
-            set {
-                _queryOptions = (QueryOptions) value;
-                ApplyQueryOptionsFromEnvironment();
-            }
+            set => _queryOptions = (QueryOptions) value;
         }
 
         /// <summary>
@@ -447,7 +425,7 @@ namespace Google.Cloud.Spanner.Data
             string databaseTable,
             SpannerParameterCollection primaryKeys = null) => new SpannerCommand(
             SpannerCommandTextBuilder.CreateDeleteTextBuilder(databaseTable), this, null,
-            primaryKeys) { QueryOptions = QueryOptions };
+            primaryKeys);
 
         /// <summary>
         /// Creates a new <see cref="SpannerCommand" /> to insert rows into a Spanner database table.
@@ -464,7 +442,7 @@ namespace Google.Cloud.Spanner.Data
             string databaseTable,
             SpannerParameterCollection insertedColumns = null) => new SpannerCommand(
             SpannerCommandTextBuilder.CreateInsertTextBuilder(databaseTable), this, null,
-            insertedColumns) { QueryOptions = QueryOptions };
+            insertedColumns);
 
         /// <summary>
         /// Creates a new <see cref="SpannerCommand" /> to insert or update rows into a Spanner database table.
@@ -481,7 +459,7 @@ namespace Google.Cloud.Spanner.Data
             string databaseTable,
             SpannerParameterCollection insertUpdateColumns = null) => new SpannerCommand(
             SpannerCommandTextBuilder.CreateInsertOrUpdateTextBuilder(databaseTable), this,
-            null, insertUpdateColumns) { QueryOptions = QueryOptions };
+            null, insertUpdateColumns);
 
         /// <summary>
         /// Creates a new <see cref="SpannerCommand" /> to select rows using a SQL query statement.
@@ -497,7 +475,7 @@ namespace Google.Cloud.Spanner.Data
         /// </param>
         /// <returns>A configured <see cref="SpannerCommand" /></returns>
         public SpannerCommand CreateSelectCommand(string sqlQueryStatement, SpannerParameterCollection selectParameters = null) =>
-            new SpannerCommand(SpannerCommandTextBuilder.CreateSelectTextBuilder(sqlQueryStatement), this, null, selectParameters) { QueryOptions = QueryOptions };
+            new SpannerCommand(SpannerCommandTextBuilder.CreateSelectTextBuilder(sqlQueryStatement), this, null, selectParameters);
 
         /// <summary>
         /// Creates a new <see cref="SpannerCommand" /> from a <see cref="CommandPartition"/>.
@@ -510,7 +488,7 @@ namespace Google.Cloud.Spanner.Data
         /// creating the <see cref="CommandPartition"/>.  See <see cref="SpannerConnection.BeginReadOnlyTransaction(TransactionId)"/>.</param>
         /// <returns>A configured <see cref="SpannerCommand" /></returns>
         public SpannerCommand CreateCommandWithPartition(CommandPartition partition, SpannerTransaction transaction) =>
-            new SpannerCommand(this, transaction, partition) { QueryOptions = QueryOptions };
+            new SpannerCommand(this, transaction, partition);
 
         /// <summary>
         /// Creates a new <see cref="SpannerCommand" /> to update rows in a Spanner database table.
@@ -525,7 +503,7 @@ namespace Google.Cloud.Spanner.Data
         /// </param>
         /// <returns>A configured <see cref="SpannerCommand" /></returns>
         public SpannerCommand CreateUpdateCommand(string databaseTable, SpannerParameterCollection updateColumns = null) =>
-            new SpannerCommand(SpannerCommandTextBuilder.CreateUpdateTextBuilder(databaseTable), this, null, updateColumns) { QueryOptions = QueryOptions };
+            new SpannerCommand(SpannerCommandTextBuilder.CreateUpdateTextBuilder(databaseTable), this, null, updateColumns);
 
         /// <summary>
         /// Creates a new <see cref="SpannerCommand" /> to execute a DDL (CREATE/DROP TABLE, etc) statement.
@@ -537,7 +515,7 @@ namespace Google.Cloud.Spanner.Data
         /// <returns>A configured <see cref="SpannerCommand" /></returns>
         public SpannerCommand CreateDdlCommand(
             string ddlStatement, params string[] extraDdlStatements) =>
-            new SpannerCommand(SpannerCommandTextBuilder.CreateDdlTextBuilder(ddlStatement, extraDdlStatements), this) { QueryOptions = QueryOptions };
+            new SpannerCommand(SpannerCommandTextBuilder.CreateDdlTextBuilder(ddlStatement, extraDdlStatements), this);
 
         /// <summary>
         /// Creates a new <see cref="SpannerCommand" /> to execute a general DML (UPDATE, INSERT, DELETE) statement.
@@ -555,7 +533,7 @@ namespace Google.Cloud.Spanner.Data
         /// </param>
         /// <returns>A configured <see cref="SpannerCommand" /></returns>
         public SpannerCommand CreateDmlCommand(string dmlStatement, SpannerParameterCollection dmlParameters = null) =>
-            new SpannerCommand(SpannerCommandTextBuilder.CreateDmlTextBuilder(dmlStatement), this, null, dmlParameters) { QueryOptions = QueryOptions };
+            new SpannerCommand(SpannerCommandTextBuilder.CreateDmlTextBuilder(dmlStatement), this, null, dmlParameters);
 
         /// <summary>
         /// Creates a new <see cref="SpannerBatchCommand"/> to execute batched DML statements with this connection, without using a transaction.


### PR DESCRIPTION
Adds the ability to set `QueryOptions` when running Cloud Spanner queries.
For now, only setting the `query_optimizer_version` is added.

`QueryOptions` can be configured through the following mechanisms.
1. At the `SpannerConnection` level.
2. Through the `SPANNER_OPTIMIZER_VERSION` environment variable.
3. At a query level.

If the options are configured through multiple mechanisms then:
1. Options set at an environment variable level will override options
configured at the `SpannerConnection` level.
2. Options set at a query-level will override options set at either the
`SpannerConnection` or environment variable level.

If no options are set, the optimizer version will default to:
1. The optimizer version the database is pinned to.
2. If the database is not pinned to a specific version, then the Cloud Spanner
backend will use the "latest" version.