### PR TITLE
Change the format of release names on GitHub.

### DIFF
--- a/tools/Google.Cloud.Tools.TagReleases/Program.cs
+++ b/tools/Google.Cloud.Tools.TagReleases/Program.cs
@@ -184,7 +184,7 @@ namespace Google.Cloud.Tools.TagReleases
                 var gitRelease = new NewRelease(tag)
                 {
                     Prerelease = !api.IsReleaseVersion,
-                    Name = $"{api.Version} release of {api.Id}",
+                    Name = $"{api.Id} version {api.Version}",
                     TargetCommitish = commit.Sha,
                     Body = unwrappedMessage
                 };


### PR DESCRIPTION
For example:

Old style: "3.0.0-beta01 release of Google.Cloud.Dialogflow.V2"
New style: "Google.Cloud.Dialogflow.V2 version 3.0.0-beta01"

Benefits:

- Consistent with the commit style and elsewhere that we refer to releases
- Effectively "most significant part first" making it easier to scan

Drawbacks:

- Inconsistency with history, unless we decide to automatically
  reformat all old releases (which is feasible...)