### PR TITLE
Release Google.Cloud.Tasks.V2 version 2.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.csproj
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta01</Version>
+    <Version>2.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/apis/Google.Cloud.Tasks.V2/docs/history.md
+++ b/apis/Google.Cloud.Tasks.V2/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 2.0.0-beta02, released 2020-03-11
+
+- [Commit 8d040c3](https://github.com/googleapis/google-cloud-dotnet/commit/8d040c3): Adds StackdriverLoggingConfig and Queue.StackdriverLoggingConfig
+
 # Version 2.0.0-beta01, released 2020-02-19
 
 This is the first prerelease targeting GAX v3. Please see the [breaking changes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1134,7 +1134,7 @@
     "protoPath": "google/cloud/tasks/v2",
     "productName": "Google Cloud Tasks",
     "productUrl": "https://cloud.google.com/tasks/",
-    "version": "2.0.0-beta01",
+    "version": "2.0.0-beta02",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Tasks API (v2), which manages the execution of large numbers of distributed requests.",
     "tags": [


### PR DESCRIPTION
Changes in this release:

- [Commit 8d040c3](https://github.com/googleapis/google-cloud-dotnet/commit/8d040c3): Adds StackdriverLoggingConfig and Queue.StackdriverLoggingConfig