### PR TITLE
Allow GoogleStackdriverAppender to be configured to create JSON payloads

### DIFF
--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/GoogleStackdriverAppender.cs
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/GoogleStackdriverAppender.cs
@@ -338,13 +338,22 @@ namespace Google.Cloud.Logging.Log4Net
             }
             var logEntry = new LogEntry
             {
-                TextPayload = RenderLoggingEvent(loggingEvent),
                 Severity = s_levelMap[loggingEvent.Level],
                 Timestamp = loggingEvent.TimeStamp.ToTimestamp(),
                 LogName = _logName,
                 Resource = _resource,
                 Labels = { labels },
             };
+            // Note that we can't just unconditionally set both TextPayload and JsonPayload, as they're items in a oneof in the proto.
+            var jsonPayload = JsonLayout?.Format(loggingEvent);
+            if (jsonPayload is null)
+            {
+                logEntry.TextPayload = RenderLoggingEvent(loggingEvent);
+            }
+            else
+            {
+                logEntry.JsonPayload = jsonPayload;
+            }
             if (sourceLocation != null)
             {
                 logEntry.SourceLocation = sourceLocation;

--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/GoogleStackdriverAppender_Configuration.cs
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/GoogleStackdriverAppender_Configuration.cs
@@ -318,6 +318,17 @@ namespace Google.Cloud.Logging.Log4Net
             set => _disposeTimeoutSeconds = ThrowIfActivated(value, nameof(DisposeTimeoutSeconds));
         }
 
+        private IJsonLayout _jsonLayout = null;
+        /// <summary>
+        /// A "layout" to use to convert each logging event into a JSON payload. If this is null (the default),
+        /// or if it returns a null JSON payload for a particular logging event, a text payload is used instead.
+        /// </summary>
+        public IJsonLayout JsonLayout
+        {
+            get => _jsonLayout;
+            set => _jsonLayout = ThrowIfActivated(value, nameof(JsonLayout));
+        }
+
         private T ThrowIfActivated<T>(T value, string name)
         {
             GaxPreconditions.CheckState(!_isActivated, "Appender already activated; cannot modify '{0}'", name);

--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/IJsonLayout.cs
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/IJsonLayout.cs
@@ -1,0 +1,35 @@
+﻿// Copyright 2020, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Protobuf.WellKnownTypes;
+using log4net.Core;
+using log4net.Layout;
+
+namespace Google.Cloud.Logging.Log4Net
+{
+    /// <summary>
+    /// The equivalent to <see cref="ILayout"/>, but for converting
+    /// a <see cref="LoggingEvent"/> to a JSON payload in the form of
+    /// a <see cref="Struct"/>.
+    /// </summary>
+    public interface IJsonLayout
+    {
+        /// <summary>
+        /// Formats the given logging event as a JSON logging payload.
+        /// </summary>
+        /// <param name="loggingEvent">The event to format. This will never be null.</param>
+        /// <returns>The JSON payload to log, or null to log a text payload instead.</returns>
+        Struct Format(LoggingEvent loggingEvent);
+    }
+}


### PR DESCRIPTION
User code needs to implement a new IJsonLayout interface, and configure the appender appropriately.
Documentation will follow in the next PR.

Note that Log4NetTest looks like it had inconsistent line endings - review without whitespace for a simple diff.

Fixes #4845.