### PR TITLE
Release Google.Cloud.Logging.V2 version 3.0.0

### DIFF
--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.csproj
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0-beta01</Version>
+    <Version>3.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -24,7 +24,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="3.0.0" />
-    <PackageReference Include="Google.Cloud.Logging.Type" Version="3.0.0-beta01" />
+    <PackageReference Include="Google.Cloud.Logging.Type" Version="3.0.0" />
     <PackageReference Include="Grpc.Core" Version="2.27.0" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />

--- a/apis/Google.Cloud.Logging.V2/docs/history.md
+++ b/apis/Google.Cloud.Logging.V2/docs/history.md
@@ -1,5 +1,14 @@
 # Version history
 
+# Version 3.0.0, released 2020-03-18
+
+- [Commit 8727521](https://github.com/googleapis/google-cloud-dotnet/commit/8727521): Large set of changes, primarily to resource names
+
+The listed commit causes lots of breaking changes, but these were expected, and almost all are due to resource name changes.
+The logging API is primarily used from integration points, so probably doesn't affect much user code.
+
+Other changes are all just dependencies and implementation details.
+
 # Version 3.0.0-beta01, released 2020-02-18
 
 This is the first prerelease targeting GAX v3. Please see the [breaking changes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -634,7 +634,7 @@
     "protoPath": "google/logging/v2",
     "productName": "Stackdriver Logging",
     "productUrl": "https://cloud.google.com/logging/",
-    "version": "3.0.0-beta01",
+    "version": "3.0.0",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Stackdriver Logging API, which writes log entries and manages your logs, log sinks, and logs-based metrics.",
     "tags": [
@@ -643,7 +643,7 @@
     ],
     "dependencies": {
       "Google.Api.Gax.Grpc.GrpcCore": "3.0.0",
-      "Google.Cloud.Logging.Type": "3.0.0-beta01",
+      "Google.Cloud.Logging.Type": "3.0.0",
       "Grpc.Core": "2.27.0"
     }
   },


### PR DESCRIPTION
Changes in this release:

- [Commit 8727521](https://github.com/googleapis/google-cloud-dotnet/commit/8727521): Large set of changes, primarily to resource names

The listed commit causes lots of breaking changes, but these were expected, and almost all are due to resource name changes.
The logging API is primarily used from integration points, so probably doesn't affect much user code.

Other changes are all just dependencies and implementation details.
