### PR TITLE
Make Google.Cloud.Diagnostics.AspNet depend on the local version of Google.Cloud.Diagnostics.Common

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/coverage.xml
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.IntegrationTests/coverage.xml
@@ -7,6 +7,9 @@
       <FilterEntry>
         <ModuleMask>Google.Cloud.Diagnostics.AspNet</ModuleMask>
       </FilterEntry>
+      <FilterEntry>
+        <ModuleMask>Google.Cloud.Diagnostics.Common</ModuleMask>
+      </FilterEntry>
     </IncludeFilters>
   </Filters>
   <AttributeFilters>

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Snippets/coverage.xml
@@ -7,6 +7,9 @@
       <FilterEntry>
         <ModuleMask>Google.Cloud.Diagnostics.AspNet</ModuleMask>
       </FilterEntry>
+      <FilterEntry>
+        <ModuleMask>Google.Cloud.Diagnostics.Common</ModuleMask>
+      </FilterEntry>
     </IncludeFilters>
   </Filters>
   <AttributeFilters>

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/coverage.xml
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.Tests/coverage.xml
@@ -7,6 +7,9 @@
       <FilterEntry>
         <ModuleMask>Google.Cloud.Diagnostics.AspNet</ModuleMask>
       </FilterEntry>
+      <FilterEntry>
+        <ModuleMask>Google.Cloud.Diagnostics.Common</ModuleMask>
+      </FilterEntry>
     </IncludeFilters>
   </Filters>
   <AttributeFilters>

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Cloud.Diagnostics.Common" Version="4.0.0" />
+    <ProjectReference Include="..\..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.csproj" />
     <PackageReference Include="Grpc.Core" Version="2.27.0" PrivateAssets="None" />
     <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.2.7" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.7" />

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -299,7 +299,7 @@
       "Diagnostics"
     ],
     "dependencies": {
-      "Google.Cloud.Diagnostics.Common": "4.0.0",
+      "Google.Cloud.Diagnostics.Common": "project",
       "Microsoft.AspNet.WebApi.Core": "5.2.7",
       "Microsoft.AspNet.WebPages": "3.2.7",
       "Microsoft.AspNet.Mvc": "5.2.7",

--- a/tools/Google.Cloud.Tools.TagReleases/Program.cs
+++ b/tools/Google.Cloud.Tools.TagReleases/Program.cs
@@ -46,9 +46,9 @@ namespace Google.Cloud.Tools.TagReleases
 
         private static int Main(string[] args)
         {
-            if (args.Length != 1)
+            if (args.Length < 1 || args.Length > 2 || args.Length == 2 && args[1] != "--force")
             {
-                Console.WriteLine("Arguments: <github access token>");
+                Console.WriteLine("Arguments: <github access token> [--force]");
                 return 1;
             }
             try
@@ -69,6 +69,7 @@ namespace Google.Cloud.Tools.TagReleases
 
         private static async Task<int> MainAsync(string[] args)
         {
+            bool force = args.Length == 2 && args[1] == "--force";
             var client = new GitHubClient(new ProductHeaderValue(ApplicationName))
             {
                 Credentials = new Octokit.Credentials(args[0])
@@ -77,7 +78,10 @@ namespace Google.Cloud.Tools.TagReleases
             ValidateLocalRepository(commit);
             var apis = ApiMetadata.LoadApis();
             var newReleases = ComputeNewReleasesAsync(apis);
-            ValidateChanges(newReleases);
+            if (!force)
+            {
+                ValidateChanges(newReleases);
+            }
             if (!ConfirmReleases(newReleases))
             {
                 return 0;


### PR DESCRIPTION
Without this, we get nasty dependency issues as the common
integration test helpers *do* depend on the local version.

With this, our normal project validation for releases will fail - so
TagReleases now has a "--force" option to skip that validation.