### PR TITLE
Release Google.Cloud.Talent.V4Beta1 version 2.0.0-beta03

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Speech.V1](https://googleapis.dev/dotnet/Google.Cloud.Speech.V1/2.0.0) | 2.0.0 | [Google Cloud Speech](https://cloud.google.com/speech) |
 | [Google.Cloud.Speech.V1P1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Speech.V1P1Beta1/2.0.0-beta02) | 2.0.0-beta02 | [Google Cloud Speech](https://cloud.google.com/speech) |
 | [Google.Cloud.Storage.V1](https://googleapis.dev/dotnet/Google.Cloud.Storage.V1/3.0.0-beta03) | 3.0.0-beta03 | [Google Cloud Storage](https://cloud.google.com/storage/) |
-| [Google.Cloud.Talent.V4Beta1](https://googleapis.dev/dotnet/Google.Cloud.Talent.V4Beta1/2.0.0-beta02) | 2.0.0-beta02 | [Google Cloud Talent Solution](https://cloud.google.com/talent-solution/) |
+| [Google.Cloud.Talent.V4Beta1](https://googleapis.dev/dotnet/Google.Cloud.Talent.V4Beta1/2.0.0-beta03) | 2.0.0-beta03 | [Google Cloud Talent Solution](https://cloud.google.com/talent-solution/) |
 | [Google.Cloud.Tasks.V2](https://googleapis.dev/dotnet/Google.Cloud.Tasks.V2/2.0.0) | 2.0.0 | [Google Cloud Tasks](https://cloud.google.com/tasks/) |
 | [Google.Cloud.Tasks.V2Beta3](https://googleapis.dev/dotnet/Google.Cloud.Tasks.V2Beta3/2.0.0-beta02) | 2.0.0-beta02 | [Google Cloud Tasks](https://cloud.google.com/tasks/) |
 | [Google.Cloud.TextToSpeech.V1](https://googleapis.dev/dotnet/Google.Cloud.TextToSpeech.V1/2.0.0) | 2.0.0 | [Google Cloud Text-to-Speech](https://cloud.google.com/text-to-speech) |

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.csproj
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta02</Version>
+    <Version>2.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/apis/Google.Cloud.Talent.V4Beta1/docs/history.md
+++ b/apis/Google.Cloud.Talent.V4Beta1/docs/history.md
@@ -1,6 +1,12 @@
 # Version history
 
-(This API has changed significantly over time, and the history is tricky to backfill. Future changes will be tracked more closely.)
+# Version 2.0.0-beta03, released 2020-04-14
+
+- [Commit 28bdca8](https://github.com/googleapis/google-cloud-dotnet/commit/28bdca8): Fix (breaking change): reorder Company and Job resources in talent API to be consistent with old gapic config.
+
+Note that this breaking change was expected, and was performed to
+improve the experience moving forward. (As part of a beta API,
+periodic breaking changes are somewhat expected.)
 
 # Version 2.0.0-beta02, released 2020-03-19
 
@@ -14,6 +20,8 @@ uses of `TenantOrProjectName` with `TenantName` or `ProjectName`.
 This is the first prerelease targeting GAX v3. Please see the [breaking changes
 guide](https://googleapis.github.io/google-cloud-dotnet/docs/guides/breaking-gax2.html)
 for details of changes to both GAX and code generation.
+
+(This API has changed significantly over time, and the history before this point is tricky to backfill.)
 
 # Version 1.0.0-beta09, released 2019-12-10
 

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1257,7 +1257,7 @@
     "protoPath": "google/cloud/talent/v4beta1",
     "productName": "Google Cloud Talent Solution",
     "productUrl": "https://cloud.google.com/talent-solution/",
-    "version": "2.0.0-beta02",
+    "version": "2.0.0-beta03",
     "releaseLevelOverride": "beta",
     "type": "grpc",
     "description": "Recommended Google client library to access the Google Cloud Talent solution API which provides the capability to create, read, update, and delete job postings, as well as search jobs based on keywords and filters.",

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -82,7 +82,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Speech.V1](Google.Cloud.Speech.V1/index.html) | 2.0.0 | [Google Cloud Speech](https://cloud.google.com/speech) |
 | [Google.Cloud.Speech.V1P1Beta1](Google.Cloud.Speech.V1P1Beta1/index.html) | 2.0.0-beta02 | [Google Cloud Speech](https://cloud.google.com/speech) |
 | [Google.Cloud.Storage.V1](Google.Cloud.Storage.V1/index.html) | 3.0.0-beta03 | [Google Cloud Storage](https://cloud.google.com/storage/) |
-| [Google.Cloud.Talent.V4Beta1](Google.Cloud.Talent.V4Beta1/index.html) | 2.0.0-beta02 | [Google Cloud Talent Solution](https://cloud.google.com/talent-solution/) |
+| [Google.Cloud.Talent.V4Beta1](Google.Cloud.Talent.V4Beta1/index.html) | 2.0.0-beta03 | [Google Cloud Talent Solution](https://cloud.google.com/talent-solution/) |
 | [Google.Cloud.Tasks.V2](Google.Cloud.Tasks.V2/index.html) | 2.0.0 | [Google Cloud Tasks](https://cloud.google.com/tasks/) |
 | [Google.Cloud.Tasks.V2Beta3](Google.Cloud.Tasks.V2Beta3/index.html) | 2.0.0-beta02 | [Google Cloud Tasks](https://cloud.google.com/tasks/) |
 | [Google.Cloud.TextToSpeech.V1](Google.Cloud.TextToSpeech.V1/index.html) | 2.0.0 | [Google Cloud Text-to-Speech](https://cloud.google.com/text-to-speech) |


### PR DESCRIPTION
Changes in this release:

- [Commit 28bdca8](https://github.com/googleapis/google-cloud-dotnet/commit/28bdca8): Fix (breaking change): reorder Company and Job resources in talent API to be consistent with old gapic config.

Note that this breaking change was expected, and was performed to
improve the experience moving forward. (As part of a beta API,
periodic breaking changes are somewhat expected.)