### PR TITLE
Release Google.Cloud.Diagnostics.AspNet version 4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Debugger.V2](https://googleapis.dev/dotnet/Google.Cloud.Debugger.V2/2.0.0) | 2.0.0 | [Google Cloud Debugger](https://cloud.google.com/debugger/) |
 | [Google.Cloud.DevTools.Common](https://googleapis.dev/dotnet/Google.Cloud.DevTools.Common/2.0.0) | 2.0.0 | Common Protocol Buffer messages for Google Cloud Developer Tools APIs |
 | [Google.Cloud.DevTools.ContainerAnalysis.V1](https://googleapis.dev/dotnet/Google.Cloud.DevTools.ContainerAnalysis.V1/2.0.0) | 2.0.0 | [Google Container Analysis](https://cloud.google.com/container-registry/docs/container-analysis/) |
-| [Google.Cloud.Diagnostics.AspNet](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.AspNet/4.0.0-beta01) | 4.0.0-beta01 | Google Stackdriver Instrumentation Libraries for ASP.NET |
+| [Google.Cloud.Diagnostics.AspNet](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.AspNet/4.0.0) | 4.0.0 | Google Stackdriver Instrumentation Libraries for ASP.NET |
 | [Google.Cloud.Diagnostics.AspNetCore](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.AspNetCore/4.0.0) | 4.0.0 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core |
 | [Google.Cloud.Diagnostics.AspNetCore.Analyzers](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.AspNetCore.Analyzers/2.0.0) | 2.0.0 | Guidelines for using Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core |
 | [Google.Cloud.Diagnostics.Common](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.Common/4.0.0) | 4.0.0 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries Common Components |

--- a/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet/Google.Cloud.Diagnostics.AspNet.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.0.0-beta01</Version>
+    <Version>4.0.0</Version>
     <TargetFrameworks>net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/apis/Google.Cloud.Diagnostics.AspNet/docs/history.md
+++ b/apis/Google.Cloud.Diagnostics.AspNet/docs/history.md
@@ -1,5 +1,14 @@
 # Version history
 
+# Version 4.0.0, released 2020-04-07
+
+This is now expected to be the last version
+of this package. It targets GAX 3.0, which allows the use of other
+new client libraries also targeting GAX 3.0, but otherwise has no
+new features. We are not expecting to continue working on this
+package at all after this release, other than if a patch is
+required.
+
 # Version 4.0.0-beta01, released 2020-03-26
 
 This is a beta for 4.0.0, which is now expected to be the last version

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -307,7 +307,7 @@
   },
   {
     "id": "Google.Cloud.Diagnostics.AspNet",
-    "version": "4.0.0-beta01",
+    "version": "4.0.0",
     "type": "other",
     "targetFrameworks": "net461",
     "testTargetFrameworks": "net461",

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -34,7 +34,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Debugger.V2](Google.Cloud.Debugger.V2/index.html) | 2.0.0 | [Google Cloud Debugger](https://cloud.google.com/debugger/) |
 | [Google.Cloud.DevTools.Common](Google.Cloud.DevTools.Common/index.html) | 2.0.0 | Common Protocol Buffer messages for Google Cloud Developer Tools APIs |
 | [Google.Cloud.DevTools.ContainerAnalysis.V1](Google.Cloud.DevTools.ContainerAnalysis.V1/index.html) | 2.0.0 | [Google Container Analysis](https://cloud.google.com/container-registry/docs/container-analysis/) |
-| [Google.Cloud.Diagnostics.AspNet](Google.Cloud.Diagnostics.AspNet/index.html) | 4.0.0-beta01 | Google Stackdriver Instrumentation Libraries for ASP.NET |
+| [Google.Cloud.Diagnostics.AspNet](Google.Cloud.Diagnostics.AspNet/index.html) | 4.0.0 | Google Stackdriver Instrumentation Libraries for ASP.NET |
 | [Google.Cloud.Diagnostics.AspNetCore](Google.Cloud.Diagnostics.AspNetCore/index.html) | 4.0.0 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core |
 | [Google.Cloud.Diagnostics.AspNetCore.Analyzers](Google.Cloud.Diagnostics.AspNetCore.Analyzers/index.html) | 2.0.0 | Guidelines for using Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core |
 | [Google.Cloud.Diagnostics.Common](Google.Cloud.Diagnostics.Common/index.html) | 4.0.0 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries Common Components |


### PR DESCRIPTION
Changes in this release:

This is now expected to be the last version
of this package. It targets GAX 3.0, which allows the use of other
new client libraries also targeting GAX 3.0, but otherwise has no
new features. We are not expecting to continue working on this
package at all after this release, other than if a patch is
required.

Fixes #4658