### PR TITLE
Release Google.Cloud.Memcache.V1Beta2 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.csproj
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/apis/Google.Cloud.Memcache.V1Beta2/docs/history.md
+++ b/apis/Google.Cloud.Memcache.V1Beta2/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+# Version 1.0.0-beta02, released 2020-03-19
+
+No API surface changes compared with 1.0.0-beta01, just dependency
+and implementation changes.
+
 # Version 1.0.0-beta01, released 2020-02-24
 
 Initial beta release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -673,7 +673,7 @@
     "protoPath": "google/cloud/memcache/v1beta2",
     "productName": "Google Cloud Memorystore for Memcache",
     "productUrl": "https://cloud.google.com/memorystore/",
-    "version": "1.0.0-beta01",
+    "version": "1.0.0-beta02",
     "type": "grpc",
     "description": "Recommended Google client library to administer Cloud Memorystore for Memcache (v1beta2).",
     "dependencies": {


### PR DESCRIPTION
Changes in this release:

No API surface changes compared with 1.0.0-beta01, just dependency
and implementation changes.