### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,5 +9,6 @@
 # explicitly taken by someone else.
 *                               @googleapis/yoshi-dotnet
 
-/apis/Google.Cloud.Bigtable*/     @GoogleCloudPlatform/bigtable-dpe @googleapis/yoshi-dotnet
-/apis/
+/apis/Google.Cloud.Bigtable*/       @GoogleCloudPlatform/bigtable-dpe @googleapis/yoshi-dotnet
+/apis/Google.Cloud.Firestore*/      @GoogleCloudPlatform/firestore-dpe @googleapis/yoshi-dotnet
+/apis/Google.Cloud.Storage*/        @GoogleCloudPlatform/storage-dpe @googleapis/yoshi-dotnet

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Code owners file.
+# This file controls who is tagged for review for any given pull request.
+#
+# For syntax help see:
+# https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
+
+
+# The yoshi-dotnet team is the default owner for anything not
+# explicitly taken by someone else.
+*                               @googleapis/yoshi-dotnet
+
+/apis/Google.Cloud.Bigtable*/     @GoogleCloudPlatform/bigtable-dpe @googleapis/yoshi-dotnet
+/apis/

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,5 +10,6 @@
 *                               @googleapis/yoshi-dotnet
 
 /apis/Google.Cloud.Bigtable*/       @GoogleCloudPlatform/bigtable-dpe @googleapis/yoshi-dotnet
+/apis/Google.Cloud.Datastore*/      @GoogleCloudPlatform/firestore-dpe @googleapis/yoshi-dotnet
 /apis/Google.Cloud.Firestore*/      @GoogleCloudPlatform/firestore-dpe @googleapis/yoshi-dotnet
 /apis/Google.Cloud.Storage*/        @GoogleCloudPlatform/storage-dpe @googleapis/yoshi-dotnet


### PR DESCRIPTION
@crwilcox requested teams for repo access across the board for SoDa teams. Adding a CODEOWNERS file with yoshi-dotnet as default and with the storage team.

The style for dotnet repo names is a bit different than the others so I may have done this wrong. If the wildcard won't do what I need to and I need a repo per client, LMK and I'll adjust :)