### PR TITLE
First pass at service YAML parsing

### DIFF
--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1549,5 +1549,12 @@
         "Grpc.Core": "2.27.0"
       }
     }
+  ],
+  "ignoredPaths": [
+    "google/ads/googleads/v1",
+    "google/ads/googleads/v2",
+    "google/ads/googleads/v3",
+    "google/cloud/bigquery/v2",
+    "google/storage/v1"
   ]
 }

--- a/tools/Google.Cloud.Tools.Common/ApiCatalog.cs
+++ b/tools/Google.Cloud.Tools.Common/ApiCatalog.cs
@@ -31,6 +31,11 @@ namespace Google.Cloud.Tools.Common
         public List<ApiMetadata> Apis { get; set; }
 
         /// <summary>
+        /// Proto paths for APIs we knowingly don't generate.
+        /// </summary>
+        public List<string> IgnoredPaths { get; set; }
+
+        /// <summary>
         /// The JSON representation of the catalog. This is populated by <see cref="Load"/> and
         /// <see cref="FromJson(string)"/>, but nothing keeps this in sync with the in-memory data.
         /// </summary>

--- a/tools/Google.Cloud.Tools.MetadataGenerator/Google.Cloud.Tools.MetadataGenerator.csproj
+++ b/tools/Google.Cloud.Tools.MetadataGenerator/Google.Cloud.Tools.MetadataGenerator.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <Description>Experimental app to create an API "directory" in googleapis</Description>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Google.Cloud.Tools.Common\Google.Cloud.Tools.Common.csproj" />
+    <PackageReference Include="YamlDotNet" Version="8.1.0" />
+  </ItemGroup>
+</Project>

--- a/tools/Google.Cloud.Tools.MetadataGenerator/Program.cs
+++ b/tools/Google.Cloud.Tools.MetadataGenerator/Program.cs
@@ -1,0 +1,78 @@
+﻿// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Tools.Common;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Google.Cloud.Tools.MetadataGenerator
+{
+    /// <summary>
+    /// Experimental crawler to load service YAML files in googleapis and make
+    /// the data within them more conveniently accessible. We might want to then write
+    /// them out as JSON in the future, but before then we can still get useful information out,
+    /// such as which stable APIs exist but aren't yet generated as C# libraries.
+    /// </summary>
+    internal class Program
+    {
+        private static void Main()
+        {
+            var root = DirectoryLayout.DetermineRootDirectory();
+            var googleapisRoot = Path.Combine(root, "googleapis");
+            var directory = LoadServiceDirectory(googleapisRoot);
+
+            var catalog = ApiCatalog.Load();
+            var paths = new HashSet<string>(catalog.Apis.Select(api => api.ProtoPath));
+            var serviceDirectories = directory.Services
+                .Where(service => service.Stable)
+                .Select(service => service.ServiceDirectory).ToList();
+
+            var ungenerated = serviceDirectories
+                .Except(paths)
+                .Except(catalog.IgnoredPaths)
+                .OrderBy(path => path).ToList();
+            ungenerated.ForEach(Console.WriteLine);
+        }
+
+        static ServiceDirectory LoadServiceDirectory(string googleapisRoot)
+        {
+            var configs = LoadServiceConfigsRecursively(googleapisRoot);
+            Console.WriteLine($"Loaded {configs.Count} service config YAML files");
+            return ServiceDirectory.FromServiceConfigs(googleapisRoot, configs);
+        }
+
+        private static readonly Regex ServiceVersionPattern = new Regex(@"^v\d+.*");
+        static IReadOnlyList<ServiceConfig> LoadServiceConfigsRecursively(string directory)
+        {
+            var configs = new List<ServiceConfig>();
+            // Only load service config files from versioned directories (e.g. "google/spanner/v1")
+            if (ServiceVersionPattern.IsMatch(Path.GetFileName(directory)))
+            {
+                var configsInDirectory = Directory.GetFiles(directory, "*.yaml")
+                    .Select(ServiceConfig.TryLoadFile)
+                    .Where(config => config != null);
+                configs.AddRange(configsInDirectory);
+            }
+
+            foreach (var subdir in Directory.GetDirectories(directory))
+            {
+                configs.AddRange(LoadServiceConfigsRecursively(subdir));
+            }
+            return configs;
+        }
+    }
+}

--- a/tools/Google.Cloud.Tools.MetadataGenerator/ServiceConfig.cs
+++ b/tools/Google.Cloud.Tools.MetadataGenerator/ServiceConfig.cs
@@ -1,0 +1,58 @@
+﻿// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Google.Cloud.Tools.MetadataGenerator
+{
+    /// <summary>
+    /// The content of an individual service config file, as stored in YAML.
+    /// </summary>
+    public class ServiceConfig
+    {
+        public string File { get; set; }
+        public string Type { get; set; }
+        public int ConfigVersion { get; set; }
+        public string Name { get; set; }
+        public string Title { get; set; }
+        public ServiceConfigDocumentation Documentation { get; set; }
+        public List<ServiceConfigApi> Apis { get; set; }
+
+        internal static ServiceConfig TryLoadFile(string file)
+        {
+            var deserializer = new DeserializerBuilder().IgnoreUnmatchedProperties().WithNamingConvention(UnderscoredNamingConvention.Instance).Build();
+            using (var reader = System.IO.File.OpenText(file))
+            {
+                var config = deserializer.Deserialize<ServiceConfig>(reader);
+                config.File = file;
+                return config.Type == "google.api.Service" ? config : null;
+            }
+        }
+    }
+
+    public class ServiceConfigApi
+    {
+        public string Name { get; set; }
+    }
+
+    public class ServiceConfigDocumentation
+    {
+        public string Summary { get; set; }
+        public string Overview { get; set; }
+    }
+}

--- a/tools/Google.Cloud.Tools.MetadataGenerator/ServiceDirectory.cs
+++ b/tools/Google.Cloud.Tools.MetadataGenerator/ServiceDirectory.cs
@@ -1,0 +1,87 @@
+﻿// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Google.Cloud.Tools.MetadataGenerator
+{
+    /// <summary>
+    /// The service directory, in a ready-to-serialize form.
+    /// </summary>
+    public class ServiceDirectory
+    {
+        public List<Service> Services { get; set; }
+
+        internal static ServiceDirectory FromServiceConfigs(string googleapisRoot, IEnumerable<ServiceConfig> configs)
+        {
+            return new ServiceDirectory { Services = configs.Select(config => Service.FromServiceConfig(googleapisRoot, config)).ToList() };
+        }
+    }
+
+    public class Service
+    {
+        private static readonly Regex StableVersionPattern = new Regex(@"^v[\d]+$");
+
+        public string ServiceDirectory { get; set; }
+        public string Name { get; set; }
+        public string Title { get; set; }
+        public string Description { get; set; }
+        public string ServiceConfigFile { get; set; }
+        public string Version { get; set; }
+        public string PackageFromDirectory { get; set; }
+        public string PackageFromProtos { get; set; }
+        public bool Stable { get; set; }
+
+        public static Service FromServiceConfig(string googleapisRoot, ServiceConfig config)
+        {
+            string relativeFile = Path.GetRelativePath(googleapisRoot, config.File).Replace('\\', '/'); // e.g. google/spanner/v1/spanner_v1.yaml
+            string relativeDirectory = Path.GetDirectoryName(relativeFile).Replace('\\', '/');          // e.g. google/spanner/v1
+            string version = Path.GetFileName(relativeDirectory);                                       // e.g. v1
+            var packageFromDirectory = relativeDirectory.Replace('/', '.');                             // e.g. google.spanner.v1
+            var packageFromProtos = LoadPackageFromProtos(Path.GetDirectoryName(config.File));
+            return new Service
+            {
+                PackageFromDirectory = packageFromDirectory,
+                PackageFromProtos = packageFromProtos,
+                Version = version,
+                ServiceConfigFile = relativeFile,
+                ServiceDirectory = relativeDirectory,
+                Name = config.Name,
+                Title = config.Title,
+                Description = config.Documentation?.Summary?.Replace('\n', ' ') ?? "<UNKNOWN - NO SERVICE CONFIG DOCUMENTATION SUMMARY>",
+                Stable = StableVersionPattern.IsMatch(version)
+            };
+        }
+
+        private static string LoadPackageFromProtos(string directory)
+        {
+            var protos = Directory.GetFiles(directory, "*.proto").OrderBy(f => f, StringComparer.Ordinal);
+            foreach (var proto in protos)
+            {
+                var lines = File.ReadAllLines(proto);
+                var package = lines.FirstOrDefault(line => line.StartsWith("package "));
+                if (package is object)
+                {
+                    return package.Substring("package ".Length).TrimEnd(';');
+                }
+            }
+            return "<UNKNOWN - NO PROTOS WITH PACKAGES>";
+        }
+    }
+}

--- a/tools/Google.Cloud.Tools.sln
+++ b/tools/Google.Cloud.Tools.sln
@@ -52,7 +52,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Tools.CompareV
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.LongRunning", "..\apis\Google.LongRunning\Google.LongRunning\Google.LongRunning.csproj", "{342C4A65-EA46-44CE-9986-1570EF96A6C9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Tools.ReleaseManager", "Google.Cloud.Tools.ReleaseManager\Google.Cloud.Tools.ReleaseManager.csproj", "{4171E471-ABAB-43B9-B759-6641BA6C4A4A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Tools.ReleaseManager", "Google.Cloud.Tools.ReleaseManager\Google.Cloud.Tools.ReleaseManager.csproj", "{4171E471-ABAB-43B9-B759-6641BA6C4A4A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Tools.MetadataGenerator", "Google.Cloud.Tools.MetadataGenerator\Google.Cloud.Tools.MetadataGenerator.csproj", "{5C768AF5-50D0-4489-BC3F-4A866AEBBBBE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -376,6 +378,18 @@ Global
 		{4171E471-ABAB-43B9-B759-6641BA6C4A4A}.Release|x64.Build.0 = Release|Any CPU
 		{4171E471-ABAB-43B9-B759-6641BA6C4A4A}.Release|x86.ActiveCfg = Release|Any CPU
 		{4171E471-ABAB-43B9-B759-6641BA6C4A4A}.Release|x86.Build.0 = Release|Any CPU
+		{5C768AF5-50D0-4489-BC3F-4A866AEBBBBE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5C768AF5-50D0-4489-BC3F-4A866AEBBBBE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5C768AF5-50D0-4489-BC3F-4A866AEBBBBE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5C768AF5-50D0-4489-BC3F-4A866AEBBBBE}.Debug|x64.Build.0 = Debug|Any CPU
+		{5C768AF5-50D0-4489-BC3F-4A866AEBBBBE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5C768AF5-50D0-4489-BC3F-4A866AEBBBBE}.Debug|x86.Build.0 = Debug|Any CPU
+		{5C768AF5-50D0-4489-BC3F-4A866AEBBBBE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5C768AF5-50D0-4489-BC3F-4A866AEBBBBE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5C768AF5-50D0-4489-BC3F-4A866AEBBBBE}.Release|x64.ActiveCfg = Release|Any CPU
+		{5C768AF5-50D0-4489-BC3F-4A866AEBBBBE}.Release|x64.Build.0 = Release|Any CPU
+		{5C768AF5-50D0-4489-BC3F-4A866AEBBBBE}.Release|x86.ActiveCfg = Release|Any CPU
+		{5C768AF5-50D0-4489-BC3F-4A866AEBBBBE}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This is all in aid of longer term API automation. For now, it allows
us to see which APIs we haven't generated - and I'm hoping it won't
be too hard to add an "add" command to Release Manager to add a new
API just based on the proto path. (I'd like to eventually remove a
bunch of our information from the API catalog, taking it from this
metadata instead.)