### PR TITLE
Release Google.Cloud.Monitoring.V3 version 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Logging.V2](https://googleapis.dev/dotnet/Google.Cloud.Logging.V2/3.0.0) | 3.0.0 | [Google Cloud Logging](https://cloud.google.com/logging/) |
 | [Google.Cloud.ManagedIdentities.V1](https://googleapis.dev/dotnet/Google.Cloud.ManagedIdentities.V1/2.0.0) | 2.0.0 | [Managed Service for Microsoft Active Directory](https://cloud.google.com/managed-microsoft-ad/) |
 | [Google.Cloud.Memcache.V1Beta2](https://googleapis.dev/dotnet/Google.Cloud.Memcache.V1Beta2/1.0.0-beta02) | 1.0.0-beta02 | [Google Cloud Memorystore for Memcache](https://cloud.google.com/memorystore/) |
-| [Google.Cloud.Monitoring.V3](https://googleapis.dev/dotnet/Google.Cloud.Monitoring.V3/2.1.0-beta01) | 2.1.0-beta01 | [Google Cloud Monitoring](https://cloud.google.com/monitoring/api/v3/) |
+| [Google.Cloud.Monitoring.V3](https://googleapis.dev/dotnet/Google.Cloud.Monitoring.V3/2.1.0) | 2.1.0 | [Google Cloud Monitoring](https://cloud.google.com/monitoring/api/v3/) |
 | [Google.Cloud.OrgPolicy.V1](https://googleapis.dev/dotnet/Google.Cloud.OrgPolicy.V1/2.0.0) | 2.0.0 | OrgPolicy API messages |
 | [Google.Cloud.OsConfig.V1](https://googleapis.dev/dotnet/Google.Cloud.OsConfig.V1/1.0.0) | 1.0.0 | [Google Cloud OS Config API](https://cloud.google.com/compute/docs/osconfig/rest) |
 | [Google.Cloud.OsLogin.Common](https://googleapis.dev/dotnet/Google.Cloud.OsLogin.Common/2.0.0) | 2.0.0 | Version-agnostic types for the Google OS Login API |

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.csproj
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0-beta01</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Monitoring API, which manages your Google Cloud Monitoring data and configurations.</Description>

--- a/apis/Google.Cloud.Monitoring.V3/docs/history.md
+++ b/apis/Google.Cloud.Monitoring.V3/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+# Version 2.1.0, released 2020-06-15
+
+- [Commit 4389faa](https://github.com/googleapis/google-cloud-dotnet/commit/4389faa): docs: Change relative URLs to absolute URLs to fix broken links.
+- [Commit 947a573](https://github.com/googleapis/google-cloud-dotnet/commit/947a573): docs: Regenerate all clients with more explicit documentation
+
+(No API surface changes relative to 2.1.0-beta01.)
+
 # Version 2.1.0-beta01, released 2020-05-06
 
 - [Commit 9c1f9d6](https://github.com/googleapis/google-cloud-dotnet/commit/9c1f9d6):

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -759,7 +759,7 @@
       "protoPath": "google/monitoring/v3",
       "productName": "Google Cloud Monitoring",
       "productUrl": "https://cloud.google.com/monitoring/api/v3/",
-      "version": "2.1.0-beta01",
+      "version": "2.1.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Monitoring API, which manages your Google Cloud Monitoring data and configurations.",
       "tags": [

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -54,7 +54,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Logging.V2](Google.Cloud.Logging.V2/index.html) | 3.0.0 | [Google Cloud Logging](https://cloud.google.com/logging/) |
 | [Google.Cloud.ManagedIdentities.V1](Google.Cloud.ManagedIdentities.V1/index.html) | 2.0.0 | [Managed Service for Microsoft Active Directory](https://cloud.google.com/managed-microsoft-ad/) |
 | [Google.Cloud.Memcache.V1Beta2](Google.Cloud.Memcache.V1Beta2/index.html) | 1.0.0-beta02 | [Google Cloud Memorystore for Memcache](https://cloud.google.com/memorystore/) |
-| [Google.Cloud.Monitoring.V3](Google.Cloud.Monitoring.V3/index.html) | 2.1.0-beta01 | [Google Cloud Monitoring](https://cloud.google.com/monitoring/api/v3/) |
+| [Google.Cloud.Monitoring.V3](Google.Cloud.Monitoring.V3/index.html) | 2.1.0 | [Google Cloud Monitoring](https://cloud.google.com/monitoring/api/v3/) |
 | [Google.Cloud.OrgPolicy.V1](Google.Cloud.OrgPolicy.V1/index.html) | 2.0.0 | OrgPolicy API messages |
 | [Google.Cloud.OsConfig.V1](Google.Cloud.OsConfig.V1/index.html) | 1.0.0 | [Google Cloud OS Config API](https://cloud.google.com/compute/docs/osconfig/rest) |
 | [Google.Cloud.OsLogin.Common](Google.Cloud.OsLogin.Common/index.html) | 2.0.0 | Version-agnostic types for the Google OS Login API |


### PR DESCRIPTION

Changes in this release:

- [Commit 4389faa](https://github.com/googleapis/google-cloud-dotnet/commit/4389faa): docs: Change relative URLs to absolute URLs to fix broken links.
- [Commit 947a573](https://github.com/googleapis/google-cloud-dotnet/commit/947a573): docs: Regenerate all clients with more explicit documentation

(No API surface changes relative to 2.1.0-beta01.)
