### PR TITLE
feat: add SpannerNumeric class to support NUMERIC

### DIFF
--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.Tests/Google.Cloud.Spanner.V1.Tests.csproj
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.Tests/Google.Cloud.Spanner.V1.Tests.csproj
@@ -19,4 +19,7 @@
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Xunit.Combinatorial" Version="1.2.7" />
+  </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.Tests/SpannerNumericTest.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.Tests/SpannerNumericTest.cs
@@ -1,0 +1,409 @@
+﻿// Copyright 2020 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.ClientTesting;
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using Xunit;
+
+namespace Google.Cloud.Spanner.V1.Tests
+{
+    public class SpannerNumericTest
+    {
+        private const string MaxText = "99999999999999999999999999999.999999999";
+        private const string MinText = "-99999999999999999999999999999.999999999";
+        private const string EpsilonText = "0.000000001";
+        private const string NegativeEpsilonText = "-0.000000001";
+
+        [Theory, CombinatorialData]
+        public void ConversionFromDecimal(
+            [CombinatorialValues(
+            "1",
+            "10",
+            "1.123456789",
+            "79228162514264337593543950335", // decimal.MaxValue
+            "1234567890123456789012345678"
+            )]
+            string text, bool negate)
+        {
+            if (negate)
+            {
+                text = "-" + text;
+            }
+            decimal parsed = decimal.Parse(text, CultureInfo.InvariantCulture);
+            SpannerNumeric numeric = (SpannerNumeric)parsed;
+            Assert.Equal(text, numeric.ToString());
+        }
+
+        [Theory]
+        [InlineData("1.123456789123", "1.123456789")]
+        [InlineData("-1.123456789123", "-1.123456789")]
+        [InlineData("0.000000000000001", "0")]
+        [InlineData("-0.000000000000001", "0")]
+        public void ConversionFromDecimal_Lossy(string decimalText, string expectedText)
+        {
+            decimal input = decimal.Parse(decimalText, CultureInfo.InvariantCulture);
+            SpannerNumeric expected = SpannerNumeric.Parse(expectedText);
+
+            SpannerNumeric conversionOutput = (SpannerNumeric)input;
+            SpannerNumeric fromDecimalOutput = SpannerNumeric.FromDecimal(input, LossOfPrecisionHandling.Truncate);
+
+            Assert.Equal(expected, conversionOutput);
+            Assert.Equal(expected, fromDecimalOutput);
+            Assert.Throws<ArgumentException>(() => SpannerNumeric.FromDecimal(input, LossOfPrecisionHandling.Throw));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(-1)]
+        [InlineData(int.MinValue)]
+        [InlineData(int.MaxValue)]
+        public void ConversionFromInt32(int input)
+        {
+            SpannerNumeric value = input;
+            Assert.Equal(input.ToString(CultureInfo.InvariantCulture), value.ToString());
+        }
+
+        [Theory]
+        [InlineData(0L)]
+        [InlineData(1L)]
+        [InlineData(-1L)]
+        [InlineData(long.MinValue)]
+        [InlineData(long.MaxValue)]
+        public void ConversionFromInt64(long input)
+        {
+            SpannerNumeric value = input;
+            Assert.Equal(input.ToString(CultureInfo.InvariantCulture), value.ToString());
+        }
+
+        [Theory]
+        [InlineData(0UL)]
+        [InlineData(1UL)]
+        [InlineData(ulong.MaxValue)]
+        public void ConversionFromUInt64(ulong input)
+        {
+            SpannerNumeric value = input;
+            Assert.Equal(input.ToString(CultureInfo.InvariantCulture), value.ToString());
+        }
+
+        [Theory, CombinatorialData]
+        public void ToDecimal_Precise(
+            [CombinatorialValues(
+                "79228162514264337593543950335", // decimal.MaxValue
+                "0.000000001", // Epsilon for numeric
+                "12345678901234567890.123456789" // Maximum significant digits with 9dps
+            )]
+            string text, LossOfPrecisionHandling handling, bool negate)
+        {
+            if (negate)
+            {
+                text = "-" + text;
+            }
+            SpannerNumeric numeric = SpannerNumeric.Parse(text);
+            decimal expected = decimal.Parse(text, CultureInfo.InvariantCulture);
+            decimal actual = numeric.ToDecimal(handling);
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory, CombinatorialData]
+        public void ToDecimal_Overflow(LossOfPrecisionHandling handling, bool negate)
+        {
+            string text = "79228162514264337593543950336"; // decimal.MaxValue + 1
+            SpannerNumeric numeric = SpannerNumeric.Parse(text);
+            if (negate)
+            {
+                numeric = -numeric;
+            }
+            Assert.Throws<OverflowException>(() => numeric.ToDecimal(handling));
+        }
+
+        [Theory, CombinatorialData]
+        public void ToDecimal_LossOfPrecision_Truncate(
+            [CombinatorialValues(
+                "79228162514264337593543950335.0000000001", // decimal.MaxValue + epsilon; doesn't count as overflow
+                "123456789012345678900.123456789" // Simpler example of more significant digits than decimal can handle
+            )]
+            string text, bool negate)
+        {
+            if (negate)
+            {
+                text = "-" + text;
+            }
+            SpannerNumeric numeric = SpannerNumeric.Parse(text);
+            // Decimal.Parse will silently lose precision
+            decimal expected = decimal.Parse(text, CultureInfo.InvariantCulture);
+            decimal actual = numeric.ToDecimal(LossOfPrecisionHandling.Truncate);
+            Assert.Equal(expected, actual);
+            // Conversion via the explicit conversion should do the same thing
+            decimal actual2 = (decimal)numeric;
+            Assert.Equal(expected, actual2);
+        }
+
+        [Theory, CombinatorialData]
+        public void ToDecimal_LossOfPrecision_Throw(
+            [CombinatorialValues(
+                "79228162514264337593543950335.000000001", // decimal.MaxValue + epsilon; doesn't count as overflow
+                "123456789012345678900.123456789" // Simpler example of more significant digits than decimal can handle
+            )]
+            string text, bool negate)
+        {
+            if (negate)
+            {
+                text = "-" + text;
+            }
+            SpannerNumeric numeric = SpannerNumeric.Parse(text);
+            Assert.Throws<InvalidOperationException>(() => numeric.ToDecimal(LossOfPrecisionHandling.Throw));
+        }
+
+        [Theory, CombinatorialData]
+        public void ParseToStringRoundTrip(
+            [CombinatorialValues(
+                "123456789012345678901234567.890123456",
+                "79228162514264337593543950335.000000001",
+                MaxText,
+                EpsilonText,
+                "5",
+                "50",
+                "50.01",
+                "0.1",
+                "0.123",
+                "0.00123"
+            )]
+            string text, bool negate)
+        {
+            if (negate)
+            {
+                text = "-" + text;
+            }
+            SpannerNumeric numeric = SpannerNumeric.Parse(text);
+            Assert.Equal(text, numeric.ToString());
+
+            // Check that TryParse works too
+            Assert.True(SpannerNumeric.TryParse(text, out var numeric2));
+            Assert.Equal(numeric, numeric2);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("-")]
+        [InlineData("+")]
+        [InlineData("non-digits")]
+        [InlineData("   ")]
+        [InlineData(" 0")]
+        [InlineData("0 ")]
+        [InlineData(" 0 ")]
+        // Overflow
+        [InlineData("100000000000000000000000000000")]
+        [InlineData("-100000000000000000000000000000")]
+        // Different parsing path but leading to overflow
+        [InlineData("100000000000000000000000000000.0")]
+        [InlineData("-100000000000000000000000000000.0")]
+        // Things we may wish to make valid later
+        [InlineData("+5")]
+        [InlineData(".5")]
+        [InlineData("-.5")]
+        [InlineData("+.5")]
+        [InlineData("1e6")]
+        [InlineData("1e-6")]
+        public void TryParse_Invalid(string text)
+        {
+            Assert.False(SpannerNumeric.TryParse(text, out var value));
+            Assert.Equal(SpannerNumeric.Zero, value);
+        }
+
+        [Theory]
+        [InlineData("1234,567", "es-ES")]
+        [InlineData("1.234,567", "es-ES")]
+        [InlineData("1234,567", "fr-FR")]
+        public void TryParse_UnsupportedCultures(string text, string culture)
+        {
+            CultureInfo oldCulture = CultureInfo.CurrentCulture;
+            try
+            {
+                CultureInfo.CurrentCulture = CultureInfo.CreateSpecificCulture(culture);
+
+                // Just to demonstrate that these numbers are properly parsed with the given culture.
+                // We don't parse them because we don't support the culture.
+                Assert.True(Decimal.TryParse(text, out decimal decimalValue));
+
+                Assert.False(SpannerNumeric.TryParse(text, out var value));
+                Assert.Equal(SpannerNumeric.Zero, value);
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = oldCulture;
+            }
+        }
+
+        [Fact]
+        public void ZeroIsDefaultValue()
+        {
+            Assert.Equal("0", default(SpannerNumeric).ToString());
+        }
+
+        [Fact]
+        public void Constants()
+        {
+            Assert.Equal(MaxText, SpannerNumeric.MaxValue.ToString());
+            Assert.Equal(MinText, SpannerNumeric.MinValue.ToString());
+            Assert.Equal(EpsilonText, SpannerNumeric.Epsilon.ToString());
+            Assert.Equal("0", SpannerNumeric.Zero.ToString());
+        }
+
+        [Theory]
+        [InlineData(MaxText, new[] { MaxText }, new[] { "99999999999999999999999999999.999999998", "99999999999999999999999999999.999999998" })]
+        [InlineData("1", new[] { "1.0", "1.00", "01" }, new[] { "-1", "0.999999999", "1.000000001" })]
+        [InlineData("0", new[] { "0.0", "-0", "-0.0" }, new[] { "0.000000001", "-0.000000001" })]
+        public void Equality(string controlText, string[] equalText, string[] unequalText)
+        {
+            SpannerNumeric control = SpannerNumeric.Parse(controlText);
+            SpannerNumeric[] equal = equalText.Select(SpannerNumeric.Parse).ToArray();
+            SpannerNumeric[] unequal = unequalText.Select(SpannerNumeric.Parse).ToArray();
+            EqualityTester.AssertEqual(control, equal, unequal);
+            EqualityTester.AssertEqualityOperators(control, equal, unequal);
+        }
+
+        [Theory]
+        [InlineData("0", EpsilonText)]
+        [InlineData(NegativeEpsilonText, "0")]
+        [InlineData("-5", "2")]
+        [InlineData("1.0", "1.1")]
+        [InlineData("99999999999999999999999999999.99999998", MaxText)]
+        [InlineData(MinText, "-99999999999999999999999999999.99999998")]
+        public void CompareTo_Unequal(string smallerText, string biggerText)
+        {
+            var smaller = SpannerNumeric.Parse(smallerText);
+            var bigger = SpannerNumeric.Parse(biggerText);
+            Assert.InRange(smaller.CompareTo(bigger), int.MinValue, -1);
+            Assert.InRange(bigger.CompareTo(smaller), 1, int.MaxValue);
+            Assert.InRange(((IComparable)smaller).CompareTo(bigger), int.MinValue, -1);
+            Assert.InRange(((IComparable)bigger).CompareTo(smaller), 1, int.MaxValue);
+        }
+
+        [Theory]
+        [InlineData("0")]
+        [InlineData("1")]
+        [InlineData("-1")]
+        [InlineData(MaxText)]
+        [InlineData(MinText)]
+        [InlineData(EpsilonText)]
+        public void CompareTo_Equal(string text)
+        {
+            var value = SpannerNumeric.Parse(text);
+            // To compare with a different instance.
+            var value1 = SpannerNumeric.Parse(text);
+            Assert.Equal(0, value.CompareTo(value));
+            Assert.Equal(0, (IComparable)value.CompareTo(value));
+            Assert.Equal(0, value1.CompareTo(value));
+            Assert.Equal(0, (IComparable)value1.CompareTo(value));
+        }
+
+        [Fact]
+        public void CompareTo_NegativeZero()
+        {
+            // These really are the same value... we don't differentiate.
+            var regularZero = SpannerNumeric.Zero;
+            var negativeZero = SpannerNumeric.Parse("-0");
+            Assert.Equal(0, regularZero.CompareTo(negativeZero));
+            Assert.Equal(0, (IComparable)regularZero.CompareTo(negativeZero));
+            Assert.Equal(0, negativeZero.CompareTo(regularZero));
+            Assert.Equal(0, (IComparable)negativeZero.CompareTo(regularZero));
+        }
+
+        [Fact]
+        public void CompareTo_Null()
+        {
+            IComparable minValue = SpannerNumeric.MinValue;
+            Assert.InRange(minValue.CompareTo(null), 1, int.MaxValue);
+        }
+
+        [Theory]
+        [InlineData("0")]
+        [InlineData("1")]
+        [InlineData("1.1")]
+        [InlineData(MaxText)]
+        public void UnaryNegation(string text)
+        {
+            var positive = SpannerNumeric.Parse(text);
+            var negative = SpannerNumeric.Parse("-" + text);
+            Assert.Equal(negative, -positive);
+            Assert.Equal(positive, -negative);
+        }
+
+        [Theory]
+        [InlineData("0")]
+        [InlineData("1")]
+        [InlineData("1.1")]
+        [InlineData("-1.1")]
+        [InlineData(MaxText)]
+        public void UnaryPlus(string text)
+        {
+            var value = SpannerNumeric.Parse(text);
+            Assert.Equal(value, +value);
+        }
+
+        [Theory]
+        [InlineData("2", "3", "5")]
+        [InlineData("1", "0.1", "1.1")]
+        [InlineData("1", "-0.1", "0.9")]
+        [InlineData("-1", "0.1", "-0.9")]
+        public void Addition_Valid(string leftText, string rightText, string expectedText)
+        {
+            var left = SpannerNumeric.Parse(leftText);
+            var right = SpannerNumeric.Parse(rightText);
+            var expected = SpannerNumeric.Parse(expectedText);
+            Assert.Equal(expected, left + right);
+        }
+
+        [Theory]
+        [InlineData("2", "3", "-1")]
+        [InlineData("1", "0.1", "0.9")]
+        [InlineData("1", "-0.1", "1.1")]
+        [InlineData("-1", "0.1", "-1.1")]
+        public void Subtraction_Valid(string leftText, string rightText, string expectedText)
+        {
+            var left = SpannerNumeric.Parse(leftText);
+            var right = SpannerNumeric.Parse(rightText);
+            var expected = SpannerNumeric.Parse(expectedText);
+            Assert.Equal(expected, left - right);
+        }
+
+        [Theory]
+        [InlineData("50000000000000000000000000000", "50000000000000000000000000000")]
+        [InlineData("-50000000000000000000000000000", "-50000000000000000000000000000")]
+        [InlineData(MaxText, EpsilonText)]
+        [InlineData(MinText, NegativeEpsilonText)]
+        public void Addition_Overflow(string leftText, string rightText)
+        {
+            var left = SpannerNumeric.Parse(leftText);
+            var right = SpannerNumeric.Parse(rightText);
+            Assert.Throws<OverflowException>(() => left + right);
+        }
+
+        [Theory]
+        [InlineData("50000000000000000000000000000", "-50000000000000000000000000000")]
+        [InlineData("-50000000000000000000000000000", "50000000000000000000000000000")]
+        [InlineData(MaxText, NegativeEpsilonText)]
+        [InlineData(MinText, EpsilonText)]
+        public void Subtraction_Overflow(string leftText, string rightText)
+        {
+            var left = SpannerNumeric.Parse(leftText);
+            var right = SpannerNumeric.Parse(rightText);
+            Assert.Throws<OverflowException>(() => left - right);
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SpannerNumeric.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SpannerNumeric.cs
@@ -1,0 +1,482 @@
+﻿// Copyright 2020 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Numerics;
+using System.Text.RegularExpressions;
+
+namespace Google.Cloud.Spanner.V1
+{
+    // TODO: Implement IFormattable?
+
+    /// <summary>
+    /// Representation of the Spanner NUMERIC type, which has 38 digits of precision,
+    /// and a fixed scale of 9 decimal places to the right of the decimal point
+    /// </summary>
+    public struct SpannerNumeric : IEquatable<SpannerNumeric>, IComparable<SpannerNumeric>, IComparable
+    {
+        private static readonly BigInteger s_maxValue = BigInteger.Parse("99999999999999999999999999999999999999");
+        private static readonly BigInteger s_minValue = -s_maxValue;
+
+        private static readonly BigInteger[] s_powersOf10 = Enumerable.Range(0, 28).Select(p => BigInteger.Pow(10, p)).ToArray();
+
+        private static readonly BigInteger s_integerScalingFactor = new BigInteger(1_000_000_000L);
+        // TODO: Don't require a 0 before the decimal point.
+        // TODO: Replace with manual validation if we find this is a performance bottleneck (as it was with field name validation).
+        private static readonly Regex s_validation = new Regex(@"^-?[0-9]+\.?[0-9]*$");
+
+        // Note: the following properties must be declared *after* s_maxValue and s_minValue. Initialization order matters.
+
+        /// <summary>
+        /// Zero represented as a <see cref="SpannerNumeric"/>. This is the default value for the type.
+        /// </summary>
+        public static SpannerNumeric Zero { get; } = default;
+
+        /// <summary>
+        /// The maximum valid value for <see cref="SpannerNumeric"/>, equal to 99999999999999999999999999999.999999999.
+        /// </summary>
+        public static SpannerNumeric MaxValue { get; } = new SpannerNumeric(s_maxValue);
+
+        /// <summary>
+        /// The minimum valid value for <see cref="SpannerNumeric"/>, equal to -99999999999999999999999999999.999999999.
+        /// </summary>
+        public static SpannerNumeric MinValue { get; } = new SpannerNumeric(s_minValue);
+
+        /// <summary>
+        /// The smallest positive value for <see cref="SpannerNumeric"/>, equal to 0.000000001.
+        /// </summary>
+        public static SpannerNumeric Epsilon { get; } = new SpannerNumeric(1);
+
+        // Integer representation, always scaled by 9 decimal places - so a value of 1 here represents
+        // a numeric value of 0.000000001 for example.
+        private readonly BigInteger _integer;
+
+        private SpannerNumeric(BigInteger integer)
+        {
+            if (!IsRawValueInRange(integer))
+            {
+                throw new OverflowException("SpannerNumeric value out of range");
+            }
+            _integer = integer;
+        }
+
+        private static bool IsRawValueInRange(BigInteger integer) => integer >= s_minValue && integer <= s_maxValue;
+
+        /// <summary>
+        /// Compares this value with <paramref name="other"/>.
+        /// </summary>
+        /// <param name="other">The value to compare with this one</param>
+        /// <returns>A negative integer if this value is less than <paramref name="other"/>; a positive integer
+        /// if it's greater than <paramref name="other"/>; zero if they're equal.</returns>
+        public int CompareTo(SpannerNumeric other) => _integer.CompareTo(other._integer);
+
+        /// <summary>
+        /// Implementation of <see cref="IComparable.CompareTo"/> to compare two <see cref="SpannerNumeric"/> values.
+        /// </summary>
+        /// <remarks>
+        /// This uses explicit interface implementation to avoid it being called accidentally. The generic implementation should usually be preferred.
+        /// </remarks>
+        /// <exception cref="ArgumentException"><paramref name="obj"/> is non-null but does not refer to an instance of <see cref="SpannerNumeric"/>.</exception>
+        /// <param name="obj">The object to compare this value with.</param>
+        /// <returns>The result of comparing this value with <paramref name="obj"/>. <paramref name="obj"/> is null, this method returns a value greater than 0.
+        /// </returns>
+        int IComparable.CompareTo(object obj)
+        {
+            if (obj == null)
+            {
+                return 1;
+            }
+            return obj is SpannerNumeric numeric
+                ? CompareTo(numeric)
+                : throw new ArgumentException($"Object must be of type {nameof(SpannerNumeric)}", nameof(obj));
+        }
+
+        /// <summary>
+        /// Compares this value with <paramref name="other"/> for equality.
+        /// </summary>
+        /// <param name="other">The value to compare with this one.</param>
+        /// <returns><c>true</c> if <paramref name="other"/> is an equal <see cref="SpannerNumeric"/> value; <c>false</c> otherwise.</returns>
+        public bool Equals(SpannerNumeric other) => _integer == other._integer;
+
+        /// <summary>
+        /// Compares this value with <paramref name="obj"/> for equality.
+        /// </summary>
+        /// <param name="obj">The value to compare with this one.</param>
+        /// <returns><c>true</c> if <paramref name="obj"/> is an equal <see cref="SpannerNumeric"/> value; <c>false</c> otherwise.</returns>
+        public override bool Equals(object obj) => obj is SpannerNumeric other && Equals(other);
+
+        /// <summary>
+        /// Returns a hash code for this value.
+        /// </summary>
+        /// <returns>A hash code for this value.</returns>
+        public override int GetHashCode() => _integer.GetHashCode();
+
+        // TODO:
+        // - Allow leading +?
+        // - Allow .5 as well as 0.5?
+        // - Allow 5. as well as 5.0 and 5?
+
+        /// <summary>
+        /// Parses a textual representation as a <see cref="SpannerNumeric"/>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <paramref name="text"/> must be a representation of a decimal value which can be represented by <see cref="SpannerNumeric"/>,
+        /// using "." as a decimal place where one is specified, and a leading "-" for negative values. Leading zeroes and insignificant
+        /// trailing digits are permitted.
+        /// </para>
+        /// </remarks>
+        /// <param name="text">The text to parse. Must not be null.</param>
+        /// <returns>The parsed value.</returns>
+        /// <exception cref="FormatException">The value could not be parsed as a <see cref="SpannerNumeric"/>.</exception>
+        public static SpannerNumeric Parse(string text)
+        {
+            string message = TryParseImpl(text, out var value);
+            return message == null ? value : throw new FormatException(message);
+        }
+
+        /// <summary>
+        /// Attempts to parse a textual representation of a <see cref="SpannerNumeric"/> value.
+        /// </summary>
+        /// <remarks>
+        /// See <see cref="Parse"/> for format details. This method will return <c>true</c> if and only if
+        /// <see cref="Parse"/> would return without an exception.
+        /// </remarks>
+        /// <param name="text">The text to parse. Must not be null.</param>
+        /// <param name="value">The parsed value, or 0 on failure.</param>
+        /// <returns><c>true</c> if <paramref name="text"/> was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string text, out SpannerNumeric value)
+        {
+            string message = TryParseImpl(text, out value);
+            return message == null;
+        }
+
+        /// <summary>
+        /// Returns the error message for a FormatException if parsing fails, or null for success.
+        /// </summary>
+        private static string TryParseImpl(string text, out SpannerNumeric value)
+        {
+            GaxPreconditions.CheckNotNull(text, nameof(text));
+            if (!s_validation.IsMatch(text))
+            {
+                value = default;
+                return "Text representation must be digits, containing an optional decimal point, and an optional leading '-' sign.";
+            }
+            int pointIndex = text.IndexOf('.');
+
+            // The raw value which will end up in the result, on success.
+            BigInteger rawValue;
+            if (pointIndex != -1)
+            {
+                int decimalPlaces = text.Length - pointIndex - 1;
+                text = text.Remove(pointIndex, 1);
+                if (decimalPlaces > 9)
+                {
+                    text = text.Substring(0, text.Length - (decimalPlaces - 9));
+                    decimalPlaces = 9;
+                }
+                BigInteger integer = BigInteger.Parse(text, CultureInfo.InvariantCulture);
+
+                if (decimalPlaces < 9)
+                {
+                    integer = integer * s_powersOf10[9 - decimalPlaces];
+                }
+                rawValue = integer;
+            }
+            else
+            {
+                BigInteger integer = BigInteger.Parse(text, CultureInfo.InvariantCulture);
+                rawValue = integer * s_integerScalingFactor;
+            }
+            if (!IsRawValueInRange(rawValue))
+            {
+                value = default;
+                return "Parsed value would overflow the range of the type.";
+            }
+            value = new SpannerNumeric(rawValue);
+            return null;
+        }
+
+        /// <summary>
+        /// Returns a canonical string representation of this value. This always uses "." as a decimal point,
+        /// and only includes as many decimal places as are required to completely represent the value. If
+        /// the value is between -1 and 1 exclusive, a "0" character is included before the decimal point.
+        /// </summary>
+        /// <returns>A canonical string representation of this value.</returns>
+        public override string ToString()
+        {
+            int sign = _integer.Sign;
+            if (sign == 0)
+            {
+                return "0";
+            }
+            var integerText = _integer.ToString(CultureInfo.InvariantCulture);
+
+            int decimalPlaces = 9;
+            for (int place = integerText.Length - 1; place > 0 && decimalPlaces > 0; place--)
+            {
+                if (integerText[place] != '0')
+                {
+                    break;
+                }
+                decimalPlaces--;
+            }
+
+            int signLength = sign > 0 ? 0 : 1;
+
+            // Always have something before the period, even if it's just a 0
+            int originalIntegerPlaces = Math.Max(integerText.Length - signLength - 9, 0);
+            int resultIntegerPlaces = Math.Max(originalIntegerPlaces, 1);
+
+            // Sign, then integer part, then period (maybe), then significant decimals
+            int resultLength = signLength + resultIntegerPlaces + (decimalPlaces > 0 ? 1 : 0) + decimalPlaces;
+            var chars = new char[resultLength];
+            int position = 0;
+
+            // Copy some text from the original string representation, including the leading '-' if necessary
+            int leadCharactersToCopy = originalIntegerPlaces + signLength;
+            for (int i = 0; i < leadCharactersToCopy; i++)
+            {
+                chars[position] = integerText[position];
+                position++;
+            }
+
+            if (originalIntegerPlaces == 0)
+            {
+                chars[position++] = '0';
+            }
+            if (decimalPlaces > 0)
+            {
+                chars[position++] = '.';
+                int decimalsToCopy = decimalPlaces;
+                
+                // Fill zeroes if necessary
+                if (originalIntegerPlaces == 0)
+                {
+                    int decimalsToFill = 9 - (integerText.Length - signLength);
+                    for (int i = 0; i < decimalsToFill; i++)
+                    {
+                        chars[position++] = '0';
+                    }
+                    decimalsToCopy -= decimalsToFill;
+                }
+
+                // Now the significant digits in the remaining text
+                int sourcePosition = leadCharactersToCopy;
+                for (int i = 0; i < decimalsToCopy; i++)
+                {
+                    chars[position++] = integerText[sourcePosition++];
+                }
+            }
+            return new string(chars);
+        }
+
+        /// <summary>
+        /// Converts a <see cref="decimal"/> value to <see cref="SpannerNumeric"/>, 
+        /// </summary>
+        /// <remarks>
+        /// This conversion may silently lose precision, depending on <paramref name="lossOfPrecisionHandling"/>.
+        /// </remarks>
+        /// <param name="value">The value to convert</param>
+        /// <param name="lossOfPrecisionHandling">How to handle values with signficant digits that would be lost by the conversion.</param>
+        /// <returns>The converted value.</returns>
+        public static SpannerNumeric FromDecimal(decimal value, LossOfPrecisionHandling lossOfPrecisionHandling)
+        {
+            GaxPreconditions.CheckEnumValue(lossOfPrecisionHandling, nameof(lossOfPrecisionHandling));
+            int[] bits = decimal.GetBits(value);
+
+            BigInteger lowBits = new BigInteger((uint) bits[0]);
+            BigInteger mediumBits = new BigInteger((uint) bits[1]) << 32;
+            BigInteger highBits = new BigInteger((uint) bits[2]) << 64;
+            BigInteger rawInteger = lowBits | mediumBits | highBits;
+            
+            int exponent = (bits[3] & 0x1f0000) >> 16;
+            if (bits[3] < 0)
+            {
+                rawInteger = -rawInteger;
+            }
+
+            int scale = 9 - exponent;
+            if (scale < 0)
+            {
+                BigInteger scaledInteger;
+                if (lossOfPrecisionHandling == LossOfPrecisionHandling.Throw)
+                {
+                    scaledInteger = BigInteger.DivRem(rawInteger, s_powersOf10[-scale], out var remainder);
+                    if (!remainder.IsZero)
+                    {
+                        throw new ArgumentException($"Conversion would lose precision, and {nameof(lossOfPrecisionHandling)} is set to {nameof(LossOfPrecisionHandling.Throw)}", nameof(value));
+                    }
+                }
+                else
+                {
+                    scaledInteger = rawInteger / s_powersOf10[-scale];
+                }
+
+                return new SpannerNumeric(scaledInteger);
+            }
+            else
+            {
+                // No possibility of loss of precision.
+                return new SpannerNumeric(rawInteger * s_powersOf10[scale]);
+            }
+        }
+
+        // Conversions from CLR types to SpannerNumeric
+
+        /// <summary>
+        /// Explicit conversion from <see cref="Decimal"/> to <see cref="SpannerNumeric"/>.
+        /// </summary>
+        /// <remarks>
+        /// This conversion may silently lose precision. Use <see cref="FromDecimal"/> passing in <see cref="LossOfPrecisionHandling.Throw"/>
+        /// for the second argument to avoid any information loss.
+        /// </remarks>
+        /// <param name="value">The decimal value to convert.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static explicit operator SpannerNumeric(decimal value) =>
+            FromDecimal(value, LossOfPrecisionHandling.Truncate);
+
+        /// <summary>
+        /// Implicit conversion from <see cref="Int32"/> to <see cref="SpannerNumeric"/>.
+        /// </summary>
+        /// <remarks>
+        /// This conversion exists to avoid ambiguity between the 64-bit conversions when using an integer literal.
+        /// </remarks>
+        /// <param name="value">The integer value to convert.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static implicit operator SpannerNumeric(int value) => (long) value;
+
+        /// <summary>
+        /// Implicit conversion from <see cref="Int64"/> to <see cref="SpannerNumeric"/>.
+        /// </summary>
+        /// <param name="value">The integer value to convert.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static implicit operator SpannerNumeric(long value) =>
+            new SpannerNumeric(s_integerScalingFactor * value);
+
+        /// <summary>
+        /// Implicit conversion from <see cref="UInt64"/> to <see cref="SpannerNumeric"/>.
+        /// </summary>
+        /// <param name="value">The integer value to convert.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static implicit operator SpannerNumeric(ulong value) =>
+            new SpannerNumeric(s_integerScalingFactor * value);
+
+        // Conversions from SpannerNumeric to CLR types.
+
+        /// <summary>
+        /// Converts this value to <see cref="SpannerNumeric"/>, 
+        /// </summary>
+        /// <remarks>
+        /// This conversion may silently lose precision, depending on <paramref name="lossOfPrecisionHandling"/>, but 
+        /// will always throw <see cref="OverflowException"/> if value is out of the range of <see cref="Decimal"/>.
+        /// </remarks>
+        /// <param name="lossOfPrecisionHandling">How to handle values with signficant digits that would be lost by the conversion.</param>
+        /// <exception cref="OverflowException">This value is outside the range of <see cref="Decimal"/>.</exception>
+        /// <returns>The converted value.</returns>
+        public decimal ToDecimal(LossOfPrecisionHandling lossOfPrecisionHandling)
+        {
+            // FIXME: Awful performance!
+            string text = ToString();
+            // Handles overflow
+            decimal dec = Decimal.Parse(text, CultureInfo.InvariantCulture);
+            if (lossOfPrecisionHandling == LossOfPrecisionHandling.Throw && this != (SpannerNumeric) dec)
+            {
+                // TODO: Is this the right exception to use?
+                throw new InvalidOperationException("Conversion would lose information");
+            }
+            return dec;
+        }
+
+        /// <summary>
+        /// Explicit conversion from <see cref="SpannerNumeric"/> to <see cref="Decimal"/>.
+        /// </summary>
+        /// <remarks>
+        /// This conversion may silently lose precision, but will throw <see cref="OverflowException"/> if the value is out of
+        /// range of <see cref="Decimal"/>. Use <see cref="ToDecimal"/> passing in <see cref="LossOfPrecisionHandling.Throw"/>
+        /// for the second argument to avoid any information loss.
+        /// </remarks>
+        /// <param name="value">The numeric value to convert.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static explicit operator decimal(SpannerNumeric value) =>
+            value.ToDecimal(LossOfPrecisionHandling.Truncate);
+
+        // Operators
+        /// <summary>
+        /// Compares two values for equality.
+        /// </summary>
+        /// <param name="lhs">The first value to compare.</param>
+        /// <param name="rhs">The second value to compare.</param>
+        /// <returns><c>true</c> if the two arguments are equal; <c>false</c> otherwise.</returns>
+        public static bool operator ==(SpannerNumeric lhs, SpannerNumeric rhs) => lhs.Equals(rhs);
+
+        /// <summary>
+        /// Compares two values for inequality.
+        /// </summary>
+        /// <param name="lhs">The first value to compare.</param>
+        /// <param name="rhs">The second value to compare.</param>
+        /// <returns><c>false</c> if the two arguments are equal; <c>true</c> otherwise.</returns>
+        public static bool operator !=(SpannerNumeric lhs, SpannerNumeric rhs) => !lhs.Equals(rhs);
+
+        /// <summary>
+        /// Returns the result of adding two <see cref="SpannerNumeric"/> values together.
+        /// </summary>
+        /// <param name="lhs">The first value to add.</param>
+        /// <param name="rhs">The second value to add.</param>
+        /// <returns>The result of adding the two values.</returns>
+        public static SpannerNumeric operator +(SpannerNumeric lhs, SpannerNumeric rhs) =>
+            new SpannerNumeric(lhs._integer + rhs._integer);
+
+        /// <summary>
+        /// Returns the result of subtracting one <see cref="SpannerNumeric"/> value from another.
+        /// </summary>
+        /// <param name="lhs">The value to subtract from.</param>
+        /// <param name="rhs">The value to subtract.</param>
+        /// <returns>The result of subtracting <paramref name="rhs"/> from <paramref name="lhs"/>.</returns>
+        public static SpannerNumeric operator -(SpannerNumeric lhs, SpannerNumeric rhs) =>
+            new SpannerNumeric(lhs._integer - rhs._integer);
+
+        /// <summary>
+        /// The unary plus operator, provided mainly for consistency.
+        /// </summary>
+        /// <param name="value">The value to return.</param>
+        /// <returns>The original value.</returns>
+        public static SpannerNumeric operator +(SpannerNumeric value) => value;
+
+        /// <summary>
+        /// The unary negation operator.
+        /// </summary>
+        /// <param name="value">The value to negate.</param>
+        /// <returns>The negation of <paramref name="value"/>.</returns>
+        public static SpannerNumeric operator -(SpannerNumeric value) => new SpannerNumeric(-value._integer);
+    }
+
+    /// <summary>
+    /// Handling for a conversion that would lose precision.
+    /// </summary>
+    public enum LossOfPrecisionHandling
+    {
+        /// <summary>
+        /// Truncate the loss of precision, truncating the result towards zero.
+        /// </summary>
+        Truncate,
+        /// <summary>
+        /// Throw an exception.
+        /// </summary>
+        Throw
+    }
+}

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SpannerNumeric.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SpannerNumeric.cs
@@ -36,7 +36,7 @@ namespace Google.Cloud.Spanner.V1
 
         private static readonly BigInteger s_integerScalingFactor = new BigInteger(1_000_000_000L);
         // TODO: Don't require a 0 before the decimal point.
-        // TODO: Replace with manual validation if we find this is a performance bottleneck (as it was with field name validation).
+        // TODO: Replace with manual validation if we find this is a performance bottleneck (as it was with BigQuery field name validations see #4976).
         private static readonly Regex s_validation = new Regex(@"^-?[0-9]+\.?[0-9]*$");
 
         // Note: the following properties must be declared *after* s_maxValue and s_minValue. Initialization order matters.


### PR DESCRIPTION
`SpannerNumeric` is a fork of [BigQueryNumeric](https://github.com/googleapis/google-cloud-dotnet/blob/master/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryNumeric.cs).