### PR TITLE
[BigQuery]: Makes BigQueryRow.TimestampConverter support dates pre 1970.

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/ExhaustiveTypesTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/ExhaustiveTypesTest.cs
@@ -151,10 +151,11 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
         }
 
         // Parameterized test to make it easy to add more test cases.
-        // It looks like we didn't have a problem with pre-1970 dates anyway.
-        // See https://github.com/googleapis/google-cloud-dotnet/issues/4031 for background.
+        // See https://github.com/googleapis/google-cloud-dotnet/issues/4031 and
+        // https://github.com/googleapis/google-cloud-dotnet/issues/4821 for background.
         [Theory]
         [InlineData("2004-07-26T15:25:28.173333Z")] // Value is "1.090855528173333E9"
+        [InlineData("1899-12-31T23:00:00.000000Z")] // Vaue is "-2.2089924E9"
         public void TimestampRounding(string timestamp)
         {
             var client = BigQueryClient.Create(_fixture.ProjectId);

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryRowTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryRowTest.cs
@@ -173,8 +173,18 @@ namespace Google.Cloud.BigQuery.V2.Tests
             Assert.Throws<InvalidOperationException>(() => row["struct"]);
         }
 
-        [Fact]
-        public void TimestampRounding()
+        public static IEnumerable<object[]> TimestampRoundingData
+        {
+            get
+            {
+                yield return new object[] { "1.090855528173333E9", new DateTime(2004, 7, 26, 15, 25, 28, DateTimeKind.Utc).AddTicks(1733330) };
+                yield return new object[] { "-2.2089924E9", new DateTime(1899, 12, 31, 23, 0, 0, 0, DateTimeKind.Utc) };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TimestampRoundingData))]
+        public void TimestampRounding(string rawValue, DateTime expected)
         {
             var schema = new TableSchemaBuilder
             {
@@ -184,11 +194,10 @@ namespace Google.Cloud.BigQuery.V2.Tests
             {
                 F = new[]
                 {
-                    new TableCell { V = "1.090855528173333E9" },
+                    new TableCell { V = rawValue },
                 }
             };
             var row = new BigQueryRow(rawRow, schema);
-            var expected = new DateTime(2004, 7, 26, 15, 25, 28, DateTimeKind.Utc).AddTicks(1733330);
             Assert.Equal(expected, (DateTime) row["timestamp"]);
         }
 

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryRow.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryRow.cs
@@ -65,7 +65,7 @@ namespace Google.Cloud.BigQuery.V2
         // Instead, we work out the number of ticks and add that.
         private static readonly Func<string, DateTime> TimestampConverter = v =>
         {
-            decimal seconds = decimal.Parse(v, NumberStyles.AllowDecimalPoint | NumberStyles.AllowExponent, CultureInfo.InvariantCulture);
+            decimal seconds = decimal.Parse(v, NumberStyles.AllowDecimalPoint | NumberStyles.AllowExponent | NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture);
             long microseconds = (long) (seconds * 1e6m);
             long ticks = microseconds * 10;
             return new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddTicks(ticks);


### PR DESCRIPTION
Fixes #4821