### PR TITLE
Release Google.Cloud.Dataproc.V1 version 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Billing.V1](https://googleapis.dev/dotnet/Google.Cloud.Billing.V1/2.0.0) | 2.0.0 | [Google Cloud Billing API](https://cloud.google.com/billing/docs/) |
 | [Google.Cloud.Container.V1](https://googleapis.dev/dotnet/Google.Cloud.Container.V1/2.0.0) | 2.0.0 | [Google Kubernetes Engine API](https://cloud.google.com/kubernetes-engine/docs/reference/rest/) |
 | [Google.Cloud.DataCatalog.V1](https://googleapis.dev/dotnet/Google.Cloud.DataCatalog.V1/1.0.0) | 1.0.0 | [Data Catalog](https://cloud.google.com/data-catalog/docs) |
-| [Google.Cloud.Dataproc.V1](https://googleapis.dev/dotnet/Google.Cloud.Dataproc.V1/2.0.0) | 2.0.0 | [Google Cloud Dataproc](https://cloud.google.com/dataproc/docs/concepts/overview) |
+| [Google.Cloud.Dataproc.V1](https://googleapis.dev/dotnet/Google.Cloud.Dataproc.V1/2.1.0) | 2.1.0 | [Google Cloud Dataproc](https://cloud.google.com/dataproc/docs/concepts/overview) |
 | [Google.Cloud.Datastore.V1](https://googleapis.dev/dotnet/Google.Cloud.Datastore.V1/3.0.0) | 3.0.0 | [Google Cloud Datastore](https://cloud.google.com/datastore/docs/concepts/overview) |
 | [Google.Cloud.Debugger.V2](https://googleapis.dev/dotnet/Google.Cloud.Debugger.V2/2.0.0) | 2.0.0 | [Google Cloud Debugger](https://cloud.google.com/debugger/) |
 | [Google.Cloud.DevTools.Common](https://googleapis.dev/dotnet/Google.Cloud.DevTools.Common/2.0.0) | 2.0.0 | Common Protocol Buffer messages for Google Cloud Developer Tools APIs |

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.csproj
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Dataproc API, which manages Hadoop-based clusters and jobs on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Dataproc.V1/docs/history.md
+++ b/apis/Google.Cloud.Dataproc.V1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+# Version 2.1.0, released 2020-05-04
+
+- [Commit cdd7342](https://github.com/googleapis/google-cloud-dotnet/commit/cdd7342): docs: change relative URLs to absolute URLs to fix broken links.
+- [Commit e644610](https://github.com/googleapis/google-cloud-dotnet/commit/e644610):
+  - Adds Dataproc Jobs.SubmitJobAsOperation RPC
+  - Adds SparkR and Presto job types to WorkflowTemplates
+  - Adds new Optional Components
+  - Clarifies usage of some APIs 
+- [Commit edebc2b](https://github.com/googleapis/google-cloud-dotnet/commit/edebc2b): fix Dataproc: add missing `REQUIRED` annotation.
+- [Commit bd045c2](https://github.com/googleapis/google-cloud-dotnet/commit/bd045c2): Adds resource name overloads for autoscaling policy operations
+
 # Version 2.0.0, released 2020-03-17
 
 - [Commit c120b77](https://github.com/googleapis/google-cloud-dotnet/commit/c120b77):

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -215,7 +215,7 @@
       "protoPath": "google/cloud/dataproc/v1",
       "productName": "Google Cloud Dataproc",
       "productUrl": "https://cloud.google.com/dataproc/docs/concepts/overview",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Dataproc API, which manages Hadoop-based clusters and jobs on Google Cloud Platform.",
       "tags": [

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -29,7 +29,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Billing.V1](Google.Cloud.Billing.V1/index.html) | 2.0.0 | [Google Cloud Billing API](https://cloud.google.com/billing/docs/) |
 | [Google.Cloud.Container.V1](Google.Cloud.Container.V1/index.html) | 2.0.0 | [Google Kubernetes Engine API](https://cloud.google.com/kubernetes-engine/docs/reference/rest/) |
 | [Google.Cloud.DataCatalog.V1](Google.Cloud.DataCatalog.V1/index.html) | 1.0.0 | [Data Catalog](https://cloud.google.com/data-catalog/docs) |
-| [Google.Cloud.Dataproc.V1](Google.Cloud.Dataproc.V1/index.html) | 2.0.0 | [Google Cloud Dataproc](https://cloud.google.com/dataproc/docs/concepts/overview) |
+| [Google.Cloud.Dataproc.V1](Google.Cloud.Dataproc.V1/index.html) | 2.1.0 | [Google Cloud Dataproc](https://cloud.google.com/dataproc/docs/concepts/overview) |
 | [Google.Cloud.Datastore.V1](Google.Cloud.Datastore.V1/index.html) | 3.0.0 | [Google Cloud Datastore](https://cloud.google.com/datastore/docs/concepts/overview) |
 | [Google.Cloud.Debugger.V2](Google.Cloud.Debugger.V2/index.html) | 2.0.0 | [Google Cloud Debugger](https://cloud.google.com/debugger/) |
 | [Google.Cloud.DevTools.Common](Google.Cloud.DevTools.Common/index.html) | 2.0.0 | Common Protocol Buffer messages for Google Cloud Developer Tools APIs |


### PR DESCRIPTION

Changes in this release:

- [Commit cdd7342](https://github.com/googleapis/google-cloud-dotnet/commit/cdd7342): docs: change relative URLs to absolute URLs to fix broken links.
- [Commit e644610](https://github.com/googleapis/google-cloud-dotnet/commit/e644610):
  - Adds Dataproc Jobs.SubmitJobAsOperation RPC
  - Adds SparkR and Presto job types to WorkflowTemplates
  - Adds new Optional Components
  - Clarifies usage of some APIs
- [Commit edebc2b](https://github.com/googleapis/google-cloud-dotnet/commit/edebc2b): fix Dataproc: add missing `REQUIRED` annotation.
- [Commit bd045c2](https://github.com/googleapis/google-cloud-dotnet/commit/bd045c2): Adds resource name overloads for autoscaling policy operations
