### PR TITLE
Update Google.Api.CommonProtos to 2.1.0 for Monitoring

### DIFF
--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.csproj
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
+    <PackageReference Include="Google.Api.CommonProtos" Version="[2.1.0, 3.0.0)" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.27.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -749,6 +749,7 @@
         "Stackdriver"
       ],
       "dependencies": {
+        "Google.Api.CommonProtos": "2.1.0",
         "Google.Api.Gax.Grpc.GrpcCore": "3.0.0",
         "Grpc.Core": "2.27.0"
       }


### PR DESCRIPTION
(This will allow the autogenerated tests to use newer aspects of the common protos.)