### PR TITLE
Release Google.Cloud.Storage.V1 version 3.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0-beta01</Version>
+    <Version>3.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/apis/Google.Cloud.Storage.V1/docs/history.md
+++ b/apis/Google.Cloud.Storage.V1/docs/history.md
@@ -1,5 +1,23 @@
 # Version history
 
+# Version 3.0.0-beta02, released 2020-03-19
+
+- [Commit cdc1f03](https://github.com/googleapis/google-cloud-dotnet/commit/cdc1f03):
+  - Fixes and new features for URL signing:
+  -   * V4 is now the default signing mechanism.
+  -   * V4: collapses tabs in header's values.
+  -   * V4: uses payload hash if provided. V2 ignores payload hash if provided (as it does with almost every other header).
+  -   * V4: supports signing of custom query parameters. V2 will throw if custom query parameters are set.
+  -   * V2 and V4: supports setting URL scheme (http or htpps only).
+  -   * V2 and V4: supports Virtual-hosted style URLs.
+  -   * V4: supports bucket bound domain URLs. V2 will throw if bucket bound domain is set.
+- [Commit 71ca7e8](https://github.com/googleapis/google-cloud-dotnet/commit/71ca7e8): Removes obsolete methods.
+
+There are breaking changes around `UrlSigner`; code that still
+compiles should be fine - otherwise, use the
+`UrlSigner.RequestTemplate` and `UrlSigner.Options` classes to
+specify options that were previously in method parameters.
+
 # Version 3.0.0-beta01, released 2020-02-20
 
 Upgrade dependencies to GAX v3. Currently there are no direct

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1122,7 +1122,7 @@
     "id": "Google.Cloud.Storage.V1",
     "productName": "Google Cloud Storage",
     "productUrl": "https://cloud.google.com/storage/",
-    "version": "3.0.0-beta01",
+    "version": "3.0.0-beta02",
     "type": "rest",
     "description": "Recommended Google client library to access the Google Cloud Storage API. It wraps the Google.Apis.Storage.v1 client library, making common operations simpler in client code. Google Cloud Storage stores and retrieves potentially large, immutable data objects.",
     "dependencies": {


### PR DESCRIPTION
Changes in this release:

- [Commit cdc1f03](https://github.com/googleapis/google-cloud-dotnet/commit/cdc1f03):
  - Fixes and new features for URL signing:
  -   * V4 is now the default signing mechanism.
  -   * V4: collapses tabs in header's values.
  -   * V4: uses payload hash if provided. V2 ignores payload hash if provided (as it does with almost every other header).
  -   * V4: supports signing of custom query parameters. V2 will throw if custom query parameters are set.
  -   * V2 and V4: supports setting URL scheme (http or htpps only).
  -   * V2 and V4: supports Virtual-hosted style URLs.
  -   * V4: supports bucket bound domain URLs. V2 will throw if bucket bound domain is set.
- [Commit 71ca7e8](https://github.com/googleapis/google-cloud-dotnet/commit/71ca7e8): Removes obsolete methods.

There are breaking changes around `UrlSigner`; code that still
compiles should be fine - otherwise, use the
`UrlSigner.RequestTemplate` and `UrlSigner.Options` classes to
specify options that were previously in method parameters.