### PR TITLE
Reinstate the "actually upload docs" part of uploaddocs.sh

### DIFF
--- a/uploaddocs.sh
+++ b/uploaddocs.sh
@@ -63,7 +63,7 @@ do
     python -m docuploader create-metadata --name $pkg --version $version --language dotnet --github-repository googleapis/google-cloud-dotnet
     
     echo "Final upload stage"
-    # python -m docuploader upload . --credentials $SERVICE_ACCOUNT_JSON --staging-bucket $STAGING_BUCKET
+    python -m docuploader upload . --credentials $SERVICE_ACCOUNT_JSON --staging-bucket $STAGING_BUCKET
     
     popd > /dev/null
   else


### PR DESCRIPTION
Unfortunately this means we don't have documentation on
googleapis.dev for:

- Google.Cloud.Dialogflow.V2 version 3.0.0-beta01
- Google.Cloud.Storage.V1 version 3.0.0-beta02
- Google.Identity.AccessContextManager.Type version 1.0.0-beta01
- Google.Identity.AccessContextManager.V1 version 1.0.0-beta01
- Google.Cloud.BigQuery.V2 version 2.0.0-beta03
- Google.Cloud.BigQuery.V2 version 1.4.1
- Google.Cloud.Asset.V1 version 2.0.0-beta03

These are all betas that will soon be superceded, except for
BigQuery 1.4.1 - which is the same as 1.4.0 (and has to be). I
therefore propose that we don't try to backfill.