### PR TITLE
Release Google.Cloud.BigQuery.V2 version 2.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta01</Version>
+    <Version>2.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/apis/Google.Cloud.BigQuery.V2/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.V2/docs/history.md
@@ -1,5 +1,24 @@
 # Version history
 
+# Version 2.0.0-beta02, released 2020-03-18
+
+- [Commit 2b4c06f](https://github.com/googleapis/google-cloud-dotnet/commit/2b4c06f):
+  - Table creation breaking change:
+  -   * All options have been removed from Google.Cloud.BigQuery.V2.TableCreateOptions.
+  -   * Table create operations overloads added that received a Google.Apis.Bigquery.v2.Data.Table instead.
+  -   * Extension methods have been added to help in setting some Google.Apis.Bigquery.v2.Data.Table properties.
+- [Commit d951c14](https://github.com/googleapis/google-cloud-dotnet/commit/d951c14):
+  - Dataset creation breaking change:
+  -   * All options have been removed from Google.Cloud.BigQuery.V2.DatasetCreateOptions.
+  -   * Dataset create operations now received a Google.Apis.Bigquery.v2.Data.Dataset instead.
+  -   * Extension methods have been added to help in setting some Google.Apis.Bigquery.v2.Data.Dataset properties.
+- [Commit acad11b](https://github.com/googleapis/google-cloud-dotnet/commit/acad11b):
+  - BigQueryResults breaking change.
+  -   * TotalRows is now ulong? instead of ulong.
+  -   * SafeTotalRows has been removed.
+  
+In addition to the above changes, this release now targets GAX 3.0.0 (GA).
+
 # Version 2.0.0-beta01, released 2020-02-20
 
 Breaking changes:

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -61,7 +61,7 @@
     "id": "Google.Cloud.BigQuery.V2",
     "productName": "Google BigQuery",
     "productUrl": "https://cloud.google.com/bigquery/",
-    "version": "2.0.0-beta01",
+    "version": "2.0.0-beta02",
     "type": "rest",
     "description": "Recommended Google client library to access the BigQuery API. It wraps the Google.Apis.Bigquery.v2 client library, making common operations simpler in client code. BigQuery is a data platform for customers to create, manage, share and query data.",
     "dependencies": {


### PR DESCRIPTION
Changes in this release:

- [Commit 2b4c06f](https://github.com/googleapis/google-cloud-dotnet/commit/2b4c06f):
  - Table creation breaking change:
  -   * All options have been removed from Google.Cloud.BigQuery.V2.TableCreateOptions.
  -   * Table create operations overloads added that received a Google.Apis.Bigquery.v2.Data.Table instead.
  -   * Extension methods have been added to help in setting some Google.Apis.Bigquery.v2.Data.Table properties.
- [Commit d951c14](https://github.com/googleapis/google-cloud-dotnet/commit/d951c14):
  - Dataset creation breaking change:
  -   * All options have been removed from Google.Cloud.BigQuery.V2.DatasetCreateOptions.
  -   * Dataset create operations now received a Google.Apis.Bigquery.v2.Data.Dataset instead.
  -   * Extension methods have been added to help in setting some Google.Apis.Bigquery.v2.Data.Dataset properties.
- [Commit acad11b](https://github.com/googleapis/google-cloud-dotnet/commit/acad11b):
  - BigQueryResults breaking change.
  -   * TotalRows is now ulong? instead of ulong.
  -   * SafeTotalRows has been removed.

In addition to the above changes, this release now targets GAX 3.0.0 (GA).