### PR TITLE
Release Google.Cloud.Logging.NLog version 3.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Kms.V1](https://googleapis.dev/dotnet/Google.Cloud.Kms.V1/2.0.0) | 2.0.0 | [Google Cloud Key Management Service](https://cloud.google.com/kms/) |
 | [Google.Cloud.Language.V1](https://googleapis.dev/dotnet/Google.Cloud.Language.V1/2.0.0) | 2.0.0 | [Google Cloud Natural Language](https://cloud.google.com/natural-language) |
 | [Google.Cloud.Logging.Log4Net](https://googleapis.dev/dotnet/Google.Cloud.Logging.Log4Net/3.1.0) | 3.1.0 | Log4Net client library for the Google Cloud Logging API |
-| [Google.Cloud.Logging.NLog](https://googleapis.dev/dotnet/Google.Cloud.Logging.NLog/3.0.0) | 3.0.0 | NLog target for the Google Cloud Logging API |
+| [Google.Cloud.Logging.NLog](https://googleapis.dev/dotnet/Google.Cloud.Logging.NLog/3.0.1) | 3.0.1 | NLog target for the Google Cloud Logging API |
 | [Google.Cloud.Logging.Type](https://googleapis.dev/dotnet/Google.Cloud.Logging.Type/3.0.0) | 3.0.0 | Version-agnostic types for the Google Cloud Logging API |
 | [Google.Cloud.Logging.V2](https://googleapis.dev/dotnet/Google.Cloud.Logging.V2/3.0.0) | 3.0.0 | [Google Cloud Logging](https://cloud.google.com/logging/) |
 | [Google.Cloud.ManagedIdentities.V1](https://googleapis.dev/dotnet/Google.Cloud.ManagedIdentities.V1/2.0.0) | 2.0.0 | [Managed Service for Microsoft Active Directory](https://cloud.google.com/managed-microsoft-ad/) |

--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.csproj
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0</Version>
+    <Version>3.0.1</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/apis/Google.Cloud.Logging.NLog/docs/history.md
+++ b/apis/Google.Cloud.Logging.NLog/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 3.0.1, released 2020-04-20
+
+- [Commit ced67e4](https://github.com/googleapis/google-cloud-dotnet/commit/ced67e4): Fix: Improve handling of System.Reflection objects that will dump all types in the application-assembly.
+
 # Version 3.0.0, released 2020-03-18
 
 No API surface changes compared with 3.0.0-beta02, just dependency

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -644,7 +644,7 @@
     },
     {
       "id": "Google.Cloud.Logging.NLog",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "type": "other",
       "targetFrameworks": "netstandard2.0;net461",
       "testTargetFrameworks": "netcoreapp2.1;net461",

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -49,7 +49,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Kms.V1](Google.Cloud.Kms.V1/index.html) | 2.0.0 | [Google Cloud Key Management Service](https://cloud.google.com/kms/) |
 | [Google.Cloud.Language.V1](Google.Cloud.Language.V1/index.html) | 2.0.0 | [Google Cloud Natural Language](https://cloud.google.com/natural-language) |
 | [Google.Cloud.Logging.Log4Net](Google.Cloud.Logging.Log4Net/index.html) | 3.1.0 | Log4Net client library for the Google Cloud Logging API |
-| [Google.Cloud.Logging.NLog](Google.Cloud.Logging.NLog/index.html) | 3.0.0 | NLog target for the Google Cloud Logging API |
+| [Google.Cloud.Logging.NLog](Google.Cloud.Logging.NLog/index.html) | 3.0.1 | NLog target for the Google Cloud Logging API |
 | [Google.Cloud.Logging.Type](Google.Cloud.Logging.Type/index.html) | 3.0.0 | Version-agnostic types for the Google Cloud Logging API |
 | [Google.Cloud.Logging.V2](Google.Cloud.Logging.V2/index.html) | 3.0.0 | [Google Cloud Logging](https://cloud.google.com/logging/) |
 | [Google.Cloud.ManagedIdentities.V1](Google.Cloud.ManagedIdentities.V1/index.html) | 2.0.0 | [Managed Service for Microsoft Active Directory](https://cloud.google.com/managed-microsoft-ad/) |


### PR DESCRIPTION
Changes in this release:

- [Commit ced67e4](https://github.com/googleapis/google-cloud-dotnet/commit/ced67e4): Fix: Improve handling of System.Reflection objects that will dump all types in the the application-assembly.