### PR TITLE
Prototype of how we might configure emulators in Spanner.

### DIFF
--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/DatabaseAdminClient.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/DatabaseAdminClient.g.cs
@@ -404,8 +404,18 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public DatabaseAdminSettings Settings { get; set; }
 
+        partial void PartialBuild(ref DatabaseAdminClient client);
+        partial void PartialBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<DatabaseAdminClient> task);
+
         /// <inheritdoc/>
         public override DatabaseAdminClient Build()
+        {
+            DatabaseAdminClient client = null;
+            PartialBuild(ref client);
+            return client ?? BuildImpl();
+        }
+
+        private DatabaseAdminClient BuildImpl()
         {
             Validate();
             grpccore::CallInvoker callInvoker = CreateCallInvoker();
@@ -413,7 +423,14 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         }
 
         /// <inheritdoc/>
-        public override async stt::Task<DatabaseAdminClient> BuildAsync(st::CancellationToken cancellationToken = default)
+        public override stt::Task<DatabaseAdminClient> BuildAsync(st::CancellationToken cancellationToken = default)
+        {
+            stt::Task<DatabaseAdminClient> task = null;
+            PartialBuildAsync(cancellationToken, ref task);
+            return task ?? BuildAsyncImpl(cancellationToken);
+        }
+
+        private async stt::Task<DatabaseAdminClient> BuildAsyncImpl(st::CancellationToken cancellationToken)
         {
             Validate();
             grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/DatabaseAdminClientBuilder.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/DatabaseAdminClientBuilder.cs
@@ -1,0 +1,57 @@
+﻿// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Cloud.Spanner.Admin.Database.V1
+{
+    // Partial class to support emulators
+    partial class DatabaseAdminClientBuilder
+    {
+        /// <summary>
+        /// Specifies how the builder responds to the presence of emulator environment variables.
+        /// </summary>
+        /// <remarks>
+        /// This property defaults to <see cref="EmulatorDetection.None"/>, meaning that environment variables are
+        /// ignored.
+        /// </remarks>
+        public new EmulatorDetection EmulatorDetection
+        {
+            get => base.EmulatorDetection;
+            set => base.EmulatorDetection = value;
+        }
+
+        private const string s_emulatorHostEnvironmentVariable = "SPANNER_EMULATOR_HOST";
+        private static readonly string[] s_emulatorEnvironmentVariables = { s_emulatorHostEnvironmentVariable };
+
+        partial void PartialBuild(ref DatabaseAdminClient client) => client = MaybeCreateEmulatorClientBuilder()?.Build();
+
+        partial void PartialBuildAsync(CancellationToken cancellationToken, ref Task<DatabaseAdminClient> task) =>
+            task = MaybeCreateEmulatorClientBuilder()?.BuildAsync(cancellationToken);
+
+        private DatabaseAdminClientBuilder MaybeCreateEmulatorClientBuilder()
+        {
+            var emulatorEnvironment = GetEmulatorEnvironment(s_emulatorEnvironmentVariables, s_emulatorEnvironmentVariables);
+            return emulatorEnvironment is null ? null :
+                new DatabaseAdminClientBuilder
+                {
+                    Settings = Settings,
+                    Endpoint = emulatorEnvironment[s_emulatorHostEnvironmentVariable],
+                    ChannelCredentials = Grpc.Core.ChannelCredentials.Insecure
+                };
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.csproj
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="3.0.0-beta01" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="3.0.0-beta03" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="2.0.0-beta01" />
     <ProjectReference Include="..\..\Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1.csproj" />
     <PackageReference Include="Google.LongRunning" Version="2.0.0-beta01" />

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -974,6 +974,7 @@
       "Spanner"
     ],
     "dependencies": {
+      "Google.Api.Gax.Grpc.GrpcCore": "3.0.0-beta03",
       "Google.LongRunning": "2.0.0-beta01",
       "Google.Cloud.Iam.V1": "2.0.0-beta01",
       "Google.Cloud.Spanner.Common.V1": "project"


### PR DESCRIPTION
Note:

- This requires a generator change in order to allow partial classes to intercept Build/BuildAsync methods
- I looked into putting common code into the common project, but the fact that every builder type has a different Settings property makes it very tricky