### PR TITLE
Changes to Spanner integration tests for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
       if: type = pull_request
       script: ./detect-pr-changes.sh
     - name: "Spanner Emulator"
-      script: ./spanner-ITs-against-emulator.sh;
+      script: apis/Google.Cloud.Spanner.Data/run-emulator-tests.sh;
     - name: "Cloud APIs A-L"
       env: API_REGEX='Google\.Cloud\.[A-L].*'
     - name: "Cloud APIs M-Z"

--- a/apis/Google.Cloud.Spanner.Data/run-emulator-tests.sh
+++ b/apis/Google.Cloud.Spanner.Data/run-emulator-tests.sh
@@ -17,6 +17,19 @@
 # Fail on any error.
 set -e
 
+# Check if we need to run
+if ! git diff master --name-only | grep -iq spanner
+then
+  echo "Skipping Spanner integration tests; no Spanner-related changes."
+  exit 0
+fi
+
+declare -r REPO_ROOT=$(readlink -f $(dirname ${BASH_SOURCE})/../..)
+
+declare -r REPO_TMP=$REPO_ROOT/tmp
+rm -rf $REPO_TMP
+mkdir $REPO_TMP
+
 export SPANNER_EMULATOR_HOST=localhost:9010
 export TEST_PROJECT=emulator-test-project
 echo "Running the Cloud Spanner emulator: $SPANNER_EMULATOR_HOST";
@@ -24,28 +37,31 @@ echo "Running the Cloud Spanner emulator: $SPANNER_EMULATOR_HOST";
 # Download the Google Cloud SDK and fetch the beta component which contains the
 # emulator.
 GOOGLE_CLOUD_SDK_VERSION=299.0.0
-wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GOOGLE_CLOUD_SDK_VERSION}-linux-x86_64.tar.gz
-tar zxf google-cloud-sdk-${GOOGLE_CLOUD_SDK_VERSION}-linux-x86_64.tar.gz
+(cd $REPO_TMP \
+ && wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GOOGLE_CLOUD_SDK_VERSION}-linux-x86_64.tar.gz \
+  -O gcloud.tgz \
+ && tar zxf gcloud.tgz)
 
 # Install the emulator.
 export CLOUDSDK_CORE_DISABLE_PROMPTS=1
-./google-cloud-sdk/bin/gcloud components install beta cloud-spanner-emulator
+$REPO_TMP/google-cloud-sdk/bin/gcloud components install beta cloud-spanner-emulator
 
 # Start the emulator.
-./google-cloud-sdk/bin/gcloud beta emulators spanner start &
+declare -r REPO_GCLOUD=$REPO_TMP/google-cloud-sdk/bin/gcloud
+$REPO_GCLOUD beta emulators spanner start &
 
 EMULATOR_PID=$!
 
 # When this shell exits, stop the emulator.
 trap "kill -15 $EMULATOR_PID; echo \"Cleaned up the emulator\";" EXIT
 
-./google-cloud-sdk/bin/gcloud config set auth/disable_credentials true
-./google-cloud-sdk/bin/gcloud config set project ${TEST_PROJECT}
-./google-cloud-sdk/bin/gcloud config set api_endpoint_overrides/spanner http://localhost:9020/
-./google-cloud-sdk/bin/gcloud spanner instances create spannerintegration \
+$REPO_GCLOUD config set auth/disable_credentials true
+$REPO_GCLOUD config set project ${TEST_PROJECT}
+$REPO_GCLOUD config set api_endpoint_overrides/spanner http://localhost:9020/
+$REPO_GCLOUD spanner instances create spannerintegration \
    --config=emulator-config --description="Test Instance" --nodes=1
 
 # Run the tests.
-cd apis/Google.Cloud.Spanner.Data
+cd $REPO_ROOT/apis/Google.Cloud.Spanner.Data
 dotnet test Google.Cloud.Spanner.Data.IntegrationTests
 dotnet test Google.Cloud.Spanner.Data.Snippets


### PR DESCRIPTION
- Move the script under Google.Cloud.Spanner.Data
- Don't do anything unless the PR contains something involving Spanner
- Unpack gcloud to a tmp directory