### PR TITLE
test: unskip Spanner PDML tests when run against the emulator

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/DmlTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/DmlTests.cs
@@ -426,10 +426,9 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             Assert.Equal(expected, actual);
         }
 
-        [SkippableFact]
+        [Fact]
         public void PartitionedUpdate_Small()
         {
-            Skip.If(_fixture.RunningOnEmulator, "Emulator doesn't support partitioned updates yet.");
             string key = _fixture.CreateTestRows();
             string table = _fixture.TableName;
             using (var connection = _fixture.GetConnection())

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/PartitionedReadTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/PartitionedReadTests.cs
@@ -29,10 +29,9 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
         public PartitionedReadTests(PartitionedReadTableFixture fixture) =>
             _fixture = fixture;
 
-        [SkippableFact]
+        [Fact]
         public async Task DistributedReadAsync()
         {
-            Skip.If(_fixture.RunningOnEmulator, "Emulator doesn't support distributed reads yet.");
             int numRows;
             using (var connection = _fixture.GetConnection())
             using (var cmd = connection.CreateSelectCommand($"SELECT COUNT(*) FROM {_fixture.TableName}"))

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/ReadTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/ReadTests.cs
@@ -426,9 +426,10 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
         }
 
         // [START spanner_test_deadline_exceeded_fails]
-        [Fact]
+        [SkippableFact]
         public async Task TimeoutFromOptions()
         {
+            Skip.If(_fixture.RunningOnEmulator, "The emulator returns too quickly to trigger timeout");
             var connectionStringBuilder = new SpannerConnectionStringBuilder(_fixture.ConnectionString)
             {
                 Timeout = 0,

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/ReadTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/ReadTests.cs
@@ -100,9 +100,10 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
         // [END spanner_test_read_invalid_table_name]
 
         // [START spanner_test_cancel_read_fails]
-        [Fact]
+        [SkippableFact]
         public async Task CancelRead()
         {
+            Skip.If(_fixture.RunningOnEmulator, "The emulator can return before query is cancelled");
             using (var connection = _fixture.GetConnection())
             {
                 var cmd = connection.CreateSelectCommand($"SELECT * FROM {_fixture.TableName}");
@@ -412,9 +413,10 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             }
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task CommandTimeout()
         {
+            Skip.If(_fixture.RunningOnEmulator, "The emulator returns too quickly to trigger timeout");
             using (var connection =
                 new SpannerConnection($"{_fixture.ConnectionString};{nameof(SpannerConnectionStringBuilder.AllowImmediateTimeouts)}=true"))
             {

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/WriteTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/WriteTests.cs
@@ -382,9 +382,10 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
         }
         // [END spanner_test_write_read_random_bytes]
 
-        [Fact]
+        [SkippableFact]
         public async Task CommandTimeout()
         {
+            Skip.If(_fixture.RunningOnEmulator, "The emulator returns too quickly to trigger timeout");
             var values = new SpannerParameterCollection
             {
                 {"StringValue", SpannerDbType.String, "abc"},


### PR DESCRIPTION
Also skipped some timeout tests that are flaky when run against the emulator since the emulator can return results faster than a timeout or cancel request can be triggered by the client.