### PR TITLE
Release Google.Cloud.Logging.Log4Net version 3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Iam.V1](https://googleapis.dev/dotnet/Google.Cloud.Iam.V1/2.0.0) | 2.0.0 | [Google Cloud Identity and Access Management (IAM)](https://cloud.google.com/iam/) |
 | [Google.Cloud.Kms.V1](https://googleapis.dev/dotnet/Google.Cloud.Kms.V1/2.0.0) | 2.0.0 | [Google Cloud Key Management Service](https://cloud.google.com/kms/) |
 | [Google.Cloud.Language.V1](https://googleapis.dev/dotnet/Google.Cloud.Language.V1/2.0.0) | 2.0.0 | [Google Cloud Natural Language](https://cloud.google.com/natural-language) |
-| [Google.Cloud.Logging.Log4Net](https://googleapis.dev/dotnet/Google.Cloud.Logging.Log4Net/3.0.0) | 3.0.0 | Log4Net client library for the Google Cloud Logging API |
+| [Google.Cloud.Logging.Log4Net](https://googleapis.dev/dotnet/Google.Cloud.Logging.Log4Net/3.1.0) | 3.1.0 | Log4Net client library for the Google Cloud Logging API |
 | [Google.Cloud.Logging.NLog](https://googleapis.dev/dotnet/Google.Cloud.Logging.NLog/3.0.0) | 3.0.0 | NLog target for the Google Cloud Logging API |
 | [Google.Cloud.Logging.Type](https://googleapis.dev/dotnet/Google.Cloud.Logging.Type/3.0.0) | 3.0.0 | Version-agnostic types for the Google Cloud Logging API |
 | [Google.Cloud.Logging.V2](https://googleapis.dev/dotnet/Google.Cloud.Logging.V2/3.0.0) | 3.0.0 | [Google Cloud Logging](https://cloud.google.com/logging/) |

--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.csproj
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0</Version>
+    <Version>3.1.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/apis/Google.Cloud.Logging.Log4Net/docs/history.md
+++ b/apis/Google.Cloud.Logging.Log4Net/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+# Version 3.1.0, released 2020-04-16
+
+- [Commit 51d65fa](https://github.com/googleapis/google-cloud-dotnet/commit/51d65fa): Feature: Allow GoogleStackdriverAppender to be configured to create JSON payloads
+  - User code needs to implement a new IJsonLayout interface, and configure the appender appropriately.
+  - Fixes [issue 4845](https://github.com/googleapis/google-cloud-dotnet/issues/4845).
+
 # Version 3.0.0, released 2020-03-18
 
 No API surface changes compared with 3.0.0-beta01, just dependency

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -620,7 +620,7 @@
   },
   {
     "id": "Google.Cloud.Logging.Log4Net",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "type": "other",
     "targetFrameworks": "netstandard2.0;net461",
     "testTargetFrameworks": "netcoreapp2.1;net461",

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -48,7 +48,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Iam.V1](Google.Cloud.Iam.V1/index.html) | 2.0.0 | [Google Cloud Identity and Access Management (IAM)](https://cloud.google.com/iam/) |
 | [Google.Cloud.Kms.V1](Google.Cloud.Kms.V1/index.html) | 2.0.0 | [Google Cloud Key Management Service](https://cloud.google.com/kms/) |
 | [Google.Cloud.Language.V1](Google.Cloud.Language.V1/index.html) | 2.0.0 | [Google Cloud Natural Language](https://cloud.google.com/natural-language) |
-| [Google.Cloud.Logging.Log4Net](Google.Cloud.Logging.Log4Net/index.html) | 3.0.0 | Log4Net client library for the Google Cloud Logging API |
+| [Google.Cloud.Logging.Log4Net](Google.Cloud.Logging.Log4Net/index.html) | 3.1.0 | Log4Net client library for the Google Cloud Logging API |
 | [Google.Cloud.Logging.NLog](Google.Cloud.Logging.NLog/index.html) | 3.0.0 | NLog target for the Google Cloud Logging API |
 | [Google.Cloud.Logging.Type](Google.Cloud.Logging.Type/index.html) | 3.0.0 | Version-agnostic types for the Google Cloud Logging API |
 | [Google.Cloud.Logging.V2](Google.Cloud.Logging.V2/index.html) | 3.0.0 | [Google Cloud Logging](https://cloud.google.com/logging/) |


### PR DESCRIPTION
Changes in this release:

- [Commit 51d65fa](https://github.com/googleapis/google-cloud-dotnet/commit/51d65fa): Feature: Allow GoogleStackdriverAppender to be configured to create JSON payloads
  - User code needs to implement a new IJsonLayout interface, and configure the appender appropriately.
  - Fixes [issue 4845](https://github.com/googleapis/google-cloud-dotnet/issues/4845).