### PR TITLE
Make the analyzers reference a versioned one

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/coverage.xml
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/coverage.xml
@@ -10,9 +10,6 @@
       <FilterEntry>
         <ModuleMask>Google.Cloud.Diagnostics.Common</ModuleMask>
       </FilterEntry>
-      <FilterEntry>
-        <ModuleMask>Google.Cloud.Diagnostics.AspNetCore.Analyzers</ModuleMask>
-      </FilterEntry>
     </IncludeFilters>
   </Filters>
   <AttributeFilters>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/coverage.xml
@@ -10,9 +10,6 @@
       <FilterEntry>
         <ModuleMask>Google.Cloud.Diagnostics.Common</ModuleMask>
       </FilterEntry>
-      <FilterEntry>
-        <ModuleMask>Google.Cloud.Diagnostics.AspNetCore.Analyzers</ModuleMask>
-      </FilterEntry>
     </IncludeFilters>
   </Filters>
   <AttributeFilters>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/coverage.xml
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/coverage.xml
@@ -10,9 +10,6 @@
       <FilterEntry>
         <ModuleMask>Google.Cloud.Diagnostics.Common</ModuleMask>
       </FilterEntry>
-      <FilterEntry>
-        <ModuleMask>Google.Cloud.Diagnostics.AspNetCore.Analyzers</ModuleMask>
-      </FilterEntry>
     </IncludeFilters>
   </Filters>
   <AttributeFilters>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <ProjectReference Include="..\..\Google.Cloud.Diagnostics.AspNetCore.Analyzers\Google.Cloud.Diagnostics.AspNetCore.Analyzers\Google.Cloud.Diagnostics.AspNetCore.Analyzers.csproj" />
+    <PackageReference Include="Google.Cloud.Diagnostics.AspNetCore.Analyzers" Version="2.0.0-beta01" />
     <ProjectReference Include="..\..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.csproj" />
     <PackageReference Include="Grpc.Core" Version="2.27.0" PrivateAssets="None" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.1.1" />

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -300,7 +300,7 @@
     ],
     "dependencies": {
       "Google.Cloud.Diagnostics.Common": "project",
-      "Google.Cloud.Diagnostics.AspNetCore.Analyzers": "project",
+      "Google.Cloud.Diagnostics.AspNetCore.Analyzers": "2.0.0-beta01",
       "Grpc.Core": "default",
       "Microsoft.AspNetCore.Hosting.Abstractions": "2.1.1",
       "Microsoft.AspNetCore.Http": "2.1.1",


### PR DESCRIPTION
(Without this change - or bumping the analyzers version - we can't release the AspNetCore package.)

Apologies for missing this before.