### PR TITLE
Generate a table of APIs in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,95 +8,86 @@
 * [Homepage](https://cloud.google.com/dotnet/)
 * [API Documentation](http://googleapis.github.io/google-cloud-dotnet/docs/)
 
-# Incompatibility with gRPC 2.x and C# 8 async sequences
-
-All the GA releases currently available on NuGet depend on [GAX](https://github.com/googleapis/gax-dotnet) version 2.10 or earlier.
-
-This makes them incompatible with any gRPC 2.x (including Grpc.Core, Grpc.Core.Api, Grpc.Net.Client, Grpc.AspNetCore etc), and also incompatible with the `await foreach` feature of C# 8, due to the dependency on System.Interactive.Async version 3.2.0.
-
-We're planning on a major version bump, taking the opportunity to migrate to a new code generator at the same time. Please see the [documented plan](https://googleapis.github.io/google-cloud-dotnet/docs/major-version.html) and subscribe to the [tracking issue](https://github.com/googleapis/google-cloud-dotnet/issues/3519) for more information.
-
 # Available APIs
 
-The following libraries are available at a [GA](#versioning) quality level:
+This repository contains code for the following client libraries.
+Each package name link to the documentation for that package.
 
-* [Google Cloud Asset Inventory](https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview) - [V1 API docs](https://googleapis.dev/dotnet/Google.Cloud.Asset.V1/latest) (GA)
-  * Additionally, the following library is available for access to beta API functionality:
-  * [V1Beta1 API docs](https://googleapis.dev/dotnet/Google.Cloud.Asset.V1Beta1/latest) (beta)
-* [Google Cloud AutoML](https://cloud.google.com/automl/) - [API docs](https://googleapis.dev/dotnet/Google.AutoML.V1/latest) (GA)
-* [Google BigQuery Data Transfer](https://cloud.google.com/bigquery/transfer/) - [API docs](https://googleapis.dev/dotnet/Google.Cloud.BigQuery.DataTransfer.V1/latest) (GA)
-* [Google BigQuery](https://cloud.google.com/bigquery/) - [API docs](https://googleapis.dev/dotnet/Google.Cloud.BigQuery.V2/latest) (GA)
-* [Google Cloud Bigtable](https://cloud.google.com/bigtable/) - [API docs](https://googleapis.dev/dotnet/Google.Cloud.Bigtable.V2/latest) (GA)
-  * Also the Bigtable admin API - [API docs](https://googleapis.dev/dotnet/Google.Cloud.Bigtable.Admin.V2/latest) (GA)
-* [Billing](https://cloud.google.com/billing/docs/) - [API docs](https://googleapis.dev/dotnet/Google.Cloud.Billing.V1/latest) (GA)
-* [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/) - [API docs](https://googleapis.dev/dotnet/Google.Cloud.Container.V1/latest) (GA)
-* [Google Cloud Dataproc](https://cloud.google.com/dataproc/) - [API docs](https://googleapis.dev/dotnet/Google.Cloud.Dataproc.V1/latest) (GA)
-* [Google Cloud Datastore](https://cloud.google.com/datastore/) - [API docs](https://googleapis.dev/dotnet/Google.Cloud.Datastore.V1/latest) (GA)
-* [Google Cloud Debugger](https://cloud.google.com/debugger/) - [API docs](https://googleapis.dev/dotnet/Google.Cloud.Debugger.V2/latest) (GA)
-* [Google Cloud Container Analysis](https://cloud.google.com/container-registry/docs/container-analysis/) - [API docs](https://googleapis.dev/dotnet/Google.Cloud.DevTools.ContainerAnalysis.V1/latest) (GA)
-  * This is an implementaiton of the [Grafeas](https://grafeas.io) API - [API docs](https://googleapis.dev/dotnet/Grafeas.V1/latest) (GA)
-* Google Cloud Diagnostics for ASP.NET - [API docs](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.AspNet/latest) (GA)
-* Google Cloud Diagnostics for ASP.NET Core - [API docs](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.AspNetCore/latest) (GA)
-* [Dialogflow Enterprise Edition](https://cloud.google.com/dialogflow-enterprise/) - [API docs](https://googleapis.dev/dotnet/Google.Cloud.Dialogflow.V2/latest) (GA)
-* [Google Cloud Data Loss Prevention](https://cloud.google.com/dlp/)
-  * [V2 API docs](https://googleapis.dev/dotnet/Google.Cloud.Dlp.V2/latest) (GA)
-  * The Google.Cloud.Dlp.V2Beta1 package has now been deprecated, and is unlisted on nuget.org.
-    Please update to Google.Cloud.Dlp.V2.
-* [Google Cloud Firestore](https://cloud.google.com/firestore/): three packages are available, all GA:
-  * [Google.Cloud.Firestore](https://googleapis.dev/dotnet/Google.Cloud.Firestore/latest): High-level client library for Google Cloud Firestore (recommended)
-  * [Google.Cloud.Firestore.V1](https://googleapis.dev/dotnet/Google.Cloud.Firestore.V1/latest): Low-level access to Firestore API
-  * [Google.Cloud.Firestore.Admin.V1](https://googleapis.dev/dotnet/Google.Cloud.Firestore.Admin.V1/latest): Admin API (e.g. for index management)
-* [Google Cloud Key Management Service (KMS)](https://cloud.google.com/kms/) - [API docs](https://googleapis.dev/dotnet/Google.Cloud.Kms.V1/latest) (GA)
-* [Google Stackdriver Logging](https://cloud.google.com/logging/) - [API docs](https://googleapis.dev/dotnet/Google.Cloud.Logging.V2/latest) (GA)
-  * Integration with Log4Net is provided via [Google.Cloud.Logging.Log4Net](https://googleapis.dev/dotnet/Google.Cloud.Logging.Log4Net/latest) (GA)
-  * Integration with NLog is provided via [Google.Cloud.Logging.NLog](https://googleapis.dev/dotnet/Google.Cloud.Logging.NLog/latest) (GA)
-* [Google Cloud Natural Language](https://cloud.google.com/natural-language/) - [API docs](https://googleapis.dev/dotnet/Google.Cloud.Language.V1/latest) (GA)
-* [Stackdriver Monitoring](https://cloud.google.com/monitoring/) - [API docs](https://googleapis.dev/dotnet/Google.Cloud.Monitoring.V3/latest) (GA)
-* [Google OS Login](https://cloud.google.com/compute/docs/instances/managing-instance-access) - [API docs](https://googleapis.dev/dotnet/Google.Cloud.OsLogin.V1/latest) (GA)
-  * The [V1Beta API package](https://googleapis.dev/dotnet/Google.Cloud.OsLogin.V1Beta/latest) is also available (beta)
-* [Google Cloud Pub/Sub](https://cloud.google.com/pubsub/) - [API docs](https://googleapis.dev/dotnet/Google.Cloud.PubSub.V1/latest) (GA)
-* [Google Cloud Memorystore for Redis](https://cloud.google.com/memorystore/) - [API docs](https://googleapis.dev/dotnet/Google.Cloud.Redis.V1/latest) (GA)
-  * The [V1Beta1 API package](https://googleapis.dev/dotnet/Google.Cloud.Redis.V1Beta1/latest) is also available (beta)
-* [Recommender](https://cloud.google.com/recommender/docs/) - [API docs](https://googleapis.dev/dotnet/Google.Cloud.Recommender.V1/latest) (GA)
-* [Google Cloud Scheduler](https://cloud.google.com/scheduler/) - [API docs](https://googleapis.dev/dotnet/Google.Cloud.Scheduler.V1/latest) (GA)
-* [Google Cloud Security Command Center](https://cloud.google.com/security-command-center/) - [API docs](https://googleapis.dev/dotnet/Google.Cloud.SecurityCenter.V1/latest) (GA)
-  * The [V1P1Beta1 API package](https://googleapis.dev/dotnet/Google.Cloud.SecurityCenter.V1P1Beta1/latest) is also available (beta)
-* [Google Cloud Spanner](https://cloud.google.com/spanner/): four packages are available, all GA:
-  * [Google.Cloud.Spanner.Data](https://googleapis.dev/dotnet/Google.Cloud.Spanner.Data/latest): ADO.NET provider for Google Cloud Spanner (recommended)
-  * [Google.Cloud.Spanner.V1](https://googleapis.dev/dotnet/Google.Cloud.Spanner.V1/latest): Low-level access to Spanner API
-  * [Google.Cloud.Spanner.Admin.Database.V1](https://googleapis.dev/dotnet/Google.Cloud.Spanner.Admin.Database.V1/latest): Database administration API
-  * [Google.Cloud.Spanner.Admin.Instance.V1](https://googleapis.dev/dotnet/Google.Cloud.Spanner.Admin.Instance.V1/latest): Instance administration API
-* [Google Cloud Speech](https://cloud.google.com/speech/) - [API docs](https://googleapis.dev/dotnet/Google.Cloud.Speech.V1/latest) (GA)
-  * The [V1P1Beta1 API package](https://googleapis.dev/dotnet/Google.Cloud.Speech.V1P1Beta1/latest) is also available (beta)
-* [Google Cloud Storage](https://cloud.google.com/storage/) - [API docs](https://googleapis.dev/dotnet/Google.Cloud.Storage.V1/latest) (GA)
-* [Google Cloud Tasks](https://cloud.google.com/tasks/) -[API docs](https://googleapis.dev/dotnet/Google.Cloud.Tasks.V2/latest) (GA)
-* [Stackdriver Trace v1](https://cloud.google.com/trace/) - [API docs](https://googleapis.dev/dotnet/Google.Cloud.Trace.V1/latest) (GA)
-* [Stackdriver Trace v2](https://cloud.google.com/trace/) - [API docs](https://googleapis.dev/dotnet/Google.Cloud.Trace.V2/latest) (GA)
-* [Google Cloud Translate](https://cloud.google.com/translate/) - [API docs](https://googleapis.dev/dotnet/Google.Cloud.Translate.V3/latest) (GA)
-  * This uses the gRPC transport for access to the Translate V3 API, whereas Google.Cloud.Translation.V2 uses the HTTP/JSON transport for access to the Translate V2 API.
-* [Google Cloud Translation](https://cloud.google.com/translate/) - [API docs](https://googleapis.dev/dotnet/Google.Cloud.Translation.V2/latest) (GA)
-* [Google Cloud Text-to-Speech](https://cloud.google.com/text-to-speech/) - [API docs](https://googleapis.dev/dotnet/Google.Cloud.TextToSpeech.V1/latest) (GA)
-* [Google Cloud Video Intelligence](https://cloud.google.com/video-intelligence/) - [API docs](https://googleapis.dev/dotnet/Google.Cloud.VideoIntelligence.V1/latest) (GA)
-* [Google Cloud Vision](https://cloud.google.com/vision/) - [API docs](https://googleapis.dev/dotnet/Google.Cloud.Vision.V1/latest) (GA)
-  * Additionally, the following libraries are available for access to beta API functionality:
-    * [Google.Cloud.Vision.V1P1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Vision.V1P1Beta1/latest)
-    * [Google.Cloud.Vision.V1P2Beta1](https://googleapis.dev/dotnet/Google.Cloud.Vision.V1P2Beta1/latest)
-
-The following libraries are available at a [beta](#versioning) quality level:
-
-* [Google BigQuery Storage](https://cloud.google.com/bigquery/docs/reference/storage/) - [API docs](https://googleapis.dev/dotnet/Google.Cloud.BigQuery.Storage.V1/latest) (beta)
-* [Managed Service for Microsoft Active Directory](https://cloud.google.com/managed-microsoft-ad/) - [API docs](https://googleapis.dev/dotnet/Google.Cloud.ManagedIdentities.V1/latest) (beta)
-* [Memorystore for Memcache](https://cloud.google.com/memorystore/) - [API docs](https://googleapis.dev/dotnet/Google.Cloud.Memcache.V1Beta2/latest) (beta)
-* [Stackdriver Error Reporting](https://cloud.google.com/error-reporting/) - [API docs](https://googleapis.dev/dotnet/Google.Cloud.ErrorReporting.V1Beta1/latest) (beta)
-* [Phishing Protection](https://cloud.google.com/phishing-protection/)- [API docs](https://googleapis.dev/dotnet/Google.Cloud.PhishingProtection.V1Beta1/latest) (beta)
-* [reCAPTCHA Enterprise](https://cloud.google.com/recaptcha-enterprise/)- [API docs](https://googleapis.dev/dotnet/Google.Cloud.RecaptchaEnterprise.V1Beta1/latest) (beta)
-* [Secret Manager](https://cloud.google.com/secret-manager): Packages for both the stable API and the beta API are available; both packages are currently in beta:
-  - [V1 API docs](https://googleapis.dev/dotnet/Google.Cloud.SecretManager.V1/latest) (beta)
-  - [V1Beta1 API docs](https://googleapis.dev/dotnet/Google.Cloud.SecretManager.V1Beta1/latest) (beta)
-* [Google Cloud Web Risk](https://cloud.google.com/web-risk/) - [API docs](https://googleapis.dev/dotnet/Google.Cloud.WebRisk.V1Beta1/latest) (Beta)
-
-See the [API documentation](https://googleapis.dev/dotnet/latest) for details of the status
-of each library.
+| Package | Latest version | Description |
+|---------|----------------|-------------|
+| [Google.Cloud.Asset.V1](https://googleapis.dev/dotnet/Google.Cloud.Asset.V1/latest) | 2.0.0-beta02 | [Google Cloud Asset Inventory](https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview) |
+| [Google.Cloud.AutoML.V1](https://googleapis.dev/dotnet/Google.Cloud.AutoML.V1/latest) | 2.0.0 | [Google AutoML](https://cloud.google.com/automl/) |
+| [Google.Cloud.BigQuery.DataTransfer.V1](https://googleapis.dev/dotnet/Google.Cloud.BigQuery.DataTransfer.V1/latest) | 2.0.0 | [Google BigQuery Data Transfer](https://cloud.google.com/bigquery/transfer/) |
+| [Google.Cloud.BigQuery.V2](https://googleapis.dev/dotnet/Google.Cloud.BigQuery.V2/latest) | 2.0.0-beta02 | [Google BigQuery](https://cloud.google.com/bigquery/) |
+| [Google.Cloud.BigQuery.Storage.V1](https://googleapis.dev/dotnet/Google.Cloud.BigQuery.Storage.V1/latest) | 2.0.0 | [Google BigQuery Storage](https://cloud.google.com/bigquery/docs/reference/storage/) |
+| [Google.Cloud.Bigtable.Admin.V2](https://googleapis.dev/dotnet/Google.Cloud.Bigtable.Admin.V2/latest) | 2.0.0-beta02 | [Google Cloud Bigtable Administration](https://cloud.google.com/bigtable/) |
+| [Google.Cloud.Bigtable.Common.V2](https://googleapis.dev/dotnet/Google.Cloud.Bigtable.Common.V2/latest) | 2.0.0-beta02 | Common code used by Bigtable V2 APIs |
+| [Google.Cloud.Bigtable.V2](https://googleapis.dev/dotnet/Google.Cloud.Bigtable.V2/latest) | 2.0.0-beta02 | [Google Bigtable](https://cloud.google.com/bigtable/) |
+| [Google.Cloud.Billing.V1](https://googleapis.dev/dotnet/Google.Cloud.Billing.V1/latest) | 2.0.0 | [Google Cloud Billing API](https://cloud.google.com/billing/docs/) |
+| [Google.Cloud.Container.V1](https://googleapis.dev/dotnet/Google.Cloud.Container.V1/latest) | 2.0.0 | [Google Kubernetes Engine API](https://cloud.google.com/kubernetes-engine/docs/reference/rest/) |
+| [Google.Cloud.Dataproc.V1](https://googleapis.dev/dotnet/Google.Cloud.Dataproc.V1/latest) | 2.0.0 | [Google Cloud Dataproc](https://cloud.google.com/dataproc/docs/concepts/overview) |
+| [Google.Cloud.Datastore.V1](https://googleapis.dev/dotnet/Google.Cloud.Datastore.V1/latest) | 3.0.0 | [Google Cloud Datastore](https://cloud.google.com/datastore/docs/concepts/overview) |
+| [Google.Cloud.Debugger.V2](https://googleapis.dev/dotnet/Google.Cloud.Debugger.V2/latest) | 2.0.0 | [Google Cloud Debugger](https://cloud.google.com/debugger/) |
+| [Google.Cloud.DevTools.Common](https://googleapis.dev/dotnet/Google.Cloud.DevTools.Common/latest) | 2.0.0 | Common Protocol Buffer messages for Google Cloud Developer Tools APIs |
+| [Google.Cloud.DevTools.ContainerAnalysis.V1](https://googleapis.dev/dotnet/Google.Cloud.DevTools.ContainerAnalysis.V1/latest) | 2.0.0 | [Google Container Analysis](https://cloud.google.com/container-registry/docs/container-analysis/) |
+| [Google.Cloud.Diagnostics.AspNetCore](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.AspNetCore/latest) | 4.0.0 | Google Cloud Logging Instrumentation Libraries for ASP.NET Core |
+| [Google.Cloud.Diagnostics.AspNetCore.Analyzers](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.AspNetCore.Analyzers/latest) | 2.0.0 | Guidelines for using Google Cloud Logging Instrumentation Libraries for ASP.NET Core |
+| [Google.Cloud.Diagnostics.Common](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.Common/latest) | 4.0.0 | Google Cloud Logging Instrumentation Libraries Common Components |
+| [Google.Cloud.Dialogflow.V2](https://googleapis.dev/dotnet/Google.Cloud.Dialogflow.V2/latest) | 2.0.0 | [Google Cloud Dialogflow](https://cloud.google.com/dialogflow-enterprise/) |
+| [Google.Cloud.Dlp.V2](https://googleapis.dev/dotnet/Google.Cloud.Dlp.V2/latest) | 2.0.0-beta02 | [Google Cloud Data Loss Prevention](https://cloud.google.com/dlp/) |
+| [Google.Cloud.ErrorReporting.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.ErrorReporting.V1Beta1/latest) | 2.0.0-beta02 | [Google Cloud Error Reporting](https://cloud.google.com/error-reporting/) |
+| [Google.Cloud.Firestore.Admin.V1](https://googleapis.dev/dotnet/Google.Cloud.Firestore.Admin.V1/latest) | 2.0.0 | [Firestore Admin](https://firebase.google.com) |
+| [Google.Cloud.Firestore](https://googleapis.dev/dotnet/Google.Cloud.Firestore/latest) | 2.0.0-beta02 | [Firestore](https://firebase.google.com/docs/firestore/) |
+| [Google.Cloud.Firestore.V1](https://googleapis.dev/dotnet/Google.Cloud.Firestore.V1/latest) | 2.0.0-beta02 | [Firestore](https://firebase.google.com) |
+| [Google.Cloud.Gaming.V1Beta](https://googleapis.dev/dotnet/Google.Cloud.Gaming.V1Beta/latest) | 1.0.0-beta01 | [Google Cloud for Games](https://cloud.google.com/solutions/gaming) |
+| [Google.Cloud.Iam.V1](https://googleapis.dev/dotnet/Google.Cloud.Iam.V1/latest) | 2.0.0 | [Google Cloud Identity and Access Management (IAM)](https://cloud.google.com/iam/) |
+| [Google.Cloud.Kms.V1](https://googleapis.dev/dotnet/Google.Cloud.Kms.V1/latest) | 2.0.0-beta03 | [Google Cloud Key Management Service](https://cloud.google.com/kms/) |
+| [Google.Cloud.Language.V1](https://googleapis.dev/dotnet/Google.Cloud.Language.V1/latest) | 2.0.0 | [Google Cloud Natural Language](https://cloud.google.com/natural-language) |
+| [Google.Cloud.Logging.Log4Net](https://googleapis.dev/dotnet/Google.Cloud.Logging.Log4Net/latest) | 3.0.0 | Log4Net client library for the Google Cloud Logging API |
+| [Google.Cloud.Logging.NLog](https://googleapis.dev/dotnet/Google.Cloud.Logging.NLog/latest) | 3.0.0 | NLog target for the Google Cloud Logging API |
+| [Google.Cloud.Logging.Type](https://googleapis.dev/dotnet/Google.Cloud.Logging.Type/latest) | 3.0.0 | Version-agnostic types for the Google Cloud Logging API |
+| [Google.Cloud.Logging.V2](https://googleapis.dev/dotnet/Google.Cloud.Logging.V2/latest) | 3.0.0 | [Google Cloud Logging](https://cloud.google.com/logging/) |
+| [Google.Cloud.ManagedIdentities.V1](https://googleapis.dev/dotnet/Google.Cloud.ManagedIdentities.V1/latest) | 2.0.0 | [Managed Service for Microsoft Active Directory](https://cloud.google.com/managed-microsoft-ad/) |
+| [Google.Cloud.Memcache.V1Beta2](https://googleapis.dev/dotnet/Google.Cloud.Memcache.V1Beta2/latest) | 1.0.0-beta02 | [Google Cloud Memorystore for Memcache](https://cloud.google.com/memorystore/) |
+| [Google.Cloud.Monitoring.V3](https://googleapis.dev/dotnet/Google.Cloud.Monitoring.V3/latest) | 2.0.0 | [Google Cloud Monitoring](https://cloud.google.com/monitoring/api/v3/) |
+| [Google.Cloud.OrgPolicy.V1](https://googleapis.dev/dotnet/Google.Cloud.OrgPolicy.V1/latest) | 2.0.0-beta03 | OrgPolicy API messages |
+| [Google.Cloud.OsLogin.Common](https://googleapis.dev/dotnet/Google.Cloud.OsLogin.Common/latest) | 2.0.0 | Version-agnostic types for the Google OS Login API |
+| [Google.Cloud.OsLogin.V1](https://googleapis.dev/dotnet/Google.Cloud.OsLogin.V1/latest) | 2.0.0 | [Google Cloud OS Login API](https://cloud.google.com/compute/docs/instances/managing-instance-access) |
+| [Google.Cloud.OsLogin.V1Beta](https://googleapis.dev/dotnet/Google.Cloud.OsLogin.V1Beta/latest) | 2.0.0-beta02 | [Google Cloud OS Login API](https://cloud.google.com/compute/docs/instances/managing-instance-access) |
+| [Google.Cloud.PhishingProtection.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.PhishingProtection.V1Beta1/latest) | 1.0.0-beta02 | [Cloud Phishing Protection](https://cloud.google.com/phishing-protection/) |
+| [Google.Cloud.PubSub.V1](https://googleapis.dev/dotnet/Google.Cloud.PubSub.V1/latest) | 2.0.0-beta02 | [Cloud Pub/Sub](https://cloud.google.com/pubsub/) |
+| [Google.Cloud.RecaptchaEnterprise.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.RecaptchaEnterprise.V1Beta1/latest) | 1.0.0-beta02 | [Google Cloud reCAPTCHA Enterprise](https://cloud.google.com/recaptcha-enterprise/) |
+| [Google.Cloud.Recommender.V1](https://googleapis.dev/dotnet/Google.Cloud.Recommender.V1/latest) | 2.0.0 | [Google Cloud Recommender](https://cloud.google.com/recommender/) |
+| [Google.Cloud.Redis.V1](https://googleapis.dev/dotnet/Google.Cloud.Redis.V1/latest) | 2.0.0 | [Google Cloud Memorystore for Redis](https://cloud.google.com/memorystore/) |
+| [Google.Cloud.Redis.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Redis.V1Beta1/latest) | 2.0.0-beta02 | [Google Cloud Memorystore for Redis](https://cloud.google.com/memorystore/) |
+| [Google.Cloud.Scheduler.V1](https://googleapis.dev/dotnet/Google.Cloud.Scheduler.V1/latest) | 2.0.0 | [Google Cloud Scheduler](https://cloud.google.com/scheduler/) |
+| [Google.Cloud.SecretManager.V1](https://googleapis.dev/dotnet/Google.Cloud.SecretManager.V1/latest) | 1.0.0 | [Secret Manager](https://cloud.google.com/secret-manager) |
+| [Google.Cloud.SecretManager.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.SecretManager.V1Beta1/latest) | 2.0.0-beta02 | [Secret Manager](https://cloud.google.com/secret-manager) |
+| [Google.Cloud.SecurityCenter.V1](https://googleapis.dev/dotnet/Google.Cloud.SecurityCenter.V1/latest) | 2.0.0 | [Google Cloud Security Command Center](https://cloud.google.com/security-command-center/) |
+| [Google.Cloud.SecurityCenter.V1P1Beta1](https://googleapis.dev/dotnet/Google.Cloud.SecurityCenter.V1P1Beta1/latest) | 2.0.0-beta02 | [Google Cloud Security Command Center](https://cloud.google.com/security-command-center/) |
+| [Google.Cloud.ServiceDirectory.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.ServiceDirectory.V1Beta1/latest) | 1.0.0-beta02 | Service Directory API |
+| [Google.Cloud.Spanner.Admin.Database.V1](https://googleapis.dev/dotnet/Google.Cloud.Spanner.Admin.Database.V1/latest) | 3.0.0-beta02 | [Google Cloud Spanner Database Administration](https://cloud.google.com/spanner/) |
+| [Google.Cloud.Spanner.Admin.Instance.V1](https://googleapis.dev/dotnet/Google.Cloud.Spanner.Admin.Instance.V1/latest) | 3.0.0-beta02 | [Google Cloud Spanner Instance Administration](https://cloud.google.com/spanner/) |
+| [Google.Cloud.Spanner.Data](https://googleapis.dev/dotnet/Google.Cloud.Spanner.Data/latest) | 3.0.0-beta02 | Google ADO.NET Provider for Google Cloud Spanner |
+| [Google.Cloud.Spanner.Common.V1](https://googleapis.dev/dotnet/Google.Cloud.Spanner.Common.V1/latest) | 3.0.0-beta02 | Common resource names used by all Spanner V1 APIs |
+| [Google.Cloud.Spanner.V1](https://googleapis.dev/dotnet/Google.Cloud.Spanner.V1/latest) | 3.0.0-beta02 | [Google Cloud Spanner](https://cloud.google.com/spanner/) |
+| [Google.Cloud.Speech.V1](https://googleapis.dev/dotnet/Google.Cloud.Speech.V1/latest) | 2.0.0 | [Google Cloud Speech](https://cloud.google.com/speech) |
+| [Google.Cloud.Speech.V1P1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Speech.V1P1Beta1/latest) | 2.0.0-beta02 | [Google Cloud Speech](https://cloud.google.com/speech) |
+| [Google.Cloud.Storage.V1](https://googleapis.dev/dotnet/Google.Cloud.Storage.V1/latest) | 3.0.0-beta02 | [Google Cloud Storage](https://cloud.google.com/storage/) |
+| [Google.Cloud.Talent.V4Beta1](https://googleapis.dev/dotnet/Google.Cloud.Talent.V4Beta1/latest) | 2.0.0-beta02 | [Google Cloud Talent Solution](https://cloud.google.com/talent-solution/) |
+| [Google.Cloud.Tasks.V2](https://googleapis.dev/dotnet/Google.Cloud.Tasks.V2/latest) | 2.0.0 | [Google Cloud Tasks](https://cloud.google.com/tasks/) |
+| [Google.Cloud.Tasks.V2Beta3](https://googleapis.dev/dotnet/Google.Cloud.Tasks.V2Beta3/latest) | 2.0.0-beta02 | [Google Cloud Tasks](https://cloud.google.com/tasks/) |
+| [Google.Cloud.TextToSpeech.V1](https://googleapis.dev/dotnet/Google.Cloud.TextToSpeech.V1/latest) | 2.0.0 | [Google Cloud Text-to-Speech](https://cloud.google.com/text-to-speech) |
+| [Google.Cloud.Trace.V1](https://googleapis.dev/dotnet/Google.Cloud.Trace.V1/latest) | 2.0.0 | [Google Cloud Trace](https://cloud.google.com/trace/) |
+| [Google.Cloud.Trace.V2](https://googleapis.dev/dotnet/Google.Cloud.Trace.V2/latest) | 2.0.0 | [Google Cloud Trace](https://cloud.google.com/trace/) |
+| [Google.Cloud.Translate.V3](https://googleapis.dev/dotnet/Google.Cloud.Translate.V3/latest) | 2.0.0 | [Google Cloud Translation](https://cloud.google.com/translate/) |
+| [Google.Cloud.Translation.V2](https://googleapis.dev/dotnet/Google.Cloud.Translation.V2/latest) | 2.0.0 | [Google Cloud Translation](https://cloud.google.com/translate/) |
+| [Google.Cloud.VideoIntelligence.V1](https://googleapis.dev/dotnet/Google.Cloud.VideoIntelligence.V1/latest) | 2.0.0 | [Google Cloud Video Intelligence](https://cloud.google.com/video-intelligence) |
+| [Google.Cloud.Vision.V1](https://googleapis.dev/dotnet/Google.Cloud.Vision.V1/latest) | 2.0.0 | [Google Cloud Vision](https://cloud.google.com/vision) |
+| [Google.Cloud.WebRisk.V1](https://googleapis.dev/dotnet/Google.Cloud.WebRisk.V1/latest) | 1.0.0-beta01 | [Google Cloud Web Risk](https://cloud.google.com/web-risk/) |
+| [Google.Cloud.WebRisk.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.WebRisk.V1Beta1/latest) | 2.0.0-beta02 | [Google Cloud Web Risk](https://cloud.google.com/web-risk/) |
+| [Google.LongRunning](https://googleapis.dev/dotnet/Google.LongRunning/latest) | 2.0.0 | Support for the Long-Running Operations API pattern |
+| [Grafeas.V1](https://googleapis.dev/dotnet/Grafeas.V1/latest) | 2.0.0 | [Grafeas](https://grafeas.io/) |
 
 If you need support for other Google APIs, check out the
 [Google .NET API Client library](https://github.com/google/google-api-dotnet-client)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 # Available APIs
 
 This repository contains code for the following client libraries.
-Each package name link to the documentation for that package.
+Each package name links to the documentation for that package.
 
 | Package | Latest version | Description |
 |---------|----------------|-------------|
@@ -30,9 +30,9 @@ Each package name link to the documentation for that package.
 | [Google.Cloud.Debugger.V2](https://googleapis.dev/dotnet/Google.Cloud.Debugger.V2/latest) | 2.0.0 | [Google Cloud Debugger](https://cloud.google.com/debugger/) |
 | [Google.Cloud.DevTools.Common](https://googleapis.dev/dotnet/Google.Cloud.DevTools.Common/latest) | 2.0.0 | Common Protocol Buffer messages for Google Cloud Developer Tools APIs |
 | [Google.Cloud.DevTools.ContainerAnalysis.V1](https://googleapis.dev/dotnet/Google.Cloud.DevTools.ContainerAnalysis.V1/latest) | 2.0.0 | [Google Container Analysis](https://cloud.google.com/container-registry/docs/container-analysis/) |
-| [Google.Cloud.Diagnostics.AspNetCore](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.AspNetCore/latest) | 4.0.0 | Google Cloud Logging Instrumentation Libraries for ASP.NET Core |
-| [Google.Cloud.Diagnostics.AspNetCore.Analyzers](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.AspNetCore.Analyzers/latest) | 2.0.0 | Guidelines for using Google Cloud Logging Instrumentation Libraries for ASP.NET Core |
-| [Google.Cloud.Diagnostics.Common](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.Common/latest) | 4.0.0 | Google Cloud Logging Instrumentation Libraries Common Components |
+| [Google.Cloud.Diagnostics.AspNetCore](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.AspNetCore/latest) | 4.0.0 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core |
+| [Google.Cloud.Diagnostics.AspNetCore.Analyzers](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.AspNetCore.Analyzers/latest) | 2.0.0 | Guidelines for using Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core |
+| [Google.Cloud.Diagnostics.Common](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.Common/latest) | 4.0.0 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries Common Components |
 | [Google.Cloud.Dialogflow.V2](https://googleapis.dev/dotnet/Google.Cloud.Dialogflow.V2/latest) | 2.0.0 | [Google Cloud Dialogflow](https://cloud.google.com/dialogflow-enterprise/) |
 | [Google.Cloud.Dlp.V2](https://googleapis.dev/dotnet/Google.Cloud.Dlp.V2/latest) | 2.0.0-beta02 | [Google Cloud Data Loss Prevention](https://cloud.google.com/dlp/) |
 | [Google.Cloud.ErrorReporting.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.ErrorReporting.V1Beta1/latest) | 2.0.0-beta02 | [Google Cloud Error Reporting](https://cloud.google.com/error-reporting/) |

--- a/apis/Google.Cloud.Diagnostics.AspNetCore.Analyzers/Google.Cloud.Diagnostics.AspNetCore.Analyzers/Google.Cloud.Diagnostics.AspNetCore.Analyzers.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore.Analyzers/Google.Cloud.Diagnostics.AspNetCore.Analyzers/Google.Cloud.Diagnostics.AspNetCore.Analyzers.csproj
@@ -9,7 +9,7 @@
     <SignAssembly>true</SignAssembly>
     <Deterministic>true</Deterministic>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Description>Guidelines for using Google Cloud Logging Instrumentation Libraries for ASP.NET Core.</Description>
+    <Description>Guidelines for using Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core.</Description>
     <PackageTags>CodeAnalysis;Analyzers;CSharp;Google;Cloud</PackageTags>
     <Copyright>Copyright 2020 Google LLC</Copyright>
     <Authors>Google LLC</Authors>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore.Analyzers/Google.Cloud.Diagnostics.AspNetCore.Analyzers/Google.Cloud.Diagnostics.AspNetCore.Analyzers.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore.Analyzers/Google.Cloud.Diagnostics.AspNetCore.Analyzers/Google.Cloud.Diagnostics.AspNetCore.Analyzers.csproj
@@ -9,7 +9,7 @@
     <SignAssembly>true</SignAssembly>
     <Deterministic>true</Deterministic>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Description>Guidelines for using Google Stackdriver Instrumentation Libraries for ASP.NET Core.</Description>
+    <Description>Guidelines for using Google Cloud Logging Instrumentation Libraries for ASP.NET Core.</Description>
     <PackageTags>CodeAnalysis;Analyzers;CSharp;Google;Cloud</PackageTags>
     <Copyright>Copyright 2020 Google LLC</Copyright>
     <Authors>Google LLC</Authors>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.csproj
@@ -9,7 +9,7 @@
     <SignAssembly>true</SignAssembly>
     <Deterministic>true</Deterministic>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Description>Google Cloud Logging Instrumentation Libraries for ASP.NET Core.</Description>
+    <Description>Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core.</Description>
     <PackageTags>Error;Reporting;Stackdriver;ExceptionLogger;Trace;Diagnostics;Google;Cloud</PackageTags>
     <Copyright>Copyright 2020 Google LLC</Copyright>
     <Authors>Google LLC</Authors>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.csproj
@@ -9,7 +9,7 @@
     <SignAssembly>true</SignAssembly>
     <Deterministic>true</Deterministic>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Description>Google Stackdriver Instrumentation Libraries for ASP.NET Core.</Description>
+    <Description>Google Cloud Logging Instrumentation Libraries for ASP.NET Core.</Description>
     <PackageTags>Error;Reporting;Stackdriver;ExceptionLogger;Trace;Diagnostics;Google;Cloud</PackageTags>
     <Copyright>Copyright 2020 Google LLC</Copyright>
     <Authors>Google LLC</Authors>

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
@@ -9,7 +9,7 @@
     <SignAssembly>true</SignAssembly>
     <Deterministic>true</Deterministic>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Description>Google Stackdriver Instrumentation Libraries Common Components.</Description>
+    <Description>Google Cloud Logging Instrumentation Libraries Common Components.</Description>
     <PackageTags>Error;Reporting;Stackdriver;ExceptionLogger;Trace;Diagnostics;Google;Cloud</PackageTags>
     <Copyright>Copyright 2020 Google LLC</Copyright>
     <Authors>Google LLC</Authors>

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
@@ -9,7 +9,7 @@
     <SignAssembly>true</SignAssembly>
     <Deterministic>true</Deterministic>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Description>Google Cloud Logging Instrumentation Libraries Common Components.</Description>
+    <Description>Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries Common Components.</Description>
     <PackageTags>Error;Reporting;Stackdriver;ExceptionLogger;Trace;Diagnostics;Google;Cloud</PackageTags>
     <Copyright>Copyright 2020 Google LLC</Copyright>
     <Authors>Google LLC</Authors>

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.csproj
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.csproj
@@ -9,7 +9,7 @@
     <SignAssembly>true</SignAssembly>
     <Deterministic>true</Deterministic>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Description>Recommended Google client library to access the Stackdriver Error Reporting API, which groups and counts similar errors from cloud services. The Stackdriver Error Reporting API provides a way to report new errors and read access to error groups and their associated errors.</Description>
+    <Description>Recommended Google client library to access the Google Cloud Error Reporting API, which groups and counts similar errors from cloud services. The Googe Cloud Error Reporting API provides a way to report new errors and read access to error groups and their associated errors.</Description>
     <PackageTags>ErrorReporting;Stackdriver;Google;Cloud</PackageTags>
     <Copyright>Copyright 2020 Google LLC</Copyright>
     <Authors>Google LLC</Authors>

--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.csproj
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.csproj
@@ -9,7 +9,7 @@
     <SignAssembly>true</SignAssembly>
     <Deterministic>true</Deterministic>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Description>Log4Net client library for the Google Stackdriver Logging API.</Description>
+    <Description>Log4Net client library for the Google Cloud Logging API.</Description>
     <PackageTags>Log4Net;Logging;Stackdriver;Google;Cloud</PackageTags>
     <Copyright>Copyright 2020 Google LLC</Copyright>
     <Authors>Google LLC</Authors>

--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.csproj
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.csproj
@@ -9,7 +9,7 @@
     <SignAssembly>true</SignAssembly>
     <Deterministic>true</Deterministic>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Description>NLog target for the Google Stackdriver Logging API.</Description>
+    <Description>NLog target for the Google Cloud Logging API.</Description>
     <PackageTags>NLog;Logging;Stackdriver;Google;Cloud</PackageTags>
     <Copyright>Copyright 2020 Google LLC</Copyright>
     <Authors>Google LLC</Authors>

--- a/apis/Google.Cloud.Logging.Type/Google.Cloud.Logging.Type/Google.Cloud.Logging.Type.csproj
+++ b/apis/Google.Cloud.Logging.Type/Google.Cloud.Logging.Type/Google.Cloud.Logging.Type.csproj
@@ -9,7 +9,7 @@
     <SignAssembly>true</SignAssembly>
     <Deterministic>true</Deterministic>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Description>Version-agnostic types for the Google Stackdriver Logging API.</Description>
+    <Description>Version-agnostic types for the Google Cloud Logging API.</Description>
     <PackageTags>Logging;Stackdriver;Google;Cloud</PackageTags>
     <Copyright>Copyright 2020 Google LLC</Copyright>
     <Authors>Google LLC</Authors>

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.csproj
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.csproj
@@ -9,7 +9,7 @@
     <SignAssembly>true</SignAssembly>
     <Deterministic>true</Deterministic>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Description>Recommended Google client library to access the Google Stackdriver Logging API, which writes log entries and manages your logs, log sinks, and logs-based metrics.</Description>
+    <Description>Recommended Google client library to access the Google Cloud Logging API, which writes log entries and manages your logs, log sinks, and logs-based metrics.</Description>
     <PackageTags>Logging;Stackdriver;Google;Cloud</PackageTags>
     <Copyright>Copyright 2020 Google LLC</Copyright>
     <Authors>Google LLC</Authors>

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.csproj
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.csproj
@@ -9,7 +9,7 @@
     <SignAssembly>true</SignAssembly>
     <Deterministic>true</Deterministic>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Description>Recommended Google client library to access the Stackdriver Monitoring API, which manages your Stackdriver Monitoring data and configurations. Most projects must be associated with a Stackdriver account, with a few exceptions as noted on the individual method pages.</Description>
+    <Description>Recommended Google client library to access the Google Cloud Monitoring API, which manages your Google Cloud Monitoring data and configurations.</Description>
     <PackageTags>Monitoring;Stackdriver;Google;Cloud</PackageTags>
     <Copyright>Copyright 2020 Google LLC</Copyright>
     <Authors>Google LLC</Authors>

--- a/apis/README.md
+++ b/apis/README.md
@@ -27,3 +27,4 @@ Fields:
 - `generator`: The generator type to use: "micro", "proto", "protogrpc"
 - `protoPath`: The path within the `googleapis` repo to the API definition
 - `serviceYaml`: (GAPIC generator only) The file (one directory above `protoPath`) containing the service definition
+- `shortDescription`: Used when listing APIs (e.g. in README.md) if there's no `productName` and the `description` is too long

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -230,7 +230,7 @@
     "id": "Google.Cloud.Debugger.V2",
     "generator": "micro",
     "protoPath": "google/devtools/clouddebugger/v2",
-    "productName": "Stackdriver Debugger",
+    "productName": "Google Cloud Debugger",
     "productUrl": "https://cloud.google.com/debugger/",
     "version": "2.0.0",
     "type": "grpc",
@@ -289,7 +289,7 @@
     "type": "other",
     "targetFrameworks": "netstandard2.0",
     "testTargetFrameworks": "netcoreapp2.1;net461",
-    "description": "Google Stackdriver Instrumentation Libraries for ASP.NET Core.",
+    "description": "Google Cloud Logging Instrumentation Libraries for ASP.NET Core.",
     "tags": [
       "Error",
       "Reporting",
@@ -326,7 +326,7 @@
     "type": "analyzers",
     "targetFrameworks": "netstandard1.3",
     "testTargetFrameworks": "netcoreapp2.0",
-    "description": "Guidelines for using Google Stackdriver Instrumentation Libraries for ASP.NET Core.",
+    "description": "Guidelines for using Google Cloud Logging Instrumentation Libraries for ASP.NET Core.",
     "tags": [
       "CodeAnalysis",
       "Analyzers",
@@ -343,7 +343,7 @@
     "type": "other",
     "targetFrameworks": "netstandard2.0",
     "testTargetFrameworks": "netcoreapp2.1;net461",
-    "description": "Google Stackdriver Instrumentation Libraries Common Components.",
+    "description": "Google Cloud Logging Instrumentation Libraries Common Components.",
     "tags": [
       "Error",
       "Reporting",
@@ -411,12 +411,12 @@
     "id": "Google.Cloud.ErrorReporting.V1Beta1",
     "generator": "micro",
     "protoPath": "google/devtools/clouderrorreporting/v1beta1",
-    "productName": "Stackdriver Error Reporting",
+    "productName": "Google Cloud Error Reporting",
     "productUrl": "https://cloud.google.com/error-reporting/",
     "version": "2.0.0-beta02",
     "releaseLevelOverride": "beta",
     "type": "grpc",
-    "description": "Recommended Google client library to access the Stackdriver Error Reporting API, which groups and counts similar errors from cloud services. The Stackdriver Error Reporting API provides a way to report new errors and read access to error groups and their associated errors.",
+    "description": "Recommended Google client library to access the Google Cloud Error Reporting API, which groups and counts similar errors from cloud services. The Googe Cloud Error Reporting API provides a way to report new errors and read access to error groups and their associated errors.",
     "tags": [
       "ErrorReporting",
       "Stackdriver"
@@ -515,6 +515,8 @@
     "id": "Google.Cloud.Iam.V1",
     "generator": "protogrpc",
     "protoPath": "google/iam/v1",
+    "productName": "Google Cloud Identity and Access Management (IAM)",
+    "productUrl": "https://cloud.google.com/iam/",
     "version": "2.0.0",
     "type": "grpc",
     "description": "gRPC services for the Google Identity and Access Management API. This library is typically used as a dependency for other API client libraries.",
@@ -572,7 +574,7 @@
     "type": "other",
     "targetFrameworks": "netstandard2.0;net461",
     "testTargetFrameworks": "netcoreapp2.1;net461",
-    "description": "Log4Net client library for the Google Stackdriver Logging API.",
+    "description": "Log4Net client library for the Google Cloud Logging API.",
     "tags": [
       "Log4Net",
       "Logging",
@@ -595,7 +597,7 @@
     "type": "other",
     "targetFrameworks": "netstandard2.0;net461",
     "testTargetFrameworks": "netcoreapp2.1;net461",
-    "description": "NLog target for the Google Stackdriver Logging API.",
+    "description": "NLog target for the Google Cloud Logging API.",
     "tags": [
       "NLog",
       "Logging",
@@ -619,7 +621,7 @@
     "version": "3.0.0",
     "type": "other",
     "targetFrameworks": "netstandard2.0;net461",
-    "description": "Version-agnostic types for the Google Stackdriver Logging API.",
+    "description": "Version-agnostic types for the Google Cloud Logging API.",
     "tags": [
       "Logging",
       "Stackdriver"
@@ -632,11 +634,11 @@
     "id": "Google.Cloud.Logging.V2",
     "generator": "micro",
     "protoPath": "google/logging/v2",
-    "productName": "Stackdriver Logging",
+    "productName": "Google Cloud Logging",
     "productUrl": "https://cloud.google.com/logging/",
     "version": "3.0.0",
     "type": "grpc",
-    "description": "Recommended Google client library to access the Google Stackdriver Logging API, which writes log entries and manages your logs, log sinks, and logs-based metrics.",
+    "description": "Recommended Google client library to access the Google Cloud Logging API, which writes log entries and manages your logs, log sinks, and logs-based metrics.",
     "tags": [
       "Logging",
       "Stackdriver"
@@ -690,11 +692,11 @@
     "id": "Google.Cloud.Monitoring.V3",
     "generator": "micro",
     "protoPath": "google/monitoring/v3",
-    "productName": "Stackdriver Monitoring",
+    "productName": "Google Cloud Monitoring",
     "productUrl": "https://cloud.google.com/monitoring/api/v3/",
     "version": "2.0.0",
     "type": "grpc",
-    "description": "Recommended Google client library to access the Stackdriver Monitoring API, which manages your Stackdriver Monitoring data and configurations. Most projects must be associated with a Stackdriver account, with a few exceptions as noted on the individual method pages.",
+    "description": "Recommended Google client library to access the Google Cloud Monitoring API, which manages your Google Cloud Monitoring data and configurations.",
     "tags": [
       "Monitoring",
       "Stackdriver"
@@ -976,6 +978,7 @@
   {
     "id": "Google.Cloud.ServiceDirectory.V1Beta1",
     "generator": "micro",
+    "shortDescription": "Service Directory API",
     "protoPath": "google/cloud/servicedirectory/v1beta1",
     "version": "1.0.0-beta02",
     "type": "grpc",
@@ -1213,7 +1216,7 @@
     "id": "Google.Cloud.Trace.V1",
     "generator": "micro",
     "protoPath": "google/devtools/cloudtrace/v1",
-    "productName": "Stackdriver Trace",
+    "productName": "Google Cloud Trace",
     "productUrl": "https://cloud.google.com/trace/",
     "version": "2.0.0",
     "type": "grpc",
@@ -1231,7 +1234,7 @@
     "id": "Google.Cloud.Trace.V2",
     "generator": "micro",
     "protoPath": "google/devtools/cloudtrace/v2",
-    "productName": "Stackdriver Trace",
+    "productName": "Google Cloud Trace",
     "productUrl": "https://cloud.google.com/trace/",
     "version": "2.0.0",
     "type": "grpc",
@@ -1357,6 +1360,7 @@
     "id": "Google.LongRunning",
     "generator": "micro",
     "protoPath": "google/longrunning",
+    "shortDescription": "Support for the Long-Running Operations API pattern",
     "version": "2.0.0",
     "type": "grpc",
     "description": "gRPC services for the Google Long Running Operations API. This library is typically used as a dependency for other API client libraries.",

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -289,7 +289,7 @@
     "type": "other",
     "targetFrameworks": "netstandard2.0",
     "testTargetFrameworks": "netcoreapp2.1;net461",
-    "description": "Google Cloud Logging Instrumentation Libraries for ASP.NET Core.",
+    "description": "Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core.",
     "tags": [
       "Error",
       "Reporting",
@@ -326,7 +326,7 @@
     "type": "analyzers",
     "targetFrameworks": "netstandard1.3",
     "testTargetFrameworks": "netcoreapp2.0",
-    "description": "Guidelines for using Google Cloud Logging Instrumentation Libraries for ASP.NET Core.",
+    "description": "Guidelines for using Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core.",
     "tags": [
       "CodeAnalysis",
       "Analyzers",
@@ -343,7 +343,7 @@
     "type": "other",
     "targetFrameworks": "netstandard2.0",
     "testTargetFrameworks": "netcoreapp2.1;net461",
-    "description": "Google Cloud Logging Instrumentation Libraries Common Components.",
+    "description": "Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries Common Components.",
     "tags": [
       "Error",
       "Reporting",

--- a/tools/Google.Cloud.Tools.Common/ApiMetadata.cs
+++ b/tools/Google.Cloud.Tools.Common/ApiMetadata.cs
@@ -27,6 +27,7 @@ namespace Google.Cloud.Tools.Common
         private static readonly Regex ReleaseVersion = new Regex(@"^[1-9]\d*\.\d+\.\d+$");
 
         public string Version { get; set; }
+        public string ReleasedVersion { get; set; }
         public string Id { get; set; }
         public ApiType Type { get; set; }
         public string TargetFrameworks { get; set; }
@@ -38,10 +39,20 @@ namespace Google.Cloud.Tools.Common
         public string ProductName { get; set; }
 
         /// <summary>
+        /// When the package isn't direclty for a product (so <see cref="ProductName "/>is null), this name appears
+        /// in the list of packages as a description. If <see cref="Description"/> is already short enough
+        /// for listing, this can be left empty.
+        /// </summary>
+        public string ShortDescription { get; set; }
+
+        /// <summary>
         /// API URL to include in documentation, e.g. "https://cloud.google.com/monitoring/api/v3/"
         /// </summary>
         public string ProductUrl { get; set; }
 
+        /// <summary>
+        /// The full description included in the NuGet package.
+        /// </summary>
         public string Description { get; set; }
 
         public List<string> Tags { get; set; } = new List<string>();


### PR DESCRIPTION
This loses significant nuance in the manually-maintained version, but is more scalable.