### PR TITLE
Release Google.Cloud.DevTools.Common version 2.0.0

### DIFF
--- a/apis/Google.Cloud.DevTools.Common/Google.Cloud.DevTools.Common/Google.Cloud.DevTools.Common.csproj
+++ b/apis/Google.Cloud.DevTools.Common/Google.Cloud.DevTools.Common/Google.Cloud.DevTools.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta01</Version>
+    <Version>2.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/apis/Google.Cloud.DevTools.Common/docs/history.md
+++ b/apis/Google.Cloud.DevTools.Common/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+# Version 2.0.0, released 2020-03-17
+
+No API surface changes compared with 2.0.0-beta01, just dependency
+and implementation changes.
+
 # Version 2.0.0-beta01, released 2020-02-18
 
 No significant changes since 1.1.0, other than depending on a new major version of Google.Api.CommonProtos.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -249,7 +249,7 @@
   },
   {
     "id": "Google.Cloud.DevTools.Common",
-    "version": "2.0.0-beta01",
+    "version": "2.0.0",
     "type": "other",
     "targetFrameworks": "netstandard2.0;net461",
     "testTargetFrameworks": "netcoreapp2.1;net461",


### PR DESCRIPTION
Changes in this release:

No API surface changes compared with 2.0.0-beta01, just dependency
and implementation changes.