### PR TITLE
Release Google.Cloud.Logging.Type version 3.0.0

### DIFF
--- a/apis/Google.Cloud.Logging.Type/Google.Cloud.Logging.Type/Google.Cloud.Logging.Type.csproj
+++ b/apis/Google.Cloud.Logging.Type/Google.Cloud.Logging.Type/Google.Cloud.Logging.Type.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0-beta01</Version>
+    <Version>3.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/apis/Google.Cloud.Logging.Type/docs/history.md
+++ b/apis/Google.Cloud.Logging.Type/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+# Version 3.0.0, released 2020-03-18
+
+No API surface changes compared with 3.0.0-beta01, just dependency
+and implementation changes.
+
 # Version 3.0.0-beta01, released 2020-02-18
 
 No significant changes since 2.1.0, other than depending on a new major version of Google.Api.CommonProtos.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -616,7 +616,7 @@
     "id": "Google.Cloud.Logging.Type",
     "generator": "proto",
     "protoPath": "google/logging/type",
-    "version": "3.0.0-beta01",
+    "version": "3.0.0",
     "type": "other",
     "targetFrameworks": "netstandard2.0;net461",
     "description": "Version-agnostic types for the Google Stackdriver Logging API.",


### PR DESCRIPTION
Changes in this release:

No API surface changes compared with 3.0.0-beta01, just dependency
and implementation changes.