### PR TITLE
Release Google.Cloud.PhishingProtection.V1Beta1 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1.csproj
+++ b/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/apis/Google.Cloud.PhishingProtection.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.PhishingProtection.V1Beta1/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+# Version 1.0.0-beta02, released 2020-03-18
+
+No API surface changes compared with 1.0.0-beta01, just dependency
+and implementation changes.
+
 # Version 1.0.0-beta01, released 2020-02-19
 
 Initial beta release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -779,7 +779,7 @@
     "protoPath": "google/cloud/phishingprotection/v1beta1",
     "productName": "Cloud Phishing Protection",
     "productUrl": "https://cloud.google.com/phishing-protection/",
-    "version": "1.0.0-beta01",
+    "version": "1.0.0-beta02",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Phishing Protection API.",
     "tags": [


### PR DESCRIPTION
Changes in this release:

No API surface changes compared with 1.0.0-beta01, just dependency
and implementation changes.