### PR TITLE
Refactor TagReleases and add new features

### DIFF
--- a/PROCESSES.md
+++ b/PROCESSES.md
@@ -226,25 +226,43 @@ $ git push
 Prerequisite: the PR above has been reviewed and merged into the
 master branch.
 
-1. Checkout the master branch and pull the latest code, which should
-now include the changes you've made.
-
-2. Run `tagreleases.sh` in the root directory, specifying a github
+Run `tagreleases.sh` in the root directory, specifying a github
 access token. This will ask you to confirm that you want to create a
-release.
+release. As of April 2020, this no longer accesses your
+local repository at all, so it doesn't matter what branch you're on.
 
 Sample session:
 
 ```text
-$ git checkout master
-$ git pull upstream master
 $ ./tagreleases.sh your_access_token_here
+
+Fetching all tags from GitHub
+Fetched 1065 tags
+Commit to tag: e6ace9f3836d9eabe9b4761598b4010b4771fede
+---------
+Release Google.Cloud.WebRisk.V1 version 1.0.0
+
+Changes in this release:
+
+No API surface changes since 1.0.0-beta01.
+---------
+APIs requiring a new release:
+Google.Cloud.WebRisk.V1                            v1.0.0
+Go ahead and create releases? (y/n) y
+Creating releases with tags:
+Google.Cloud.WebRisk.V1-1.0.0
 ```
 
 Note that `tagreleases.sh` checks that there are no project
 references from APIs being released now to APIs that *aren't* being
 released. Without this check, it's possible for a released version
-to depend on unreleased changes.
+to depend on unreleased changes. The `--force` command line option
+will skip this check, but we strongly recommend that you don't use
+this without checking with the core .NET client library team.
+
+`tagreleases.sh` allows a specific commit to be the target of the
+tag, rather than the HEAD of master. Just use `--commit=<sha>` as a
+command line argument after the GitHub token.
 
 **Building and publishing the release**
 

--- a/tagreleases.sh
+++ b/tagreleases.sh
@@ -2,13 +2,4 @@
 
 set -e 
 
-if [ -z "$1" ]
-then
-  echo Please specify a github access token
-  exit 1
-fi
-
-# Make sure we have all the tags locally.
-git fetch --all --tags -f -q
-
-dotnet run -p tools/Google.Cloud.Tools.TagReleases -- $1
+dotnet run -p tools/Google.Cloud.Tools.TagReleases -- $*

--- a/tools/Google.Cloud.Tools.Common/ApiMetadata.cs
+++ b/tools/Google.Cloud.Tools.Common/ApiMetadata.cs
@@ -86,6 +86,11 @@ namespace Google.Cloud.Tools.Common
         public static string CatalogPath => Path.Combine(DirectoryLayout.DetermineRootDirectory(), "apis", "apis.json");
 
         /// <summary>
+        /// The relative path to the catalog path, e.g. for use when fetching from GitHub.
+        /// </summary>
+        public static string RelativeCatalogPath = "apis/apis.json";
+
+        /// <summary>
         /// The release level to record in .repo-metadata.json, if this differs from the one
         /// inferred from the JSON. (For example, we will have 2.0.0-alpha00 versions that didn't
         /// have a 1.0.0.)
@@ -107,10 +112,11 @@ namespace Google.Cloud.Tools.Common
             }
         }
 
-        public static List<ApiMetadata> LoadApis()
-        {
-            var json = File.ReadAllText(CatalogPath);
-            return JsonConvert.DeserializeObject<List<ApiMetadata>>(json);
-        }
+        // TODO: Introduce an ApiCatalog type rather than dealing with lists all the time.
+        public static List<ApiMetadata> LoadApis() =>
+            LoadApisFromJson(File.ReadAllText(CatalogPath));
+
+        public static List<ApiMetadata> LoadApisFromJson(string json) =>
+            JsonConvert.DeserializeObject<List<ApiMetadata>>(json);
     }
 }

--- a/tools/Google.Cloud.Tools.TagReleases/Config.cs
+++ b/tools/Google.Cloud.Tools.TagReleases/Config.cs
@@ -1,0 +1,88 @@
+﻿// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Tools.Common;
+using System;
+using System.Linq;
+
+namespace Google.Cloud.Tools.TagReleases
+{
+    /// <summary>
+    /// The configuration specified on the commandline.
+    /// </summary>
+    public sealed class Config
+    {
+        /// <summary>
+        /// Access token to github
+        /// </summary>
+        public string GitHubToken { get; }
+
+        /// <summary>
+        /// Committish (e.g. master, a commit hash or a branch) to tag.
+        /// </summary>
+        public string Committish { get; }
+
+        /// <summary>
+        /// Whether to skip the check for "all project references must be released along with the package that references them".
+        /// </summary>
+        public bool SkipProjectReferenceCheck { get; }
+
+        private Config(string gitHubToken, string committish, bool skipProjectReferenceCheck) =>
+            (GitHubToken, Committish, SkipProjectReferenceCheck) =
+            (gitHubToken, committish, skipProjectReferenceCheck);
+
+        /// <summary>
+        /// Creates a configuration from the command line arguments. The returned configuration may not be valid;
+        /// use <see cref="IsValid"/> to check.
+        /// </summary>
+        public static Config FromCommandLine(string[] args)
+        {
+            string token = null;
+            string committish = "master";
+            bool skipProjectReferenceCheck = false;
+            // First command line option is always the token.
+            if (args.Length > 0)
+            {
+                token = args[0];
+            }
+            // After that, we have "named" arguments
+            foreach (var arg in args.Skip(1))
+            {
+                if (arg.StartsWith("--commit="))
+                {
+                    committish = arg.Substring("--commit=".Length);
+                }
+                else if (arg == "--force")
+                {
+                    skipProjectReferenceCheck = true;
+                }
+                else
+                {
+                    throw new UserErrorException($"Unhandled command line argument: '{arg}'");
+                }
+            }
+            return new Config(token, committish, skipProjectReferenceCheck);
+        }
+
+        public bool IsValid => !string.IsNullOrEmpty(GitHubToken) && !string.IsNullOrEmpty(Committish);
+
+        public void DisplayUsage()
+        {
+            Console.WriteLine($"Command line arguments: <token> [--commit=...] [--force]");
+            Console.WriteLine("token: The GitHub access token. Required.");
+            Console.WriteLine($"--commit: The remote 'committish' to tag; defaults to 'master', but can be a hash, branch or another tag.");
+            Console.WriteLine($"--force: Disables the check for project reference integrity. Use with care; consult the team if uncertain.");
+        }
+    }
+}

--- a/tools/Google.Cloud.Tools.TagReleases/Google.Cloud.Tools.TagReleases.csproj
+++ b/tools/Google.Cloud.Tools.TagReleases/Google.Cloud.Tools.TagReleases.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp" Version="0.26.1" />
     <PackageReference Include="Octokit" Version="0.32.0" />
   </ItemGroup>
 


### PR DESCRIPTION
- Command line parsing is now extracted to Config.cs
- We now don't use the local repo at all
- New feature: specify a commit to tag instead of depending on master