### PR TITLE
Release Google.Cloud.BigQuery.V2 version 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Asset.V1](https://googleapis.dev/dotnet/Google.Cloud.Asset.V1/2.1.0) | 2.1.0 | [Google Cloud Asset Inventory](https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview) |
 | [Google.Cloud.AutoML.V1](https://googleapis.dev/dotnet/Google.Cloud.AutoML.V1/2.0.0) | 2.0.0 | [Google AutoML](https://cloud.google.com/automl/) |
 | [Google.Cloud.BigQuery.DataTransfer.V1](https://googleapis.dev/dotnet/Google.Cloud.BigQuery.DataTransfer.V1/2.0.0) | 2.0.0 | [Google BigQuery Data Transfer](https://cloud.google.com/bigquery/transfer/) |
-| [Google.Cloud.BigQuery.V2](https://googleapis.dev/dotnet/Google.Cloud.BigQuery.V2/2.0.0-beta04) | 2.0.0-beta04 | [Google BigQuery](https://cloud.google.com/bigquery/) |
+| [Google.Cloud.BigQuery.V2](https://googleapis.dev/dotnet/Google.Cloud.BigQuery.V2/2.0.0) | 2.0.0 | [Google BigQuery](https://cloud.google.com/bigquery/) |
 | [Google.Cloud.BigQuery.Storage.V1](https://googleapis.dev/dotnet/Google.Cloud.BigQuery.Storage.V1/2.0.0) | 2.0.0 | [Google BigQuery Storage](https://cloud.google.com/bigquery/docs/reference/storage/) |
 | [Google.Cloud.Bigtable.Admin.V2](https://googleapis.dev/dotnet/Google.Cloud.Bigtable.Admin.V2/2.1.0) | 2.1.0 | [Google Cloud Bigtable Administration](https://cloud.google.com/bigtable/) |
 | [Google.Cloud.Bigtable.Common.V2](https://googleapis.dev/dotnet/Google.Cloud.Bigtable.Common.V2/2.0.0) | 2.0.0 | Common code used by Bigtable V2 APIs |

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta04</Version>
+    <Version>2.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery API. It wraps the Google.Apis.Bigquery.v2 client library, making common operations simpler in client code. BigQuery is a data platform for customers to create, manage, share and query data.</Description>
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Rest" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Google.Apis.Bigquery.v2" Version="[1.45.0.1915, 2.0.0.0)" />
+    <PackageReference Include="Google.Apis.Bigquery.v2" Version="[1.46.0.1969, 2.0.0.0)" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.BigQuery.V2/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.V2/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+# Version 2.0.0, released 2020-06-04
+
+- [Commit 0970dff](https://github.com/googleapis/google-cloud-dotnet/commit/0970dff): Fix: Propagates some cancellation tokens that weren't being propagated before.
+- [Commit e9e6a47](https://github.com/googleapis/google-cloud-dotnet/commit/e9e6a47): Binary breaking change: Adds missing CancellationToken parameter on BigQueryDataset.DeleteModelAsync.
+- [Commit 8e9c40f](https://github.com/googleapis/google-cloud-dotnet/commit/8e9c40f): Adds BigQuery Routines CRUD operations.
+  - Fixes [issue 3762](https://github.com/googleapis/google-cloud-dotnet/issues/3762)
+- [Commit 575c61a](https://github.com/googleapis/google-cloud-dotnet/commit/575c61a):
+  - Convert BigQuery field validation from a regex to hand-written code.
+  - This is entirely for the sake of performance. Benchmark results are approximately 10x better.
+  - Fixes [issue 4975](https://github.com/googleapis/google-cloud-dotnet/issues/4975)
+
 # Version 2.0.0-beta04, released 2020-04-07
 
 - [Commit f58fa79](https://github.com/googleapis/google-cloud-dotnet/commit/f58fa79): Makes BigQueryRow.TimestampConverter accept pre 1970 dates. Fixes [issue 4821](https://github.com/googleapis/google-cloud-dotnet/issues/4821).

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -65,11 +65,12 @@
       "id": "Google.Cloud.BigQuery.V2",
       "productName": "Google BigQuery",
       "productUrl": "https://cloud.google.com/bigquery/",
-      "version": "2.0.0-beta04",
+      "version": "2.0.0",
       "type": "rest",
       "description": "Recommended Google client library to access the BigQuery API. It wraps the Google.Apis.Bigquery.v2 client library, making common operations simpler in client code. BigQuery is a data platform for customers to create, manage, share and query data.",
       "dependencies": {
-        "Google.Apis.Bigquery.v2": "1.45.0.1915"
+        "Google.Apis.Bigquery.v2": "1.46.0.1969",
+        "Google.Api.Gax.Rest": "3.0.0"
       },
       "testDependencies": {
         "Google.Cloud.Storage.V1": "project"

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -21,7 +21,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Asset.V1](Google.Cloud.Asset.V1/index.html) | 2.1.0 | [Google Cloud Asset Inventory](https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview) |
 | [Google.Cloud.AutoML.V1](Google.Cloud.AutoML.V1/index.html) | 2.0.0 | [Google AutoML](https://cloud.google.com/automl/) |
 | [Google.Cloud.BigQuery.DataTransfer.V1](Google.Cloud.BigQuery.DataTransfer.V1/index.html) | 2.0.0 | [Google BigQuery Data Transfer](https://cloud.google.com/bigquery/transfer/) |
-| [Google.Cloud.BigQuery.V2](Google.Cloud.BigQuery.V2/index.html) | 2.0.0-beta04 | [Google BigQuery](https://cloud.google.com/bigquery/) |
+| [Google.Cloud.BigQuery.V2](Google.Cloud.BigQuery.V2/index.html) | 2.0.0 | [Google BigQuery](https://cloud.google.com/bigquery/) |
 | [Google.Cloud.BigQuery.Storage.V1](Google.Cloud.BigQuery.Storage.V1/index.html) | 2.0.0 | [Google BigQuery Storage](https://cloud.google.com/bigquery/docs/reference/storage/) |
 | [Google.Cloud.Bigtable.Admin.V2](Google.Cloud.Bigtable.Admin.V2/index.html) | 2.1.0 | [Google Cloud Bigtable Administration](https://cloud.google.com/bigtable/) |
 | [Google.Cloud.Bigtable.Common.V2](Google.Cloud.Bigtable.Common.V2/index.html) | 2.0.0 | Common code used by Bigtable V2 APIs |


### PR DESCRIPTION

Changes in this release:

- [Commit 0970dff](https://github.com/googleapis/google-cloud-dotnet/commit/0970dff): Fix: Propagates some cancellation tokens that weren't being propagated before.
- [Commit e9e6a47](https://github.com/googleapis/google-cloud-dotnet/commit/e9e6a47): Binary breaking change: Adds missing CancellationToken parameter on BigQueryDataset.DeleteModelAsync.
- [Commit 8e9c40f](https://github.com/googleapis/google-cloud-dotnet/commit/8e9c40f): Adds BigQuery Routines CRUD operations.
  - Fixes [issue 3762](https://github.com/googleapis/google-cloud-dotnet/issues/3762)
- [Commit 575c61a](https://github.com/googleapis/google-cloud-dotnet/commit/575c61a):
  - Convert BigQuery field validation from a regex to hand-written code.
  - This is entirely for the sake of performance. Benchmark results are aproximately 10x better.
  - Fixes [issue 4975](https://github.com/googleapis/google-cloud-dotnet/issues/4975)
