### PR TITLE
Allow general iterable object to be serialized (but not deserialized) in Firestore

### DIFF
--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/ValueDeserializerTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/ValueDeserializerTest.cs
@@ -22,6 +22,7 @@ using BclType = System.Type;
 using wkt = Google.Protobuf.WellKnownTypes;
 using static Google.Cloud.Firestore.Tests.DocumentSnapshotHelpers;
 using System.Collections;
+using System.Linq;
 
 namespace Google.Cloud.Firestore.Tests
 {
@@ -274,6 +275,14 @@ namespace Google.Cloud.Firestore.Tests
             // We should get a clone back.
             Assert.NotSame(value, deserialized);
             Assert.Equal(value, deserialized);
+        }
+
+        [Fact]
+        public void DeserializeToLinqResult_Fails()
+        {
+            var sequence = Enumerable.Range(1, 3);
+            var value = ValueSerializer.Serialize(SerializationContext.Default, sequence);
+            Assert.Throws<NotSupportedException>(() => ValueDeserializer.Deserialize(SerializationTestData.Context, value, sequence.GetType()));
         }
 
         // These three classes exist for testing unknown property handling

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/ValueSerializerTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/ValueSerializerTest.cs
@@ -17,6 +17,7 @@ using Google.Protobuf;
 using System;
 using System.Collections.Generic;
 using System.Dynamic;
+using System.Linq;
 using Xunit;
 using wkt = Google.Protobuf.WellKnownTypes;
 
@@ -173,6 +174,28 @@ namespace Google.Cloud.Firestore.Tests
                 }
             };
             var actual = ValueSerializer.Serialize(SerializationContext.Default, nestedArray);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void LinqResult()
+        {
+            // We should be able to serialize the result of a LINQ query as if it were a list.
+            // This is *relatively* rarely useful, but generally still a good thing to support.
+            var sequence = Enumerable.Range(1, 3);
+            var expected = new Value
+            {
+                ArrayValue = new ArrayValue
+                {
+                    Values =
+                    {
+                        new Value { IntegerValue = 1 },
+                        new Value { IntegerValue = 2 },
+                        new Value { IntegerValue = 3 },
+                    }
+                }
+            };
+            var actual = ValueSerializer.Serialize(SerializationContext.Default, sequence);
             Assert.Equal(expected, actual);
         }
 

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Converters/SequenceConverter.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Converters/SequenceConverter.cs
@@ -1,0 +1,36 @@
+﻿// Copyright 2020, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Firestore.V1;
+using Google.Protobuf.Collections;
+using System;
+using BclType = System.Type;
+
+namespace Google.Cloud.Firestore.Converters
+{
+    /// <summary>
+    /// List converter that only supports serialization. This is used by
+    /// <see cref="ConverterCache"/> as a final option when we know something can
+    /// be iterated over, but that's all. We can't deserialize to it, but that may well be okay.
+    /// </summary>
+    internal sealed class SequenceConverter : ListConverterBase
+    {
+        internal SequenceConverter(BclType targetType) : base(targetType)
+        {
+        }
+
+        protected override object DeserializeArray(DeserializationContext context, RepeatedField<Value> values) =>
+            throw new NotSupportedException($"Type {TargetType} cannot be used for deserialization; only serialization.");
+    }
+}


### PR DESCRIPTION
Aside from anything else, this allows filters in queries (which are
serialized internally) to be expressed in terms of LINQ queries.