### PR TITLE
Update the Dockerfile for .NET Core SDK 3.1.100

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Start with the .NET Core SDK
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1.100
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1.100-bionic
 
 RUN apt-get update
 RUN apt-get install -y git

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Start with the .NET Core SDK
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1.100
 
 RUN apt-get update
 RUN apt-get install -y git


### PR DESCRIPTION
This seems to be the required version when using `prepare-release.sh`.