### PR TITLE
[Diagnostics] GoogleExceptionLogger accepts null HttpContext.

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/ErrorReporting/GoogleExceptionLoggerTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/ErrorReporting/GoogleExceptionLoggerTest.cs
@@ -50,6 +50,18 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Tests
         }
 
         [Fact]
+        public void Log_NoContext_NoAccessorContext()
+        {
+            var mockAccessor = new Mock<IHttpContextAccessor>();
+            mockAccessor.Setup(a => a.HttpContext).Returns<DefaultHttpContext>(null);
+            var mockContextLogger = new Mock<IContextExceptionLogger>();
+            var logger = new GoogleExceptionLogger(mockContextLogger.Object, mockAccessor.Object);
+
+            logger.Log(_exception);
+            mockContextLogger.Verify(lb => lb.Log(_exception, It.IsAny<HttpContextWrapper>()));
+        }
+
+        [Fact]
         public async Task LogAsync()
         {
             var mockAccessor = new Mock<IHttpContextAccessor>();

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/ErrorReporting/HttpContextWrapperTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/ErrorReporting/HttpContextWrapperTest.cs
@@ -50,5 +50,14 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Tests
             Assert.Equal("http://google.com", wrapper.GetUri());
             Assert.Equal("", wrapper.GetUserAgent());
         }
+
+        [Fact]
+        public void NoContextToWrap()
+        {
+            var wrapper = new HttpContextWrapper(null);
+            Assert.Null(wrapper.GetHttpMethod());
+            Assert.Null(wrapper.GetUri());
+            Assert.Null(wrapper.GetUserAgent());
+        }
     }
 }

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/ErrorReporting/HttpContextWrapper.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/ErrorReporting/HttpContextWrapper.cs
@@ -28,16 +28,16 @@ namespace Google.Cloud.Diagnostics.AspNetCore
 
         internal HttpContextWrapper(HttpContext context)
         {
-            _context = GaxPreconditions.CheckNotNull(context, nameof(context));
+            _context = context;
         }
 
         /// <inheritdoc />
-        public string GetHttpMethod() => _context.Request?.Method?.ToString();
+        public string GetHttpMethod() => _context?.Request?.Method?.ToString();
 
         /// <inheritdoc />
-        public string GetUri() => _context.Request?.GetDisplayUrl();
+        public string GetUri() => _context?.Request?.GetDisplayUrl();
 
         /// <inheritdoc />
-        public string GetUserAgent() => _context.Request?.Headers["User-Agent"].ToString();
+        public string GetUserAgent() => _context?.Request?.Headers["User-Agent"].ToString();
     }
 }


### PR DESCRIPTION
Fixes #4441 