### PR TITLE
Fix autorelease report publication

### DIFF
--- a/.kokoro/autorelease.sh
+++ b/.kokoro/autorelease.sh
@@ -7,6 +7,10 @@ SCRIPT_DIR=$(dirname "$SCRIPT")
 
 cd $SCRIPT_DIR
 
+# The publish reporter script uses "python3" which doesn't exist on Windows.
+# We already know how to find it though, so let's just use an alias.
+alias python3=$(source toolversions.sh && echo $PYTHON3)
+
 # Make sure we have the most recent version of pip, then install the gcp-releasetool package
 python -m pip install --upgrade pip
 python -m pip install gcp-releasetool


### PR DESCRIPTION
Currently the build runs automatically, but we don't get a report in
the PR in the way we'd expect.