### PR TITLE
Release Google.Cloud.VideoIntelligence.V1 version 2.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1.csproj
+++ b/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta01</Version>
+    <Version>2.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/apis/Google.Cloud.VideoIntelligence.V1/docs/history.md
+++ b/apis/Google.Cloud.VideoIntelligence.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+# Version 2.0.0-beta02, released 2020-03-12
+
+- [Commit 1d8b26a](https://github.com/googleapis/google-cloud-dotnet/commit/1d8b26a): Generator change to allow interception of builder methods
+- [Commit 9982d04](https://github.com/googleapis/google-cloud-dotnet/commit/9982d04): Feature: Logo recognition
+- [Commit ba6f275](https://github.com/googleapis/google-cloud-dotnet/commit/ba6f275): Documentation: Links in comments are now full URLs
+
 # Version 2.0.0-beta01, released 2020-02-19
 
 This is the first prerelease targeting GAX v3. Please see the [breaking changes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1258,7 +1258,7 @@
     "protoPath": "google/cloud/videointelligence/v1",
     "productName": "Google Cloud Video Intelligence",
     "productUrl": "https://cloud.google.com/video-intelligence",
-    "version": "2.0.0-beta01",
+    "version": "2.0.0-beta02",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Video Intelligence API.",
     "tags": [


### PR DESCRIPTION
Changes in this release:

- [Commit 1d8b26a](https://github.com/googleapis/google-cloud-dotnet/commit/1d8b26a): Generator change to allow interception of builder methods
- [Commit 9982d04](https://github.com/googleapis/google-cloud-dotnet/commit/9982d04): Feature: Logo recognition
- [Commit ba6f275](https://github.com/googleapis/google-cloud-dotnet/commit/ba6f275): Documentation: Links in comments are now full URLs