### PR TITLE
[BigQuery] Removes SafeTotalRows from BigQueryResults.

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/QueryTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/QueryTest.cs
@@ -668,7 +668,7 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
                 $"INSERT INTO {table} (player, gameStarted, score) VALUES (@player, @gameStarted, @score)",
                 parameters)
                 .ThrowOnAnyError();
-            Assert.Null(results.SafeTotalRows);
+            Assert.Null(results.TotalRows);
             Assert.Equal(1, results.NumDmlAffectedRows);
 
             // This used to query the whole table; now it returns empty results (as we're using GetQueryResults rather than ListRows).
@@ -683,8 +683,8 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             string sql = "DECLARE accumulator INT64 DEFAULT 5; SELECT accumulator;";
             var results = client.ExecuteQuery(sql, null).ThrowOnAnyError();
 
-            Assert.True(results.SafeTotalRows.HasValue);
-            Assert.Equal<ulong>(1, results.SafeTotalRows.Value);
+            Assert.True(results.TotalRows.HasValue);
+            Assert.Equal<ulong>(1, results.TotalRows.Value);
 
             var row = results.Single();
             Assert.Equal((long)5, row[0]);

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryResults.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryResults.cs
@@ -15,7 +15,6 @@
 using Google.Api.Gax;
 using Google.Apis.Bigquery.v2.Data;
 using Google.Apis.Requests;
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -51,21 +50,9 @@ namespace Google.Cloud.BigQuery.V2
         public TableReference TableReference { get; }
 
         /// <summary>
-        /// The total number of rows in the results.
-        /// </summary>
-        /// <remarks>
-        /// In certain cases, the query results do not provide a row count. In these cases, accessing this property
-        /// will throw an <see cref="InvalidOperationException"/>. The <see cref="SafeTotalRows"/> property provides
-        /// a way of accessing the same value, but with a nullable value which will be null if the query results do not
-        /// provide a row count.
-        /// </remarks>
-        /// <exception cref="InvalidOperationException">The query results do not provide a row count.</exception>
-        public ulong TotalRows => _response.TotalRows.Value;
-
-        /// <summary>
         /// The total number of rows in the results, or <c>null</c> if the query results do not provide a row count.
         /// </summary>
-        public ulong? SafeTotalRows => _response.TotalRows;
+        public ulong? TotalRows => _response.TotalRows;
 
         /// <summary>
         /// The total number of rows affected by a DML statement, or <c>null</c> for non-DML results.


### PR DESCRIPTION
  * TotalRows is now ulong? instead of ulong.
  * SafeTotalRows has been removed.