### PR TITLE
Release Google.Cloud.Diagnostics.AspNetCore (and Common) version 4.0.0

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.0.0-beta02</Version>
+    <Version>4.0.0</Version>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -23,7 +23,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Cloud.Diagnostics.AspNetCore.Analyzers" Version="2.0.0-beta01" />
+    <PackageReference Include="Google.Cloud.Diagnostics.AspNetCore.Analyzers" Version="2.0.0" />
     <ProjectReference Include="..\..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.csproj" />
     <PackageReference Include="Grpc.Core" Version="2.27.0" PrivateAssets="None" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.1.1" />

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/docs/history.md
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+# Version 4.0.0, released 2020-03-18
+
+No API surface changes compared with 4.0.0-beta02, just dependency
+and implementation changes.
+
 # Version 4.0.0-beta02, released 2020-03-10
 
 - [Commit 5bc0cf5](https://github.com/googleapis/google-cloud-dotnet/commit/5bc0cf5): GoogleExceptionLogger accepts null HttpContext.

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Google.Cloud.Diagnostics.Common.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Google.Cloud.Diagnostics.Common.IntegrationTests.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.csproj" />
-    <PackageReference Include="Google.Cloud.ErrorReporting.V1Beta1" Version="2.0.0-beta01" />
+    <PackageReference Include="Google.Cloud.ErrorReporting.V1Beta1" Version="2.0.0-beta02" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Google.Cloud.Diagnostics.Common.Tests.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Google.Cloud.Diagnostics.Common.Tests.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.csproj" />
-    <PackageReference Include="Google.Cloud.ErrorReporting.V1Beta1" Version="2.0.0-beta01" />
+    <PackageReference Include="Google.Cloud.ErrorReporting.V1Beta1" Version="2.0.0-beta02" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.0.0-beta02</Version>
+    <Version>4.0.0</Version>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -23,8 +23,8 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="3.0.0" />
-    <PackageReference Include="Google.Cloud.Logging.V2" Version="3.0.0-beta01" />
-    <PackageReference Include="Google.Cloud.Trace.V1" Version="2.0.0-beta01" />
+    <PackageReference Include="Google.Cloud.Logging.V2" Version="3.0.0" />
+    <PackageReference Include="Google.Cloud.Trace.V1" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -285,7 +285,7 @@
   },
   {
     "id": "Google.Cloud.Diagnostics.AspNetCore",
-    "version": "4.0.0-beta02",
+    "version": "4.0.0",
     "type": "other",
     "targetFrameworks": "netstandard2.0",
     "testTargetFrameworks": "netcoreapp2.1;net461",
@@ -300,8 +300,8 @@
     ],
     "dependencies": {
       "Google.Cloud.Diagnostics.Common": "project",
-      "Google.Cloud.Diagnostics.AspNetCore.Analyzers": "2.0.0-beta01",
-      "Grpc.Core": "default",
+      "Google.Cloud.Diagnostics.AspNetCore.Analyzers": "2.0.0",
+      "Grpc.Core": "2.27.0",
       "Microsoft.AspNetCore.Hosting.Abstractions": "2.1.1",
       "Microsoft.AspNetCore.Http": "2.1.1",
       "Microsoft.AspNetCore.Http.Extensions": "2.1.1",
@@ -310,7 +310,7 @@
     "testDependencies": {
       "Google.Cloud.Diagnostics.Common.Tests": "project",
       "Google.Cloud.Diagnostics.Common.IntegrationTests": "project",
-      "Google.Api.Gax.Testing": "default",
+      "Google.Api.Gax.Testing": "3.0.0",
       "Microsoft.AspNetCore.Mvc": "2.1.3",
       "Microsoft.AspNetCore.TestHost": "2.1.1",
       "Microsoft.Extensions.Http": "2.1.1"
@@ -339,7 +339,7 @@
   },
   {
     "id": "Google.Cloud.Diagnostics.Common",
-    "version": "4.0.0-beta02",
+    "version": "4.0.0",
     "type": "other",
     "targetFrameworks": "netstandard2.0",
     "testTargetFrameworks": "netcoreapp2.1;net461",
@@ -353,15 +353,15 @@
       "Diagnostics"
     ],
     "dependencies": {
-      "Google.Api.Gax.Grpc.GrpcCore": "default",
-      "Google.Cloud.Logging.V2": "3.0.0-beta01",
-      "Google.Cloud.Trace.V1": "2.0.0-beta01",
+      "Google.Api.Gax.Grpc.GrpcCore": "3.0.0",
+      "Google.Cloud.Logging.V2": "3.0.0",
+      "Google.Cloud.Trace.V1": "2.0.0",
       "Microsoft.AspNetCore.Http.Abstractions": "2.1.1",
       "Microsoft.Extensions.Http": "2.1.1",
       "System.Diagnostics.StackTrace": "4.3.0"
     },
     "testDependencies": {
-      "Google.Cloud.ErrorReporting.V1Beta1": "2.0.0-beta01",
+      "Google.Cloud.ErrorReporting.V1Beta1": "2.0.0-beta02",
       "Microsoft.AspNetCore.Http": "2.1.1"
     }
   },


### PR DESCRIPTION
No API surface changes compared with 4.0.0-beta02, just dependency
and implementation changes.