### PR TITLE
Release Google.Cloud.ErrorReporting.V1Beta1 version 2.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.csproj
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta01</Version>
+    <Version>2.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+# Version 2.0.0-beta02, released 2020-03-18
+
+No API surface changes compared with 2.0.0-beta01, just dependency
+and implementation changes.
+
 # Version 2.0.0-beta01, released 2020-02-18
 
 This is the first prerelease targeting GAX v3. Please see the [breaking changes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -413,7 +413,7 @@
     "protoPath": "google/devtools/clouderrorreporting/v1beta1",
     "productName": "Stackdriver Error Reporting",
     "productUrl": "https://cloud.google.com/error-reporting/",
-    "version": "2.0.0-beta01",
+    "version": "2.0.0-beta02",
     "releaseLevelOverride": "beta",
     "type": "grpc",
     "description": "Recommended Google client library to access the Stackdriver Error Reporting API, which groups and counts similar errors from cloud services. The Stackdriver Error Reporting API provides a way to report new errors and read access to error groups and their associated errors.",


### PR DESCRIPTION
Changes in this release:

No API surface changes compared with 2.0.0-beta01, just dependency
and implementation changes.