### PR TITLE
Release Google.Cloud.PubSub.V1 version 2.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta01</Version>
+    <Version>2.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/apis/Google.Cloud.PubSub.V1/docs/history.md
+++ b/apis/Google.Cloud.PubSub.V1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+# Version 2.0.0-beta02, released 2020-03-18
+
+- [Commit 2096b6d](https://github.com/googleapis/google-cloud-dotnet/commit/2096b6d): Feature: Subscription.RetryPolicy
+- [Commit e4226b7](https://github.com/googleapis/google-cloud-dotnet/commit/e4226b7):
+  - Regenerate Google.Cloud.PubSub.V1 ([issue 4515](https://github.com/googleapis/google-cloud-dotnet/issues/4515))
+  - PullRequest.ReturnImmediately is now obsolete
+  - ListTopicSnapshots methods have new overloads accepting a topic name
+  - GetSnapshot methods have new overloads accepting a snapshot name
+
+Additionally, dependencies have been updated to target GAX 3.0.0.
+
 # Version 2.0.0-beta01, released 2020-02-18
 
 This is the first prerelease targeting GAX v3. Please see the [breaking changes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -793,7 +793,7 @@
     "protoPath": "google/pubsub/v1",
     "productName": "Cloud Pub/Sub",
     "productUrl": "https://cloud.google.com/pubsub/",
-    "version": "2.0.0-beta01",
+    "version": "2.0.0-beta02",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.",
     "dependencies": {


### PR DESCRIPTION
Changes in this release:

- [Commit 2096b6d](https://github.com/googleapis/google-cloud-dotnet/commit/2096b6d): Feature: Subscription.RetryPolicy
- [Commit e4226b7](https://github.com/googleapis/google-cloud-dotnet/commit/e4226b7):
  - Regenerate Google.Cloud.PubSub.V1 ([issue 4515](https://github.com/googleapis/google-cloud-dotnet/issues/4515))
  - PullRequest.ReturnImmediately is now obsolete
  - ListTopicSnapshots methods have new overloads accepting a topic name
  - GetSnapshot methods have new overloads accepting a snapshot name

Additionally, dependencies have been updated to target GAX 3.0.0.