### PR TITLE
Release Google.Cloud.Firestore version 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Dlp.V2](https://googleapis.dev/dotnet/Google.Cloud.Dlp.V2/3.0.0) | 3.0.0 | [Google Cloud Data Loss Prevention](https://cloud.google.com/dlp/) |
 | [Google.Cloud.ErrorReporting.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.ErrorReporting.V1Beta1/2.0.0-beta02) | 2.0.0-beta02 | [Google Cloud Error Reporting](https://cloud.google.com/error-reporting/) |
 | [Google.Cloud.Firestore.Admin.V1](https://googleapis.dev/dotnet/Google.Cloud.Firestore.Admin.V1/2.0.0) | 2.0.0 | [Firestore Administration (e.g. index management)](https://firebase.google.com) |
-| [Google.Cloud.Firestore](https://googleapis.dev/dotnet/Google.Cloud.Firestore/2.0.0) | 2.0.0 | [Firestore high-level library](https://firebase.google.com/docs/firestore/) |
+| [Google.Cloud.Firestore](https://googleapis.dev/dotnet/Google.Cloud.Firestore/2.1.0) | 2.1.0 | [Firestore high-level library](https://firebase.google.com/docs/firestore/) |
 | [Google.Cloud.Firestore.V1](https://googleapis.dev/dotnet/Google.Cloud.Firestore.V1/2.0.0) | 2.0.0 | [Firestore low-level API access](https://firebase.google.com) |
 | [Google.Cloud.Gaming.V1Beta](https://googleapis.dev/dotnet/Google.Cloud.Gaming.V1Beta/1.0.0-beta04) | 1.0.0-beta04 | [Google Cloud for Games](https://cloud.google.com/solutions/gaming) |
 | [Google.Cloud.Iam.V1](https://googleapis.dev/dotnet/Google.Cloud.Iam.V1/2.0.0) | 2.0.0 | [Google Cloud Identity and Access Management (IAM)](https://cloud.google.com/iam/) |

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/coverage.xml
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/coverage.xml
@@ -7,9 +7,6 @@
       <FilterEntry>
         <ModuleMask>Google.Cloud.Firestore</ModuleMask>
       </FilterEntry>
-      <FilterEntry>
-        <ModuleMask>Google.Cloud.Firestore.V1</ModuleMask>
-      </FilterEntry>
     </IncludeFilters>
   </Filters>
   <AttributeFilters>

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/coverage.xml
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/coverage.xml
@@ -7,9 +7,6 @@
       <FilterEntry>
         <ModuleMask>Google.Cloud.Firestore</ModuleMask>
       </FilterEntry>
-      <FilterEntry>
-        <ModuleMask>Google.Cloud.Firestore.V1</ModuleMask>
-      </FilterEntry>
     </IncludeFilters>
   </Filters>
   <AttributeFilters>

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/coverage.xml
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/coverage.xml
@@ -7,9 +7,6 @@
       <FilterEntry>
         <ModuleMask>Google.Cloud.Firestore</ModuleMask>
       </FilterEntry>
-      <FilterEntry>
-        <ModuleMask>Google.Cloud.Firestore.V1</ModuleMask>
-      </FilterEntry>
     </IncludeFilters>
   </Filters>
   <AttributeFilters>

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Google.Cloud.Firestore.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Google.Cloud.Firestore.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Firestore API.</Description>
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <ProjectReference Include="..\..\Google.Cloud.Firestore.V1\Google.Cloud.Firestore.V1\Google.Cloud.Firestore.V1.csproj" />
+    <PackageReference Include="Google.Cloud.Firestore.V1" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.27.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />

--- a/apis/Google.Cloud.Firestore/docs/history.md
+++ b/apis/Google.Cloud.Firestore/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+# Version 2.1.0, released 2020-06-02
+
+- [Commit 48cef0e](https://github.com/googleapis/google-cloud-dotnet/commit/48cef0e): Allow nested arrays to be constructed client-side, relying on server-side validation
+- [Commit b1e6e8b](https://github.com/googleapis/google-cloud-dotnet/commit/b1e6e8b): Perform some more client-side validation for WhereIn queries to avoid an unfortunate type safety mistake
+- [Commit 2517e6e](https://github.com/googleapis/google-cloud-dotnet/commit/2517e6e): Convert strings into references for DocumentId queries. Fixes [issue 4981](https://github.com/googleapis/google-cloud-dotnet/issues/4981)
+
+Note that although this release doesn't involve any API surface
+changes, the features here (particularly converting strings into
+references for DocumentId queries) feel significant enough to
+warrant a minor version instead of a patch release. (They are
+effectively features rather than bug fixes.)
+
 # Version 2.0.0, released 2020-05-12
 
 - [Commit 2f25d1c](https://github.com/googleapis/google-cloud-dotnet/commit/2f25d1c): Implement Query.LimitToLast

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -501,7 +501,7 @@
       "productName": "Firestore",
       "productUrl": "https://firebase.google.com/docs/firestore/",
       "listingDescription": "Firestore high-level library",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "type": "other",
       "targetFrameworks": "netstandard2.0;net461",
       "testTargetFrameworks": "netcoreapp2.1;net461",
@@ -511,7 +511,7 @@
         "firebase"
       ],
       "dependencies": {
-        "Google.Cloud.Firestore.V1": "project",
+        "Google.Cloud.Firestore.V1": "2.0.0",
         "Grpc.Core": "2.27.0",
         "System.Collections.Immutable": "1.4.0",
         "System.Linq.Async": "4.0.0"

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -42,7 +42,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Dlp.V2](Google.Cloud.Dlp.V2/index.html) | 3.0.0 | [Google Cloud Data Loss Prevention](https://cloud.google.com/dlp/) |
 | [Google.Cloud.ErrorReporting.V1Beta1](Google.Cloud.ErrorReporting.V1Beta1/index.html) | 2.0.0-beta02 | [Google Cloud Error Reporting](https://cloud.google.com/error-reporting/) |
 | [Google.Cloud.Firestore.Admin.V1](Google.Cloud.Firestore.Admin.V1/index.html) | 2.0.0 | [Firestore Administration (e.g. index management)](https://firebase.google.com) |
-| [Google.Cloud.Firestore](Google.Cloud.Firestore/index.html) | 2.0.0 | [Firestore high-level library](https://firebase.google.com/docs/firestore/) |
+| [Google.Cloud.Firestore](Google.Cloud.Firestore/index.html) | 2.1.0 | [Firestore high-level library](https://firebase.google.com/docs/firestore/) |
 | [Google.Cloud.Firestore.V1](Google.Cloud.Firestore.V1/index.html) | 2.0.0 | [Firestore low-level API access](https://firebase.google.com) |
 | [Google.Cloud.Gaming.V1Beta](Google.Cloud.Gaming.V1Beta/index.html) | 1.0.0-beta04 | [Google Cloud for Games](https://cloud.google.com/solutions/gaming) |
 | [Google.Cloud.Iam.V1](Google.Cloud.Iam.V1/index.html) | 2.0.0 | [Google Cloud Identity and Access Management (IAM)](https://cloud.google.com/iam/) |


### PR DESCRIPTION

Changes in this release:

- [Commit 48cef0e](https://github.com/googleapis/google-cloud-dotnet/commit/48cef0e): Allow nested arrays to be constructed client-side, relying on server-side validation
- [Commit b1e6e8b](https://github.com/googleapis/google-cloud-dotnet/commit/b1e6e8b): Perform some more client-side validation for WhereIn queries to avoid an unfortunate type safety mistake
- [Commit 2517e6e](https://github.com/googleapis/google-cloud-dotnet/commit/2517e6e): Convert strings into references for DocumentId queries. Fixes [issue 4981](https://github.com/googleapis/google-cloud-dotnet/issues/4981)

Note that although this release doesn't involve any API surface changes, the features here (particularly converting strings into references for DocumentId queries) feel significant enough to warrant a minor version instead of a patch release. (They are effectively features rather than bug fixes.)
