### PR TITLE
Release Google.Cloud.SecurityCenter.V1P1Beta1 version 2.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.csproj
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta01</Version>
+    <Version>2.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/docs/history.md
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+# Version 2.0.0-beta02, released 2020-03-19
+
+- [Commit 8746b2d](https://github.com/googleapis/google-cloud-dotnet/commit/8746b2d): Amended retry configuration
+
+No API surface changes compared with 2.0.0-beta01, just dependency
+and implementation changes.
+
 # Version 2.0.0-beta01, released 2020-02-18
 
 This is the first prerelease targeting GAX v3. Please see the [breaking changes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -959,7 +959,7 @@
     "protoPath": "google/cloud/securitycenter/v1p1beta1",
     "productName": "Google Cloud Security Command Center",
     "productUrl": "https://cloud.google.com/security-command-center/",
-    "version": "2.0.0-beta01",
+    "version": "2.0.0-beta02",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Security Command Center API version v1p1beta1, which helps security teams gather data, identify threats, and act on them before they result in business damage or loss.",
     "dependencies": {


### PR DESCRIPTION
Changes in this release:

- [Commit 8746b2d](https://github.com/googleapis/google-cloud-dotnet/commit/8746b2d): Amended retry configuration

No API surface changes compared with 2.0.0-beta01, just dependency
and implementation changes.