### PR TITLE
Change Bigtable dependency on Bigtable.Common to be a NuGet dependency

### DIFF
--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.IntegrationTests/coverage.xml
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.IntegrationTests/coverage.xml
@@ -7,9 +7,6 @@
       <FilterEntry>
         <ModuleMask>Google.Cloud.Bigtable.V2</ModuleMask>
       </FilterEntry>
-      <FilterEntry>
-        <ModuleMask>Google.Cloud.Bigtable.Common.V2</ModuleMask>
-      </FilterEntry>
     </IncludeFilters>
   </Filters>
   <AttributeFilters>

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Snippets/coverage.xml
@@ -7,9 +7,6 @@
       <FilterEntry>
         <ModuleMask>Google.Cloud.Bigtable.V2</ModuleMask>
       </FilterEntry>
-      <FilterEntry>
-        <ModuleMask>Google.Cloud.Bigtable.Common.V2</ModuleMask>
-      </FilterEntry>
     </IncludeFilters>
   </Filters>
   <AttributeFilters>

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/coverage.xml
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/coverage.xml
@@ -7,9 +7,6 @@
       <FilterEntry>
         <ModuleMask>Google.Cloud.Bigtable.V2</ModuleMask>
       </FilterEntry>
-      <FilterEntry>
-        <ModuleMask>Google.Cloud.Bigtable.Common.V2</ModuleMask>
-      </FilterEntry>
     </IncludeFilters>
   </Filters>
   <AttributeFilters>

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.Gcp" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.0.0, 4.0.0)" />
-    <ProjectReference Include="..\..\Google.Cloud.Bigtable.Common.V2\Google.Cloud.Bigtable.Common.V2\Google.Cloud.Bigtable.Common.V2.csproj" />
+    <PackageReference Include="Google.Cloud.Bigtable.Common.V2" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.27.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -147,7 +147,7 @@
       "dependencies": {
         "Google.Api.Gax.Grpc.GrpcCore": "3.0.0",
         "Google.Api.Gax.Grpc.Gcp": "3.0.0",
-        "Google.Cloud.Bigtable.Common.V2": "project",
+        "Google.Cloud.Bigtable.Common.V2": "2.0.0",
         "Grpc.Core": "2.27.0"
       },
       "testDependencies": {


### PR DESCRIPTION
(Bigtable.V2 depends on Bigtable.Admin.V2 for tests, so they need to be
consistent in terms of either both depending on Bigtable.Common.V2
via a NuGet reference or via a project reference.)