### PR TITLE
Release Google.LongRunning version 2.0.0

### DIFF
--- a/apis/Google.LongRunning/Google.LongRunning/Google.LongRunning.csproj
+++ b/apis/Google.LongRunning/Google.LongRunning/Google.LongRunning.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta01</Version>
+    <Version>2.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/apis/Google.LongRunning/docs/history.md
+++ b/apis/Google.LongRunning/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+# Version 2.0.0, released 2020-03-16
+
+No API surface changes compared with 2.0.0-beta01, just dependencies
+and implementation changes.
+
 # Version 2.0.0-beta01, released 2020-02-17
 
 This is the first prerelease targeting GAX v3. Please see the [breaking changes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1330,13 +1330,16 @@
     "id": "Google.LongRunning",
     "generator": "micro",
     "protoPath": "google/longrunning",
-    "version": "2.0.0-beta01",
+    "version": "2.0.0",
     "type": "grpc",
     "description": "gRPC services for the Google Long Running Operations API. This library is typically used as a dependency for other API client libraries.",
     "tags": [
       "LongRunning"
     ],
-    "dependencies": {},
+    "dependencies": {
+      "Google.Api.Gax.Grpc.GrpcCore": "3.0.0",
+      "Grpc.Core": "2.27.0"
+    },
     "testDependencies": {
       "Google.Api.Gax.Testing": "3.0.0"
     }


### PR DESCRIPTION
Changes in this release:

No API surface changes compared with 2.0.0-beta01, just dependencies
and implementation changes.