### PR TITLE
Refactor ReleaseManager into a separate class per command

### DIFF
--- a/tools/Google.Cloud.Tools.ReleaseManager/ApiVersionPair.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/ApiVersionPair.cs
@@ -14,7 +14,7 @@
 
 namespace Google.Cloud.Tools.ReleaseManager
 {
-    internal sealed class ApiVersionPair
+    public sealed class ApiVersionPair
     {
         /// <summary>
         /// The API ID, e.g. "Google.Cloud.Storage.V1"

--- a/tools/Google.Cloud.Tools.ReleaseManager/CommandBase.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/CommandBase.cs
@@ -1,0 +1,96 @@
+﻿// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Tools.Common;
+using LibGit2Sharp;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Google.Cloud.Tools.ReleaseManager
+{
+    /// <summary>
+    /// Base class for commands, providing rudimentary validation and common command code.
+    /// </summary>
+    public abstract class CommandBase : ICommand
+    {
+        // The branch we're thinking of as master. It may actually be some other branch for occasional
+        // releases, but fundamentally it's "the current source of truth we're basing this release on".
+        private const string MasterBranch = "master";
+
+        private readonly int _expectedArgCount;
+
+        public string Description { get; }
+
+        public string Command { get; }
+
+        public string ExpectedArguments { get; }
+
+
+        protected CommandBase(string command, string description, params string[] argNames)
+        {
+            Command = command;
+            Description = description;
+            _expectedArgCount = argNames.Length;
+            ExpectedArguments = string.Join(" ", argNames.Select(arg => $"<{arg}>"));
+        }
+
+        public void Execute(string[] args)
+        {
+            if (args.Length != _expectedArgCount)
+            {
+                throw new UserErrorException(_expectedArgCount == 0
+                    ? $"{Command} does not accept additional arguments"
+                    : $"{Command} expected arguments: {ExpectedArguments}");
+            }
+            ExecuteImpl(args);
+        }
+
+        /// <summary>
+        /// Executes the command.
+        /// </summary>
+        /// <param name="args">The command line arguments other than the command name.
+        /// This will have been validated to have the expected number of arguments.</param>
+        protected abstract void ExecuteImpl(string[] args);
+
+        protected List<ApiVersionPair> FindChangedVersions()
+        {
+            var currentCatalog = ApiCatalog.Load();
+            var masterCatalog = LoadMasterCatalog();
+            var currentVersions = currentCatalog.CreateRawVersionMap();
+            var masterVersions = masterCatalog.CreateRawVersionMap();
+            return currentVersions.Keys.Concat(masterVersions.Keys)
+                .Distinct()
+                .OrderBy(id => id)
+                .Select(id => new ApiVersionPair(id, masterVersions.GetValueOrDefault(id), currentVersions.GetValueOrDefault(id)))
+                .Where(v => v.NewVersion != v.OldVersion)
+                .ToList();
+        }
+
+        protected ApiCatalog LoadMasterCatalog()
+        {
+            var root = DirectoryLayout.DetermineRootDirectory();
+            using (var repo = new Repository(root))
+            {
+                var master = repo.Branches.FirstOrDefault(b => b.FriendlyName == MasterBranch);
+                if (master == null)
+                {
+                    throw new UserErrorException($"Unable to find branch '{MasterBranch}'.");
+                }
+
+                var masterCatalogJson = master.Commits.First()["apis/apis.json"].Target.Peel<Blob>().GetContentText();
+                return ApiCatalog.FromJson(masterCatalogJson);
+            }
+        }
+    }
+}

--- a/tools/Google.Cloud.Tools.ReleaseManager/CommitCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/CommitCommand.cs
@@ -1,0 +1,85 @@
+﻿// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Tools.Common;
+using Google.Cloud.Tools.UpdateReleaseNotes;
+using LibGit2Sharp;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Google.Cloud.Tools.ReleaseManager
+{
+    public sealed class CommitCommand : CommandBase
+    {
+        public CommitCommand()
+            : base("commit", "Commit the current set of changes with an appropriate commit message")
+        {
+        }
+
+        protected override void ExecuteImpl(string[] args)
+        {
+            var diffs = FindChangedVersions();
+            if (diffs.Count != 1)
+            {
+                throw new UserErrorException($"Can only automate a release commit with exactly 1 release. Found {diffs.Count}.");
+            }
+            var diff = diffs[0];
+            if (diff.NewVersion is null)
+            {
+                throw new UserErrorException($"Cannot automate a release commit for a deleted API.");
+            }
+
+            var historyFilePath = HistoryFile.GetPathForPackage(diff.Id);
+            if (!File.Exists(historyFilePath))
+            {
+                throw new UserErrorException($"Cannot automate a release commit without a version history file.");
+            }
+
+            var historyFile = HistoryFile.Load(historyFilePath);
+            var section = historyFile.Sections.FirstOrDefault(s => s.Version?.ToString() == diff.NewVersion);
+            if (section is null)
+            {
+                throw new UserErrorException($"Unable to find history file section for {diff.NewVersion}. Cannot automate a release commit in this state.");
+            }
+
+            string header = $"Release {diff.Id} version {diff.NewVersion}";
+            var message = string.Join("\n", new[] { header, "", "Changes in this release:", "" }.Concat(section.Lines.Skip(2)));
+
+            var root = DirectoryLayout.DetermineRootDirectory();
+            using (var repo = new Repository(root))
+            {
+                RepositoryStatus status = repo.RetrieveStatus();
+                // TODO: Work out whether this is enough, and whether we actually need all of these.
+                // We basically want git add --all.
+                AddAll(status.Modified);
+                AddAll(status.Missing);
+                AddAll(status.Untracked);
+                repo.Index.Write();
+                var signature = repo.Config.BuildSignature(DateTimeOffset.UtcNow);
+                var commit = repo.Commit(message, signature, signature);
+                Console.WriteLine($"Created commit {commit.Sha}. Review the message and amend if necessary.");
+
+                void AddAll(IEnumerable<StatusEntry> entries)
+                {
+                    foreach (var entry in entries)
+                    {
+                        repo.Index.Add(entry.FilePath);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tools/Google.Cloud.Tools.ReleaseManager/CompareCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/CompareCommand.cs
@@ -1,0 +1,54 @@
+﻿// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Tools.Common;
+using System;
+using System.Collections.Generic;
+
+namespace Google.Cloud.Tools.ReleaseManager
+{
+    public sealed class CompareCommand : CommandBase
+    {
+        public CompareCommand()
+            : base("compare", "Compare each changed version with the previous release")
+        {
+        }
+
+        protected override void ExecuteImpl(string[] args)
+        {
+            var idsToCheck = new List<string>();
+            foreach (var diff in FindChangedVersions())
+            {
+                if (diff.OldVersion is null)
+                {
+                    Console.WriteLine($"{diff.Id} is new; no comparison required.");
+                }
+                else if (diff.NewVersion is null)
+                {
+                    Console.WriteLine($"{diff.Id} has been deleted; no comparison required.");
+                }
+                else
+                {
+                    // Found an API to compare. Build it locally first, so we know we're up-to-date.
+                    var api = diff.Id;
+                    idsToCheck.Add(api);
+                    Console.WriteLine($"Building {api} locally");
+                    var sourceRoot = DirectoryLayout.ForApi(api).SourceDirectory;
+                    Processes.RunDotnet(sourceRoot, "build", "-nologo", "-clp:NoSummary", "-v", "quiet", "-c", "Release", api);
+                }
+            }
+            CheckVersionCompatibility.Program.Main(idsToCheck.ToArray());
+        }
+    }
+}

--- a/tools/Google.Cloud.Tools.ReleaseManager/ICommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/ICommand.cs
@@ -1,0 +1,45 @@
+﻿// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Google.Cloud.Tools.ReleaseManager
+{
+    /// <summary>
+    /// Simple (simplistic!) approach to a command line interface. Implementations
+    /// are expected to have a parameterless constructor.
+    /// </summary>
+    public interface ICommand
+    {
+        /// <summary>
+        /// The description to display in the usage instructions.
+        /// </summary>
+        string Description { get; }
+
+        /// <summary>
+        /// The name of the command (specified as the first command line parameter).
+        /// </summary>
+        string Command { get; }
+
+        /// <summary>
+        /// Description of the expected arguments, e.g. "&lt;id&gt; &lt;new-version&gt;".
+        /// </summary>
+        string ExpectedArguments { get; }
+
+        /// <summary>
+        /// Executes the command. If this throws <see cref="UserErrorException"/>, the exception
+        /// will be caught and displayed in a brief form. Other exceptions result in a full stack trace.
+        /// </summary>
+        /// <param name="args">The command line parameters, excluding the command name.</param>
+        void Execute(string[] args);
+    }
+}

--- a/tools/Google.Cloud.Tools.ReleaseManager/IncrementVersionCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/IncrementVersionCommand.cs
@@ -1,0 +1,65 @@
+﻿// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Tools.Common;
+using System.Text.RegularExpressions;
+
+namespace Google.Cloud.Tools.ReleaseManager
+{
+    public sealed class IncrementVersionCommand : CommandBase
+    {
+        public IncrementVersionCommand()
+            : base("increment-version", "Increment a version in apis.json and generate project files", "id")
+        {
+        }
+
+        protected override void ExecuteImpl(string[] args)
+        {
+            string id = args[0];
+
+            // It's slightly inefficient that we load the API catalog once here and once later on, and the code duplication
+            // is annoying too, but it's insignficant really - and at least the code is simple.
+            var catalog = ApiCatalog.Load();
+            var api = catalog[id];
+            var version = IncrementStructuredVersion(api.StructuredVersion).ToString();
+            new SetVersionCommand().Execute(new[] { id, version });
+
+            StructuredVersion IncrementStructuredVersion(StructuredVersion originalVersion)
+            {
+                // Any GA version just increments the minor version.
+                if (originalVersion.Prerelease is null)
+                {
+                    return StructuredVersion.FromMajorMinorPatch(originalVersion.Major, originalVersion.Minor + 1, 0, null);
+                }
+
+                // For prereleases, expect something like "beta01" which should be incremented to "beta02".
+                var prereleasePattern = new Regex(@"^([^\d]*)(\d+)$");
+                var match = prereleasePattern.Match(originalVersion.Prerelease);
+                if (!match.Success)
+                {
+                    throw new UserErrorException($"Don't know how to auto-increment version '{originalVersion}'");
+                }
+                var prefix = match.Groups[1].Value;
+                var suffix = match.Groups[2].Value;
+                if (!int.TryParse(suffix, out var counter))
+                {
+                    throw new UserErrorException($"Don't know how to auto-increment version '{originalVersion}'");
+                }
+                counter++;
+                var newSuffix = counter.ToString().PadLeft(suffix.Length, '0');
+                return StructuredVersion.FromMajorMinorPatch(originalVersion.Major, originalVersion.Minor, originalVersion.Patch, $"{prefix}{newSuffix}");
+            }
+        }
+    }
+}

--- a/tools/Google.Cloud.Tools.ReleaseManager/Program.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/Program.cs
@@ -13,15 +13,10 @@
 // limitations under the License.
 
 using Google.Cloud.Tools.Common;
-using Google.Cloud.Tools.UpdateReleaseNotes;
-using LibGit2Sharp;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
+using System.Text;
 
 namespace Google.Cloud.Tools.ReleaseManager
 {
@@ -31,57 +26,34 @@ namespace Google.Cloud.Tools.ReleaseManager
     /// </summary>
     internal sealed class Program
     {
-        // The branch we're thinking of as master. It may actually be some other branch for occasional
-        // releases, but fundamentally it's "the current source of truth we're basing this release on".
-        private const string MasterBranch = "master";
-
-        private const string ShowVersionCommand = "show-version";
-        private const string SetVersionCommand = "set-version";
-        private const string IncrementVersionCommand = "increment-version";
-        private const string ShowCommand = "show";
-        private const string CompareCommand = "compare";
-        private const string UpdateHistoryCommand = "update-history";
-        private const string CommitCommand = "commit";
-
         private static int Main(string[] args)
         {
             try
             {
+                var allCommands = typeof(Program).Assembly.GetTypes()
+                    .Where(t => !t.IsAbstract && typeof(ICommand).IsAssignableFrom(t))
+                    .Select(Activator.CreateInstance)
+                    .Cast<ICommand>()
+                    .OrderBy(c => c.Command)
+                    .ToList();
                 if (args.Length == 0)
                 {
-                    ShowUsage();
+                    ShowUsage(allCommands);
                     return 0;
                 }
-                var command = args[0];
+
+
+                var commandName = args[0];
                 var commandArgs = args.Skip(1).ToArray();
-                switch (command)
+
+                var selectedCommand = allCommands.Where(c => c.Command == commandName).FirstOrDefault();
+                if (selectedCommand is null)
                 {
-                    case ShowVersionCommand:
-                        ShowVersion(commandArgs);
-                        break;
-                    case SetVersionCommand:
-                        SetVersion(commandArgs);
-                        break;
-                    case IncrementVersionCommand:
-                        IncrementVersion(commandArgs);
-                        break;
-                    case ShowCommand:
-                        ShowVersions(commandArgs);
-                        break;
-                    case CompareCommand:
-                        CompareVersions(commandArgs);
-                        break;
-                    case UpdateHistoryCommand:
-                        UpdateHistory(commandArgs);
-                        break;
-                    case CommitCommand:
-                        Commit(commandArgs);
-                        break;
-                    default:
-                        Console.WriteLine($"Unknown command: '{command}'");
-                        ShowUsage();
-                        return 1;
+                    Console.WriteLine($"Unknown command: '{commandName}'");
+                    ShowUsage(allCommands);
+                    return 0;
                 }
+                selectedCommand.Execute(commandArgs);
                 return 0;
             }
             catch (UserErrorException e)
@@ -96,255 +68,20 @@ namespace Google.Cloud.Tools.ReleaseManager
             }
         }
 
-        private static void ShowUsage()
+        private static void ShowUsage(IList<ICommand> commands)
         {
             Console.WriteLine($"{nameof(ReleaseManager)} commands:");
             Console.WriteLine("");
-            Console.WriteLine($"{SetVersionCommand} <id> <new-version>: Set a version in apis.json and generate project files");
-            Console.WriteLine($"{IncrementVersionCommand} <id>: Increment a version in apis.json and generate project files");
-            Console.WriteLine($"{ShowVersionCommand} <id>: Show the current version of the given API on the master branch");
-            Console.WriteLine($"{ShowCommand}: Show the versions changes in the current PR");
-            Console.WriteLine($"{CompareCommand}: Compare each changed version with the previous release");
-            Console.WriteLine($"{UpdateHistoryCommand}: Update the release history file for each changed version");
-            Console.WriteLine($"{CommitCommand}: Commit the current set of changes with an appropriate commit message");
-        }
-
-        private static void SetVersion(string[] args)
-        {
-            if (args.Length != 2)
+            foreach (var command in commands)
             {
-                throw new UserErrorException($"{SetVersionCommand} requires two arguments: the package ID and the new version");
-            }
-            SetVersion(args[0], args[1]);
-        }
-
-        private static void ShowVersion(string[] args)
-        {
-            if (args.Length != 1)
-            {
-                throw new UserErrorException($"{ShowVersionCommand} requires one argument: the package ID");
-            }
-            string id = args[0];
-            var masterCatalog = LoadMasterCatalog();
-            var api = masterCatalog[id];
-            Console.WriteLine($"Current version of {id} on master branch: {api.Version}");
-        }
-
-        private static void IncrementVersion(string[] args)
-        {
-            if (args.Length != 1)
-            {
-                throw new UserErrorException($"{IncrementVersionCommand} requires one argument: the package ID");
-            }
-            string id = args[0];
-
-            // It's slightly inefficient that we load the API catalog once here and once later on, and the code duplication
-            // is annoying too, but it's insignficant really - and at least the code is simple.
-
-            var catalog = ApiCatalog.Load();
-            var api = catalog[id];
-            var version = IncrementStructuredVersion(api.StructuredVersion).ToString();
-            SetVersion(id, version);
-
-            StructuredVersion IncrementStructuredVersion(StructuredVersion originalVersion)
-            {
-                // Any GA version just increments the minor version.
-                if (originalVersion.Prerelease is null)
-                {
-                    return StructuredVersion.FromMajorMinorPatch(originalVersion.Major, originalVersion.Minor + 1, 0, null);
-                }
-
-                // For prereleases, expect something like "beta01" which should be incremented to "beta02".
-                var prereleasePattern = new Regex(@"^([^\d]*)(\d+)$");
-                var match = prereleasePattern.Match(originalVersion.Prerelease);
-                if (!match.Success)
-                {
-                    throw new UserErrorException($"Don't know how to auto-increment version '{originalVersion}'");
-                }
-                var prefix = match.Groups[1].Value;
-                var suffix = match.Groups[2].Value;
-                if (!int.TryParse(suffix, out var counter))
-                {
-                    throw new UserErrorException($"Don't know how to auto-increment version '{originalVersion}'");
-                }
-                counter++;
-                var newSuffix = counter.ToString().PadLeft(suffix.Length, '0');
-                return StructuredVersion.FromMajorMinorPatch(originalVersion.Major, originalVersion.Minor, originalVersion.Patch, $"{prefix}{newSuffix}");
-            }
-        }
-
-        private static void SetVersion(string id, string version)
-        {
-            var catalog = ApiCatalog.Load();
-            var api = catalog[id];
-
-            string oldVersion = api.Version;
-            api.Version = version;
-            var layout = DirectoryLayout.ForApi(id);
-            var apiNames = catalog.CreateIdHashSet();
-            ProjectGenerator.Program.GenerateMetadataFile(layout.SourceDirectory, api);
-            ProjectGenerator.Program.GenerateProjects(layout.SourceDirectory, api, apiNames);
-            ProjectGenerator.Program.RewriteReadme(catalog);
-            ProjectGenerator.Program.RewriteDocsRootIndex(catalog);
-
-            // Update the parsed JObject associated with the ID, and write it back to apis.json.
-            api.Json["version"] = version;
-            string formatted = catalog.FormatJson();
-            File.WriteAllText(ApiCatalog.CatalogPath, formatted);
-            Console.WriteLine("Updated apis.json");
-            Console.WriteLine();
-            Console.WriteLine(new ApiVersionPair(id, oldVersion, version));
-        }
-
-        private static void ShowVersions(string[] args)
-        {
-            if (args.Length != 0)
-            {
-                throw new UserErrorException($"{ShowCommand} does not accept additional arguments");
-            }
-
-            foreach (var change in FindChangedVersions())
-            {
-                Console.WriteLine(change);
-            }
-        }
-
-        private static List<ApiVersionPair> FindChangedVersions()
-        {
-            var currentCatalog = ApiCatalog.Load();
-            var masterCatalog = LoadMasterCatalog();
-            var currentVersions = currentCatalog.CreateRawVersionMap();
-            var masterVersions = masterCatalog.CreateRawVersionMap();
-            return currentVersions.Keys.Concat(masterVersions.Keys)
-                .Distinct()
-                .OrderBy(id => id)
-                .Select(id => new ApiVersionPair(id, masterVersions.GetValueOrDefault(id), currentVersions.GetValueOrDefault(id)))
-                .Where(v => v.NewVersion != v.OldVersion)
-                .ToList();
-        }
-
-        private static ApiCatalog LoadMasterCatalog()
-        {
-            var root = DirectoryLayout.DetermineRootDirectory();
-            using (var repo = new Repository(root))
-            {
-                var master = repo.Branches.FirstOrDefault(b => b.FriendlyName == MasterBranch);
-                if (master == null)
-                {
-                    throw new UserErrorException($"Unable to find branch '{MasterBranch}'.");
-                }
-
-                var masterCatalogJson = master.Commits.First()["apis/apis.json"].Target.Peel<Blob>().GetContentText();
-                return ApiCatalog.FromJson(masterCatalogJson);
-            }
-        }
-
-        private static void CompareVersions(string[] args)
-        {
-            if (args.Length != 0)
-            {
-                throw new UserErrorException($"{CompareCommand} does not accept additional arguments");
-            }
-
-            var idsToCheck = new List<string>();
-            foreach (var diff in FindChangedVersions())
-            {
-                if (diff.OldVersion is null)
-                {
-                    Console.WriteLine($"{diff.Id} is new; no comparison required.");
-                }
-                else if (diff.NewVersion is null)
-                {
-                    Console.WriteLine($"{diff.Id} has been deleted; no comparison required.");
-                }
-                else
-                {
-                    // Found an API to compare. Build it locally first, so we know we're up-to-date.
-                    var api = diff.Id;
-                    idsToCheck.Add(api);
-                    Console.WriteLine($"Building {api} locally");
-                    var sourceRoot = DirectoryLayout.ForApi(api).SourceDirectory;
-                    Processes.RunDotnet(sourceRoot, "build", "-nologo", "-clp:NoSummary", "-v", "quiet", "-c", "Release", api);
-                }
-            }
-            CheckVersionCompatibility.Program.Main(idsToCheck.ToArray());
-        }
-
-        private static void UpdateHistory(string[] args)
-        {
-            if (args.Length != 0)
-            {
-                throw new UserErrorException($"{UpdateHistoryCommand} does not accept additional arguments");
-            }
-
-            foreach (var diff in FindChangedVersions())
-            {
-                if (diff.NewVersion is null)
-                {
-                    Console.WriteLine($"{diff.Id} has been deleted; no history required.");
-                }
-                else
-                {
-                    UpdateReleaseNotes.Program.Execute(diff.Id);
-                }
-            }
-        }
-
-        private static void Commit(string[] args)
-        {
-            if (args.Length != 0)
-            {
-                throw new UserErrorException($"{CommitCommand} does not accept additional arguments");
-            }
-
-            var diffs = FindChangedVersions();
-            if (diffs.Count != 1)
-            {
-                throw new UserErrorException($"Can only automate a release commit with exactly 1 release. Found {diffs.Count}.");
-            }
-            var diff = diffs[0];
-            if (diff.NewVersion is null)
-            {
-                throw new UserErrorException($"Cannot automate a release commit for a deleted API.");
-            }
-
-            var historyFilePath = HistoryFile.GetPathForPackage(diff.Id);
-            if (!File.Exists(historyFilePath))
-            {
-                throw new UserErrorException($"Cannot automate a release commit without a version history file.");
-            }
-
-            var historyFile = HistoryFile.Load(historyFilePath);
-            var section = historyFile.Sections.FirstOrDefault(s  => s.Version?.ToString() == diff.NewVersion);
-            if (section is null)
-            {
-                throw new UserErrorException($"Unable to find history file section for {diff.NewVersion}. Cannot automate a release commit in this state.");
-            }
-
-            string header = $"Release {diff.Id} version {diff.NewVersion}";
-            var message = string.Join("\n", new[] { header, "", "Changes in this release:", "" }.Concat(section.Lines.Skip(2)));
-
-            var root = DirectoryLayout.DetermineRootDirectory();
-            using (var repo = new Repository(root))
-            {
-                RepositoryStatus status = repo.RetrieveStatus();
-                // TODO: Work out whether this is enough, and whether we actually need all of these.
-                // We basically want git add --all.
-                AddAll(status.Modified);
-                AddAll(status.Missing);
-                AddAll(status.Untracked);
-                repo.Index.Write();
-                var signature = repo.Config.BuildSignature(DateTimeOffset.UtcNow);
-                var commit = repo.Commit(message, signature, signature);
-                Console.WriteLine($"Created commit {commit.Sha}. Review the message and amend if necessary.");
-
-                void AddAll(IEnumerable<StatusEntry> entries)
-                {
-                    foreach (var entry in entries)
-                    {
-                        repo.Index.Add(entry.FilePath);
-                    }
-                }
+                // The conditional aspect of ExpectedArguments makes this ugly to do with
+                // string interpolation.
+                var builder = new StringBuilder()
+                    .Append(command.Command)
+                    .Append(string.IsNullOrEmpty(command.ExpectedArguments) ? "" : " " + command.ExpectedArguments)
+                    .Append(": ")
+                    .Append(command.Description);
+                Console.WriteLine(builder);
             }
         }
     }

--- a/tools/Google.Cloud.Tools.ReleaseManager/SetVersionCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/SetVersionCommand.cs
@@ -1,0 +1,54 @@
+﻿// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Tools.Common;
+using System;
+using System.IO;
+
+namespace Google.Cloud.Tools.ReleaseManager
+{
+    public sealed class SetVersionCommand : CommandBase
+    {
+        public SetVersionCommand()
+            : base("set-version", "Set a version in apis.json and generate project files", "id", "new-version")
+        {
+        }
+
+        protected override void ExecuteImpl(string[] args)
+        {
+            string id = args[0];
+            string version = args[1];
+
+            var catalog = ApiCatalog.Load();
+            var api = catalog[id];
+
+            string oldVersion = api.Version;
+            api.Version = version;
+            var layout = DirectoryLayout.ForApi(id);
+            var apiNames = catalog.CreateIdHashSet();
+            ProjectGenerator.Program.GenerateMetadataFile(layout.SourceDirectory, api);
+            ProjectGenerator.Program.GenerateProjects(layout.SourceDirectory, api, apiNames);
+            ProjectGenerator.Program.RewriteReadme(catalog);
+            ProjectGenerator.Program.RewriteDocsRootIndex(catalog);
+
+            // Update the parsed JObject associated with the ID, and write it back to apis.json.
+            api.Json["version"] = version;
+            string formatted = catalog.FormatJson();
+            File.WriteAllText(ApiCatalog.CatalogPath, formatted);
+            Console.WriteLine("Updated apis.json");
+            Console.WriteLine();
+            Console.WriteLine(new ApiVersionPair(id, oldVersion, version));
+        }
+    }
+}

--- a/tools/Google.Cloud.Tools.ReleaseManager/ShowCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/ShowCommand.cs
@@ -1,0 +1,34 @@
+﻿// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Google.Cloud.Tools.ReleaseManager
+{
+    public sealed class ShowCommand : CommandBase
+    {
+        public ShowCommand()
+            : base("show", "Show the versions changes in the current PR")
+        {
+        }
+
+        protected override void ExecuteImpl(string[] args)
+        {
+            foreach (var change in FindChangedVersions())
+            {
+                Console.WriteLine(change);
+            }
+        }
+    }
+}

--- a/tools/Google.Cloud.Tools.ReleaseManager/UpdateHistoryCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/UpdateHistoryCommand.cs
@@ -1,0 +1,41 @@
+﻿// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Google.Cloud.Tools.ReleaseManager
+{
+    public sealed class UpdateHistoryCommand : CommandBase
+    {
+        public UpdateHistoryCommand()
+            : base("update-history", "Update the release history file for each changed version")
+        {
+        }
+
+        protected override void ExecuteImpl(string[] args)
+        {
+            foreach (var diff in FindChangedVersions())
+            {
+                if (diff.NewVersion is null)
+                {
+                    Console.WriteLine($"{diff.Id} has been deleted; no history required.");
+                }
+                else
+                {
+                    UpdateReleaseNotes.Program.Execute(diff.Id);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is in preparation for creating a new "push" command. I couldn't
bear adding to the mess of a huge Program.cs