### PR TITLE
Regenerate all clients with more explicit documentation

### DIFF
--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/AssetServiceClient.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/AssetServiceClient.g.cs
@@ -180,7 +180,7 @@ namespace Google.Cloud.Asset.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<AssetServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override AssetServiceClient Build()
         {
             AssetServiceClient client = null;
@@ -188,7 +188,7 @@ namespace Google.Cloud.Asset.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<AssetServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<AssetServiceClient> task = null;
@@ -210,16 +210,18 @@ namespace Google.Cloud.Asset.V1
             return AssetServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => AssetServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => AssetServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => AssetServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/AssetServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/AssetServiceResourceNames.g.cs
@@ -282,10 +282,11 @@ namespace Google.Cloud.Asset.V1
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -298,7 +299,7 @@ namespace Google.Cloud.Asset.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Asset.V1/synth.metadata
+++ b/apis/Google.Cloud.Asset.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7be2811ad17013a5ea24cd75dfd9e399dd6e18fe"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/AnnotationSpecResourceNames.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/AnnotationSpecResourceNames.g.cs
@@ -250,10 +250,11 @@ namespace Google.Cloud.AutoML.V1
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -264,7 +265,7 @@ namespace Google.Cloud.AutoML.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/AutoMlClient.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/AutoMlClient.g.cs
@@ -501,7 +501,7 @@ namespace Google.Cloud.AutoML.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<AutoMlClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override AutoMlClient Build()
         {
             AutoMlClient client = null;
@@ -509,7 +509,7 @@ namespace Google.Cloud.AutoML.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<AutoMlClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<AutoMlClient> task = null;
@@ -531,16 +531,18 @@ namespace Google.Cloud.AutoML.V1
             return AutoMlClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => AutoMlClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => AutoMlClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => AutoMlClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/DatasetResourceNames.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/DatasetResourceNames.g.cs
@@ -218,10 +218,11 @@ namespace Google.Cloud.AutoML.V1
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -232,7 +233,7 @@ namespace Google.Cloud.AutoML.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/ModelEvaluationResourceNames.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/ModelEvaluationResourceNames.g.cs
@@ -250,10 +250,11 @@ namespace Google.Cloud.AutoML.V1
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -264,7 +265,7 @@ namespace Google.Cloud.AutoML.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/ModelResourceNames.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/ModelResourceNames.g.cs
@@ -218,10 +218,11 @@ namespace Google.Cloud.AutoML.V1
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -232,7 +233,7 @@ namespace Google.Cloud.AutoML.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/PredictionServiceClient.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/PredictionServiceClient.g.cs
@@ -112,7 +112,7 @@ namespace Google.Cloud.AutoML.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<PredictionServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override PredictionServiceClient Build()
         {
             PredictionServiceClient client = null;
@@ -120,7 +120,7 @@ namespace Google.Cloud.AutoML.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<PredictionServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<PredictionServiceClient> task = null;
@@ -142,16 +142,18 @@ namespace Google.Cloud.AutoML.V1
             return PredictionServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => PredictionServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => PredictionServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => PredictionServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.AutoML.V1/synth.metadata
+++ b/apis/Google.Cloud.AutoML.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "371206424e6db4df2cb3734bb1013dcaac9dbe4b"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/DataTransferServiceClient.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/DataTransferServiceClient.g.cs
@@ -291,7 +291,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<DataTransferServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override DataTransferServiceClient Build()
         {
             DataTransferServiceClient client = null;
@@ -299,7 +299,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<DataTransferServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<DataTransferServiceClient> task = null;
@@ -321,16 +321,18 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             return DataTransferServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => DataTransferServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => DataTransferServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => DataTransferServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/DatatransferResourceNames.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/DatatransferResourceNames.g.cs
@@ -263,10 +263,11 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -278,7 +279,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/TransferResourceNames.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/TransferResourceNames.g.cs
@@ -269,10 +269,11 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// </summary>
         public string TransferConfigId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -284,7 +285,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -571,10 +572,11 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// </summary>
         public string TransferConfigId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -586,7 +588,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/synth.metadata
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/synth.metadata
@@ -1,11 +1,10 @@
 {
-  "updateTime": "2020-04-08T05:37:35.012840Z",
   "sources": [
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "af7da29c24814a1c873c22f477e9dd8dd5a17b0b"
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/BigQueryReadClient.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/BigQueryReadClient.g.cs
@@ -106,7 +106,7 @@ namespace Google.Cloud.BigQuery.Storage.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<BigQueryReadClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override BigQueryReadClient Build()
         {
             BigQueryReadClient client = null;
@@ -114,7 +114,7 @@ namespace Google.Cloud.BigQuery.Storage.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<BigQueryReadClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<BigQueryReadClient> task = null;
@@ -136,16 +136,18 @@ namespace Google.Cloud.BigQuery.Storage.V1
             return BigQueryReadClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => BigQueryReadClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => BigQueryReadClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => BigQueryReadClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/StorageResourceNames.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/StorageResourceNames.g.cs
@@ -219,10 +219,11 @@ namespace Google.Cloud.BigQuery.Storage.V1
         /// </summary>
         public string TableId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -233,7 +234,7 @@ namespace Google.Cloud.BigQuery.Storage.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/StreamResourceNames.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/StreamResourceNames.g.cs
@@ -220,10 +220,11 @@ namespace Google.Cloud.BigQuery.Storage.V1
         /// </summary>
         public string SessionId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -234,7 +235,7 @@ namespace Google.Cloud.BigQuery.Storage.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -477,10 +478,11 @@ namespace Google.Cloud.BigQuery.Storage.V1
         /// </summary>
         public string StreamId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -491,7 +493,7 @@ namespace Google.Cloud.BigQuery.Storage.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.BigQuery.Storage.V1/synth.metadata
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/synth.metadata
@@ -1,11 +1,10 @@
 {
-  "updateTime": "2020-04-08T05:38:43.423291Z",
   "sources": [
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "3f767aa32b4b3313027d05b503aaba63e0c432a3"
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/BigtableInstanceAdminClient.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/BigtableInstanceAdminClient.g.cs
@@ -460,7 +460,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<BigtableInstanceAdminClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override BigtableInstanceAdminClient Build()
         {
             BigtableInstanceAdminClient client = null;
@@ -468,7 +468,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<BigtableInstanceAdminClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<BigtableInstanceAdminClient> task = null;
@@ -490,16 +490,18 @@ namespace Google.Cloud.Bigtable.Admin.V2
             return BigtableInstanceAdminClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => BigtableInstanceAdminClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => BigtableInstanceAdminClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => BigtableInstanceAdminClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/BigtableTableAdminClient.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/BigtableTableAdminClient.g.cs
@@ -461,7 +461,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<BigtableTableAdminClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override BigtableTableAdminClient Build()
         {
             BigtableTableAdminClient client = null;
@@ -469,7 +469,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<BigtableTableAdminClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<BigtableTableAdminClient> task = null;
@@ -491,16 +491,18 @@ namespace Google.Cloud.Bigtable.Admin.V2
             return BigtableTableAdminClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => BigtableTableAdminClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => BigtableTableAdminClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => BigtableTableAdminClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/InstanceResourceNames.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/InstanceResourceNames.g.cs
@@ -206,10 +206,11 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -220,7 +221,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -434,10 +435,11 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -448,7 +450,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -672,10 +674,11 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -686,7 +689,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/TableResourceNames.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/TableResourceNames.g.cs
@@ -247,10 +247,11 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// </summary>
         public string SnapshotId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -261,7 +262,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -502,10 +503,11 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -516,7 +518,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Bigtable.Admin.V2/synth.metadata
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "756b174de4a122461993c1c583345533d819936d"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableServiceApiClient.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableServiceApiClient.g.cs
@@ -137,7 +137,7 @@ namespace Google.Cloud.Bigtable.V2
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<BigtableServiceApiClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override BigtableServiceApiClient Build()
         {
             BigtableServiceApiClient client = null;
@@ -145,7 +145,7 @@ namespace Google.Cloud.Bigtable.V2
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<BigtableServiceApiClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<BigtableServiceApiClient> task = null;
@@ -167,13 +167,15 @@ namespace Google.Cloud.Bigtable.V2
             return BigtableServiceApiClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => BigtableServiceApiClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => BigtableServiceApiClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Bigtable.V2/synth.metadata
+++ b/apis/Google.Cloud.Bigtable.V2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7be2811ad17013a5ea24cd75dfd9e399dd6e18fe"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/CloudBillingClient.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/CloudBillingClient.g.cs
@@ -199,7 +199,7 @@ namespace Google.Cloud.Billing.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<CloudBillingClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override CloudBillingClient Build()
         {
             CloudBillingClient client = null;
@@ -207,7 +207,7 @@ namespace Google.Cloud.Billing.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<CloudBillingClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<CloudBillingClient> task = null;
@@ -229,16 +229,18 @@ namespace Google.Cloud.Billing.V1
             return CloudBillingClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => CloudBillingClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => CloudBillingClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => CloudBillingClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/CloudCatalogClient.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/CloudCatalogClient.g.cs
@@ -92,7 +92,7 @@ namespace Google.Cloud.Billing.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<CloudCatalogClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override CloudCatalogClient Build()
         {
             CloudCatalogClient client = null;
@@ -100,7 +100,7 @@ namespace Google.Cloud.Billing.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<CloudCatalogClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<CloudCatalogClient> task = null;
@@ -122,16 +122,18 @@ namespace Google.Cloud.Billing.V1
             return CloudCatalogClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => CloudCatalogClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => CloudCatalogClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => CloudCatalogClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/CloudCatalogResourceNames.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/CloudCatalogResourceNames.g.cs
@@ -182,10 +182,11 @@ namespace Google.Cloud.Billing.V1
         /// </summary>
         public string ServiceId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -196,7 +197,7 @@ namespace Google.Cloud.Billing.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -382,10 +383,11 @@ namespace Google.Cloud.Billing.V1
         /// </summary>
         public string SkuId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -396,7 +398,7 @@ namespace Google.Cloud.Billing.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Billing.V1/synth.metadata
+++ b/apis/Google.Cloud.Billing.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7be2811ad17013a5ea24cd75dfd9e399dd6e18fe"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/ClusterManagerClient.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/ClusterManagerClient.g.cs
@@ -502,7 +502,7 @@ namespace Google.Cloud.Container.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ClusterManagerClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override ClusterManagerClient Build()
         {
             ClusterManagerClient client = null;
@@ -510,7 +510,7 @@ namespace Google.Cloud.Container.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<ClusterManagerClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<ClusterManagerClient> task = null;
@@ -532,16 +532,18 @@ namespace Google.Cloud.Container.V1
             return ClusterManagerClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => ClusterManagerClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => ClusterManagerClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => ClusterManagerClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Container.V1/synth.metadata
+++ b/apis/Google.Cloud.Container.V1/synth.metadata
@@ -2,16 +2,9 @@
   "sources": [
     {
       "git": {
-        "name": ".",
-        "remote": "https://github.com/googleapis/google-cloud-dotnet.git",
-        "sha": "1469d9650cba00fcb7a6109c417772b4e4a6db29"
-      }
-    },
-    {
-      "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "9af7212bc2cba8a7184f032e1ab6662ccf604b3a"
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/DataCatalogClient.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/DataCatalogClient.g.cs
@@ -444,7 +444,7 @@ namespace Google.Cloud.DataCatalog.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<DataCatalogClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override DataCatalogClient Build()
         {
             DataCatalogClient client = null;
@@ -452,7 +452,7 @@ namespace Google.Cloud.DataCatalog.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<DataCatalogClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<DataCatalogClient> task = null;
@@ -474,16 +474,18 @@ namespace Google.Cloud.DataCatalog.V1
             return DataCatalogClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => DataCatalogClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => DataCatalogClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => DataCatalogClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/DatacatalogResourceNames.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/DatacatalogResourceNames.g.cs
@@ -246,10 +246,11 @@ namespace Google.Cloud.DataCatalog.V1
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -260,7 +261,7 @@ namespace Google.Cloud.DataCatalog.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -484,10 +485,11 @@ namespace Google.Cloud.DataCatalog.V1
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -498,7 +500,7 @@ namespace Google.Cloud.DataCatalog.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/TagsResourceNames.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/TagsResourceNames.g.cs
@@ -253,10 +253,11 @@ namespace Google.Cloud.DataCatalog.V1
         /// </summary>
         public string TagId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -267,7 +268,7 @@ namespace Google.Cloud.DataCatalog.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -491,10 +492,11 @@ namespace Google.Cloud.DataCatalog.V1
         /// </summary>
         public string TagTemplateId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -505,7 +507,7 @@ namespace Google.Cloud.DataCatalog.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -750,10 +752,11 @@ namespace Google.Cloud.DataCatalog.V1
         /// </summary>
         public string TagTemplateId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -764,7 +767,7 @@ namespace Google.Cloud.DataCatalog.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.DataCatalog.V1/synth.metadata
+++ b/apis/Google.Cloud.DataCatalog.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "684dfea7decfeca7a7526ea96a8e9256694dd5d8"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/AutoscalingPoliciesResourceNames.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/AutoscalingPoliciesResourceNames.g.cs
@@ -305,10 +305,11 @@ namespace Google.Cloud.Dataproc.V1
         /// </summary>
         public string RegionId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -320,7 +321,7 @@ namespace Google.Cloud.Dataproc.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -520,10 +521,11 @@ namespace Google.Cloud.Dataproc.V1
         /// </summary>
         public string RegionId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -534,7 +536,7 @@ namespace Google.Cloud.Dataproc.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/AutoscalingPolicyServiceClient.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/AutoscalingPolicyServiceClient.g.cs
@@ -150,7 +150,7 @@ namespace Google.Cloud.Dataproc.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<AutoscalingPolicyServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override AutoscalingPolicyServiceClient Build()
         {
             AutoscalingPolicyServiceClient client = null;
@@ -158,7 +158,7 @@ namespace Google.Cloud.Dataproc.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<AutoscalingPolicyServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<AutoscalingPolicyServiceClient> task = null;
@@ -180,16 +180,18 @@ namespace Google.Cloud.Dataproc.V1
             return AutoscalingPolicyServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => AutoscalingPolicyServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => AutoscalingPolicyServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => AutoscalingPolicyServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/ClusterControllerClient.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/ClusterControllerClient.g.cs
@@ -241,7 +241,7 @@ namespace Google.Cloud.Dataproc.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ClusterControllerClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override ClusterControllerClient Build()
         {
             ClusterControllerClient client = null;
@@ -249,7 +249,7 @@ namespace Google.Cloud.Dataproc.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<ClusterControllerClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<ClusterControllerClient> task = null;
@@ -271,16 +271,18 @@ namespace Google.Cloud.Dataproc.V1
             return ClusterControllerClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => ClusterControllerClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => ClusterControllerClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => ClusterControllerClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/JobControllerClient.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/JobControllerClient.g.cs
@@ -200,7 +200,7 @@ namespace Google.Cloud.Dataproc.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<JobControllerClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override JobControllerClient Build()
         {
             JobControllerClient client = null;
@@ -208,7 +208,7 @@ namespace Google.Cloud.Dataproc.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<JobControllerClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<JobControllerClient> task = null;
@@ -230,16 +230,18 @@ namespace Google.Cloud.Dataproc.V1
             return JobControllerClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => JobControllerClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => JobControllerClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => JobControllerClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/WorkflowTemplateServiceClient.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/WorkflowTemplateServiceClient.g.cs
@@ -230,7 +230,7 @@ namespace Google.Cloud.Dataproc.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<WorkflowTemplateServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override WorkflowTemplateServiceClient Build()
         {
             WorkflowTemplateServiceClient client = null;
@@ -238,7 +238,7 @@ namespace Google.Cloud.Dataproc.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<WorkflowTemplateServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<WorkflowTemplateServiceClient> task = null;
@@ -260,16 +260,18 @@ namespace Google.Cloud.Dataproc.V1
             return WorkflowTemplateServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => WorkflowTemplateServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => WorkflowTemplateServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => WorkflowTemplateServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/WorkflowTemplatesResourceNames.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/WorkflowTemplatesResourceNames.g.cs
@@ -297,10 +297,11 @@ namespace Google.Cloud.Dataproc.V1
         /// </summary>
         public string WorkflowTemplateId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -312,7 +313,7 @@ namespace Google.Cloud.Dataproc.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Dataproc.V1/synth.metadata
+++ b/apis/Google.Cloud.Dataproc.V1/synth.metadata
@@ -1,11 +1,10 @@
 {
-  "updateTime": "2020-04-08T05:43:22.195160Z",
   "sources": [
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "744591190e828440f72745aef217f883afd1fd71"
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreClient.g.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreClient.g.cs
@@ -166,7 +166,7 @@ namespace Google.Cloud.Datastore.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<DatastoreClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override DatastoreClient Build()
         {
             DatastoreClient client = null;
@@ -174,7 +174,7 @@ namespace Google.Cloud.Datastore.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<DatastoreClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<DatastoreClient> task = null;
@@ -196,16 +196,18 @@ namespace Google.Cloud.Datastore.V1
             return DatastoreClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => DatastoreClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => DatastoreClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => DatastoreClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Datastore.V1/synth.metadata
+++ b/apis/Google.Cloud.Datastore.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "1b5a8d2bbb69c5a04db26bd546d2888e609c6bab"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2/Controller2Client.g.cs
+++ b/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2/Controller2Client.g.cs
@@ -110,7 +110,7 @@ namespace Google.Cloud.Debugger.V2
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<Controller2Client> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override Controller2Client Build()
         {
             Controller2Client client = null;
@@ -118,7 +118,7 @@ namespace Google.Cloud.Debugger.V2
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<Controller2Client> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<Controller2Client> task = null;
@@ -140,16 +140,18 @@ namespace Google.Cloud.Debugger.V2
             return Controller2Client.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => Controller2Client.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => Controller2Client.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => Controller2Client.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2/Debugger2Client.g.cs
+++ b/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2/Debugger2Client.g.cs
@@ -143,7 +143,7 @@ namespace Google.Cloud.Debugger.V2
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<Debugger2Client> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override Debugger2Client Build()
         {
             Debugger2Client client = null;
@@ -151,7 +151,7 @@ namespace Google.Cloud.Debugger.V2
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<Debugger2Client> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<Debugger2Client> task = null;
@@ -173,16 +173,18 @@ namespace Google.Cloud.Debugger.V2
             return Debugger2Client.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => Debugger2Client.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => Debugger2Client.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => Debugger2Client.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Debugger.V2/synth.metadata
+++ b/apis/Google.Cloud.Debugger.V2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7be2811ad17013a5ea24cd75dfd9e399dd6e18fe"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1/ContainerAnalysisClient.g.cs
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1/ContainerAnalysisClient.g.cs
@@ -107,7 +107,7 @@ namespace Google.Cloud.DevTools.ContainerAnalysis.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ContainerAnalysisClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override ContainerAnalysisClient Build()
         {
             ContainerAnalysisClient client = null;
@@ -115,7 +115,7 @@ namespace Google.Cloud.DevTools.ContainerAnalysis.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<ContainerAnalysisClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<ContainerAnalysisClient> task = null;
@@ -137,16 +137,18 @@ namespace Google.Cloud.DevTools.ContainerAnalysis.V1
             return ContainerAnalysisClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => ContainerAnalysisClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => ContainerAnalysisClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => ContainerAnalysisClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/synth.metadata
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7be2811ad17013a5ea24cd75dfd9e399dd6e18fe"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/AgentResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/AgentResourceNames.g.cs
@@ -182,10 +182,11 @@ namespace Google.Cloud.Dialogflow.V2
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -196,7 +197,7 @@ namespace Google.Cloud.Dialogflow.V2
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/AgentsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/AgentsClient.g.cs
@@ -283,7 +283,7 @@ namespace Google.Cloud.Dialogflow.V2
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<AgentsClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override AgentsClient Build()
         {
             AgentsClient client = null;
@@ -291,7 +291,7 @@ namespace Google.Cloud.Dialogflow.V2
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<AgentsClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<AgentsClient> task = null;
@@ -313,16 +313,18 @@ namespace Google.Cloud.Dialogflow.V2
             return AgentsClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => AgentsClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => AgentsClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => AgentsClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ContextResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ContextResourceNames.g.cs
@@ -306,10 +306,11 @@ namespace Google.Cloud.Dialogflow.V2
         /// </summary>
         public string UserId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -321,7 +322,7 @@ namespace Google.Cloud.Dialogflow.V2
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ContextsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ContextsClient.g.cs
@@ -157,7 +157,7 @@ namespace Google.Cloud.Dialogflow.V2
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ContextsClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override ContextsClient Build()
         {
             ContextsClient client = null;
@@ -165,7 +165,7 @@ namespace Google.Cloud.Dialogflow.V2
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<ContextsClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<ContextsClient> task = null;
@@ -187,16 +187,18 @@ namespace Google.Cloud.Dialogflow.V2
             return ContextsClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => ContextsClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => ContextsClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => ContextsClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/EntityTypeResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/EntityTypeResourceNames.g.cs
@@ -209,10 +209,11 @@ namespace Google.Cloud.Dialogflow.V2
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -223,7 +224,7 @@ namespace Google.Cloud.Dialogflow.V2
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/EntityTypesClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/EntityTypesClient.g.cs
@@ -308,7 +308,7 @@ namespace Google.Cloud.Dialogflow.V2
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<EntityTypesClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override EntityTypesClient Build()
         {
             EntityTypesClient client = null;
@@ -316,7 +316,7 @@ namespace Google.Cloud.Dialogflow.V2
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<EntityTypesClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<EntityTypesClient> task = null;
@@ -338,16 +338,18 @@ namespace Google.Cloud.Dialogflow.V2
             return EntityTypesClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => EntityTypesClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => EntityTypesClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => EntityTypesClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/EnvironmentResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/EnvironmentResourceNames.g.cs
@@ -210,10 +210,11 @@ namespace Google.Cloud.Dialogflow.V2
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -224,7 +225,7 @@ namespace Google.Cloud.Dialogflow.V2
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/EnvironmentsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/EnvironmentsClient.g.cs
@@ -82,7 +82,7 @@ namespace Google.Cloud.Dialogflow.V2
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<EnvironmentsClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override EnvironmentsClient Build()
         {
             EnvironmentsClient client = null;
@@ -90,7 +90,7 @@ namespace Google.Cloud.Dialogflow.V2
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<EnvironmentsClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<EnvironmentsClient> task = null;
@@ -112,16 +112,18 @@ namespace Google.Cloud.Dialogflow.V2
             return EnvironmentsClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => EnvironmentsClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => EnvironmentsClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => EnvironmentsClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/IntentResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/IntentResourceNames.g.cs
@@ -204,10 +204,11 @@ namespace Google.Cloud.Dialogflow.V2
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -218,7 +219,7 @@ namespace Google.Cloud.Dialogflow.V2
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/IntentsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/IntentsClient.g.cs
@@ -209,7 +209,7 @@ namespace Google.Cloud.Dialogflow.V2
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<IntentsClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override IntentsClient Build()
         {
             IntentsClient client = null;
@@ -217,7 +217,7 @@ namespace Google.Cloud.Dialogflow.V2
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<IntentsClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<IntentsClient> task = null;
@@ -239,16 +239,18 @@ namespace Google.Cloud.Dialogflow.V2
             return IntentsClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => IntentsClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => IntentsClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => IntentsClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/SessionEntityTypeResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/SessionEntityTypeResourceNames.g.cs
@@ -319,10 +319,11 @@ namespace Google.Cloud.Dialogflow.V2
         /// </summary>
         public string UserId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -334,7 +335,7 @@ namespace Google.Cloud.Dialogflow.V2
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/SessionEntityTypesClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/SessionEntityTypesClient.g.cs
@@ -147,7 +147,7 @@ namespace Google.Cloud.Dialogflow.V2
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<SessionEntityTypesClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override SessionEntityTypesClient Build()
         {
             SessionEntityTypesClient client = null;
@@ -155,7 +155,7 @@ namespace Google.Cloud.Dialogflow.V2
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<SessionEntityTypesClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<SessionEntityTypesClient> task = null;
@@ -177,16 +177,18 @@ namespace Google.Cloud.Dialogflow.V2
             return SessionEntityTypesClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => SessionEntityTypesClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => SessionEntityTypesClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => SessionEntityTypesClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/SessionResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/SessionResourceNames.g.cs
@@ -276,10 +276,11 @@ namespace Google.Cloud.Dialogflow.V2
         /// </summary>
         public string UserId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -291,7 +292,7 @@ namespace Google.Cloud.Dialogflow.V2
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/SessionsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/SessionsClient.g.cs
@@ -99,7 +99,7 @@ namespace Google.Cloud.Dialogflow.V2
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<SessionsClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override SessionsClient Build()
         {
             SessionsClient client = null;
@@ -107,7 +107,7 @@ namespace Google.Cloud.Dialogflow.V2
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<SessionsClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<SessionsClient> task = null;
@@ -129,16 +129,18 @@ namespace Google.Cloud.Dialogflow.V2
             return SessionsClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => SessionsClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => SessionsClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => SessionsClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Dialogflow.V2/synth.metadata
+++ b/apis/Google.Cloud.Dialogflow.V2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "ee9e8e4e67f06aba881392a1a2956fbe7a42d216"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/DlpResourceNames.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/DlpResourceNames.g.cs
@@ -219,10 +219,11 @@ namespace Google.Cloud.Dlp.V2
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -233,7 +234,7 @@ namespace Google.Cloud.Dlp.V2
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -618,10 +619,11 @@ namespace Google.Cloud.Dlp.V2
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -635,7 +637,7 @@ namespace Google.Cloud.Dlp.V2
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -1041,10 +1043,11 @@ namespace Google.Cloud.Dlp.V2
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -1058,7 +1061,7 @@ namespace Google.Cloud.Dlp.V2
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -1316,10 +1319,11 @@ namespace Google.Cloud.Dlp.V2
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -1331,7 +1335,7 @@ namespace Google.Cloud.Dlp.V2
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -1578,10 +1582,11 @@ namespace Google.Cloud.Dlp.V2
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -1593,7 +1598,7 @@ namespace Google.Cloud.Dlp.V2
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -1978,10 +1983,11 @@ namespace Google.Cloud.Dlp.V2
         /// </summary>
         public string StoredInfoTypeId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -1995,7 +2001,7 @@ namespace Google.Cloud.Dlp.V2
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -2209,10 +2215,11 @@ namespace Google.Cloud.Dlp.V2
         /// </summary>
         public string OrganizationId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -2223,7 +2230,7 @@ namespace Google.Cloud.Dlp.V2
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/DlpServiceClient.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/DlpServiceClient.g.cs
@@ -579,7 +579,7 @@ namespace Google.Cloud.Dlp.V2
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<DlpServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override DlpServiceClient Build()
         {
             DlpServiceClient client = null;
@@ -587,7 +587,7 @@ namespace Google.Cloud.Dlp.V2
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<DlpServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<DlpServiceClient> task = null;
@@ -609,16 +609,18 @@ namespace Google.Cloud.Dlp.V2
             return DlpServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => DlpServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => DlpServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => DlpServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Dlp.V2/synth.metadata
+++ b/apis/Google.Cloud.Dlp.V2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "1b8b77db10a0bd0ff47a4259ae9804b6237bc1c7"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/CommonResourceNames.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/CommonResourceNames.g.cs
@@ -198,10 +198,11 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -212,7 +213,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ErrorGroupServiceClient.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ErrorGroupServiceClient.g.cs
@@ -98,7 +98,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ErrorGroupServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override ErrorGroupServiceClient Build()
         {
             ErrorGroupServiceClient client = null;
@@ -106,7 +106,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<ErrorGroupServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<ErrorGroupServiceClient> task = null;
@@ -128,16 +128,18 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
             return ErrorGroupServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => ErrorGroupServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => ErrorGroupServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => ErrorGroupServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ErrorStatsServiceClient.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ErrorStatsServiceClient.g.cs
@@ -116,7 +116,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ErrorStatsServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override ErrorStatsServiceClient Build()
         {
             ErrorStatsServiceClient client = null;
@@ -124,7 +124,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<ErrorStatsServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<ErrorStatsServiceClient> task = null;
@@ -146,16 +146,18 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
             return ErrorStatsServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => ErrorStatsServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => ErrorStatsServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => ErrorStatsServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ReportErrorsServiceClient.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ReportErrorsServiceClient.g.cs
@@ -81,7 +81,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ReportErrorsServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override ReportErrorsServiceClient Build()
         {
             ReportErrorsServiceClient client = null;
@@ -89,7 +89,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<ReportErrorsServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<ReportErrorsServiceClient> task = null;
@@ -111,16 +111,18 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
             return ReportErrorsServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => ReportErrorsServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => ReportErrorsServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => ReportErrorsServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7be2811ad17013a5ea24cd75dfd9e399dd6e18fe"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/FieldResourceNames.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/FieldResourceNames.g.cs
@@ -245,10 +245,11 @@ namespace Google.Cloud.Firestore.Admin.V1
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -259,7 +260,7 @@ namespace Google.Cloud.Firestore.Admin.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/FirestoreAdminClient.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/FirestoreAdminClient.g.cs
@@ -277,7 +277,7 @@ namespace Google.Cloud.Firestore.Admin.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<FirestoreAdminClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override FirestoreAdminClient Build()
         {
             FirestoreAdminClient client = null;
@@ -285,7 +285,7 @@ namespace Google.Cloud.Firestore.Admin.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<FirestoreAdminClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<FirestoreAdminClient> task = null;
@@ -307,16 +307,18 @@ namespace Google.Cloud.Firestore.Admin.V1
             return FirestoreAdminClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => FirestoreAdminClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => FirestoreAdminClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => FirestoreAdminClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/FirestoreAdminResourceNames.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/FirestoreAdminResourceNames.g.cs
@@ -205,10 +205,11 @@ namespace Google.Cloud.Firestore.Admin.V1
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -219,7 +220,7 @@ namespace Google.Cloud.Firestore.Admin.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -446,10 +447,11 @@ namespace Google.Cloud.Firestore.Admin.V1
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -460,7 +462,7 @@ namespace Google.Cloud.Firestore.Admin.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/IndexResourceNames.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/IndexResourceNames.g.cs
@@ -245,10 +245,11 @@ namespace Google.Cloud.Firestore.Admin.V1
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -259,7 +260,7 @@ namespace Google.Cloud.Firestore.Admin.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Firestore.Admin.V1/synth.metadata
+++ b/apis/Google.Cloud.Firestore.Admin.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7be2811ad17013a5ea24cd75dfd9e399dd6e18fe"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/FirestoreClient.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/FirestoreClient.g.cs
@@ -256,7 +256,7 @@ namespace Google.Cloud.Firestore.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<FirestoreClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override FirestoreClient Build()
         {
             FirestoreClient client = null;
@@ -264,7 +264,7 @@ namespace Google.Cloud.Firestore.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<FirestoreClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<FirestoreClient> task = null;
@@ -286,16 +286,18 @@ namespace Google.Cloud.Firestore.V1
             return FirestoreClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => FirestoreClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => FirestoreClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => FirestoreClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Firestore.V1/synth.metadata
+++ b/apis/Google.Cloud.Firestore.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7be2811ad17013a5ea24cd75dfd9e399dd6e18fe"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/GameServerClustersResourceNames.g.cs
+++ b/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/GameServerClustersResourceNames.g.cs
@@ -249,10 +249,11 @@ namespace Google.Cloud.Gaming.V1Beta
         /// </summary>
         public string RealmId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -263,7 +264,7 @@ namespace Google.Cloud.Gaming.V1Beta
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/GameServerClustersServiceClient.g.cs
+++ b/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/GameServerClustersServiceClient.g.cs
@@ -240,7 +240,7 @@ namespace Google.Cloud.Gaming.V1Beta
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<GameServerClustersServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override GameServerClustersServiceClient Build()
         {
             GameServerClustersServiceClient client = null;
@@ -248,7 +248,7 @@ namespace Google.Cloud.Gaming.V1Beta
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<GameServerClustersServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<GameServerClustersServiceClient> task = null;
@@ -270,16 +270,18 @@ namespace Google.Cloud.Gaming.V1Beta
             return GameServerClustersServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => GameServerClustersServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => GameServerClustersServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => GameServerClustersServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/GameServerConfigsResourceNames.g.cs
+++ b/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/GameServerConfigsResourceNames.g.cs
@@ -249,10 +249,11 @@ namespace Google.Cloud.Gaming.V1Beta
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -263,7 +264,7 @@ namespace Google.Cloud.Gaming.V1Beta
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/GameServerConfigsServiceClient.g.cs
+++ b/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/GameServerConfigsServiceClient.g.cs
@@ -164,7 +164,7 @@ namespace Google.Cloud.Gaming.V1Beta
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<GameServerConfigsServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override GameServerConfigsServiceClient Build()
         {
             GameServerConfigsServiceClient client = null;
@@ -172,7 +172,7 @@ namespace Google.Cloud.Gaming.V1Beta
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<GameServerConfigsServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<GameServerConfigsServiceClient> task = null;
@@ -194,16 +194,18 @@ namespace Google.Cloud.Gaming.V1Beta
             return GameServerConfigsServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => GameServerConfigsServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => GameServerConfigsServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => GameServerConfigsServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/GameServerDeploymentsResourceNames.g.cs
+++ b/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/GameServerDeploymentsResourceNames.g.cs
@@ -245,10 +245,11 @@ namespace Google.Cloud.Gaming.V1Beta
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -259,7 +260,7 @@ namespace Google.Cloud.Gaming.V1Beta
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -510,10 +511,11 @@ namespace Google.Cloud.Gaming.V1Beta
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -524,7 +526,7 @@ namespace Google.Cloud.Gaming.V1Beta
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/GameServerDeploymentsServiceClient.g.cs
+++ b/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/GameServerDeploymentsServiceClient.g.cs
@@ -278,7 +278,7 @@ namespace Google.Cloud.Gaming.V1Beta
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<GameServerDeploymentsServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override GameServerDeploymentsServiceClient Build()
         {
             GameServerDeploymentsServiceClient client = null;
@@ -286,7 +286,7 @@ namespace Google.Cloud.Gaming.V1Beta
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<GameServerDeploymentsServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<GameServerDeploymentsServiceClient> task = null;
@@ -308,16 +308,18 @@ namespace Google.Cloud.Gaming.V1Beta
             return GameServerDeploymentsServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => GameServerDeploymentsServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => GameServerDeploymentsServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => GameServerDeploymentsServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/RealmsResourceNames.g.cs
+++ b/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/RealmsResourceNames.g.cs
@@ -219,10 +219,11 @@ namespace Google.Cloud.Gaming.V1Beta
         /// </summary>
         public string RealmId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -233,7 +234,7 @@ namespace Google.Cloud.Gaming.V1Beta
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/RealmsServiceClient.g.cs
+++ b/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/RealmsServiceClient.g.cs
@@ -205,7 +205,7 @@ namespace Google.Cloud.Gaming.V1Beta
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<RealmsServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override RealmsServiceClient Build()
         {
             RealmsServiceClient client = null;
@@ -213,7 +213,7 @@ namespace Google.Cloud.Gaming.V1Beta
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<RealmsServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<RealmsServiceClient> task = null;
@@ -235,16 +235,18 @@ namespace Google.Cloud.Gaming.V1Beta
             return RealmsServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => RealmsServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => RealmsServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => RealmsServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Gaming.V1Beta/synth.metadata
+++ b/apis/Google.Cloud.Gaming.V1Beta/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7be2811ad17013a5ea24cd75dfd9e399dd6e18fe"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.Iam.V1/synth.metadata
+++ b/apis/Google.Cloud.Iam.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7be2811ad17013a5ea24cd75dfd9e399dd6e18fe"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/KeyManagementServiceClient.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/KeyManagementServiceClient.g.cs
@@ -443,7 +443,7 @@ namespace Google.Cloud.Kms.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<KeyManagementServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override KeyManagementServiceClient Build()
         {
             KeyManagementServiceClient client = null;
@@ -451,7 +451,7 @@ namespace Google.Cloud.Kms.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<KeyManagementServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<KeyManagementServiceClient> task = null;
@@ -473,16 +473,18 @@ namespace Google.Cloud.Kms.V1
             return KeyManagementServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => KeyManagementServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => KeyManagementServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => KeyManagementServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/ResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/ResourcesResourceNames.g.cs
@@ -218,10 +218,11 @@ namespace Google.Cloud.Kms.V1
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -232,7 +233,7 @@ namespace Google.Cloud.Kms.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -474,10 +475,11 @@ namespace Google.Cloud.Kms.V1
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -488,7 +490,7 @@ namespace Google.Cloud.Kms.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -761,10 +763,11 @@ namespace Google.Cloud.Kms.V1
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -775,7 +778,7 @@ namespace Google.Cloud.Kms.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -1045,10 +1048,11 @@ namespace Google.Cloud.Kms.V1
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -1059,7 +1063,7 @@ namespace Google.Cloud.Kms.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -1301,10 +1305,11 @@ namespace Google.Cloud.Kms.V1
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -1315,7 +1320,7 @@ namespace Google.Cloud.Kms.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Kms.V1/synth.metadata
+++ b/apis/Google.Cloud.Kms.V1/synth.metadata
@@ -1,11 +1,10 @@
 {
-  "updateTime": "2020-04-06T15:42:13.335926Z",
   "sources": [
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a005f045a301535eeb4c4b3fa7bb94eec9d22a8b"
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/LanguageServiceClient.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/LanguageServiceClient.g.cs
@@ -163,7 +163,7 @@ namespace Google.Cloud.Language.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<LanguageServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override LanguageServiceClient Build()
         {
             LanguageServiceClient client = null;
@@ -171,7 +171,7 @@ namespace Google.Cloud.Language.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<LanguageServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<LanguageServiceClient> task = null;
@@ -193,16 +193,18 @@ namespace Google.Cloud.Language.V1
             return LanguageServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => LanguageServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => LanguageServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => LanguageServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Language.V1/synth.metadata
+++ b/apis/Google.Cloud.Language.V1/synth.metadata
@@ -1,11 +1,10 @@
 {
-  "updateTime": "2020-04-04T06:23:07.510464Z",
   "sources": [
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a8d76f99d3073aaccabdcc122c798a63e812c4fe"
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.Logging.Type/synth.metadata
+++ b/apis/Google.Cloud.Logging.Type/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7be2811ad17013a5ea24cd75dfd9e399dd6e18fe"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/ConfigServiceV2Client.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/ConfigServiceV2Client.g.cs
@@ -285,7 +285,7 @@ namespace Google.Cloud.Logging.V2
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ConfigServiceV2Client> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override ConfigServiceV2Client Build()
         {
             ConfigServiceV2Client client = null;
@@ -293,7 +293,7 @@ namespace Google.Cloud.Logging.V2
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<ConfigServiceV2Client> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<ConfigServiceV2Client> task = null;
@@ -315,16 +315,18 @@ namespace Google.Cloud.Logging.V2
             return ConfigServiceV2Client.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => ConfigServiceV2Client.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => ConfigServiceV2Client.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => ConfigServiceV2Client.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/LogEntryResourceNames.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/LogEntryResourceNames.g.cs
@@ -323,10 +323,11 @@ namespace Google.Cloud.Logging.V2
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -340,7 +341,7 @@ namespace Google.Cloud.Logging.V2
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/LoggingConfigResourceNames.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/LoggingConfigResourceNames.g.cs
@@ -380,10 +380,11 @@ namespace Google.Cloud.Logging.V2
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -397,7 +398,7 @@ namespace Google.Cloud.Logging.V2
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -725,10 +726,11 @@ namespace Google.Cloud.Logging.V2
         /// </summary>
         public string SinkId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -742,7 +744,7 @@ namespace Google.Cloud.Logging.V2
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -1078,10 +1080,11 @@ namespace Google.Cloud.Logging.V2
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -1095,7 +1098,7 @@ namespace Google.Cloud.Logging.V2
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -1410,10 +1413,11 @@ namespace Google.Cloud.Logging.V2
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -1427,7 +1431,7 @@ namespace Google.Cloud.Logging.V2
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -1641,10 +1645,11 @@ namespace Google.Cloud.Logging.V2
         /// </summary>
         public string OrganizationId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -1655,7 +1660,7 @@ namespace Google.Cloud.Logging.V2
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -1859,10 +1864,11 @@ namespace Google.Cloud.Logging.V2
         /// </summary>
         public string LocationId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -1873,7 +1879,7 @@ namespace Google.Cloud.Logging.V2
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -2087,10 +2093,11 @@ namespace Google.Cloud.Logging.V2
         /// </summary>
         public string LocationId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -2101,7 +2108,7 @@ namespace Google.Cloud.Logging.V2
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/LoggingMetricsResourceNames.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/LoggingMetricsResourceNames.g.cs
@@ -206,10 +206,11 @@ namespace Google.Cloud.Logging.V2
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -220,7 +221,7 @@ namespace Google.Cloud.Logging.V2
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/LoggingServiceV2Client.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/LoggingServiceV2Client.g.cs
@@ -151,7 +151,7 @@ namespace Google.Cloud.Logging.V2
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<LoggingServiceV2Client> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override LoggingServiceV2Client Build()
         {
             LoggingServiceV2Client client = null;
@@ -159,7 +159,7 @@ namespace Google.Cloud.Logging.V2
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<LoggingServiceV2Client> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<LoggingServiceV2Client> task = null;
@@ -181,16 +181,18 @@ namespace Google.Cloud.Logging.V2
             return LoggingServiceV2Client.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => LoggingServiceV2Client.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => LoggingServiceV2Client.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => LoggingServiceV2Client.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/MetricsServiceV2Client.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/MetricsServiceV2Client.g.cs
@@ -146,7 +146,7 @@ namespace Google.Cloud.Logging.V2
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<MetricsServiceV2Client> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override MetricsServiceV2Client Build()
         {
             MetricsServiceV2Client client = null;
@@ -154,7 +154,7 @@ namespace Google.Cloud.Logging.V2
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<MetricsServiceV2Client> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<MetricsServiceV2Client> task = null;
@@ -176,16 +176,18 @@ namespace Google.Cloud.Logging.V2
             return MetricsServiceV2Client.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => MetricsServiceV2Client.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => MetricsServiceV2Client.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => MetricsServiceV2Client.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Logging.V2/synth.metadata
+++ b/apis/Google.Cloud.Logging.V2/synth.metadata
@@ -1,11 +1,10 @@
 {
-  "updateTime": "2020-04-04T06:24:45.334599Z",
   "sources": [
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "9514fa9e390a4c0715972c5b510cf4c10ad049a1"
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1/ManagedIdentitiesServiceClient.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1/ManagedIdentitiesServiceClient.g.cs
@@ -344,7 +344,7 @@ namespace Google.Cloud.ManagedIdentities.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ManagedIdentitiesServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override ManagedIdentitiesServiceClient Build()
         {
             ManagedIdentitiesServiceClient client = null;
@@ -352,7 +352,7 @@ namespace Google.Cloud.ManagedIdentities.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<ManagedIdentitiesServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<ManagedIdentitiesServiceClient> task = null;
@@ -374,16 +374,18 @@ namespace Google.Cloud.ManagedIdentities.V1
             return ManagedIdentitiesServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => ManagedIdentitiesServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => ManagedIdentitiesServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => ManagedIdentitiesServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1/ResourceResourceNames.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1/ResourceResourceNames.g.cs
@@ -218,10 +218,11 @@ namespace Google.Cloud.ManagedIdentities.V1
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -232,7 +233,7 @@ namespace Google.Cloud.ManagedIdentities.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.ManagedIdentities.V1/synth.metadata
+++ b/apis/Google.Cloud.ManagedIdentities.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7be2811ad17013a5ea24cd75dfd9e399dd6e18fe"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2/CloudMemcacheClient.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2/CloudMemcacheClient.g.cs
@@ -257,7 +257,7 @@ namespace Google.Cloud.Memcache.V1Beta2
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<CloudMemcacheClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override CloudMemcacheClient Build()
         {
             CloudMemcacheClient client = null;
@@ -265,7 +265,7 @@ namespace Google.Cloud.Memcache.V1Beta2
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<CloudMemcacheClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<CloudMemcacheClient> task = null;
@@ -287,16 +287,18 @@ namespace Google.Cloud.Memcache.V1Beta2
             return CloudMemcacheClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => CloudMemcacheClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => CloudMemcacheClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => CloudMemcacheClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2/CloudMemcacheResourceNames.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2/CloudMemcacheResourceNames.g.cs
@@ -220,10 +220,11 @@ namespace Google.Cloud.Memcache.V1Beta2
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -234,7 +235,7 @@ namespace Google.Cloud.Memcache.V1Beta2
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Memcache.V1Beta2/synth.metadata
+++ b/apis/Google.Cloud.Memcache.V1Beta2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7be2811ad17013a5ea24cd75dfd9e399dd6e18fe"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/AlertPolicyServiceClient.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/AlertPolicyServiceClient.g.cs
@@ -147,7 +147,7 @@ namespace Google.Cloud.Monitoring.V3
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<AlertPolicyServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override AlertPolicyServiceClient Build()
         {
             AlertPolicyServiceClient client = null;
@@ -155,7 +155,7 @@ namespace Google.Cloud.Monitoring.V3
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<AlertPolicyServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<AlertPolicyServiceClient> task = null;
@@ -177,16 +177,18 @@ namespace Google.Cloud.Monitoring.V3
             return AlertPolicyServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => AlertPolicyServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => AlertPolicyServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => AlertPolicyServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/AlertResourceNames.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/AlertResourceNames.g.cs
@@ -362,10 +362,11 @@ namespace Google.Cloud.Monitoring.V3
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -378,7 +379,7 @@ namespace Google.Cloud.Monitoring.V3
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -672,10 +673,11 @@ namespace Google.Cloud.Monitoring.V3
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -688,7 +690,7 @@ namespace Google.Cloud.Monitoring.V3
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/GroupResourceNames.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/GroupResourceNames.g.cs
@@ -289,10 +289,11 @@ namespace Google.Cloud.Monitoring.V3
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -305,7 +306,7 @@ namespace Google.Cloud.Monitoring.V3
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/GroupServiceClient.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/GroupServiceClient.g.cs
@@ -162,7 +162,7 @@ namespace Google.Cloud.Monitoring.V3
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<GroupServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override GroupServiceClient Build()
         {
             GroupServiceClient client = null;
@@ -170,7 +170,7 @@ namespace Google.Cloud.Monitoring.V3
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<GroupServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<GroupServiceClient> task = null;
@@ -192,16 +192,18 @@ namespace Google.Cloud.Monitoring.V3
             return GroupServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => GroupServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => GroupServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => GroupServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/MetricServiceClient.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/MetricServiceClient.g.cs
@@ -196,7 +196,7 @@ namespace Google.Cloud.Monitoring.V3
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<MetricServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override MetricServiceClient Build()
         {
             MetricServiceClient client = null;
@@ -204,7 +204,7 @@ namespace Google.Cloud.Monitoring.V3
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<MetricServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<MetricServiceClient> task = null;
@@ -226,16 +226,18 @@ namespace Google.Cloud.Monitoring.V3
             return MetricServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => MetricServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => MetricServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => MetricServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/MetricServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/MetricServiceResourceNames.g.cs
@@ -314,10 +314,11 @@ namespace Google.Cloud.Monitoring.V3
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -330,7 +331,7 @@ namespace Google.Cloud.Monitoring.V3
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -717,10 +718,11 @@ namespace Google.Cloud.Monitoring.V3
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -733,7 +735,7 @@ namespace Google.Cloud.Monitoring.V3
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/NotificationChannelServiceClient.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/NotificationChannelServiceClient.g.cs
@@ -232,7 +232,7 @@ namespace Google.Cloud.Monitoring.V3
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<NotificationChannelServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override NotificationChannelServiceClient Build()
         {
             NotificationChannelServiceClient client = null;
@@ -240,7 +240,7 @@ namespace Google.Cloud.Monitoring.V3
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<NotificationChannelServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<NotificationChannelServiceClient> task = null;
@@ -262,16 +262,18 @@ namespace Google.Cloud.Monitoring.V3
             return NotificationChannelServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => NotificationChannelServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => NotificationChannelServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => NotificationChannelServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/NotificationResourceNames.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/NotificationResourceNames.g.cs
@@ -359,10 +359,11 @@ namespace Google.Cloud.Monitoring.V3
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -375,7 +376,7 @@ namespace Google.Cloud.Monitoring.V3
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -716,10 +717,11 @@ namespace Google.Cloud.Monitoring.V3
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -732,7 +734,7 @@ namespace Google.Cloud.Monitoring.V3
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/ServiceMonitoringServiceClient.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/ServiceMonitoringServiceClient.g.cs
@@ -228,7 +228,7 @@ namespace Google.Cloud.Monitoring.V3
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ServiceMonitoringServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override ServiceMonitoringServiceClient Build()
         {
             ServiceMonitoringServiceClient client = null;
@@ -236,7 +236,7 @@ namespace Google.Cloud.Monitoring.V3
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<ServiceMonitoringServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<ServiceMonitoringServiceClient> task = null;
@@ -258,16 +258,18 @@ namespace Google.Cloud.Monitoring.V3
             return ServiceMonitoringServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => ServiceMonitoringServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => ServiceMonitoringServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => ServiceMonitoringServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/ServiceResourceNames.g.cs
@@ -289,10 +289,11 @@ namespace Google.Cloud.Monitoring.V3
         /// </summary>
         public string ServiceId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -305,7 +306,7 @@ namespace Google.Cloud.Monitoring.V3
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -695,10 +696,11 @@ namespace Google.Cloud.Monitoring.V3
         /// </summary>
         public string ServiceLevelObjectiveId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -711,7 +713,7 @@ namespace Google.Cloud.Monitoring.V3
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/UptimeCheckServiceClient.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/UptimeCheckServiceClient.g.cs
@@ -165,7 +165,7 @@ namespace Google.Cloud.Monitoring.V3
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<UptimeCheckServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override UptimeCheckServiceClient Build()
         {
             UptimeCheckServiceClient client = null;
@@ -173,7 +173,7 @@ namespace Google.Cloud.Monitoring.V3
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<UptimeCheckServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<UptimeCheckServiceClient> task = null;
@@ -195,16 +195,18 @@ namespace Google.Cloud.Monitoring.V3
             return UptimeCheckServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => UptimeCheckServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => UptimeCheckServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => UptimeCheckServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/UptimeResourceNames.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/UptimeResourceNames.g.cs
@@ -313,10 +313,11 @@ namespace Google.Cloud.Monitoring.V3
         /// </summary>
         public string UptimeCheckConfigId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -329,7 +330,7 @@ namespace Google.Cloud.Monitoring.V3
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Monitoring.V3/synth.metadata
+++ b/apis/Google.Cloud.Monitoring.V3/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a3a0bf0f6291d69f2ff3df7fcd63d28ee20ac727"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.OrgPolicy.V1/synth.metadata
+++ b/apis/Google.Cloud.OrgPolicy.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7be2811ad17013a5ea24cd75dfd9e399dd6e18fe"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/OsConfigServiceClient.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/OsConfigServiceClient.g.cs
@@ -217,7 +217,7 @@ namespace Google.Cloud.OsConfig.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<OsConfigServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override OsConfigServiceClient Build()
         {
             OsConfigServiceClient client = null;
@@ -225,7 +225,7 @@ namespace Google.Cloud.OsConfig.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<OsConfigServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<OsConfigServiceClient> task = null;
@@ -247,16 +247,18 @@ namespace Google.Cloud.OsConfig.V1
             return OsConfigServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => OsConfigServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => OsConfigServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => OsConfigServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/OsconfigServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/OsconfigServiceResourceNames.g.cs
@@ -218,10 +218,11 @@ namespace Google.Cloud.OsConfig.V1
         /// </summary>
         public string ZoneId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -232,7 +233,7 @@ namespace Google.Cloud.OsConfig.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/PatchDeploymentsResourceNames.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/PatchDeploymentsResourceNames.g.cs
@@ -214,10 +214,11 @@ namespace Google.Cloud.OsConfig.V1
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -228,7 +229,7 @@ namespace Google.Cloud.OsConfig.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/PatchJobsResourceNames.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/PatchJobsResourceNames.g.cs
@@ -206,10 +206,11 @@ namespace Google.Cloud.OsConfig.V1
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -220,7 +221,7 @@ namespace Google.Cloud.OsConfig.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.OsConfig.V1/synth.metadata
+++ b/apis/Google.Cloud.OsConfig.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "6e0ac551e057e20a6c41ab0b21ffa9623e463326"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.OsLogin.Common/Google.Cloud.OsLogin.Common/CommonResourceNames.g.cs
+++ b/apis/Google.Cloud.OsLogin.Common/Google.Cloud.OsLogin.Common/CommonResourceNames.g.cs
@@ -198,10 +198,11 @@ namespace Google.Cloud.OsLogin.Common
         /// </summary>
         public string UserId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -212,7 +213,7 @@ namespace Google.Cloud.OsLogin.Common
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -414,10 +415,11 @@ namespace Google.Cloud.OsLogin.Common
         /// </summary>
         public string UserId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -428,7 +430,7 @@ namespace Google.Cloud.OsLogin.Common
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -604,10 +606,11 @@ namespace Google.Cloud.OsLogin.Common
         /// </summary>
         public string UserId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -618,7 +621,7 @@ namespace Google.Cloud.OsLogin.Common
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.OsLogin.Common/synth.metadata
+++ b/apis/Google.Cloud.OsLogin.Common/synth.metadata
@@ -1,11 +1,10 @@
 {
-  "updateTime": "2020-04-05T06:21:08.129559Z",
   "sources": [
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "5077b1e4674afdbbf11dac3f5f43d36285ba53ff"
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1/OsLoginServiceClient.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1/OsLoginServiceClient.g.cs
@@ -164,7 +164,7 @@ namespace Google.Cloud.OsLogin.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<OsLoginServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override OsLoginServiceClient Build()
         {
             OsLoginServiceClient client = null;
@@ -172,7 +172,7 @@ namespace Google.Cloud.OsLogin.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<OsLoginServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<OsLoginServiceClient> task = null;
@@ -194,16 +194,18 @@ namespace Google.Cloud.OsLogin.V1
             return OsLoginServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => OsLoginServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => OsLoginServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => OsLoginServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.OsLogin.V1/synth.metadata
+++ b/apis/Google.Cloud.OsLogin.V1/synth.metadata
@@ -1,11 +1,10 @@
 {
-  "updateTime": "2020-04-03T16:51:09.749136Z",
   "sources": [
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "1b969c28a6579265e89cd35e6c2ecacc89970e2d"
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/OsLoginServiceClient.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/OsLoginServiceClient.g.cs
@@ -164,7 +164,7 @@ namespace Google.Cloud.OsLogin.V1Beta
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<OsLoginServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override OsLoginServiceClient Build()
         {
             OsLoginServiceClient client = null;
@@ -172,7 +172,7 @@ namespace Google.Cloud.OsLogin.V1Beta
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<OsLoginServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<OsLoginServiceClient> task = null;
@@ -194,16 +194,18 @@ namespace Google.Cloud.OsLogin.V1Beta
             return OsLoginServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => OsLoginServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => OsLoginServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => OsLoginServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.OsLogin.V1Beta/synth.metadata
+++ b/apis/Google.Cloud.OsLogin.V1Beta/synth.metadata
@@ -1,11 +1,10 @@
 {
-  "updateTime": "2020-04-03T16:52:15.620575Z",
   "sources": [
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "1b969c28a6579265e89cd35e6c2ecacc89970e2d"
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1/PhishingProtectionServiceV1Beta1Client.g.cs
+++ b/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1/PhishingProtectionServiceV1Beta1Client.g.cs
@@ -83,7 +83,7 @@ namespace Google.Cloud.PhishingProtection.V1Beta1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<PhishingProtectionServiceV1Beta1Client> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override PhishingProtectionServiceV1Beta1Client Build()
         {
             PhishingProtectionServiceV1Beta1Client client = null;
@@ -91,7 +91,7 @@ namespace Google.Cloud.PhishingProtection.V1Beta1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<PhishingProtectionServiceV1Beta1Client> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<PhishingProtectionServiceV1Beta1Client> task = null;
@@ -113,17 +113,19 @@ namespace Google.Cloud.PhishingProtection.V1Beta1
             return PhishingProtectionServiceV1Beta1Client.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => PhishingProtectionServiceV1Beta1Client.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() =>
             PhishingProtectionServiceV1Beta1Client.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => PhishingProtectionServiceV1Beta1Client.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.PhishingProtection.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.PhishingProtection.V1Beta1/synth.metadata
@@ -1,11 +1,10 @@
 {
-  "updateTime": "2020-04-04T06:27:45.985312Z",
   "sources": [
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "62a2a7cc33d3535638d220df238823eefcca930d"
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/PublisherServiceApiClient.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/PublisherServiceApiClient.g.cs
@@ -175,7 +175,7 @@ namespace Google.Cloud.PubSub.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<PublisherServiceApiClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override PublisherServiceApiClient Build()
         {
             PublisherServiceApiClient client = null;
@@ -183,7 +183,7 @@ namespace Google.Cloud.PubSub.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<PublisherServiceApiClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<PublisherServiceApiClient> task = null;
@@ -205,16 +205,18 @@ namespace Google.Cloud.PubSub.V1
             return PublisherServiceApiClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => PublisherServiceApiClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => PublisherServiceApiClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => PublisherServiceApiClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/PubsubResourceNames.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/PubsubResourceNames.g.cs
@@ -232,10 +232,11 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         public string TopicId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -247,7 +248,7 @@ namespace Google.Cloud.PubSub.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -452,10 +453,11 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         public string SubscriptionId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -466,7 +468,7 @@ namespace Google.Cloud.PubSub.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -667,10 +669,11 @@ namespace Google.Cloud.PubSub.V1
         /// </summary>
         public string SnapshotId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -681,7 +684,7 @@ namespace Google.Cloud.PubSub.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberServiceApiClient.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberServiceApiClient.g.cs
@@ -292,7 +292,7 @@ namespace Google.Cloud.PubSub.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<SubscriberServiceApiClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override SubscriberServiceApiClient Build()
         {
             SubscriberServiceApiClient client = null;
@@ -300,7 +300,7 @@ namespace Google.Cloud.PubSub.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<SubscriberServiceApiClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<SubscriberServiceApiClient> task = null;
@@ -322,16 +322,18 @@ namespace Google.Cloud.PubSub.V1
             return SubscriberServiceApiClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => SubscriberServiceApiClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => SubscriberServiceApiClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => SubscriberServiceApiClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.PubSub.V1/synth.metadata
+++ b/apis/Google.Cloud.PubSub.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "73d4b5d9a791f8b1ee63d439ffe909bb8ffa07f7"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1/RecaptchaEnterpriseServiceClient.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1/RecaptchaEnterpriseServiceClient.g.cs
@@ -167,7 +167,7 @@ namespace Google.Cloud.RecaptchaEnterprise.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<RecaptchaEnterpriseServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override RecaptchaEnterpriseServiceClient Build()
         {
             RecaptchaEnterpriseServiceClient client = null;
@@ -175,7 +175,7 @@ namespace Google.Cloud.RecaptchaEnterprise.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<RecaptchaEnterpriseServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<RecaptchaEnterpriseServiceClient> task = null;
@@ -197,16 +197,18 @@ namespace Google.Cloud.RecaptchaEnterprise.V1
             return RecaptchaEnterpriseServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => RecaptchaEnterpriseServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => RecaptchaEnterpriseServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => RecaptchaEnterpriseServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1/RecaptchaenterpriseResourceNames.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1/RecaptchaenterpriseResourceNames.g.cs
@@ -207,10 +207,11 @@ namespace Google.Cloud.RecaptchaEnterprise.V1
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -221,7 +222,7 @@ namespace Google.Cloud.RecaptchaEnterprise.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -407,10 +408,11 @@ namespace Google.Cloud.RecaptchaEnterprise.V1
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -421,7 +423,7 @@ namespace Google.Cloud.RecaptchaEnterprise.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/synth.metadata
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/synth.metadata
@@ -1,11 +1,10 @@
 {
-  "updateTime": "2020-04-04T06:30:17.955703Z",
   "sources": [
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "23848c8f64a5e81a239d6133378468185f1756dc"
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1/RecaptchaEnterpriseServiceV1Beta1Client.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1/RecaptchaEnterpriseServiceV1Beta1Client.g.cs
@@ -172,7 +172,7 @@ namespace Google.Cloud.RecaptchaEnterprise.V1Beta1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<RecaptchaEnterpriseServiceV1Beta1Client> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override RecaptchaEnterpriseServiceV1Beta1Client Build()
         {
             RecaptchaEnterpriseServiceV1Beta1Client client = null;
@@ -180,7 +180,7 @@ namespace Google.Cloud.RecaptchaEnterprise.V1Beta1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<RecaptchaEnterpriseServiceV1Beta1Client> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<RecaptchaEnterpriseServiceV1Beta1Client> task = null;
@@ -202,17 +202,19 @@ namespace Google.Cloud.RecaptchaEnterprise.V1Beta1
             return RecaptchaEnterpriseServiceV1Beta1Client.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => RecaptchaEnterpriseServiceV1Beta1Client.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() =>
             RecaptchaEnterpriseServiceV1Beta1Client.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => RecaptchaEnterpriseServiceV1Beta1Client.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1/RecaptchaenterpriseResourceNames.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1/RecaptchaenterpriseResourceNames.g.cs
@@ -207,10 +207,11 @@ namespace Google.Cloud.RecaptchaEnterprise.V1Beta1
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -221,7 +222,7 @@ namespace Google.Cloud.RecaptchaEnterprise.V1Beta1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -407,10 +408,11 @@ namespace Google.Cloud.RecaptchaEnterprise.V1Beta1
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -421,7 +423,7 @@ namespace Google.Cloud.RecaptchaEnterprise.V1Beta1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/synth.metadata
@@ -1,11 +1,10 @@
 {
-  "updateTime": "2020-04-04T06:31:23.153113Z",
   "sources": [
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "23848c8f64a5e81a239d6133378468185f1756dc"
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/RecommendationResourceNames.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/RecommendationResourceNames.g.cs
@@ -251,10 +251,11 @@ namespace Google.Cloud.Recommender.V1
         /// </summary>
         public string RecommenderId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -265,7 +266,7 @@ namespace Google.Cloud.Recommender.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -489,10 +490,11 @@ namespace Google.Cloud.Recommender.V1
         /// </summary>
         public string RecommenderId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -503,7 +505,7 @@ namespace Google.Cloud.Recommender.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/RecommenderClient.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/RecommenderClient.g.cs
@@ -140,7 +140,7 @@ namespace Google.Cloud.Recommender.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<RecommenderClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override RecommenderClient Build()
         {
             RecommenderClient client = null;
@@ -148,7 +148,7 @@ namespace Google.Cloud.Recommender.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<RecommenderClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<RecommenderClient> task = null;
@@ -170,16 +170,18 @@ namespace Google.Cloud.Recommender.V1
             return RecommenderClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => RecommenderClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => RecommenderClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => RecommenderClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Recommender.V1/synth.metadata
+++ b/apis/Google.Cloud.Recommender.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7be2811ad17013a5ea24cd75dfd9e399dd6e18fe"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1/CloudRedisClient.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1/CloudRedisClient.g.cs
@@ -287,7 +287,7 @@ namespace Google.Cloud.Redis.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<CloudRedisClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override CloudRedisClient Build()
         {
             CloudRedisClient client = null;
@@ -295,7 +295,7 @@ namespace Google.Cloud.Redis.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<CloudRedisClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<CloudRedisClient> task = null;
@@ -317,16 +317,18 @@ namespace Google.Cloud.Redis.V1
             return CloudRedisClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => CloudRedisClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => CloudRedisClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => CloudRedisClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1/CloudRedisResourceNames.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1/CloudRedisResourceNames.g.cs
@@ -220,10 +220,11 @@ namespace Google.Cloud.Redis.V1
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -234,7 +235,7 @@ namespace Google.Cloud.Redis.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Redis.V1/synth.metadata
+++ b/apis/Google.Cloud.Redis.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7be2811ad17013a5ea24cd75dfd9e399dd6e18fe"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1/CloudRedisClient.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1/CloudRedisClient.g.cs
@@ -319,7 +319,7 @@ namespace Google.Cloud.Redis.V1Beta1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<CloudRedisClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override CloudRedisClient Build()
         {
             CloudRedisClient client = null;
@@ -327,7 +327,7 @@ namespace Google.Cloud.Redis.V1Beta1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<CloudRedisClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<CloudRedisClient> task = null;
@@ -349,16 +349,18 @@ namespace Google.Cloud.Redis.V1Beta1
             return CloudRedisClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => CloudRedisClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => CloudRedisClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => CloudRedisClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1/CloudRedisResourceNames.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1/CloudRedisResourceNames.g.cs
@@ -220,10 +220,11 @@ namespace Google.Cloud.Redis.V1Beta1
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -234,7 +235,7 @@ namespace Google.Cloud.Redis.V1Beta1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Redis.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.Redis.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7be2811ad17013a5ea24cd75dfd9e399dd6e18fe"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1/CloudSchedulerClient.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1/CloudSchedulerClient.g.cs
@@ -182,7 +182,7 @@ namespace Google.Cloud.Scheduler.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<CloudSchedulerClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override CloudSchedulerClient Build()
         {
             CloudSchedulerClient client = null;
@@ -190,7 +190,7 @@ namespace Google.Cloud.Scheduler.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<CloudSchedulerClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<CloudSchedulerClient> task = null;
@@ -212,16 +212,18 @@ namespace Google.Cloud.Scheduler.V1
             return CloudSchedulerClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => CloudSchedulerClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => CloudSchedulerClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => CloudSchedulerClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1/JobResourceNames.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1/JobResourceNames.g.cs
@@ -215,10 +215,11 @@ namespace Google.Cloud.Scheduler.V1
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -229,7 +230,7 @@ namespace Google.Cloud.Scheduler.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1/TargetResourceNames.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1/TargetResourceNames.g.cs
@@ -196,10 +196,11 @@ namespace Google.Cloud.Scheduler.V1
         /// </summary>
         public string TopicId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -210,7 +211,7 @@ namespace Google.Cloud.Scheduler.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Scheduler.V1/synth.metadata
+++ b/apis/Google.Cloud.Scheduler.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7be2811ad17013a5ea24cd75dfd9e399dd6e18fe"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1/ResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1/ResourcesResourceNames.g.cs
@@ -204,10 +204,11 @@ namespace Google.Cloud.SecretManager.V1
         /// </summary>
         public string SecretId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -218,7 +219,7 @@ namespace Google.Cloud.SecretManager.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -445,10 +446,11 @@ namespace Google.Cloud.SecretManager.V1
         /// </summary>
         public string SecretVersionId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -459,7 +461,7 @@ namespace Google.Cloud.SecretManager.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1/SecretManagerServiceClient.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1/SecretManagerServiceClient.g.cs
@@ -276,7 +276,7 @@ namespace Google.Cloud.SecretManager.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<SecretManagerServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override SecretManagerServiceClient Build()
         {
             SecretManagerServiceClient client = null;
@@ -284,7 +284,7 @@ namespace Google.Cloud.SecretManager.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<SecretManagerServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<SecretManagerServiceClient> task = null;
@@ -306,16 +306,18 @@ namespace Google.Cloud.SecretManager.V1
             return SecretManagerServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => SecretManagerServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => SecretManagerServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => SecretManagerServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.SecretManager.V1/synth.metadata
+++ b/apis/Google.Cloud.SecretManager.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "358c09c45c681c6773b49aeb136f0a7ccbf7720c"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1/ResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1/ResourcesResourceNames.g.cs
@@ -204,10 +204,11 @@ namespace Google.Cloud.SecretManager.V1Beta1
         /// </summary>
         public string SecretId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -218,7 +219,7 @@ namespace Google.Cloud.SecretManager.V1Beta1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -445,10 +446,11 @@ namespace Google.Cloud.SecretManager.V1Beta1
         /// </summary>
         public string SecretVersionId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -459,7 +461,7 @@ namespace Google.Cloud.SecretManager.V1Beta1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1/SecretManagerServiceClient.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1/SecretManagerServiceClient.g.cs
@@ -276,7 +276,7 @@ namespace Google.Cloud.SecretManager.V1Beta1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<SecretManagerServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override SecretManagerServiceClient Build()
         {
             SecretManagerServiceClient client = null;
@@ -284,7 +284,7 @@ namespace Google.Cloud.SecretManager.V1Beta1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<SecretManagerServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<SecretManagerServiceClient> task = null;
@@ -306,16 +306,18 @@ namespace Google.Cloud.SecretManager.V1Beta1
             return SecretManagerServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => SecretManagerServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => SecretManagerServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => SecretManagerServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.SecretManager.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "839fae42335ee1bb1e70767f3e6c51738683892b"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1/ComponentSettingsResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1/ComponentSettingsResourceNames.g.cs
@@ -505,10 +505,11 @@ namespace Google.Cloud.SecurityCenter.Settings.V1Beta1
         /// </summary>
         public string ZoneId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -524,7 +525,7 @@ namespace Google.Cloud.SecurityCenter.Settings.V1Beta1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1/SecurityCenterSettingsServiceClient.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1/SecurityCenterSettingsServiceClient.g.cs
@@ -292,7 +292,7 @@ namespace Google.Cloud.SecurityCenter.Settings.V1Beta1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<SecurityCenterSettingsServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override SecurityCenterSettingsServiceClient Build()
         {
             SecurityCenterSettingsServiceClient client = null;
@@ -300,7 +300,7 @@ namespace Google.Cloud.SecurityCenter.Settings.V1Beta1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<SecurityCenterSettingsServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<SecurityCenterSettingsServiceClient> task = null;
@@ -322,17 +322,19 @@ namespace Google.Cloud.SecurityCenter.Settings.V1Beta1
             return SecurityCenterSettingsServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => SecurityCenterSettingsServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() =>
             SecurityCenterSettingsServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => SecurityCenterSettingsServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1/SecuritycenterSettingsServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1/SecuritycenterSettingsServiceResourceNames.g.cs
@@ -201,10 +201,11 @@ namespace Google.Cloud.SecurityCenter.Settings.V1Beta1
         /// </summary>
         public string OrganizationId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -215,7 +216,7 @@ namespace Google.Cloud.SecurityCenter.Settings.V1Beta1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1/SettingsResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1/SettingsResourceNames.g.cs
@@ -434,10 +434,11 @@ namespace Google.Cloud.SecurityCenter.Settings.V1Beta1
         /// </summary>
         public string ZoneId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -453,7 +454,7 @@ namespace Google.Cloud.SecurityCenter.Settings.V1Beta1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7be2811ad17013a5ea24cd75dfd9e399dd6e18fe"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/AssetResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/AssetResourceNames.g.cs
@@ -205,10 +205,11 @@ namespace Google.Cloud.SecurityCenter.V1
         /// </summary>
         public string OrganizationId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -219,7 +220,7 @@ namespace Google.Cloud.SecurityCenter.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/FindingResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/FindingResourceNames.g.cs
@@ -227,10 +227,11 @@ namespace Google.Cloud.SecurityCenter.V1
         /// </summary>
         public string SourceId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -241,7 +242,7 @@ namespace Google.Cloud.SecurityCenter.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/NotificationConfigResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/NotificationConfigResourceNames.g.cs
@@ -231,10 +231,11 @@ namespace Google.Cloud.SecurityCenter.V1
         /// </summary>
         public string OrganizationId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -245,7 +246,7 @@ namespace Google.Cloud.SecurityCenter.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -437,10 +438,11 @@ namespace Google.Cloud.SecurityCenter.V1
         /// </summary>
         public string TopicId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -451,7 +453,7 @@ namespace Google.Cloud.SecurityCenter.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/OrganizationSettingsResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/OrganizationSettingsResourceNames.g.cs
@@ -207,10 +207,11 @@ namespace Google.Cloud.SecurityCenter.V1
         /// </summary>
         public string OrganizationId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -221,7 +222,7 @@ namespace Google.Cloud.SecurityCenter.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/SecurityCenterClient.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/SecurityCenterClient.g.cs
@@ -429,7 +429,7 @@ namespace Google.Cloud.SecurityCenter.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<SecurityCenterClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override SecurityCenterClient Build()
         {
             SecurityCenterClient client = null;
@@ -437,7 +437,7 @@ namespace Google.Cloud.SecurityCenter.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<SecurityCenterClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<SecurityCenterClient> task = null;
@@ -459,16 +459,18 @@ namespace Google.Cloud.SecurityCenter.V1
             return SecurityCenterClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => SecurityCenterClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => SecurityCenterClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => SecurityCenterClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/SecurityMarksResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/SecurityMarksResourceNames.g.cs
@@ -282,10 +282,11 @@ namespace Google.Cloud.SecurityCenter.V1
         /// </summary>
         public string SourceId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -297,7 +298,7 @@ namespace Google.Cloud.SecurityCenter.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/SourceResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/SourceResourceNames.g.cs
@@ -206,10 +206,11 @@ namespace Google.Cloud.SecurityCenter.V1
         /// </summary>
         public string SourceId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -220,7 +221,7 @@ namespace Google.Cloud.SecurityCenter.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.SecurityCenter.V1/synth.metadata
+++ b/apis/Google.Cloud.SecurityCenter.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7be2811ad17013a5ea24cd75dfd9e399dd6e18fe"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/AssetResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/AssetResourceNames.g.cs
@@ -205,10 +205,11 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1
         /// </summary>
         public string OrganizationId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -219,7 +220,7 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/FindingResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/FindingResourceNames.g.cs
@@ -227,10 +227,11 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1
         /// </summary>
         public string SourceId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -241,7 +242,7 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/NotificationConfigResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/NotificationConfigResourceNames.g.cs
@@ -231,10 +231,11 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1
         /// </summary>
         public string OrganizationId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -245,7 +246,7 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -437,10 +438,11 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1
         /// </summary>
         public string TopicId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -451,7 +453,7 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/OrganizationSettingsResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/OrganizationSettingsResourceNames.g.cs
@@ -207,10 +207,11 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1
         /// </summary>
         public string OrganizationId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -221,7 +222,7 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/SecurityCenterClient.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/SecurityCenterClient.g.cs
@@ -429,7 +429,7 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<SecurityCenterClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override SecurityCenterClient Build()
         {
             SecurityCenterClient client = null;
@@ -437,7 +437,7 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<SecurityCenterClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<SecurityCenterClient> task = null;
@@ -459,16 +459,18 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1
             return SecurityCenterClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => SecurityCenterClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => SecurityCenterClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => SecurityCenterClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/SecurityMarksResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/SecurityMarksResourceNames.g.cs
@@ -282,10 +282,11 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1
         /// </summary>
         public string SourceId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -297,7 +298,7 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/SourceResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/SourceResourceNames.g.cs
@@ -206,10 +206,11 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1
         /// </summary>
         public string SourceId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -220,7 +221,7 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/synth.metadata
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/synth.metadata
@@ -1,11 +1,10 @@
 {
-  "updateTime": "2020-04-08T05:53:42.144939Z",
   "sources": [
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "29aac60f121dc43382b37ff92f2dbb692d94143a"
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/EndpointResourceNames.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/EndpointResourceNames.g.cs
@@ -263,10 +263,11 @@ namespace Google.Cloud.ServiceDirectory.V1Beta1
         /// </summary>
         public string ServiceId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -277,7 +278,7 @@ namespace Google.Cloud.ServiceDirectory.V1Beta1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/LookupServiceClient.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/LookupServiceClient.g.cs
@@ -82,7 +82,7 @@ namespace Google.Cloud.ServiceDirectory.V1Beta1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<LookupServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override LookupServiceClient Build()
         {
             LookupServiceClient client = null;
@@ -90,7 +90,7 @@ namespace Google.Cloud.ServiceDirectory.V1Beta1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<LookupServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<LookupServiceClient> task = null;
@@ -112,16 +112,18 @@ namespace Google.Cloud.ServiceDirectory.V1Beta1
             return LookupServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => LookupServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => LookupServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => LookupServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/NamespaceResourceNames.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/NamespaceResourceNames.g.cs
@@ -227,10 +227,11 @@ namespace Google.Cloud.ServiceDirectory.V1Beta1
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -241,7 +242,7 @@ namespace Google.Cloud.ServiceDirectory.V1Beta1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/RegistrationServiceClient.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/RegistrationServiceClient.g.cs
@@ -359,7 +359,7 @@ namespace Google.Cloud.ServiceDirectory.V1Beta1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<RegistrationServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override RegistrationServiceClient Build()
         {
             RegistrationServiceClient client = null;
@@ -367,7 +367,7 @@ namespace Google.Cloud.ServiceDirectory.V1Beta1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<RegistrationServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<RegistrationServiceClient> task = null;
@@ -389,16 +389,18 @@ namespace Google.Cloud.ServiceDirectory.V1Beta1
             return RegistrationServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => RegistrationServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => RegistrationServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => RegistrationServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/ServiceResourceNames.g.cs
@@ -245,10 +245,11 @@ namespace Google.Cloud.ServiceDirectory.V1Beta1
         /// </summary>
         public string ServiceId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -259,7 +260,7 @@ namespace Google.Cloud.ServiceDirectory.V1Beta1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7be2811ad17013a5ea24cd75dfd9e399dd6e18fe"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/BackupResourceNames.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/BackupResourceNames.g.cs
@@ -219,10 +219,11 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -233,7 +234,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/DatabaseAdminClient.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/DatabaseAdminClient.g.cs
@@ -408,7 +408,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<DatabaseAdminClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override DatabaseAdminClient Build()
         {
             DatabaseAdminClient client = null;
@@ -416,7 +416,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<DatabaseAdminClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<DatabaseAdminClient> task = null;
@@ -438,16 +438,18 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
             return DatabaseAdminClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => DatabaseAdminClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => DatabaseAdminClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => DatabaseAdminClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/synth.metadata
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/synth.metadata
@@ -2,16 +2,9 @@
   "sources": [
     {
       "git": {
-        "name": ".",
-        "remote": "https://github.com/googleapis/google-cloud-dotnet.git",
-        "sha": "f3e627ac0972417f8af7e51937b3a8541c089cac"
-      }
-    },
-    {
-      "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "ab5d07c2883026eec395d73ff59a17f4ad0153db"
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/InstanceAdminClient.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/InstanceAdminClient.g.cs
@@ -258,7 +258,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<InstanceAdminClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override InstanceAdminClient Build()
         {
             InstanceAdminClient client = null;
@@ -266,7 +266,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<InstanceAdminClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<InstanceAdminClient> task = null;
@@ -288,16 +288,18 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
             return InstanceAdminClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => InstanceAdminClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => InstanceAdminClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => InstanceAdminClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/SpannerInstanceAdminResourceNames.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/SpannerInstanceAdminResourceNames.g.cs
@@ -215,10 +215,11 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -229,7 +230,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/synth.metadata
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7be2811ad17013a5ea24cd75dfd9e399dd6e18fe"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SpannerClient.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SpannerClient.g.cs
@@ -303,7 +303,7 @@ namespace Google.Cloud.Spanner.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<SpannerClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override SpannerClient Build()
         {
             SpannerClient client = null;
@@ -311,7 +311,7 @@ namespace Google.Cloud.Spanner.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<SpannerClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<SpannerClient> task = null;
@@ -333,16 +333,18 @@ namespace Google.Cloud.Spanner.V1
             return SpannerClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => SpannerClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => SpannerClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => SpannerClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SpannerResourceNames.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SpannerResourceNames.g.cs
@@ -246,10 +246,11 @@ namespace Google.Cloud.Spanner.V1
         /// </summary>
         public string SessionId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -260,7 +261,7 @@ namespace Google.Cloud.Spanner.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Spanner.V1/synth.metadata
+++ b/apis/Google.Cloud.Spanner.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7be2811ad17013a5ea24cd75dfd9e399dd6e18fe"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/SpeechClient.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/SpeechClient.g.cs
@@ -130,7 +130,7 @@ namespace Google.Cloud.Speech.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<SpeechClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override SpeechClient Build()
         {
             SpeechClient client = null;
@@ -138,7 +138,7 @@ namespace Google.Cloud.Speech.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<SpeechClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<SpeechClient> task = null;
@@ -160,16 +160,18 @@ namespace Google.Cloud.Speech.V1
             return SpeechClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => SpeechClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => SpeechClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => SpeechClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Speech.V1/synth.metadata
+++ b/apis/Google.Cloud.Speech.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7be2811ad17013a5ea24cd75dfd9e399dd6e18fe"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/ResourceResourceNames.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/ResourceResourceNames.g.cs
@@ -229,10 +229,11 @@ namespace Google.Cloud.Speech.V1P1Beta1
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -243,7 +244,7 @@ namespace Google.Cloud.Speech.V1P1Beta1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -466,10 +467,11 @@ namespace Google.Cloud.Speech.V1P1Beta1
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -480,7 +482,7 @@ namespace Google.Cloud.Speech.V1P1Beta1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/SpeechClient.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/SpeechClient.g.cs
@@ -130,7 +130,7 @@ namespace Google.Cloud.Speech.V1P1Beta1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<SpeechClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override SpeechClient Build()
         {
             SpeechClient client = null;
@@ -138,7 +138,7 @@ namespace Google.Cloud.Speech.V1P1Beta1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<SpeechClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<SpeechClient> task = null;
@@ -160,16 +160,18 @@ namespace Google.Cloud.Speech.V1P1Beta1
             return SpeechClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => SpeechClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => SpeechClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => SpeechClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Speech.V1P1Beta1/synth.metadata
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/synth.metadata
@@ -2,16 +2,9 @@
   "sources": [
     {
       "git": {
-        "name": ".",
-        "remote": "https://github.com/googleapis/google-cloud-dotnet.git",
-        "sha": "f2f7630e58f4a8a2c62fb8082d610ed5b4576374"
-      }
-    },
-    {
-      "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "4d61e1cb40184a7ad63ef37b1813f6608718674a"
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/ApplicationResourceNames.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/ApplicationResourceNames.g.cs
@@ -247,10 +247,11 @@ namespace Google.Cloud.Talent.V4Beta1
         /// </summary>
         public string TenantId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -261,7 +262,7 @@ namespace Google.Cloud.Talent.V4Beta1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/ApplicationServiceClient.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/ApplicationServiceClient.g.cs
@@ -145,7 +145,7 @@ namespace Google.Cloud.Talent.V4Beta1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ApplicationServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override ApplicationServiceClient Build()
         {
             ApplicationServiceClient client = null;
@@ -153,7 +153,7 @@ namespace Google.Cloud.Talent.V4Beta1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<ApplicationServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<ApplicationServiceClient> task = null;
@@ -175,16 +175,18 @@ namespace Google.Cloud.Talent.V4Beta1
             return ApplicationServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => ApplicationServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => ApplicationServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => ApplicationServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/CompanyResourceNames.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/CompanyResourceNames.g.cs
@@ -254,10 +254,11 @@ namespace Google.Cloud.Talent.V4Beta1
         /// </summary>
         public string TenantId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -269,7 +270,7 @@ namespace Google.Cloud.Talent.V4Beta1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/CompanyServiceClient.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/CompanyServiceClient.g.cs
@@ -143,7 +143,7 @@ namespace Google.Cloud.Talent.V4Beta1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<CompanyServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override CompanyServiceClient Build()
         {
             CompanyServiceClient client = null;
@@ -151,7 +151,7 @@ namespace Google.Cloud.Talent.V4Beta1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<CompanyServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<CompanyServiceClient> task = null;
@@ -173,16 +173,18 @@ namespace Google.Cloud.Talent.V4Beta1
             return CompanyServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => CompanyServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => CompanyServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => CompanyServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/CompletionClient.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/CompletionClient.g.cs
@@ -81,7 +81,7 @@ namespace Google.Cloud.Talent.V4Beta1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<CompletionClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override CompletionClient Build()
         {
             CompletionClient client = null;
@@ -89,7 +89,7 @@ namespace Google.Cloud.Talent.V4Beta1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<CompletionClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<CompletionClient> task = null;
@@ -111,16 +111,18 @@ namespace Google.Cloud.Talent.V4Beta1
             return CompletionClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => CompletionClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => CompletionClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => CompletionClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/EventServiceClient.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/EventServiceClient.g.cs
@@ -79,7 +79,7 @@ namespace Google.Cloud.Talent.V4Beta1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<EventServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override EventServiceClient Build()
         {
             EventServiceClient client = null;
@@ -87,7 +87,7 @@ namespace Google.Cloud.Talent.V4Beta1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<EventServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<EventServiceClient> task = null;
@@ -109,16 +109,18 @@ namespace Google.Cloud.Talent.V4Beta1
             return EventServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => EventServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => EventServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => EventServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/JobResourceNames.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/JobResourceNames.g.cs
@@ -246,10 +246,11 @@ namespace Google.Cloud.Talent.V4Beta1
         /// </summary>
         public string TenantId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -261,7 +262,7 @@ namespace Google.Cloud.Talent.V4Beta1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/JobServiceClient.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/JobServiceClient.g.cs
@@ -246,7 +246,7 @@ namespace Google.Cloud.Talent.V4Beta1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<JobServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override JobServiceClient Build()
         {
             JobServiceClient client = null;
@@ -254,7 +254,7 @@ namespace Google.Cloud.Talent.V4Beta1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<JobServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<JobServiceClient> task = null;
@@ -276,16 +276,18 @@ namespace Google.Cloud.Talent.V4Beta1
             return JobServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => JobServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => JobServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => JobServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/ProfileResourceNames.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/ProfileResourceNames.g.cs
@@ -218,10 +218,11 @@ namespace Google.Cloud.Talent.V4Beta1
         /// </summary>
         public string TenantId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -232,7 +233,7 @@ namespace Google.Cloud.Talent.V4Beta1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/ProfileServiceClient.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/ProfileServiceClient.g.cs
@@ -155,7 +155,7 @@ namespace Google.Cloud.Talent.V4Beta1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ProfileServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override ProfileServiceClient Build()
         {
             ProfileServiceClient client = null;
@@ -163,7 +163,7 @@ namespace Google.Cloud.Talent.V4Beta1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<ProfileServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<ProfileServiceClient> task = null;
@@ -185,16 +185,18 @@ namespace Google.Cloud.Talent.V4Beta1
             return ProfileServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => ProfileServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => ProfileServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => ProfileServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/TenantResourceNames.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/TenantResourceNames.g.cs
@@ -204,10 +204,11 @@ namespace Google.Cloud.Talent.V4Beta1
         /// </summary>
         public string TenantId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -218,7 +219,7 @@ namespace Google.Cloud.Talent.V4Beta1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/TenantServiceClient.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/TenantServiceClient.g.cs
@@ -143,7 +143,7 @@ namespace Google.Cloud.Talent.V4Beta1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<TenantServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override TenantServiceClient Build()
         {
             TenantServiceClient client = null;
@@ -151,7 +151,7 @@ namespace Google.Cloud.Talent.V4Beta1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<TenantServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<TenantServiceClient> task = null;
@@ -173,16 +173,18 @@ namespace Google.Cloud.Talent.V4Beta1
             return TenantServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => TenantServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => TenantServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => TenantServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Talent.V4Beta1/synth.metadata
+++ b/apis/Google.Cloud.Talent.V4Beta1/synth.metadata
@@ -2,16 +2,9 @@
   "sources": [
     {
       "git": {
-        "name": ".",
-        "remote": "https://github.com/googleapis/google-cloud-dotnet.git",
-        "sha": "1469d9650cba00fcb7a6109c417772b4e4a6db29"
-      }
-    },
-    {
-      "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "ac1f904979899bc598fb0567cf7a367f08b40b43"
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/CloudTasksClient.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/CloudTasksClient.g.cs
@@ -301,7 +301,7 @@ namespace Google.Cloud.Tasks.V2
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<CloudTasksClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override CloudTasksClient Build()
         {
             CloudTasksClient client = null;
@@ -309,7 +309,7 @@ namespace Google.Cloud.Tasks.V2
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<CloudTasksClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<CloudTasksClient> task = null;
@@ -331,16 +331,18 @@ namespace Google.Cloud.Tasks.V2
             return CloudTasksClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => CloudTasksClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => CloudTasksClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => CloudTasksClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/QueueResourceNames.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/QueueResourceNames.g.cs
@@ -218,10 +218,11 @@ namespace Google.Cloud.Tasks.V2
         /// </summary>
         public string QueueId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -232,7 +233,7 @@ namespace Google.Cloud.Tasks.V2
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/TaskResourceNames.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/TaskResourceNames.g.cs
@@ -234,10 +234,11 @@ namespace Google.Cloud.Tasks.V2
         /// </summary>
         public string TaskId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -248,7 +249,7 @@ namespace Google.Cloud.Tasks.V2
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Tasks.V2/synth.metadata
+++ b/apis/Google.Cloud.Tasks.V2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7be2811ad17013a5ea24cd75dfd9e399dd6e18fe"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3/CloudTasksClient.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3/CloudTasksClient.g.cs
@@ -301,7 +301,7 @@ namespace Google.Cloud.Tasks.V2Beta3
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<CloudTasksClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override CloudTasksClient Build()
         {
             CloudTasksClient client = null;
@@ -309,7 +309,7 @@ namespace Google.Cloud.Tasks.V2Beta3
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<CloudTasksClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<CloudTasksClient> task = null;
@@ -331,16 +331,18 @@ namespace Google.Cloud.Tasks.V2Beta3
             return CloudTasksClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => CloudTasksClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => CloudTasksClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => CloudTasksClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3/QueueResourceNames.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3/QueueResourceNames.g.cs
@@ -218,10 +218,11 @@ namespace Google.Cloud.Tasks.V2Beta3
         /// </summary>
         public string QueueId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -232,7 +233,7 @@ namespace Google.Cloud.Tasks.V2Beta3
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3/TaskResourceNames.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3/TaskResourceNames.g.cs
@@ -234,10 +234,11 @@ namespace Google.Cloud.Tasks.V2Beta3
         /// </summary>
         public string TaskId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -248,7 +249,7 @@ namespace Google.Cloud.Tasks.V2Beta3
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Tasks.V2Beta3/synth.metadata
+++ b/apis/Google.Cloud.Tasks.V2Beta3/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7be2811ad17013a5ea24cd75dfd9e399dd6e18fe"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/TextToSpeechClient.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/TextToSpeechClient.g.cs
@@ -97,7 +97,7 @@ namespace Google.Cloud.TextToSpeech.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<TextToSpeechClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override TextToSpeechClient Build()
         {
             TextToSpeechClient client = null;
@@ -105,7 +105,7 @@ namespace Google.Cloud.TextToSpeech.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<TextToSpeechClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<TextToSpeechClient> task = null;
@@ -127,16 +127,18 @@ namespace Google.Cloud.TextToSpeech.V1
             return TextToSpeechClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => TextToSpeechClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => TextToSpeechClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => TextToSpeechClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.TextToSpeech.V1/synth.metadata
+++ b/apis/Google.Cloud.TextToSpeech.V1/synth.metadata
@@ -2,16 +2,9 @@
   "sources": [
     {
       "git": {
-        "name": ".",
-        "remote": "https://github.com/googleapis/google-cloud-dotnet.git",
-        "sha": "1469d9650cba00fcb7a6109c417772b4e4a6db29"
-      }
-    },
-    {
-      "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "b8c7c4e8da56547fc32bee9b563d306fadabdb6f"
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/TraceServiceClient.g.cs
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/TraceServiceClient.g.cs
@@ -115,7 +115,7 @@ namespace Google.Cloud.Trace.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<TraceServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override TraceServiceClient Build()
         {
             TraceServiceClient client = null;
@@ -123,7 +123,7 @@ namespace Google.Cloud.Trace.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<TraceServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<TraceServiceClient> task = null;
@@ -145,16 +145,18 @@ namespace Google.Cloud.Trace.V1
             return TraceServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => TraceServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => TraceServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => TraceServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Trace.V1/synth.metadata
+++ b/apis/Google.Cloud.Trace.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7be2811ad17013a5ea24cd75dfd9e399dd6e18fe"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/TraceResourceNames.g.cs
+++ b/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/TraceResourceNames.g.cs
@@ -213,10 +213,11 @@ namespace Google.Cloud.Trace.V2
         /// </summary>
         public string TraceId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -227,7 +228,7 @@ namespace Google.Cloud.Trace.V2
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/TraceServiceClient.g.cs
+++ b/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/TraceServiceClient.g.cs
@@ -96,7 +96,7 @@ namespace Google.Cloud.Trace.V2
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<TraceServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override TraceServiceClient Build()
         {
             TraceServiceClient client = null;
@@ -104,7 +104,7 @@ namespace Google.Cloud.Trace.V2
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<TraceServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<TraceServiceClient> task = null;
@@ -126,16 +126,18 @@ namespace Google.Cloud.Trace.V2
             return TraceServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => TraceServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => TraceServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => TraceServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Trace.V2/synth.metadata
+++ b/apis/Google.Cloud.Trace.V2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7be2811ad17013a5ea24cd75dfd9e399dd6e18fe"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3/TranslationServiceClient.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3/TranslationServiceClient.g.cs
@@ -244,7 +244,7 @@ namespace Google.Cloud.Translate.V3
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<TranslationServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override TranslationServiceClient Build()
         {
             TranslationServiceClient client = null;
@@ -252,7 +252,7 @@ namespace Google.Cloud.Translate.V3
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<TranslationServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<TranslationServiceClient> task = null;
@@ -274,16 +274,18 @@ namespace Google.Cloud.Translate.V3
             return TranslationServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => TranslationServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => TranslationServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => TranslationServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3/TranslationServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3/TranslationServiceResourceNames.g.cs
@@ -228,10 +228,11 @@ namespace Google.Cloud.Translate.V3
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -242,7 +243,7 @@ namespace Google.Cloud.Translate.V3
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Translate.V3/synth.metadata
+++ b/apis/Google.Cloud.Translate.V3/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7be2811ad17013a5ea24cd75dfd9e399dd6e18fe"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1/VideoIntelligenceServiceClient.g.cs
+++ b/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1/VideoIntelligenceServiceClient.g.cs
@@ -105,7 +105,7 @@ namespace Google.Cloud.VideoIntelligence.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<VideoIntelligenceServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override VideoIntelligenceServiceClient Build()
         {
             VideoIntelligenceServiceClient client = null;
@@ -113,7 +113,7 @@ namespace Google.Cloud.VideoIntelligence.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<VideoIntelligenceServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<VideoIntelligenceServiceClient> task = null;
@@ -135,16 +135,18 @@ namespace Google.Cloud.VideoIntelligence.V1
             return VideoIntelligenceServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => VideoIntelligenceServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => VideoIntelligenceServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => VideoIntelligenceServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.VideoIntelligence.V1/synth.metadata
+++ b/apis/Google.Cloud.VideoIntelligence.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7be2811ad17013a5ea24cd75dfd9e399dd6e18fe"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ImageAnnotatorClient.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ImageAnnotatorClient.g.cs
@@ -171,7 +171,7 @@ namespace Google.Cloud.Vision.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ImageAnnotatorClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override ImageAnnotatorClient Build()
         {
             ImageAnnotatorClient client = null;
@@ -179,7 +179,7 @@ namespace Google.Cloud.Vision.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<ImageAnnotatorClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<ImageAnnotatorClient> task = null;
@@ -201,16 +201,18 @@ namespace Google.Cloud.Vision.V1
             return ImageAnnotatorClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => ImageAnnotatorClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => ImageAnnotatorClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => ImageAnnotatorClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ProductSearchClient.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ProductSearchClient.g.cs
@@ -415,7 +415,7 @@ namespace Google.Cloud.Vision.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ProductSearchClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override ProductSearchClient Build()
         {
             ProductSearchClient client = null;
@@ -423,7 +423,7 @@ namespace Google.Cloud.Vision.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<ProductSearchClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<ProductSearchClient> task = null;
@@ -445,16 +445,18 @@ namespace Google.Cloud.Vision.V1
             return ProductSearchClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => ProductSearchClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => ProductSearchClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => ProductSearchClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ProductSearchServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ProductSearchServiceResourceNames.g.cs
@@ -219,10 +219,11 @@ namespace Google.Cloud.Vision.V1
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -233,7 +234,7 @@ namespace Google.Cloud.Vision.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -457,10 +458,11 @@ namespace Google.Cloud.Vision.V1
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -471,7 +473,7 @@ namespace Google.Cloud.Vision.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -717,10 +719,11 @@ namespace Google.Cloud.Vision.V1
         /// </summary>
         public string ReferenceImageId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -731,7 +734,7 @@ namespace Google.Cloud.Vision.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Vision.V1/synth.metadata
+++ b/apis/Google.Cloud.Vision.V1/synth.metadata
@@ -1,11 +1,10 @@
 {
-  "updateTime": "2020-04-03T17:30:44.576030Z",
   "sources": [
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "4a6a01ce0ead505c245d11a2ce156de34800c58f"
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1/WebRiskServiceClient.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1/WebRiskServiceClient.g.cs
@@ -129,7 +129,7 @@ namespace Google.Cloud.WebRisk.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<WebRiskServiceClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override WebRiskServiceClient Build()
         {
             WebRiskServiceClient client = null;
@@ -137,7 +137,7 @@ namespace Google.Cloud.WebRisk.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<WebRiskServiceClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<WebRiskServiceClient> task = null;
@@ -159,16 +159,18 @@ namespace Google.Cloud.WebRisk.V1
             return WebRiskServiceClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => WebRiskServiceClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => WebRiskServiceClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => WebRiskServiceClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.WebRisk.V1/synth.metadata
+++ b/apis/Google.Cloud.WebRisk.V1/synth.metadata
@@ -1,11 +1,10 @@
 {
-  "updateTime": "2020-04-08T05:58:58.225979Z",
   "sources": [
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "9ede34d093b9d786a974448fc7a3a17948c203e2"
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1/WebRiskServiceV1Beta1Client.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1/WebRiskServiceV1Beta1Client.g.cs
@@ -117,7 +117,7 @@ namespace Google.Cloud.WebRisk.V1Beta1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<WebRiskServiceV1Beta1Client> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override WebRiskServiceV1Beta1Client Build()
         {
             WebRiskServiceV1Beta1Client client = null;
@@ -125,7 +125,7 @@ namespace Google.Cloud.WebRisk.V1Beta1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<WebRiskServiceV1Beta1Client> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<WebRiskServiceV1Beta1Client> task = null;
@@ -147,16 +147,18 @@ namespace Google.Cloud.WebRisk.V1Beta1
             return WebRiskServiceV1Beta1Client.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => WebRiskServiceV1Beta1Client.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => WebRiskServiceV1Beta1Client.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => WebRiskServiceV1Beta1Client.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.Cloud.WebRisk.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.WebRisk.V1Beta1/synth.metadata
@@ -1,11 +1,10 @@
 {
-  "updateTime": "2020-04-08T06:00:10.170107Z",
   "sources": [
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "9ede34d093b9d786a974448fc7a3a17948c203e2"
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Identity.AccessContextManager.Type/synth.metadata
+++ b/apis/Google.Identity.AccessContextManager.Type/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7be2811ad17013a5ea24cd75dfd9e399dd6e18fe"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.Identity.AccessContextManager.V1/synth.metadata
+++ b/apis/Google.Identity.AccessContextManager.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7be2811ad17013a5ea24cd75dfd9e399dd6e18fe"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Google.LongRunning/Google.LongRunning/OperationsClient.g.cs
+++ b/apis/Google.LongRunning/Google.LongRunning/OperationsClient.g.cs
@@ -144,7 +144,7 @@ namespace Google.LongRunning
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<OperationsClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override OperationsClient Build()
         {
             OperationsClient client = null;
@@ -152,7 +152,7 @@ namespace Google.LongRunning
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<OperationsClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<OperationsClient> task = null;
@@ -174,16 +174,18 @@ namespace Google.LongRunning
             return OperationsClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</summary>
         protected override string GetDefaultEndpoint() => OperationsClient.DefaultEndpoint;
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => OperationsClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
         protected override gaxgrpc::ChannelPool GetChannelPool() => OperationsClient.ChannelPool;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Google.LongRunning/synth.metadata
+++ b/apis/Google.LongRunning/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7be2811ad17013a5ea24cd75dfd9e399dd6e18fe"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]

--- a/apis/Grafeas.V1/Grafeas.V1/GrafeasClient.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1/GrafeasClient.g.cs
@@ -273,7 +273,7 @@ namespace Grafeas.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<GrafeasClient> task);
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client.</summary>
         public override GrafeasClient Build()
         {
             GrafeasClient client = null;
@@ -281,7 +281,7 @@ namespace Grafeas.V1
             return client ?? BuildImpl();
         }
 
-        /// <inheritdoc/>
+        /// <summary>Builds the resulting client asynchronously.</summary>
         public override stt::Task<GrafeasClient> BuildAsync(st::CancellationToken cancellationToken = default)
         {
             stt::Task<GrafeasClient> task = null;
@@ -303,10 +303,12 @@ namespace Grafeas.V1
             return GrafeasClient.Create(callInvoker, Settings);
         }
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Returns the default scopes for this builder type, used if no scopes are otherwise specified.
+        /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => GrafeasClient.DefaultScopes;
 
-        /// <inheritdoc/>
+        /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
 

--- a/apis/Grafeas.V1/Grafeas.V1/GrafeasResourceNames.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1/GrafeasResourceNames.g.cs
@@ -206,10 +206,11 @@ namespace Grafeas.V1
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -220,7 +221,7 @@ namespace Grafeas.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -408,10 +409,11 @@ namespace Grafeas.V1
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -422,7 +424,7 @@ namespace Grafeas.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>
@@ -600,10 +602,11 @@ namespace Grafeas.V1
         /// </summary>
         public string ProjectId { get; }
 
-        /// <inheritdoc/>
+        /// <summary>Whether this instance contains a resource name with a known pattern.</summary>
         public bool IsKnownPattern => Type != ResourceNameType.Unparsed;
 
-        /// <inheritdoc/>
+        /// <summary>The string representation of the resource name.</summary>
+        /// <returns>The string representation of the resource name.</returns>
         public override string ToString()
         {
             switch (Type)
@@ -614,7 +617,7 @@ namespace Grafeas.V1
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>Returns a hash code for this resource name.</summary>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <inheritdoc/>

--- a/apis/Grafeas.V1/synth.metadata
+++ b/apis/Grafeas.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7be2811ad17013a5ea24cd75dfd9e399dd6e18fe"        
+        "sha": "89e89786896d256c70f43e68a975470c4f4f220e"        
       }
     }
   ]


### PR DESCRIPTION
The use of "inheritdoc" breaks docfx in many cases. The generator
has been improved to generate more explicit documentation. This PR only
contains changes due to that generator change.