### PR TITLE
Handle deserializing sequence interfaces to List<T>

### DIFF
--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Converters/ConverterCacheTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Converters/ConverterCacheTest.cs
@@ -37,8 +37,7 @@ namespace Google.Cloud.Firestore.Tests
         [InlineData(typeof(List<string>), null)]
         public void TryGetStringDictionaryValueType(BclType input, BclType expectedElementType)
         {
-            var actual = ConverterCache.TryGetStringDictionaryValueType(input, out var actualElementType);
-            Assert.Equal(expectedElementType != null, actual);
+            var actualElementType = ConverterCache.TryGetStringDictionaryValueType(input);
             Assert.Equal(expectedElementType, actualElementType);
         }
 

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Converters/ConverterCacheTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Converters/ConverterCacheTest.cs
@@ -41,5 +41,24 @@ namespace Google.Cloud.Firestore.Tests
             Assert.Equal(expectedElementType != null, actual);
             Assert.Equal(expectedElementType, actualElementType);
         }
+
+        [Theory]
+        [InlineData(typeof(List<int>), typeof(List<int>))]
+        [InlineData(typeof(IEnumerable<int>), typeof(List<int>))]
+        [InlineData(typeof(IReadOnlyList<string>), typeof(List<string>))]
+        [InlineData(typeof(ExtendedList<string>), null)] // We can't assign a List<string> to an ExtendedList<string> property.
+        [InlineData(typeof(int[]), null)] // Implements IEnumerable<T>, but List<T> isn't compatible.
+        [InlineData(typeof(ConcurrentQueue<int>), null)] // Implements IEnumerable<T>, but List<T> isn't compatible.
+        [InlineData(typeof(System.Guid), null)] // Doesn't implement IEnumerable<T>
+        [InlineData(typeof(Dictionary<int, int>), null)] // Implements IEnumerable<T>, but List<T> isn't compatible.
+        public void TryGetListTypeArgument(BclType input, BclType expectedType)
+        {
+            var actualType = ConverterCache.TryGetListType(input);
+            Assert.Equal(expectedType, actualType);
+        }
+
+        private class ExtendedList<T> : List<T>
+        {
+        }
     }
 }

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/ValueDeserializerTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/ValueDeserializerTest.cs
@@ -21,6 +21,7 @@ using Xunit;
 using BclType = System.Type;
 using wkt = Google.Protobuf.WellKnownTypes;
 using static Google.Cloud.Firestore.Tests.DocumentSnapshotHelpers;
+using System.Collections;
 
 namespace Google.Cloud.Firestore.Tests
 {
@@ -223,6 +224,15 @@ namespace Google.Cloud.Firestore.Tests
             var deserialized = DeserializeDefault(value, typeof(object));
             Assert.IsType<List<object>>(deserialized);
             Assert.Equal(new List<object> { 1L, 2L }, deserialized);
+        }
+
+        [Fact]
+        public void DeserializeArrayToArrayListUsesArrayList()
+        {
+            var value = ValueSerializer.Serialize(SerializationContext.Default, new[] { 1, 2 });
+            var deserialized = DeserializeDefault(value, typeof(ArrayList));
+            Assert.IsType<ArrayList>(deserialized);
+            Assert.Equal(new ArrayList { 1L, 2L }, deserialized);
         }
 
         [Fact]

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/ValueDeserializerTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/ValueDeserializerTest.cs
@@ -225,6 +225,15 @@ namespace Google.Cloud.Firestore.Tests
             Assert.Equal(new List<object> { 1L, 2L }, deserialized);
         }
 
+        [Fact]
+        public void DeserializeArrayToGenericIEnumerableUsesList()
+        {
+            var value = ValueSerializer.Serialize(SerializationContext.Default, new[] { 1, 2 });
+            var deserialized = DeserializeDefault(value, typeof(IEnumerable<int>));
+            Assert.IsType<List<int>>(deserialized);
+            Assert.Equal(new List<int> { 1, 2 }, deserialized);
+        }
+
         [Theory]
         [InlineData(typeof(int?))]
         [InlineData(typeof(string))]

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Converters/ConverterCache.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Converters/ConverterCache.cs
@@ -93,7 +93,7 @@ namespace Google.Cloud.Firestore.Converters
             {
                 return new EnumConverter(targetType);
             }
-            if (TryGetStringDictionaryValueType(targetType, out var dictionaryElementType))
+            if (TryGetStringDictionaryValueType(targetType) is BclType dictionaryElementType)
             {
                 var method = s_createDictionaryConverter.MakeGenericMethod(dictionaryElementType);
                 try
@@ -126,16 +126,15 @@ namespace Google.Cloud.Firestore.Converters
         // Internal for testing
 
         /// <summary>
-        /// If <paramref name="type"/> implements (or is) <see cref="IDictionary{TKey, TValue}"/> with TKey equal to string, returns true and sets
-        /// <paramref name="elementType"/> to TValue. Otherwise, returns false and sets <paramref name="elementType"/> to null.
+        /// If <paramref name="type"/> implements (or is) <see cref="IDictionary{TKey, TValue}"/> with TKey equal to string, returns TValue.
+        /// Otherwise, returns null.
         /// </summary>
-        internal static bool TryGetStringDictionaryValueType(BclType type, out BclType elementType)
+        internal static BclType TryGetStringDictionaryValueType(BclType type)
         {
-            elementType = type.GetTypeInfo()
+            return type.GetTypeInfo()
                 .GetInterfaces()
                 .Concat(new[] { type }) // Make this method handle IDictionary<,> as an input; GetInterfaces doesn't return the type you call it on
                 .Select(MapInterfaceToDictionaryValueTypeArgument).FirstOrDefault(t => t != null);
-            return elementType != null;
 
             BclType MapInterfaceToDictionaryValueTypeArgument(BclType iface)
             {

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Converters/ListConverter.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Converters/ListConverter.cs
@@ -35,18 +35,13 @@ namespace Google.Cloud.Firestore.Converters
 
         internal ListConverter(BclType targetType) : base(targetType)
         {
-            _elementType = typeof(object);
-
             // We could make this type generic, like DictionaryConverter. There's a difference
             // in that we don't need a generic interface in the conversion code here.
             var interfaces = targetType.GetTypeInfo().GetInterfaces();
-            // TODO: Use IEnumerable<T> instead of IList<T>?
-            // TODO: Handle non-generic types, e.g. ArrayList.
-            var genericEnumerable = interfaces.Select(t => t.GetTypeInfo()).FirstOrDefault(iface => iface.IsGenericType && iface.GetGenericTypeDefinition() == typeof(IList<>));
-            if (genericEnumerable != null)
-            {
-                _elementType = genericEnumerable.GenericTypeArguments[0];
-            }
+
+            var genericListInterface = interfaces.Select(t => t.GetTypeInfo()).FirstOrDefault(iface => iface.IsGenericType && iface.GetGenericTypeDefinition() == typeof(IList<>));
+            // Just use object if the type isn't actually generic.
+            _elementType = genericListInterface?.GenericTypeArguments[0] ?? typeof(object);
         }
 
         protected override object DeserializeArray(DeserializationContext context, RepeatedField<Value> values)

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Converters/ListConverter.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Converters/ListConverter.cs
@@ -37,10 +37,11 @@ namespace Google.Cloud.Firestore.Converters
         {
             _elementType = typeof(object);
 
-            // TODO: Use List<T> if we have an interface? That's what we do for dictionaries.
-            // (We could also make this type generic, like DictionaryConverter. There's a difference
-            // in that we don't need a generic interface in the conversion code here.)
+            // We could make this type generic, like DictionaryConverter. There's a difference
+            // in that we don't need a generic interface in the conversion code here.
             var interfaces = targetType.GetTypeInfo().GetInterfaces();
+            // TODO: Use IEnumerable<T> instead of IList<T>?
+            // TODO: Handle non-generic types, e.g. ArrayList.
             var genericEnumerable = interfaces.Select(t => t.GetTypeInfo()).FirstOrDefault(iface => iface.IsGenericType && iface.GetGenericTypeDefinition() == typeof(IList<>));
             if (genericEnumerable != null)
             {


### PR DESCRIPTION
Fixes #4176 - at least as far as I think we need to. It doesn't allow any particular custom conversion, but users could always specify that in the ConverterRegistry beforehand if they really want to.

The first commit implements the feature; the other two are just tidy-ups from things I noticed while working on the code.