### PR TITLE
Use custom SessionPoolOptions for emulator clients

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerCommandTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerCommandTests.cs
@@ -183,14 +183,12 @@ namespace Google.Cloud.Spanner.Data.Tests
                 MaintenanceLoopDelay = TimeSpan.Zero
             };
 
+            // TODO: Check the UsesEmulator property, but only if we can actually control the
+            // environment.
             var emulatorDetection = EmulatorDetection.EmulatorOrProduction;
             var sessionPoolManager = new SessionPoolManager(
                 sessionPoolOptions, spannerClient.Settings.Logger,
-                (_o, _s, _l) =>
-                {
-                    Assert.Equal(_o.EmulatorDetection, emulatorDetection);
-                    return Task.FromResult(spannerClient);
-                }
+                (_o, _s, _l) => Task.FromResult(spannerClient)
             );
 
             SpannerConnectionStringBuilder builder = new SpannerConnectionStringBuilder


### PR DESCRIPTION
Additionally, simplify the way we handle emulators in
SpannerClientCreationOptions. We don't need to keep the
EmulatorDetection around - we can detect once, and use the endpoint
and credentials from that if we're actually talking to the emulator.