### PR TITLE
Manual change to synth.metadata just to try to fix autosynth

### DIFF
--- a/apis/Google.Cloud.SecretManager.V1/synth.metadata
+++ b/apis/Google.Cloud.SecretManager.V1/synth.metadata
@@ -2,8 +2,8 @@
   "sources": [
     {
       "git": {
-        "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
+        "name": "googleapis",
         "sha": "7be2811ad17013a5ea24cd75dfd9e399dd6e18fe"        
       }
     }


### PR DESCRIPTION
(I'm expecting this to fix Google.Cloud.SecretManager.V1, but not
the other APIs.)