### PR TITLE
Release Bigtable packages version 2.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.csproj
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta01</Version>
+    <Version>2.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/apis/Google.Cloud.Bigtable.Admin.V2/docs/history.md
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+# Version 2.0.0-beta02, released 2020-03-17
+
+No API surface changes compared with 2.0.0-beta01, just dependency
+and implementation changes.
+
 # Version 2.0.0-beta01, released 2020-02-17
 
 This is the first prerelease targeting GAX v3. Please see the [breaking changes

--- a/apis/Google.Cloud.Bigtable.Common.V2/Google.Cloud.Bigtable.Common.V2/Google.Cloud.Bigtable.Common.V2.csproj
+++ b/apis/Google.Cloud.Bigtable.Common.V2/Google.Cloud.Bigtable.Common.V2/Google.Cloud.Bigtable.Common.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta01</Version>
+    <Version>2.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/apis/Google.Cloud.Bigtable.Common.V2/docs/history.md
+++ b/apis/Google.Cloud.Bigtable.Common.V2/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+# Version 2.0.0-beta02, released 2020-03-17
+
+No API surface changes compared with 2.0.0-beta01, just dependency
+and implementation changes.
+
 # Version 2.0.0-beta01, released 2020-02-17
 
 This is the first prerelease targeting GAX v3. Please see the [breaking changes

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta01</Version>
+    <Version>2.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/apis/Google.Cloud.Bigtable.V2/docs/history.md
+++ b/apis/Google.Cloud.Bigtable.V2/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+# Version 2.0.0-beta02, released 2020-03-17
+
+No API surface changes compared with 2.0.0-beta01, just dependency
+and implementation changes.
+
 # Version 2.0.0-beta01, released 2020-02-17
 
 This is the first prerelease targeting GAX v3. Please see the [breaking changes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -97,7 +97,7 @@
     "protoPath": "google/bigtable/admin/v2",
     "productName": "Google Cloud Bigtable Administration",
     "productUrl": "https://cloud.google.com/bigtable/",
-    "version": "2.0.0-beta01",
+    "version": "2.0.0-beta02",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Bigtable Instance and Table Admin APIs.",
     "tags": [
@@ -118,7 +118,7 @@
     "id": "Google.Cloud.Bigtable.Common.V2",
     "type": "other",
     "targetFrameworks": "netstandard2.0;net461",
-    "version": "2.0.0-beta01",
+    "version": "2.0.0-beta02",
     "description": "Common code used by Bigtable V2 APIs",
     "tags": [
       "Bigtable"
@@ -134,7 +134,7 @@
     "protoPath": "google/bigtable/v2",
     "productName": "Google Bigtable",
     "productUrl": "https://cloud.google.com/bigtable/",
-    "version": "2.0.0-beta01",
+    "version": "2.0.0-beta02",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Bigtable API.",
     "tags": [


### PR DESCRIPTION
No API surface changes compared with 2.0.0-beta01, just dependency
and implementation changes.