### PR TITLE
Release Google.Cloud.ManagedIdentities.V1 version 2.0.0

### DIFF
--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.csproj
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta01</Version>
+    <Version>2.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/apis/Google.Cloud.ManagedIdentities.V1/docs/history.md
+++ b/apis/Google.Cloud.ManagedIdentities.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+# Version 2.0.0, released 2020-03-18
+
+First GA release of this library.
+
+No API surface changes compared with 2.0.0-beta01, just dependency
+and implementation changes.
+
 # Version 2.0.0-beta01, released 2020-02-18
 
 This is the first prerelease targeting GAX v3. Please see the [breaking changes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -653,7 +653,7 @@
     "protoPath": "google/cloud/managedidentities/v1",
     "productName": "Managed Service for Microsoft Active Directory",
     "productUrl": "https://cloud.google.com/managed-microsoft-ad/",
-    "version": "2.0.0-beta01",
+    "version": "2.0.0",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Managed Identities API.",
     "tags": [


### PR DESCRIPTION
Changes in this release:

First GA release of this library.

No API surface changes compared with 2.0.0-beta01, just dependency
and implementation changes.