### PR TITLE
Release Google.Cloud.Logging.NLog version 3.0.0

### DIFF
--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.csproj
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0-beta02</Version>
+    <Version>3.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -24,8 +24,8 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="3.0.0" />
-    <PackageReference Include="Google.Cloud.DevTools.Common" Version="2.0.0-beta01" />
-    <PackageReference Include="Google.Cloud.Logging.V2" Version="3.0.0-beta01" />
+    <PackageReference Include="Google.Cloud.DevTools.Common" Version="2.0.0" />
+    <PackageReference Include="Google.Cloud.Logging.V2" Version="3.0.0" />
     <PackageReference Include="Grpc.Core" Version="2.27.0" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />

--- a/apis/Google.Cloud.Logging.NLog/docs/history.md
+++ b/apis/Google.Cloud.Logging.NLog/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+# Version 3.0.0, released 2020-03-18
+
+No API surface changes compared with 3.0.0-beta02, just dependency
+changes.
+
 # Version 3.0.0-beta02, released 2020-03-10
 
 - [Commit 528388f](https://github.com/googleapis/google-cloud-dotnet/commit/528388f): Configured Project ID takes precedence over Project ID of project in which the code is running for using as log writing target.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -591,7 +591,7 @@
   },
   {
     "id": "Google.Cloud.Logging.NLog",
-    "version": "3.0.0-beta02",
+    "version": "3.0.0",
     "type": "other",
     "targetFrameworks": "netstandard2.0;net461",
     "testTargetFrameworks": "netcoreapp2.1;net461",
@@ -604,8 +604,8 @@
     "dependencies": {
       "NLog": "4.5.11",
       "Google.Api.Gax.Grpc.GrpcCore": "3.0.0",
-      "Google.Cloud.Logging.V2": "3.0.0-beta01",
-      "Google.Cloud.DevTools.Common": "2.0.0-beta01",
+      "Google.Cloud.Logging.V2": "3.0.0",
+      "Google.Cloud.DevTools.Common": "2.0.0",
       "Grpc.Core": "2.27.0"
     },
     "testDependencies": {


### PR DESCRIPTION
Changes in this release:

No API surface changes compared with 3.0.0-beta02, just dependency
changes.