### PR TITLE
Release Google.Cloud.Gaming.V1Beta version 1.0.0-beta03

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Firestore.Admin.V1](https://googleapis.dev/dotnet/Google.Cloud.Firestore.Admin.V1/2.0.0) | 2.0.0 | [Firestore Admin](https://firebase.google.com) |
 | [Google.Cloud.Firestore](https://googleapis.dev/dotnet/Google.Cloud.Firestore/2.0.0-beta02) | 2.0.0-beta02 | [Firestore](https://firebase.google.com/docs/firestore/) |
 | [Google.Cloud.Firestore.V1](https://googleapis.dev/dotnet/Google.Cloud.Firestore.V1/2.0.0-beta02) | 2.0.0-beta02 | [Firestore](https://firebase.google.com) |
-| [Google.Cloud.Gaming.V1Beta](https://googleapis.dev/dotnet/Google.Cloud.Gaming.V1Beta/1.0.0-beta02) | 1.0.0-beta02 | [Google Cloud for Games](https://cloud.google.com/solutions/gaming) |
+| [Google.Cloud.Gaming.V1Beta](https://googleapis.dev/dotnet/Google.Cloud.Gaming.V1Beta/1.0.0-beta03) | 1.0.0-beta03 | [Google Cloud for Games](https://cloud.google.com/solutions/gaming) |
 | [Google.Cloud.Iam.V1](https://googleapis.dev/dotnet/Google.Cloud.Iam.V1/2.0.0) | 2.0.0 | [Google Cloud Identity and Access Management (IAM)](https://cloud.google.com/iam/) |
 | [Google.Cloud.Kms.V1](https://googleapis.dev/dotnet/Google.Cloud.Kms.V1/2.0.0) | 2.0.0 | [Google Cloud Key Management Service](https://cloud.google.com/kms/) |
 | [Google.Cloud.Language.V1](https://googleapis.dev/dotnet/Google.Cloud.Language.V1/2.0.0) | 2.0.0 | [Google Cloud Natural Language](https://cloud.google.com/natural-language) |

--- a/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta.csproj
+++ b/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Gaming API, version v1beta.</Description>

--- a/apis/Google.Cloud.Gaming.V1Beta/docs/history.md
+++ b/apis/Google.Cloud.Gaming.V1Beta/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.0.0-beta03, released 2020-04-22
+
+No API changes; this release is for release automation testing.
+
 # Version 1.0.0-beta02, released 2020-04-17
 
 No API changes; this release is for release automation testing.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -547,7 +547,7 @@
       "id": "Google.Cloud.Gaming.V1Beta",
       "generator": "micro",
       "protoPath": "google/cloud/gaming/v1beta",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0-beta03",
       "type": "grpc",
       "productName": "Google Cloud for Games",
       "productUrl": "https://cloud.google.com/solutions/gaming",

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -44,7 +44,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Firestore.Admin.V1](Google.Cloud.Firestore.Admin.V1/index.html) | 2.0.0 | [Firestore Admin](https://firebase.google.com) |
 | [Google.Cloud.Firestore](Google.Cloud.Firestore/index.html) | 2.0.0-beta02 | [Firestore](https://firebase.google.com/docs/firestore/) |
 | [Google.Cloud.Firestore.V1](Google.Cloud.Firestore.V1/index.html) | 2.0.0-beta02 | [Firestore](https://firebase.google.com) |
-| [Google.Cloud.Gaming.V1Beta](Google.Cloud.Gaming.V1Beta/index.html) | 1.0.0-beta02 | [Google Cloud for Games](https://cloud.google.com/solutions/gaming) |
+| [Google.Cloud.Gaming.V1Beta](Google.Cloud.Gaming.V1Beta/index.html) | 1.0.0-beta03 | [Google Cloud for Games](https://cloud.google.com/solutions/gaming) |
 | [Google.Cloud.Iam.V1](Google.Cloud.Iam.V1/index.html) | 2.0.0 | [Google Cloud Identity and Access Management (IAM)](https://cloud.google.com/iam/) |
 | [Google.Cloud.Kms.V1](Google.Cloud.Kms.V1/index.html) | 2.0.0 | [Google Cloud Key Management Service](https://cloud.google.com/kms/) |
 | [Google.Cloud.Language.V1](Google.Cloud.Language.V1/index.html) | 2.0.0 | [Google Cloud Natural Language](https://cloud.google.com/natural-language) |


### PR DESCRIPTION
Changes in this release:

No API changes; this release is for release automation testing.

- Release Google.Cloud.Gaming.V1Beta version 1.0.0-beta03