### PR TITLE
First stage of fixing existing docs

### DIFF
--- a/.kokoro/release.sh
+++ b/.kokoro/release.sh
@@ -52,7 +52,7 @@ fake_release Google.Cloud.Logging.Type 3.0.0
 fake_release Google.Cloud.Language.V1 2.0.0
 fake_release Google.Cloud.Kms.V1 2.0.0-beta03
 fake_release Google.Cloud.Firestore 2.0.0-beta02
-fake-release Google.Cloud.Firestore.V1 2.0.0-beta02
+fake_release Google.Cloud.Firestore.V1 2.0.0-beta02
 fake_release Google.Cloud.Firestore.Admin.V1 2.0.0
 fake_release Google.Cloud.ErrorReporting.V1Beta1 2.0.0-beta02
 fake_release Google.Cloud.Dialogflow.V2 2.0.0

--- a/.kokoro/release.sh
+++ b/.kokoro/release.sh
@@ -39,8 +39,41 @@ fake_release() {
   touch tmp/nuget/${API}.${VERSION}.nupkg
 }
 
-fake_release Google.Cloud.AutoML.V1 2.0.0
-fake_release Google.Cloud.BigQuery.Storage.V1 2.0.0
+fake_release Google.Cloud.OrgPolicy.V1 2.0.0-beta02
+fake_release Google.Cloud.Trace.V1 2.0.0
+fake_release Google.Cloud.Trace.V2 2.0.0
+fake_release Google.Cloud.Diagnostics.AspNetCore.Analyzers 2.0.0
+fake_release Google.Cloud.BigQuery.V2 2.0.0-beta02
+fake_release Google.Cloud.Asset.V1 2.0.0-beta02
+fake_release Google.Cloud.Logging.NLog 3.0.0
+fake_release Google.Cloud.Logging.Log4Net 3.0.0
+fake_release Google.Cloud.Logging.V2 3.0.0
+fake_release Google.Cloud.Logging.Type 3.0.0
+fake_release Google.Cloud.Language.V1 2.0.0
+fake_release Google.Cloud.Kms.V1 2.0.0-beta03
+fake_release Google.Cloud.Firestore 2.0.0-beta02
+fake-release Google.Cloud.Firestore.V1 2.0.0-beta02
+fake_release Google.Cloud.Firestore.Admin.V1 2.0.0
+fake_release Google.Cloud.ErrorReporting.V1Beta1 2.0.0-beta02
+fake_release Google.Cloud.Dialogflow.V2 2.0.0
+fake_release Google.Cloud.Spanner.Common.V1 3.0.0-beta02
+fake_release Google.Cloud.Spanner.Data 3.0.0-beta02
+fake_release Google.Cloud.Spanner.Admin.Database.V1 3.0.0-beta02
+fake_release Google.Cloud.Spanner.Admin.Instance 3.0.0-beta02
+fake_release Google.Cloud.Spanner.V1 3.0.0-beta02
+fake_release Google.Cloud.Debugger.V2 2.0.0
+fake_release Google.Cloud.DevTools.Common 2.0.0
+fake_release Google.Cloud.Datastore.V1 3.0.0
+fake_release Google.Cloud.Dataproc.V1 2.0.0
+fake_release Google.Cloud.Container.V1 2.0.0
+fake_release Google.Cloud.Billing.V1 2.0.0
+fake_release Google.Cloud.Bigtable.V2 2.0.0-beta02
+fake_release Google.Cloud.Bigtable.Admin 2.0.0-beta02
+fake_release Google.Cloud.Bigtable.Common 2.0.0-beta02
+fake_release Google.Cloud.BigQuery.DataTransfer.V1 2.0.0
+fake_release Google.Cloud.Iam.V1 2.0.0
+fake_release Google.LongRunning 2.0.0
+
 
 echo "Uploading documentation to googleapis.dev"
 ./uploaddocs.sh tmp/nuget tmp/docfx_output $DOCS_CREDENTIALS docs-staging

--- a/.kokoro/release.sh
+++ b/.kokoro/release.sh
@@ -59,7 +59,7 @@ fake_release Google.Cloud.Dialogflow.V2 2.0.0
 fake_release Google.Cloud.Spanner.Common.V1 3.0.0-beta02
 fake_release Google.Cloud.Spanner.Data 3.0.0-beta02
 fake_release Google.Cloud.Spanner.Admin.Database.V1 3.0.0-beta02
-fake_release Google.Cloud.Spanner.Admin.Instance 3.0.0-beta02
+fake_release Google.Cloud.Spanner.Admin.Instance.V1 3.0.0-beta02
 fake_release Google.Cloud.Spanner.V1 3.0.0-beta02
 fake_release Google.Cloud.Debugger.V2 2.0.0
 fake_release Google.Cloud.DevTools.Common 2.0.0

--- a/.kokoro/release.sh
+++ b/.kokoro/release.sh
@@ -68,8 +68,8 @@ fake_release Google.Cloud.Dataproc.V1 2.0.0
 fake_release Google.Cloud.Container.V1 2.0.0
 fake_release Google.Cloud.Billing.V1 2.0.0
 fake_release Google.Cloud.Bigtable.V2 2.0.0-beta02
-fake_release Google.Cloud.Bigtable.Admin 2.0.0-beta02
-fake_release Google.Cloud.Bigtable.Common 2.0.0-beta02
+fake_release Google.Cloud.Bigtable.Admin.V2 2.0.0-beta02
+fake_release Google.Cloud.Bigtable.Common.V2 2.0.0-beta02
 fake_release Google.Cloud.BigQuery.DataTransfer.V1 2.0.0
 fake_release Google.Cloud.Iam.V1 2.0.0
 fake_release Google.LongRunning 2.0.0

--- a/broken-apis.txt
+++ b/broken-apis.txt
@@ -1,0 +1,28 @@
+Google.Cloud.OrgPolicy.V1 version 2.0.0-beta02
+Google.Cloud.Trace (V1 and V2 packages) version 2.0.0
+Google.Cloud.Diagnostics.AspNetCore.Analyzers version 2.0.0
+Google.Cloud.BigQuery.V2 version 2.0.0-beta02
+Google.Cloud.Asset.V1 version 2.0.0-beta02
+Google.Cloud.Logging.NLog version 3.0.0
+Google.Cloud.Logging.Log4Net version 3.0.0
+Google.Cloud.Logging.V2 version 3.0.0
+Google.Cloud.Logging.Type version 3.0.0
+Google.Cloud.Language.V1 version 2.0.0
+Google.Cloud.Kms.V1 version 2.0.0-beta03
+Google.Cloud.Firestore and Google.Cloud.Firestore.V1 2.0.0-beta02
+Google.Cloud.Firestore.Admin.V1 version 2.0.0
+Google.Cloud.ErrorReporting.V1Beta1 version 2.0.0-beta02
+Google.Cloud.Dialogflow.V2 version 2.0.0
+Spanner libraries version 3.0.0-beta02
+Google.Cloud.Debugger.V2 version 2.0.0
+Google.Cloud.DevTools.Common version 2.0.0
+Google.Cloud.Datastore.V1 version 3.0.0
+Google.Cloud.Dataproc.V1 version 2.0.0
+Google.Cloud.Container.V1 version 2.0.0
+Google.Cloud.Billing.V1 version 2.0.0
+Bigtable packages version 2.0.0-beta02
+Google.Cloud.BigQuery.Storage.V1 version 2.0.0
+Google.Cloud.BigQuery.DataTransfer.V1 version 2.0.0
+Google.Cloud.AutoML.V1 version 2.0.0
+Google.Cloud.Iam.V1 version 2.0.0
+Google.LongRunning version 2.0.0

--- a/uploaddocs.sh
+++ b/uploaddocs.sh
@@ -22,7 +22,7 @@ do
   pair=$(basename $nupkg | sed -r 's/^(.*)\.([0-9]+\.[0-9]+\.[0-9]+(-.*)?)\.nupkg$/\1 \2/g')
   pkg=$(echo $pair | cut -d\  -f 1)
   version=$(echo $pair | cut -d\  -f 2)
-  
+
   # Currently we don't generate documentation for libraries such as
   # Google.Cloud.Spanner.V1.Common. When we've moved entirely to googleapis.dev,
   # we can change this to generate reference documentation for all packages.
@@ -49,7 +49,8 @@ do
     python -m docuploader create-metadata --name $pkg --version $version --language dotnet --github-repository googleapis/google-cloud-dotnet
     
     echo "Final upload stage"
-    python -m docuploader upload . --credentials $SERVICE_ACCOUNT_JSON --staging-bucket $STAGING_BUCKET
+    echo "(Not really doing it, but would upload $PWD)"
+    echo python -m docuploader upload . --credentials $SERVICE_ACCOUNT_JSON --staging-bucket $STAGING_BUCKET
     
     popd > /dev/null
   else

--- a/uploaddocs.sh
+++ b/uploaddocs.sh
@@ -22,7 +22,7 @@ do
   pair=$(basename $nupkg | sed -r 's/^(.*)\.([0-9]+\.[0-9]+\.[0-9]+(-.*)?)\.nupkg$/\1 \2/g')
   pkg=$(echo $pair | cut -d\  -f 1)
   version=$(echo $pair | cut -d\  -f 2)
-
+  
   # Currently we don't generate documentation for libraries such as
   # Google.Cloud.Spanner.V1.Common. When we've moved entirely to googleapis.dev,
   # we can change this to generate reference documentation for all packages.
@@ -49,8 +49,7 @@ do
     python -m docuploader create-metadata --name $pkg --version $version --language dotnet --github-repository googleapis/google-cloud-dotnet
     
     echo "Final upload stage"
-    echo "(Not really doing it, but would upload $PWD)"
-    echo python -m docuploader upload . --credentials $SERVICE_ACCOUNT_JSON --staging-bucket $STAGING_BUCKET
+    python -m docuploader upload . --credentials $SERVICE_ACCOUNT_JSON --staging-bucket $STAGING_BUCKET
     
     popd > /dev/null
   else


### PR DESCRIPTION
Plan:

- Run Kokoro with this commit. We should see output saying that it
  *would* upload docs for 2 APIs, but it's just a dry run.
- Revert the uploaddocs.sh change in another commit, so we can actually do it for
  those 2 APIs, and wait for those APIs to be published.
- Do it for the rest of the APIs.