### PR TITLE
Release Google.Cloud.Logging.Log4Net version 3.0.0

### DIFF
--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.csproj
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0-beta01</Version>
+    <Version>3.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -24,8 +24,8 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="3.0.0" />
-    <PackageReference Include="Google.Cloud.DevTools.Common" Version="2.0.0-beta01" />
-    <PackageReference Include="Google.Cloud.Logging.V2" Version="3.0.0-beta01" />
+    <PackageReference Include="Google.Cloud.DevTools.Common" Version="2.0.0" />
+    <PackageReference Include="Google.Cloud.Logging.V2" Version="3.0.0" />
     <PackageReference Include="Grpc.Core" Version="2.27.0" PrivateAssets="None" />
     <PackageReference Include="log4net" Version="2.0.8" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.Logging.Log4Net/docs/history.md
+++ b/apis/Google.Cloud.Logging.Log4Net/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+# Version 3.0.0, released 2020-03-18
+
+No API surface changes compared with 3.0.0-beta01, just dependency
+and implementation changes.
+
 # Version 3.0.0-beta01, released 2020-02-18
 
 This is the first prerelease targeting GAX v3. Please see the [breaking changes guide](https://googleapis.github.io/google-cloud-dotnet/docs/guides/breaking-gax2.html) for details of changes to both GAX and code generation.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -568,7 +568,7 @@
   },
   {
     "id": "Google.Cloud.Logging.Log4Net",
-    "version": "3.0.0-beta01",
+    "version": "3.0.0",
     "type": "other",
     "targetFrameworks": "netstandard2.0;net461",
     "testTargetFrameworks": "netcoreapp2.1;net461",
@@ -581,8 +581,8 @@
     "dependencies": {
       "log4net": "2.0.8",
       "Google.Api.Gax.Grpc.GrpcCore": "3.0.0",
-      "Google.Cloud.Logging.V2": "3.0.0-beta01",
-      "Google.Cloud.DevTools.Common": "2.0.0-beta01",
+      "Google.Cloud.Logging.V2": "3.0.0",
+      "Google.Cloud.DevTools.Common": "2.0.0",
       "Grpc.Core": "2.27.0"
     },
     "testDependencies": {


### PR DESCRIPTION
Changes in this release:

No API surface changes compared with 3.0.0-beta01, just dependency
and implementation changes.