### PR TITLE
Remove now-unnecessary patch shell scripts for DocumentAI

### DIFF
--- a/apis/Google.Cloud.DocumentAI.V1Beta2/postgeneration.sh
+++ b/apis/Google.Cloud.DocumentAI.V1Beta2/postgeneration.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -e
-
-# Undo the changes made in pregeneration.sh
-git -C $GOOGLEAPIS checkout google/cloud/documentai/v1beta2

--- a/apis/Google.Cloud.DocumentAI.V1Beta2/pregeneration.sh
+++ b/apis/Google.Cloud.DocumentAI.V1Beta2/pregeneration.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-set -e
-
-# Temporary hack to add the C# namespace to the protos, until
-# they're present in GitHub.
-sed -i '/^option go_package/i option csharp_namespace = "Google.Cloud.DocumentAI.V1Beta2";' \
-  $GOOGLEAPIS/google/cloud/documentai/v1beta2/*.proto


### PR DESCRIPTION
(This namespace option is now present in GitHub.)

Fixes #5047.