### PR TITLE
Release Google.Cloud.Storage.V1 version 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Spanner.V1](https://googleapis.dev/dotnet/Google.Cloud.Spanner.V1/3.0.0) | 3.0.0 | [Google Cloud Spanner](https://cloud.google.com/spanner/) |
 | [Google.Cloud.Speech.V1](https://googleapis.dev/dotnet/Google.Cloud.Speech.V1/2.0.0) | 2.0.0 | [Google Cloud Speech (V1 API)](https://cloud.google.com/speech) |
 | [Google.Cloud.Speech.V1P1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Speech.V1P1Beta1/2.0.0-beta02) | 2.0.0-beta02 | [Google Cloud Speech (V1P1Beta1 API)](https://cloud.google.com/speech) |
-| [Google.Cloud.Storage.V1](https://googleapis.dev/dotnet/Google.Cloud.Storage.V1/3.0.0-beta03) | 3.0.0-beta03 | [Google Cloud Storage](https://cloud.google.com/storage/) |
+| [Google.Cloud.Storage.V1](https://googleapis.dev/dotnet/Google.Cloud.Storage.V1/3.0.0) | 3.0.0 | [Google Cloud Storage](https://cloud.google.com/storage/) |
 | [Google.Cloud.Talent.V4Beta1](https://googleapis.dev/dotnet/Google.Cloud.Talent.V4Beta1/2.0.0-beta03) | 2.0.0-beta03 | [Google Cloud Talent Solution](https://cloud.google.com/talent-solution/) |
 | [Google.Cloud.Tasks.V2](https://googleapis.dev/dotnet/Google.Cloud.Tasks.V2/2.0.0) | 2.0.0 | [Google Cloud Tasks (V2 API)](https://cloud.google.com/tasks/) |
 | [Google.Cloud.Tasks.V2Beta3](https://googleapis.dev/dotnet/Google.Cloud.Tasks.V2Beta3/2.0.0-beta02) | 2.0.0-beta02 | [Google Cloud Tasks (V2Beta3 API)](https://cloud.google.com/tasks/) |

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0-beta03</Version>
+    <Version>3.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Storage API. It wraps the Google.Apis.Storage.v1 client library, making common operations simpler in client code. Google Cloud Storage stores and retrieves potentially large, immutable data objects.</Description>

--- a/apis/Google.Cloud.Storage.V1/docs/history.md
+++ b/apis/Google.Cloud.Storage.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+# Version 3.0.0, released 2020-05-12
+
+- [Commit c0dfc6f](https://github.com/googleapis/google-cloud-dotnet/commit/c0dfc6f): feat: POST policy V4 signing support.
+
+This is the first GA release of this package depending on GAX v3.
+
 # Version 3.0.0-beta03, released 2020-04-02
 
 No API surface changes; just updated dependencies. In particular,

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1245,7 +1245,7 @@
       "id": "Google.Cloud.Storage.V1",
       "productName": "Google Cloud Storage",
       "productUrl": "https://cloud.google.com/storage/",
-      "version": "3.0.0-beta03",
+      "version": "3.0.0",
       "type": "rest",
       "description": "Recommended Google client library to access the Google Cloud Storage API. It wraps the Google.Apis.Storage.v1 client library, making common operations simpler in client code. Google Cloud Storage stores and retrieves potentially large, immutable data objects.",
       "dependencies": {

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -81,7 +81,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Spanner.V1](Google.Cloud.Spanner.V1/index.html) | 3.0.0 | [Google Cloud Spanner](https://cloud.google.com/spanner/) |
 | [Google.Cloud.Speech.V1](Google.Cloud.Speech.V1/index.html) | 2.0.0 | [Google Cloud Speech (V1 API)](https://cloud.google.com/speech) |
 | [Google.Cloud.Speech.V1P1Beta1](Google.Cloud.Speech.V1P1Beta1/index.html) | 2.0.0-beta02 | [Google Cloud Speech (V1P1Beta1 API)](https://cloud.google.com/speech) |
-| [Google.Cloud.Storage.V1](Google.Cloud.Storage.V1/index.html) | 3.0.0-beta03 | [Google Cloud Storage](https://cloud.google.com/storage/) |
+| [Google.Cloud.Storage.V1](Google.Cloud.Storage.V1/index.html) | 3.0.0 | [Google Cloud Storage](https://cloud.google.com/storage/) |
 | [Google.Cloud.Talent.V4Beta1](Google.Cloud.Talent.V4Beta1/index.html) | 2.0.0-beta03 | [Google Cloud Talent Solution](https://cloud.google.com/talent-solution/) |
 | [Google.Cloud.Tasks.V2](Google.Cloud.Tasks.V2/index.html) | 2.0.0 | [Google Cloud Tasks (V2 API)](https://cloud.google.com/tasks/) |
 | [Google.Cloud.Tasks.V2Beta3](Google.Cloud.Tasks.V2Beta3/index.html) | 2.0.0-beta02 | [Google Cloud Tasks (V2Beta3 API)](https://cloud.google.com/tasks/) |


### PR DESCRIPTION

Changes in this release:

- [Commit c0dfc6f](https://github.com/googleapis/google-cloud-dotnet/commit/c0dfc6f): feat: POST policy V4 signing support.

This is the first GA release of this package depending on GAX v3.
