### PR TITLE
Add readme for log4net to satisfy existing documentation

### DIFF
--- a/apis/Google.Cloud.Logging.Log4Net/readme.md
+++ b/apis/Google.Cloud.Logging.Log4Net/readme.md
@@ -1,0 +1,6 @@
+## Configuration documentation has moved
+
+The configuration documentation for the Log4Net appender is now here:
+https://googleapis.dev/dotnet/Google.Cloud.Logging.Log4Net/latest/configuration.html
+
+This file only exists to satisfy old documentation that links to it.


### PR DESCRIPTION
(Example: https://googleapis.dev/dotnet/Google.Cloud.Logging.Log4Net/3.0.0/index.html links to it.)