### PR TITLE
NLog GoogleStackdriverTarget improve handling of System.Reflection objects

### DIFF
--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/GoogleStackdriverTarget.cs
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/GoogleStackdriverTarget.cs
@@ -136,6 +136,9 @@ namespace Google.Cloud.Logging.NLog
                 ReferenceLoopHandling = Newtonsoft.Json.ReferenceLoopHandling.Ignore
             };
             jsonSettings.Converters.Add(new Newtonsoft.Json.Converters.StringEnumConverter());
+            jsonSettings.Converters.Add(new ToStringJsonConverter(typeof(MethodInfo)));
+            jsonSettings.Converters.Add(new ToStringJsonConverter(typeof(Assembly)));
+            jsonSettings.Converters.Add(new ToStringJsonConverter(typeof(Module)));
             jsonSettings.Error = (sender, args) =>
             {
                 // Serialization of properties that throws exceptions should not break everything

--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/ToStringJsonConverter.cs
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/ToStringJsonConverter.cs
@@ -1,0 +1,57 @@
+﻿// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Newtonsoft.Json;
+
+namespace Google.Cloud.Logging.NLog
+{
+    internal sealed class ToStringJsonConverter : JsonConverter
+    {
+        private readonly System.Type _type;
+
+        /// <inheritdoc />
+        public override bool CanRead { get; } = false;
+
+        public ToStringJsonConverter(System.Type type)
+        {
+            _type = type;
+        }
+
+        /// <inheritdoc />
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            if (value == null)
+            {
+                writer.WriteNull();
+            }
+            else
+            {
+                writer.WriteValue(value.ToString());
+            }
+        }
+
+        /// <inheritdoc />
+        public override object ReadJson(JsonReader reader, System.Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            throw new NotSupportedException("Only serialization is supported");
+        }
+
+        /// <inheritdoc />
+        public override bool CanConvert(System.Type objectType)
+        {
+            return _type.IsAssignableFrom(objectType);
+        }
+    }
+}


### PR DESCRIPTION
Protect against System.Reflection Objects like `Assembly`, `MethodInfo`, `Module`, that will dump all types in the the application-assembly.