### PR TITLE
Make sure we have docs for Google.Api.Gax.Grpc

### DIFF
--- a/tools/Google.Cloud.Tools.GenerateDocfxSources/Project.cs
+++ b/tools/Google.Cloud.Tools.GenerateDocfxSources/Project.cs
@@ -54,10 +54,12 @@ namespace Google.Cloud.Tools.GenerateDocfxSources
                 // Likewise add protobuf and GRPC whenever we depend on Gax.Grpc...
                 // (It would be quite nice to do all this automatically...)
                 if (dependencies.Contains("Google.Api.Gax.Grpc") ||
-                    dependencies.Contains("Google.Api.Gax.Grpc.GrpcCore"))
+                    dependencies.Contains("Google.Api.Gax.Grpc.GrpcCore") ||
+                    dependencies.Contains("Google.Api.Gax.Grpc.Gcp"))
                 {
                     dependencies.Add("Google.Protobuf");
                     dependencies.Add("Google.Api.CommonProtos");
+                    dependencies.Add("Google.Api.Gax.Grpc");
                     dependencies.Add("Grpc.Core");
                 }
                 return dependencies;


### PR DESCRIPTION
(In most cases we only have Gax.Grpc.Gcp or Gax.Grpc.GrpcCore listed directly.)

This makes the docs for each concrete ClientBuilder *much* more useful.