### PR TITLE
Touch synth.metadata to get SecretManager APIs building

### DIFF
--- a/apis/Google.Cloud.SecretManager.V1/synth.metadata
+++ b/apis/Google.Cloud.SecretManager.V1/synth.metadata
@@ -2,8 +2,8 @@
   "sources": [
     {
       "git": {
-        "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
+        "name": "googleapis",
         "sha": "7be2811ad17013a5ea24cd75dfd9e399dd6e18fe"        
       }
     }

--- a/apis/Google.Cloud.SecretManager.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/synth.metadata
@@ -2,8 +2,8 @@
   "sources": [
     {
       "git": {
-        "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
+        "name": "googleapis",
         "sha": "7be2811ad17013a5ea24cd75dfd9e399dd6e18fe"        
       }
     }


### PR DESCRIPTION
(This is a temporary approach just to clear the issues for now - we
need to get autosynth to just use HEAD.)