### PR TITLE
Release Google.Cloud.WebRisk.V1 version 1.0.0-beta01

### DIFF
--- a/apis/Google.Cloud.WebRisk.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.WebRisk.V1/.repo-metadata.json
@@ -1,0 +1,5 @@
+{
+  "distribution_name": "Google.Cloud.WebRisk.V1",
+  "release_level": "beta",
+  "client_documentation": "https://googleapis.dev/dotnet/Google.Cloud.WebRisk.V1/latest"
+}

--- a/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.csproj
+++ b/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta00</Version>
+    <Version>1.0.0-beta01</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/apis/Google.Cloud.WebRisk.V1/docs/history.md
+++ b/apis/Google.Cloud.WebRisk.V1/docs/history.md
@@ -1,0 +1,7 @@
+# Version history
+
+# Version 1.0.0-beta01, released 2020-03-19
+
+Initial beta release for V1 API.
+
+

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1322,7 +1322,7 @@
     "protoPath": "google/cloud/webrisk/v1",
     "productName": "Google Cloud Web Risk",
     "productUrl": "https://cloud.google.com/web-risk/",
-    "version": "1.0.0-beta00",
+    "version": "1.0.0-beta01",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Web Risk API v1, which lets client applications check URLs against Google's constantly updated lists of unsafe web resources.",
     "tags": [


### PR DESCRIPTION
Changes in this release:

Initial beta release for V1 API.