### PR TITLE
[BigQuery] Unskips Routine's and Model's Etag tests.

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/ModelTests.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/ModelTests.cs
@@ -50,7 +50,7 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             Assert.Equal(fetched.Resource.ETag, patched.Resource.ETag);
         }
 
-        [Fact(Skip="It seems that ETag is not being used in Model to prevent concurrent modifications")]
+        [Fact]
         public void PatchModel_ConflictMatchEtag()
         {
             var client = BigQueryClient.Create(_fixture.ProjectId);

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/RoutineTests.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/RoutineTests.cs
@@ -196,8 +196,8 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             Assert.Equal("SELECT 2;", updated.Resource.DefinitionBody);
         }
 
-        [Fact(Skip = "It seems that ETag is not being used in Routine to prevent concurrent modifications.")]
-        public void UpdateModel_ConflictMatchEtag()
+        [Fact]
+        public void UpdateRoutine_ConflictMatchEtag()
         {
             var client = BigQueryClient.Create(_fixture.ProjectId);
             string datasetId = _fixture.DatasetId;


### PR DESCRIPTION
  * Fixes #5005
  * Fixes #4232

The tests are now passing locally. The API fixes must have been rolled out already. We can unskip the tests and close the issues.