### PR TITLE
Fix code coverage

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -144,7 +144,7 @@ then
     if [[ "$runcoverage" = true && -f "$testdir/coverage.xml" ]]
     then
       echo "(Running with coverage)"
-      (cd "$testdir"; $DOTCOVER cover "coverage.xml" -ReturnTargetExitCode)
+      (cd "$testdir"; $DOTCOVER cover "coverage.xml" --ReturnTargetExitCode)
     else
       dotnet test -nologo -c Release --no-build $testproject
     fi

--- a/createcoveragereport.sh
+++ b/createcoveragereport.sh
@@ -8,7 +8,9 @@ then
  mkdir coverage
 fi
 
-if ! compgen -G "coverage/*.dvcr"
+rm -f coverage/all.dvcr
+
+if ! compgen -G "coverage/*.dvcr" > /dev/null
 then
   echo "No coverage reports found to merge."
   # This isn't an error
@@ -43,13 +45,11 @@ while (( "$#" )); do
   shift
 done
 
-rm -f coverage/all.dvcr
-
 echo "Merging reports..."
-$DOTCOVER merge -Source=$(echo coverage/*.dvcr | sed 's/ /;/g') -Output=coverage/all.dvcr ""
+$DOTCOVER merge --Source="$(echo coverage/*.dvcr | sed 's/ /;/g')" --Output=coverage/all.dvcr ""
 
 echo "Generating detailed xml report..."
-$DOTCOVER report -Source=coverage/all.dvcr -Output=coverage/coverage.xml -ReportType=DetailedXML ""
+$DOTCOVER report --Source=coverage/all.dvcr --Output=coverage/coverage.xml --ReportType=DetailedXML ""
 
 # We assume the tools solution has already been restored as part of the build
 echo "Filtering xml report..."


### PR DESCRIPTION
- Remove unnecessary output when checking for coverage files
- dotCover now uses -- instead of - for options