### PR TITLE
Release Google.Cloud.SecretManager.V1 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.SecretManager.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.SecretManager.V1/.repo-metadata.json
@@ -1,5 +1,5 @@
 {
   "distribution_name": "Google.Cloud.SecretManager.V1",
-  "release_level": "beta",
+  "release_level": "ga",
   "client_documentation": "https://googleapis.dev/dotnet/Google.Cloud.SecretManager.V1/latest"
 }

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.csproj
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/apis/Google.Cloud.SecretManager.V1/docs/history.md
+++ b/apis/Google.Cloud.SecretManager.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+# Version 1.0.0, released 2020-03-19
+
+No API surface changes compared with 1.0.0-beta01, just dependency
+and implementation changes.
+
+This is the first GA release for this API.
+
 # Version 1.0.0-beta01, released 2020-02-26
 
 Initial beta release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -900,11 +900,13 @@
     "protoPath": "google/cloud/secretmanager/v1",
     "productName": "Secret Manager",
     "productUrl": "https://cloud.google.com/secret-manager",
-    "version": "1.0.0-beta01",
+    "version": "1.0.0",
     "type": "grpc",
     "description": "Recommended Google client library to access the Secret Manager API.",
     "dependencies": {
-      "Google.Cloud.Iam.V1": "2.0.0"
+      "Google.Api.Gax.Grpc.GrpcCore": "3.0.0",
+      "Google.Cloud.Iam.V1": "2.0.0",
+      "Grpc.Core": "2.27.0"
     },
     "tags": [
       "secret",


### PR DESCRIPTION
Changes in this release:

No API surface changes compared with 1.0.0-beta01, just dependency
and implementation changes.

This is the first GA release for this API.