### PR TITLE
Release Google.Cloud.VideoIntelligence.V1 version 2.0.0

### DIFF
--- a/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1.csproj
+++ b/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta02</Version>
+    <Version>2.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/apis/Google.Cloud.VideoIntelligence.V1/docs/history.md
+++ b/apis/Google.Cloud.VideoIntelligence.V1/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+# Version 2.0.0, released 2020-03-19
+
+No API surface changes compared with 2.0.0-beta02, just dependency
+and implementation changes.
+
 # Version 2.0.0-beta02, released 2020-03-12
 
 - [Commit 1d8b26a](https://github.com/googleapis/google-cloud-dotnet/commit/1d8b26a): Generator change to allow interception of builder methods

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1286,7 +1286,7 @@
     "protoPath": "google/cloud/videointelligence/v1",
     "productName": "Google Cloud Video Intelligence",
     "productUrl": "https://cloud.google.com/video-intelligence",
-    "version": "2.0.0-beta02",
+    "version": "2.0.0",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Video Intelligence API.",
     "tags": [


### PR DESCRIPTION
Changes in this release:

No API surface changes compared with 2.0.0-beta02, just dependency
and implementation changes.