### PR TITLE
Release Google.Cloud.Trace (V1 and V2 packages) version 2.0.0

### DIFF
--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.csproj
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta01</Version>
+    <Version>2.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/apis/Google.Cloud.Trace.V1/docs/history.md
+++ b/apis/Google.Cloud.Trace.V1/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+# Version 2.0.0, released 2020-03-18
+
+No API surface changes compared with 2.0.0-beta01, just dependency
+and implementation changes.
+
 # Version 2.0.0-beta01, released 2020-02-19
 
 This is the first prerelease targeting GAX v3. Please see the [breaking changes

--- a/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.csproj
+++ b/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta01</Version>
+    <Version>2.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/apis/Google.Cloud.Trace.V2/docs/history.md
+++ b/apis/Google.Cloud.Trace.V2/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+# Version 2.0.0, released 2020-03-18
+
+No API surface changes compared with 2.0.0-beta01, just dependency
+and implementation changes.
+
 # Version 2.0.0-beta01, released 2020-02-19
 
 This is the first prerelease targeting GAX v3. Please see the [breaking changes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1206,7 +1206,7 @@
     "protoPath": "google/devtools/cloudtrace/v1",
     "productName": "Stackdriver Trace",
     "productUrl": "https://cloud.google.com/trace/",
-    "version": "2.0.0-beta01",
+    "version": "2.0.0",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Trace API, which sends and retrieves trace data from Google Cloud Trace. Data is generated and available by default for all App Engine applications. Data from other applications can be written to Cloud Trace for display, reporting, and analysis.",
     "dependencies": {
@@ -1224,7 +1224,7 @@
     "protoPath": "google/devtools/cloudtrace/v2",
     "productName": "Stackdriver Trace",
     "productUrl": "https://cloud.google.com/trace/",
-    "version": "2.0.0-beta01",
+    "version": "2.0.0",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Trace V2 API, which sends and retrieves trace data from Google Cloud Trace. Data is generated and available by default for all App Engine applications. Data from other applications can be written to Cloud Trace for display, reporting, and analysis.",
     "dependencies": {


### PR DESCRIPTION
No API surface changes compared with 2.0.0-beta01, just dependency and implementation changes.