### PR TITLE
Improvements to GetOrdinal behavior

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/ReadTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/ReadTests.cs
@@ -563,5 +563,33 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 }
             }
         }
+
+        [Fact]
+        public void GetOrdinal()
+        {
+            using (var connection = _fixture.GetConnection())
+            {
+                var cmd = connection.CreateSelectCommand($"SELECT StringValue, Key FROM {_fixture.TableName} LIMIT 1");
+                using (var reader = cmd.ExecuteReader())
+                {
+                    Assert.Equal(0, reader.GetOrdinal("StringValue"));
+                    Assert.Equal(1, reader.GetOrdinal("Key"));
+                }
+            }
+        }
+
+        [Fact]
+        public async Task GetOrdinalAsync()
+        {
+            using (var connection = _fixture.GetConnection())
+            {
+                var cmd = connection.CreateSelectCommand($"SELECT StringValue, Key FROM {_fixture.TableName} LIMIT 1");
+                using (var reader = await cmd.ExecuteReaderAsync())
+                {
+                    Assert.Equal(0, await reader.GetOrdinalAsync("StringValue"));
+                    Assert.Equal(1, await reader.GetOrdinalAsync("Key"));
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
- Avoid an unnecessary call to Task.Run if we already have metadata but haven't populated the field index
- Add GetOrdinalAsync for async callers who want to avoid Task.Run entirely

Note that GetOrdinal is called by GetFieldValue<T> and this[string], which are called after Read/ReadAsync - this would previously have involved a Task.Run call for a task that completed immediately, whereas now we'll spot that we already have metadata, and complete synchronously.

Fixes #5114