### PR TITLE
Release Google.Cloud.BigQuery.Connection.V1 version 1.0.0-beta01

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Each package name links to the documentation for that package.
 |---------|----------------|-------------|
 | [Google.Cloud.Asset.V1](https://googleapis.dev/dotnet/Google.Cloud.Asset.V1/2.1.0) | 2.1.0 | [Google Cloud Asset Inventory](https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview) |
 | [Google.Cloud.AutoML.V1](https://googleapis.dev/dotnet/Google.Cloud.AutoML.V1/2.0.0) | 2.0.0 | [Google AutoML](https://cloud.google.com/automl/) |
+| [Google.Cloud.BigQuery.Connection.V1](https://googleapis.dev/dotnet/Google.Cloud.BigQuery.Connection.V1/1.0.0-beta01) | 1.0.0-beta01 | [BigQuery Connection API](https://cloud.google.com/bigquery/docs/reference/bigqueryconnection) |
 | [Google.Cloud.BigQuery.DataTransfer.V1](https://googleapis.dev/dotnet/Google.Cloud.BigQuery.DataTransfer.V1/2.0.0) | 2.0.0 | [Google BigQuery Data Transfer](https://cloud.google.com/bigquery/transfer/) |
 | [Google.Cloud.BigQuery.V2](https://googleapis.dev/dotnet/Google.Cloud.BigQuery.V2/2.0.0) | 2.0.0 | [Google BigQuery](https://cloud.google.com/bigquery/) |
 | [Google.Cloud.BigQuery.Storage.V1](https://googleapis.dev/dotnet/Google.Cloud.BigQuery.Storage.V1/2.0.0) | 2.0.0 | [Google BigQuery Storage](https://cloud.google.com/bigquery/docs/reference/storage/) |

--- a/apis/Google.Cloud.BigQuery.Connection.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/.repo-metadata.json
@@ -1,0 +1,5 @@
+{
+  "distribution_name": "Google.Cloud.BigQuery.Connection.V1",
+  "release_level": "beta",
+  "client_documentation": "https://googleapis.dev/dotnet/Google.Cloud.BigQuery.Connection.V1/latest"
+}

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta00</Version>
+    <Version>1.0.0-beta01</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery connection API, which allows users to manage BigQuery connections to external data sources.</Description>

--- a/apis/Google.Cloud.BigQuery.Connection.V1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/docs/history.md
@@ -1,0 +1,7 @@
+# Version history
+
+# Version 1.0.0-beta01, released 2020-06-09
+
+Initial beta release.
+
+

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -45,7 +45,7 @@
     },
     {
       "id": "Google.Cloud.BigQuery.Connection.V1",
-      "version": "1.0.0-beta00",
+      "version": "1.0.0-beta01",
       "type": "grpc",
       "productName": "BigQuery Connection API",
       "productUrl": "https://cloud.google.com/bigquery/docs/reference/bigqueryconnection",

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -20,6 +20,7 @@ Each package name links to the documentation for that package.
 |---------|----------------|-------------|
 | [Google.Cloud.Asset.V1](Google.Cloud.Asset.V1/index.html) | 2.1.0 | [Google Cloud Asset Inventory](https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview) |
 | [Google.Cloud.AutoML.V1](Google.Cloud.AutoML.V1/index.html) | 2.0.0 | [Google AutoML](https://cloud.google.com/automl/) |
+| [Google.Cloud.BigQuery.Connection.V1](Google.Cloud.BigQuery.Connection.V1/index.html) | 1.0.0-beta01 | [BigQuery Connection API](https://cloud.google.com/bigquery/docs/reference/bigqueryconnection) |
 | [Google.Cloud.BigQuery.DataTransfer.V1](Google.Cloud.BigQuery.DataTransfer.V1/index.html) | 2.0.0 | [Google BigQuery Data Transfer](https://cloud.google.com/bigquery/transfer/) |
 | [Google.Cloud.BigQuery.V2](Google.Cloud.BigQuery.V2/index.html) | 2.0.0 | [Google BigQuery](https://cloud.google.com/bigquery/) |
 | [Google.Cloud.BigQuery.Storage.V1](Google.Cloud.BigQuery.Storage.V1/index.html) | 2.0.0 | [Google BigQuery Storage](https://cloud.google.com/bigquery/docs/reference/storage/) |


### PR DESCRIPTION

Changes in this release:

Initial beta release.
