### PR TITLE
Add Release Manager command to add a new API

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/coverage.xml
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/coverage.xml
@@ -8,13 +8,13 @@
         <ModuleMask>Google.Cloud.Spanner.Data</ModuleMask>
       </FilterEntry>
       <FilterEntry>
-        <ModuleMask>Google.Cloud.Spanner.V1</ModuleMask>
-      </FilterEntry>
-      <FilterEntry>
         <ModuleMask>Google.Cloud.Spanner.Admin.Database.V1</ModuleMask>
       </FilterEntry>
       <FilterEntry>
         <ModuleMask>Google.Cloud.Spanner.Admin.Instance.V1</ModuleMask>
+      </FilterEntry>
+      <FilterEntry>
+        <ModuleMask>Google.Cloud.Spanner.V1</ModuleMask>
       </FilterEntry>
     </IncludeFilters>
   </Filters>

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/coverage.xml
@@ -8,13 +8,13 @@
         <ModuleMask>Google.Cloud.Spanner.Data</ModuleMask>
       </FilterEntry>
       <FilterEntry>
-        <ModuleMask>Google.Cloud.Spanner.V1</ModuleMask>
-      </FilterEntry>
-      <FilterEntry>
         <ModuleMask>Google.Cloud.Spanner.Admin.Database.V1</ModuleMask>
       </FilterEntry>
       <FilterEntry>
         <ModuleMask>Google.Cloud.Spanner.Admin.Instance.V1</ModuleMask>
+      </FilterEntry>
+      <FilterEntry>
+        <ModuleMask>Google.Cloud.Spanner.V1</ModuleMask>
       </FilterEntry>
     </IncludeFilters>
   </Filters>

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/coverage.xml
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/coverage.xml
@@ -8,13 +8,13 @@
         <ModuleMask>Google.Cloud.Spanner.Data</ModuleMask>
       </FilterEntry>
       <FilterEntry>
-        <ModuleMask>Google.Cloud.Spanner.V1</ModuleMask>
-      </FilterEntry>
-      <FilterEntry>
         <ModuleMask>Google.Cloud.Spanner.Admin.Database.V1</ModuleMask>
       </FilterEntry>
       <FilterEntry>
         <ModuleMask>Google.Cloud.Spanner.Admin.Instance.V1</ModuleMask>
+      </FilterEntry>
+      <FilterEntry>
+        <ModuleMask>Google.Cloud.Spanner.V1</ModuleMask>
       </FilterEntry>
     </IncludeFilters>
   </Filters>

--- a/tools/Google.Cloud.Tools.Common/ApiMetadata.cs
+++ b/tools/Google.Cloud.Tools.Common/ApiMetadata.cs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -26,9 +28,9 @@ namespace Google.Cloud.Tools.Common
         private static readonly Regex PrereleaseApiPattern = new Regex(@"^V[1-9]\d*[^\d]+.*$");
         private static readonly Regex ReleaseVersion = new Regex(@"^[1-9]\d*\.\d+\.\d+$");
 
+        public string Id { get; set; }
         public string Version { get; set; }
         public string ReleasedVersion { get; set; }
-        public string Id { get; set; }
         public ApiType Type { get; set; }
         public string TargetFrameworks { get; set; }
         public string TestTargetFrameworks { get; set; }
@@ -38,6 +40,7 @@ namespace Google.Cloud.Tools.Common
         /// e.g. Google.Cloud.OSLogin.V1Beta would return V1Beta.
         /// Returns null if there's no match, e.g. for Google.Cloud.Firestore.
         /// </summary>
+        [JsonIgnore]
         public string ApiVersion
         {
             get
@@ -67,6 +70,7 @@ namespace Google.Cloud.Tools.Common
         // The product name or brief description is usually a sentence fragment, so if we *do*
         // use the full description, we trim any trailing periods.
         /// </summary>
+        [JsonIgnore]
         public string EffectiveListingDescription => ListingDescription ?? ProductName ?? Description.TrimEnd('.');
 
         /// <summary>
@@ -80,8 +84,9 @@ namespace Google.Cloud.Tools.Common
         public string Description { get; set; }
 
         public List<string> Tags { get; set; } = new List<string>();
-        public Dictionary<string, string> Dependencies { get; set; } = new Dictionary<string, string>();
-        public Dictionary<string, string> TestDependencies { get; set; } = new Dictionary<string, string>();
+        // Using a SortedDictionary means we'll keep dependencies in alphabetical order.
+        public SortedDictionary<string, string> Dependencies { get; set; } = new SortedDictionary<string, string>(StringComparer.Ordinal);
+        public SortedDictionary<string, string> TestDependencies { get; set; } = new SortedDictionary<string, string>(StringComparer.Ordinal);
         public List<string> MetaApis { get; set; } // TODO: enum?
         
         /// <summary>
@@ -100,8 +105,10 @@ namespace Google.Cloud.Tools.Common
         /// </summary>
         public string ServiceYaml { get; set; }
 
+        [JsonIgnore]
         public bool IsReleaseVersion => ReleaseVersion.IsMatch(Version);
 
+        [JsonIgnore]
         public StructuredVersion StructuredVersion => StructuredVersion.FromString(Version);
 
         /// <summary>
@@ -112,6 +119,7 @@ namespace Google.Cloud.Tools.Common
         public string ReleaseLevelOverride { get; set; }
 
         // TODO: Optimize to do this lazily if it's ever an issue
+        [JsonIgnore]
         public bool CanHaveGaRelease
         {
             get

--- a/tools/Google.Cloud.Tools.MetadataGenerator/ServiceDirectory.cs
+++ b/tools/Google.Cloud.Tools.MetadataGenerator/ServiceDirectory.cs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Cloud.Tools.Common;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
 
 namespace Google.Cloud.Tools.MetadataGenerator
@@ -26,11 +26,51 @@ namespace Google.Cloud.Tools.MetadataGenerator
     /// </summary>
     public class ServiceDirectory
     {
+        private static readonly Regex ServiceVersionPattern = new Regex(@"^v\d+.*");
         public List<Service> Services { get; set; }
 
         internal static ServiceDirectory FromServiceConfigs(string googleapisRoot, IEnumerable<ServiceConfig> configs)
         {
             return new ServiceDirectory { Services = configs.Select(config => Service.FromServiceConfig(googleapisRoot, config)).ToList() };
+        }
+
+        /// <summary>
+        /// Loads the service directory from service config files in the "googleapis"
+        /// directory under the root layout.
+        /// </summary>
+        public static ServiceDirectory LoadFromGoogleapis()
+        {
+            var root = DirectoryLayout.DetermineRootDirectory();
+            var googleapisRoot = Path.Combine(root, "googleapis");
+            return LoadFromGoogleapis(googleapisRoot);
+        }
+
+        /// <summary>
+        /// Loads the service directory from service config files in the specified directory.
+        /// </summary>
+        public static ServiceDirectory LoadFromGoogleapis(string googleApisRoot)
+        {
+            var configs = LoadServiceConfigsRecursively(googleApisRoot);
+            return FromServiceConfigs(googleApisRoot, configs);
+
+            IReadOnlyList<ServiceConfig> LoadServiceConfigsRecursively(string directory)
+            {
+                var configs = new List<ServiceConfig>();
+                // Only load service config files from versioned directories (e.g. "google/spanner/v1")
+                if (ServiceVersionPattern.IsMatch(Path.GetFileName(directory)))
+                {
+                    var configsInDirectory = Directory.GetFiles(directory, "*.yaml")
+                        .Select(ServiceConfig.TryLoadFile)
+                        .Where(config => config != null);
+                    configs.AddRange(configsInDirectory);
+                }
+
+                foreach (var subdir in Directory.GetDirectories(directory))
+                {
+                    configs.AddRange(LoadServiceConfigsRecursively(subdir));
+                }
+                return configs;
+            }
         }
     }
 
@@ -46,6 +86,7 @@ namespace Google.Cloud.Tools.MetadataGenerator
         public string Version { get; set; }
         public string PackageFromDirectory { get; set; }
         public string PackageFromProtos { get; set; }
+        public List<string> ImportDirectories { get; set; }
         public bool Stable { get; set; }
 
         public static Service FromServiceConfig(string googleapisRoot, ServiceConfig config)
@@ -54,11 +95,24 @@ namespace Google.Cloud.Tools.MetadataGenerator
             string relativeDirectory = Path.GetDirectoryName(relativeFile).Replace('\\', '/');          // e.g. google/spanner/v1
             string version = Path.GetFileName(relativeDirectory);                                       // e.g. v1
             var packageFromDirectory = relativeDirectory.Replace('/', '.');                             // e.g. google.spanner.v1
-            var packageFromProtos = LoadPackageFromProtos(Path.GetDirectoryName(config.File));
+
+            var protos = Directory.GetFiles(Path.GetDirectoryName(config.File), "*.proto")
+                .OrderBy(f => f, StringComparer.Ordinal)
+                .Select(ProtoFileSummary.Load)
+                .ToList();
+
+            var distinctPackagesFromProtos = protos.Select(proto => proto.Package).Distinct().Where(p => p is object).ToList();
+            var packageFromProtos = distinctPackagesFromProtos.Count switch
+            {
+                0 => "<UNKNOWN - NO PROTOS WITH PACKAGES>",
+                1 => distinctPackagesFromProtos[0],
+                _ => $"<AMBIGUOUS: {string.Join(", ", distinctPackagesFromProtos)}>"
+            };
             return new Service
             {
                 PackageFromDirectory = packageFromDirectory,
                 PackageFromProtos = packageFromProtos,
+                ImportDirectories = protos.SelectMany(p => p.ImportDirectories).Distinct().OrderBy(import => import).ToList(),
                 Version = version,
                 ServiceConfigFile = relativeFile,
                 ServiceDirectory = relativeDirectory,
@@ -69,19 +123,34 @@ namespace Google.Cloud.Tools.MetadataGenerator
             };
         }
 
-        private static string LoadPackageFromProtos(string directory)
+        public class ProtoFileSummary
         {
-            var protos = Directory.GetFiles(directory, "*.proto").OrderBy(f => f, StringComparer.Ordinal);
-            foreach (var proto in protos)
+            private static readonly char[] ImportTrimChars = { ' ', '"', ';'};
+
+            public string Package { get; }
+            public IReadOnlyList<string> ImportDirectories { get; }
+            // TODO: Options?
+
+            private ProtoFileSummary(string package, IReadOnlyList<string> importDirectories) =>
+                (Package, ImportDirectories) = (package, importDirectories);
+
+            internal static ProtoFileSummary Load(string file)
             {
-                var lines = File.ReadAllLines(proto);
+                var lines = File.ReadAllLines(file);
                 var package = lines.FirstOrDefault(line => line.StartsWith("package "));
                 if (package is object)
                 {
-                    return package.Substring("package ".Length).TrimEnd(';');
+                    package = package.Substring("package ".Length).TrimEnd(';');
                 }
+                var importDirectories = lines
+                    .Where(line => line.StartsWith("import "))
+                    .Select(line => line.Substring("import ".Length).Trim(ImportTrimChars))
+                    .Select(file => Path.GetDirectoryName(file).Replace('\\', '/'))
+                    .Distinct()
+                    .OrderBy(import => import)
+                    .ToList();
+                return new ProtoFileSummary(package, importDirectories);
             }
-            return "<UNKNOWN - NO PROTOS WITH PACKAGES>";
         }
     }
 }

--- a/tools/Google.Cloud.Tools.ReleaseManager/AddCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/AddCommand.cs
@@ -1,0 +1,105 @@
+﻿// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Tools.Common;
+using Google.Cloud.Tools.MetadataGenerator;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace Google.Cloud.Tools.ReleaseManager
+{
+    /// <summary>
+    /// Tool to add a new library based on the service config (and protos) for an API.
+    /// </summary>
+    public class AddCommand : CommandBase
+    {
+        public AddCommand()
+            : base("add", "Adds an API to the API catalog", "id", "protoPath")
+        {
+        }
+
+        protected override void ExecuteImpl(string[] args)
+        {
+            string id = args[0];
+            string protoPath = args[1];
+
+            var catalog = ApiCatalog.Load();
+            if (catalog.Apis.Any(api => api.Id == id))
+            {
+                throw new UserErrorException($"API {id} already exists in the API catalog.");
+            }
+            var serviceDirectory = ServiceDirectory.LoadFromGoogleapis();
+
+            var service = serviceDirectory.Services.FirstOrDefault(service => service.ServiceDirectory == protoPath);
+            if (service is null)
+            {
+                throw new UserErrorException($"No service found with proto path '{protoPath}'");
+            }
+            var api = new ApiMetadata
+            {
+                Id = id,
+                ProtoPath = protoPath,
+                ProductName = service.Title,
+                Description = service.Description,
+                Version = "1.0.0-beta00",
+                Type = ApiType.Grpc,
+                Generator = GeneratorType.Micro,
+                // Let's not include test dependencies, which are rarely useful.
+                TestDependencies = null
+            };
+
+            // Add dependencies discovered via the proto imports.
+            // This doesn't fail on any dependencies that aren't found - we could tighten this up later
+            // by knowing about common protos, for example.
+            var apisByProtoPath = catalog.Apis.Where(api => api.ProtoPath is object).ToDictionary(api => api.ProtoPath);
+            foreach (var import in service.ImportDirectories)
+            {
+                if (apisByProtoPath.TryGetValue(import, out var dependency))
+                {
+                    api.Dependencies.Add(dependency.Id, dependency.Version);
+                }
+            }
+
+            // Now work out what the new API metadata looks like in JSON.
+            var serializer = new JsonSerializer
+            {
+                NullValueHandling = NullValueHandling.Ignore,
+                Converters = { new StringEnumConverter(camelCaseText: true) },
+                ContractResolver = new DefaultContractResolver { NamingStrategy = new CamelCaseNamingStrategy() }
+            };            
+            api.Json = JToken.FromObject(api, serializer);
+
+            var followingApi = catalog.Apis.FirstOrDefault(api => string.Compare(api.Id, id, StringComparison.Ordinal) > 0);
+            if (followingApi is object)
+            {
+                followingApi.Json.AddBeforeSelf(api.Json);
+            }
+            else
+            {
+                // Looks like this API will be last in the list.
+                catalog.Apis.Last().Json.AddAfterSelf(api.Json);
+            }
+
+            // Done. Let's write out the catalog and display what we've done.
+            File.WriteAllText(ApiCatalog.CatalogPath, catalog.FormatJson());
+            Console.WriteLine($"Added {id} to the API catalog with the following configuration:");
+            Console.WriteLine(api.Json.ToString(Formatting.Indented));
+        }
+    }
+}

--- a/tools/Google.Cloud.Tools.ReleaseManager/Google.Cloud.Tools.ReleaseManager.csproj
+++ b/tools/Google.Cloud.Tools.ReleaseManager/Google.Cloud.Tools.ReleaseManager.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,6 +10,7 @@
     <ProjectReference Include="..\Google.Cloud.Tools.ProjectGenerator\Google.Cloud.Tools.ProjectGenerator.csproj" />
     <ProjectReference Include="..\Google.Cloud.Tools.UpdateReleaseNotes\Google.Cloud.Tools.UpdateReleaseNotes.csproj" />
     <ProjectReference Include="..\Google.Cloud.Tools.CheckVersionCompatibility\Google.Cloud.Tools.CheckVersionCompatibility.csproj" />
+    <ProjectReference Include="..\Google.Cloud.Tools.MetadataGenerator\Google.Cloud.Tools.MetadataGenerator.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This gets all the information it can from service configs and protos.

We might want to fix our terminology and consolidate our tools at
some point: "add library" isn't obviously part of a *release*
manager, and we've conflated "API" and "package" quite a lot. But
that can all happen later.