### PR TITLE
Regenerate all APIs with service comments in client documentation

### DIFF
--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/AssetServiceClient.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/AssetServiceClient.g.cs
@@ -269,6 +269,9 @@ namespace Google.Cloud.Asset.V1
     }
 
     /// <summary>AssetService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Asset service definition.
+    /// </remarks>
     public abstract partial class AssetServiceClient
     {
         /// <summary>
@@ -1279,6 +1282,9 @@ namespace Google.Cloud.Asset.V1
     }
 
     /// <summary>AssetService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Asset service definition.
+    /// </remarks>
     public sealed partial class AssetServiceClientImpl : AssetServiceClient
     {
         private readonly gaxgrpc::ApiCall<ExportAssetsRequest, lro::Operation> _callExportAssets;

--- a/apis/Google.Cloud.Asset.V1/synth.metadata
+++ b/apis/Google.Cloud.Asset.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "49883ad9b196aa7b44869d24749104b504cafad0"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/AutoMlClient.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/AutoMlClient.g.cs
@@ -547,6 +547,22 @@ namespace Google.Cloud.AutoML.V1
     }
 
     /// <summary>AutoMl client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// AutoML Server API.
+    /// 
+    /// The resource names are assigned by the server.
+    /// The server never reuses names that it has created after the resources with
+    /// those names are deleted.
+    /// 
+    /// An ID of a resource is the last element of the item's resource name. For
+    /// `projects/{project_id}/locations/{location_id}/datasets/{dataset_id}`, then
+    /// the id for the item is `{dataset_id}`.
+    /// 
+    /// Currently the only supported `location_id` is "us-central1".
+    /// 
+    /// On any input that is documented to expect a string parameter in
+    /// snake_case or kebab-case, either of those cases is accepted.
+    /// </remarks>
     public abstract partial class AutoMlClient
     {
         /// <summary>
@@ -3310,6 +3326,22 @@ namespace Google.Cloud.AutoML.V1
     }
 
     /// <summary>AutoMl client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// AutoML Server API.
+    /// 
+    /// The resource names are assigned by the server.
+    /// The server never reuses names that it has created after the resources with
+    /// those names are deleted.
+    /// 
+    /// An ID of a resource is the last element of the item's resource name. For
+    /// `projects/{project_id}/locations/{location_id}/datasets/{dataset_id}`, then
+    /// the id for the item is `{dataset_id}`.
+    /// 
+    /// Currently the only supported `location_id` is "us-central1".
+    /// 
+    /// On any input that is documented to expect a string parameter in
+    /// snake_case or kebab-case, either of those cases is accepted.
+    /// </remarks>
     public sealed partial class AutoMlClientImpl : AutoMlClient
     {
         private readonly gaxgrpc::ApiCall<CreateDatasetRequest, lro::Operation> _callCreateDataset;

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/PredictionServiceClient.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/PredictionServiceClient.g.cs
@@ -158,6 +158,12 @@ namespace Google.Cloud.AutoML.V1
     }
 
     /// <summary>PredictionService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// AutoML Prediction API.
+    /// 
+    /// On any input that is documented to expect a string parameter in
+    /// snake_case or kebab-case, either of those cases is accepted.
+    /// </remarks>
     public abstract partial class PredictionServiceClient
     {
         /// <summary>
@@ -1731,6 +1737,12 @@ namespace Google.Cloud.AutoML.V1
     }
 
     /// <summary>PredictionService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// AutoML Prediction API.
+    /// 
+    /// On any input that is documented to expect a string parameter in
+    /// snake_case or kebab-case, either of those cases is accepted.
+    /// </remarks>
     public sealed partial class PredictionServiceClientImpl : PredictionServiceClient
     {
         private readonly gaxgrpc::ApiCall<PredictRequest, PredictResponse> _callPredict;

--- a/apis/Google.Cloud.AutoML.V1/synth.metadata
+++ b/apis/Google.Cloud.AutoML.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1/ConnectionServiceClient.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1/ConnectionServiceClient.g.cs
@@ -230,6 +230,9 @@ namespace Google.Cloud.BigQuery.Connection.V1
     }
 
     /// <summary>ConnectionService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Manages external data source connections and credentials.
+    /// </remarks>
     public abstract partial class ConnectionServiceClient
     {
         /// <summary>
@@ -1521,6 +1524,9 @@ namespace Google.Cloud.BigQuery.Connection.V1
     }
 
     /// <summary>ConnectionService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Manages external data source connections and credentials.
+    /// </remarks>
     public sealed partial class ConnectionServiceClientImpl : ConnectionServiceClient
     {
         private readonly gaxgrpc::ApiCall<CreateConnectionRequest, Connection> _callCreateConnection;

--- a/apis/Google.Cloud.BigQuery.Connection.V1/synth.metadata
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "163aa04ede887024d245ab2c6af2528d9460bb9c"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/DataTransferServiceClient.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/DataTransferServiceClient.g.cs
@@ -337,6 +337,12 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
     }
 
     /// <summary>DataTransferService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// The Google BigQuery Data Transfer Service API enables BigQuery users to
+    /// configure the transfer of their data from other Google Products into
+    /// BigQuery. This service contains methods that are end user exposed. It backs
+    /// up the frontend.
+    /// </remarks>
     public abstract partial class DataTransferServiceClient
     {
         /// <summary>
@@ -2319,6 +2325,12 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
     }
 
     /// <summary>DataTransferService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// The Google BigQuery Data Transfer Service API enables BigQuery users to
+    /// configure the transfer of their data from other Google Products into
+    /// BigQuery. This service contains methods that are end user exposed. It backs
+    /// up the frontend.
+    /// </remarks>
     public sealed partial class DataTransferServiceClientImpl : DataTransferServiceClient
     {
         private readonly gaxgrpc::ApiCall<GetDataSourceRequest, DataSource> _callGetDataSource;

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/synth.metadata
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1/ReservationServiceClient.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1/ReservationServiceClient.g.cs
@@ -405,6 +405,23 @@ namespace Google.Cloud.BigQuery.Reservation.V1
     }
 
     /// <summary>ReservationService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// This API allows users to manage their flat-rate BigQuery reservations.
+    /// 
+    /// A reservation provides computational resource guarantees, in the form of
+    /// [slots](https://cloud.google.com/bigquery/docs/slots), to users. A slot is a
+    /// unit of computational power in BigQuery, and serves as the basic unit of
+    /// parallelism. In a scan of a multi-partitioned table, a single slot operates
+    /// on a single partition of the table. A reservation resource exists as a child
+    /// resource of the admin project and location, e.g.:
+    /// `projects/myproject/locations/US/reservations/reservationName`.
+    /// 
+    /// A capacity commitment is a way to purchase compute capacity for BigQuery jobs
+    /// (in the form of slots) with some committed period of usage. A capacity
+    /// commitment resource exists as a child resource of the admin project and
+    /// location, e.g.:
+    /// `projects/myproject/locations/US/capacityCommitments/id`.
+    /// </remarks>
     public abstract partial class ReservationServiceClient
     {
         /// <summary>
@@ -3701,6 +3718,23 @@ namespace Google.Cloud.BigQuery.Reservation.V1
     }
 
     /// <summary>ReservationService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// This API allows users to manage their flat-rate BigQuery reservations.
+    /// 
+    /// A reservation provides computational resource guarantees, in the form of
+    /// [slots](https://cloud.google.com/bigquery/docs/slots), to users. A slot is a
+    /// unit of computational power in BigQuery, and serves as the basic unit of
+    /// parallelism. In a scan of a multi-partitioned table, a single slot operates
+    /// on a single partition of the table. A reservation resource exists as a child
+    /// resource of the admin project and location, e.g.:
+    /// `projects/myproject/locations/US/reservations/reservationName`.
+    /// 
+    /// A capacity commitment is a way to purchase compute capacity for BigQuery jobs
+    /// (in the form of slots) with some committed period of usage. A capacity
+    /// commitment resource exists as a child resource of the admin project and
+    /// location, e.g.:
+    /// `projects/myproject/locations/US/capacityCommitments/id`.
+    /// </remarks>
     public sealed partial class ReservationServiceClientImpl : ReservationServiceClient
     {
         private readonly gaxgrpc::ApiCall<CreateReservationRequest, Reservation> _callCreateReservation;

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/synth.metadata
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/BigQueryReadClient.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/BigQueryReadClient.g.cs
@@ -152,6 +152,11 @@ namespace Google.Cloud.BigQuery.Storage.V1
     }
 
     /// <summary>BigQueryRead client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// BigQuery Read API.
+    /// 
+    /// The Read API can be used to read data from BigQuery.
+    /// </remarks>
     public abstract partial class BigQueryReadClient
     {
         /// <summary>
@@ -727,6 +732,11 @@ namespace Google.Cloud.BigQuery.Storage.V1
     }
 
     /// <summary>BigQueryRead client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// BigQuery Read API.
+    /// 
+    /// The Read API can be used to read data from BigQuery.
+    /// </remarks>
     public sealed partial class BigQueryReadClientImpl : BigQueryReadClient
     {
         private readonly gaxgrpc::ApiCall<CreateReadSessionRequest, ReadSession> _callCreateReadSession;

--- a/apis/Google.Cloud.BigQuery.Storage.V1/synth.metadata
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/BigtableInstanceAdminClient.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/BigtableInstanceAdminClient.g.cs
@@ -506,6 +506,11 @@ namespace Google.Cloud.Bigtable.Admin.V2
     }
 
     /// <summary>BigtableInstanceAdmin client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Service for creating, configuring, and deleting Cloud Bigtable Instances and
+    /// Clusters. Provides access to the Instance and Cluster schemas only, not the
+    /// tables' metadata or data stored in those tables.
+    /// </remarks>
     public abstract partial class BigtableInstanceAdminClient
     {
         /// <summary>
@@ -3018,6 +3023,11 @@ namespace Google.Cloud.Bigtable.Admin.V2
     }
 
     /// <summary>BigtableInstanceAdmin client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Service for creating, configuring, and deleting Cloud Bigtable Instances and
+    /// Clusters. Provides access to the Instance and Cluster schemas only, not the
+    /// tables' metadata or data stored in those tables.
+    /// </remarks>
     public sealed partial class BigtableInstanceAdminClientImpl : BigtableInstanceAdminClient
     {
         private readonly gaxgrpc::ApiCall<CreateInstanceRequest, lro::Operation> _callCreateInstance;

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/BigtableTableAdminClient.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/BigtableTableAdminClient.g.cs
@@ -507,6 +507,13 @@ namespace Google.Cloud.Bigtable.Admin.V2
     }
 
     /// <summary>BigtableTableAdmin client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Service for creating, configuring, and deleting Cloud Bigtable tables.
+    /// 
+    /// 
+    /// Provides access to the table schemas only, not the data stored within
+    /// the tables.
+    /// </remarks>
     public abstract partial class BigtableTableAdminClient
     {
         /// <summary>
@@ -4014,6 +4021,13 @@ namespace Google.Cloud.Bigtable.Admin.V2
     }
 
     /// <summary>BigtableTableAdmin client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Service for creating, configuring, and deleting Cloud Bigtable tables.
+    /// 
+    /// 
+    /// Provides access to the table schemas only, not the data stored within
+    /// the tables.
+    /// </remarks>
     public sealed partial class BigtableTableAdminClientImpl : BigtableTableAdminClient
     {
         private readonly gaxgrpc::ApiCall<CreateTableRequest, Table> _callCreateTable;

--- a/apis/Google.Cloud.Bigtable.Admin.V2/synth.metadata
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableClient.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableClient.cs
@@ -33,6 +33,9 @@ using Google.Api.Gax;
 namespace Google.Cloud.Bigtable.V2
 {
     /// <summary>BigtableServiceApi client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Service for reading from and writing to existing Bigtable tables.
+    /// </remarks>
     public partial class BigtableClient
     {
         /// <summary>Streams back the contents of all requested rows in key order, optionally applying the same Reader filter to each.</summary>
@@ -270,6 +273,9 @@ namespace Google.Cloud.Bigtable.V2
     }
 
     /// <summary>BigtableServiceApi client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Service for reading from and writing to existing Bigtable tables.
+    /// </remarks>
     public sealed partial class BigtableClientImpl : BigtableClient
     {
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableServiceApiClient.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableServiceApiClient.g.cs
@@ -195,6 +195,9 @@ namespace Google.Cloud.Bigtable.V2
     }
 
     /// <summary>BigtableServiceApi client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Service for reading from and writing to existing Bigtable tables.
+    /// </remarks>
     public abstract partial class BigtableServiceApiClient
     {
         /// <summary>
@@ -2069,6 +2072,9 @@ namespace Google.Cloud.Bigtable.V2
     }
 
     /// <summary>BigtableServiceApi client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Service for reading from and writing to existing Bigtable tables.
+    /// </remarks>
     public sealed partial class BigtableServiceApiClientImpl : BigtableServiceApiClient
     {
         private readonly gaxgrpc::ApiServerStreamingCall<ReadRowsRequest, ReadRowsResponse> _callReadRows;

--- a/apis/Google.Cloud.Bigtable.V2/synth.metadata
+++ b/apis/Google.Cloud.Bigtable.V2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/CloudBillingClient.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/CloudBillingClient.g.cs
@@ -272,6 +272,9 @@ namespace Google.Cloud.Billing.V1
     }
 
     /// <summary>CloudBilling client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Retrieves GCP Console billing accounts and associates them with projects.
+    /// </remarks>
     public abstract partial class CloudBillingClient
     {
         /// <summary>
@@ -1838,6 +1841,9 @@ namespace Google.Cloud.Billing.V1
     }
 
     /// <summary>CloudBilling client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Retrieves GCP Console billing accounts and associates them with projects.
+    /// </remarks>
     public sealed partial class CloudBillingClientImpl : CloudBillingClient
     {
         private readonly gaxgrpc::ApiCall<GetBillingAccountRequest, BillingAccount> _callGetBillingAccount;

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/CloudCatalogClient.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/CloudCatalogClient.g.cs
@@ -138,6 +138,11 @@ namespace Google.Cloud.Billing.V1
     }
 
     /// <summary>CloudCatalog client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// A catalog of Google Cloud Platform services and SKUs.
+    /// Provides pricing information and metadata on Google Cloud Platform services
+    /// and SKUs.
+    /// </remarks>
     public abstract partial class CloudCatalogClient
     {
         /// <summary>
@@ -392,6 +397,11 @@ namespace Google.Cloud.Billing.V1
     }
 
     /// <summary>CloudCatalog client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// A catalog of Google Cloud Platform services and SKUs.
+    /// Provides pricing information and metadata on Google Cloud Platform services
+    /// and SKUs.
+    /// </remarks>
     public sealed partial class CloudCatalogClientImpl : CloudCatalogClient
     {
         private readonly gaxgrpc::ApiCall<ListServicesRequest, ListServicesResponse> _callListServices;

--- a/apis/Google.Cloud.Billing.V1/synth.metadata
+++ b/apis/Google.Cloud.Billing.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "5920d376e8771e7dd245a0d1d0341952ca15e41d"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/ClusterManagerClient.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/ClusterManagerClient.g.cs
@@ -548,6 +548,9 @@ namespace Google.Cloud.Container.V1
     }
 
     /// <summary>ClusterManager client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Google Kubernetes Engine Cluster Manager v1
+    /// </remarks>
     public abstract partial class ClusterManagerClient
     {
         /// <summary>
@@ -4912,6 +4915,9 @@ namespace Google.Cloud.Container.V1
     }
 
     /// <summary>ClusterManager client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Google Kubernetes Engine Cluster Manager v1
+    /// </remarks>
     public sealed partial class ClusterManagerClientImpl : ClusterManagerClient
     {
         private readonly gaxgrpc::ApiCall<ListClustersRequest, ListClustersResponse> _callListClusters;

--- a/apis/Google.Cloud.Container.V1/synth.metadata
+++ b/apis/Google.Cloud.Container.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/DataCatalogClient.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/DataCatalogClient.g.cs
@@ -490,6 +490,10 @@ namespace Google.Cloud.DataCatalog.V1
     }
 
     /// <summary>DataCatalog client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Data Catalog API service allows clients to discover, understand, and manage
+    /// their data.
+    /// </remarks>
     public abstract partial class DataCatalogClient
     {
         /// <summary>
@@ -5534,6 +5538,10 @@ namespace Google.Cloud.DataCatalog.V1
     }
 
     /// <summary>DataCatalog client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Data Catalog API service allows clients to discover, understand, and manage
+    /// their data.
+    /// </remarks>
     public sealed partial class DataCatalogClientImpl : DataCatalogClient
     {
         private readonly gaxgrpc::ApiCall<SearchCatalogRequest, SearchCatalogResponse> _callSearchCatalog;

--- a/apis/Google.Cloud.DataCatalog.V1/synth.metadata
+++ b/apis/Google.Cloud.DataCatalog.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/AutoscalingPolicyServiceClient.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/AutoscalingPolicyServiceClient.g.cs
@@ -196,6 +196,10 @@ namespace Google.Cloud.Dataproc.V1
     }
 
     /// <summary>AutoscalingPolicyService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// The API interface for managing autoscaling policies in the
+    /// Dataproc API.
+    /// </remarks>
     public abstract partial class AutoscalingPolicyServiceClient
     {
         /// <summary>
@@ -1162,6 +1166,10 @@ namespace Google.Cloud.Dataproc.V1
     }
 
     /// <summary>AutoscalingPolicyService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// The API interface for managing autoscaling policies in the
+    /// Dataproc API.
+    /// </remarks>
     public sealed partial class AutoscalingPolicyServiceClientImpl : AutoscalingPolicyServiceClient
     {
         private readonly gaxgrpc::ApiCall<CreateAutoscalingPolicyRequest, AutoscalingPolicy> _callCreateAutoscalingPolicy;

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/ClusterControllerClient.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/ClusterControllerClient.g.cs
@@ -287,6 +287,10 @@ namespace Google.Cloud.Dataproc.V1
     }
 
     /// <summary>ClusterController client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// The ClusterControllerService provides methods to manage clusters
+    /// of Compute Engine instances.
+    /// </remarks>
     public abstract partial class ClusterControllerClient
     {
         /// <summary>
@@ -1346,6 +1350,10 @@ namespace Google.Cloud.Dataproc.V1
     }
 
     /// <summary>ClusterController client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// The ClusterControllerService provides methods to manage clusters
+    /// of Compute Engine instances.
+    /// </remarks>
     public sealed partial class ClusterControllerClientImpl : ClusterControllerClient
     {
         private readonly gaxgrpc::ApiCall<CreateClusterRequest, lro::Operation> _callCreateCluster;

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/JobControllerClient.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/JobControllerClient.g.cs
@@ -246,6 +246,9 @@ namespace Google.Cloud.Dataproc.V1
     }
 
     /// <summary>JobController client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// The JobController provides methods to manage jobs.
+    /// </remarks>
     public abstract partial class JobControllerClient
     {
         /// <summary>
@@ -1031,6 +1034,9 @@ namespace Google.Cloud.Dataproc.V1
     }
 
     /// <summary>JobController client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// The JobController provides methods to manage jobs.
+    /// </remarks>
     public sealed partial class JobControllerClientImpl : JobControllerClient
     {
         private readonly gaxgrpc::ApiCall<SubmitJobRequest, Job> _callSubmitJob;

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/WorkflowTemplateServiceClient.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/WorkflowTemplateServiceClient.g.cs
@@ -276,6 +276,10 @@ namespace Google.Cloud.Dataproc.V1
     }
 
     /// <summary>WorkflowTemplateService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// The API interface for managing Workflow Templates in the
+    /// Dataproc API.
+    /// </remarks>
     public abstract partial class WorkflowTemplateServiceClient
     {
         /// <summary>
@@ -2458,6 +2462,10 @@ namespace Google.Cloud.Dataproc.V1
     }
 
     /// <summary>WorkflowTemplateService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// The API interface for managing Workflow Templates in the
+    /// Dataproc API.
+    /// </remarks>
     public sealed partial class WorkflowTemplateServiceClientImpl : WorkflowTemplateServiceClient
     {
         private readonly gaxgrpc::ApiCall<CreateWorkflowTemplateRequest, WorkflowTemplate> _callCreateWorkflowTemplate;

--- a/apis/Google.Cloud.Dataproc.V1/synth.metadata
+++ b/apis/Google.Cloud.Dataproc.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreClient.g.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreClient.g.cs
@@ -212,6 +212,14 @@ namespace Google.Cloud.Datastore.V1
     }
 
     /// <summary>Datastore client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Each RPC normalizes the partition IDs of the keys in its input entities,
+    /// and always returns entities with keys with normalized partition IDs.
+    /// This applies to all keys and entities, including those in values, except keys
+    /// with both an empty path and an empty or unset partition ID. Normalization of
+    /// input keys sets the project ID (if not already set) to the project ID from
+    /// the request.
+    /// </remarks>
     public abstract partial class DatastoreClient
     {
         /// <summary>
@@ -1002,6 +1010,14 @@ namespace Google.Cloud.Datastore.V1
     }
 
     /// <summary>Datastore client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Each RPC normalizes the partition IDs of the keys in its input entities,
+    /// and always returns entities with keys with normalized partition IDs.
+    /// This applies to all keys and entities, including those in values, except keys
+    /// with both an empty path and an empty or unset partition ID. Normalization of
+    /// input keys sets the project ID (if not already set) to the project ID from
+    /// the request.
+    /// </remarks>
     public sealed partial class DatastoreClientImpl : DatastoreClient
     {
         private readonly gaxgrpc::ApiCall<LookupRequest, LookupResponse> _callLookup;

--- a/apis/Google.Cloud.Datastore.V1/synth.metadata
+++ b/apis/Google.Cloud.Datastore.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2/Controller2Client.g.cs
+++ b/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2/Controller2Client.g.cs
@@ -156,6 +156,28 @@ namespace Google.Cloud.Debugger.V2
     }
 
     /// <summary>Controller2 client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// The Controller service provides the API for orchestrating a collection of
+    /// debugger agents to perform debugging tasks. These agents are each attached
+    /// to a process of an application which may include one or more replicas.
+    /// 
+    /// The debugger agents register with the Controller to identify the application
+    /// being debugged, the Debuggee. All agents that register with the same data,
+    /// represent the same Debuggee, and are assigned the same `debuggee_id`.
+    /// 
+    /// The debugger agents call the Controller to retrieve  the list of active
+    /// Breakpoints. Agents with the same `debuggee_id` get the same breakpoints
+    /// list. An agent that can fulfill the breakpoint request updates the
+    /// Controller with the breakpoint result. The controller selects the first
+    /// result received and discards the rest of the results.
+    /// Agents that poll again for active breakpoints will no longer have
+    /// the completed breakpoint in the list and should remove that breakpoint from
+    /// their attached process.
+    /// 
+    /// The Controller service does not provide a way to retrieve the results of
+    /// a completed breakpoint. This functionality is available using the Debugger
+    /// service.
+    /// </remarks>
     public abstract partial class Controller2Client
     {
         /// <summary>
@@ -625,6 +647,28 @@ namespace Google.Cloud.Debugger.V2
     }
 
     /// <summary>Controller2 client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// The Controller service provides the API for orchestrating a collection of
+    /// debugger agents to perform debugging tasks. These agents are each attached
+    /// to a process of an application which may include one or more replicas.
+    /// 
+    /// The debugger agents register with the Controller to identify the application
+    /// being debugged, the Debuggee. All agents that register with the same data,
+    /// represent the same Debuggee, and are assigned the same `debuggee_id`.
+    /// 
+    /// The debugger agents call the Controller to retrieve  the list of active
+    /// Breakpoints. Agents with the same `debuggee_id` get the same breakpoints
+    /// list. An agent that can fulfill the breakpoint request updates the
+    /// Controller with the breakpoint result. The controller selects the first
+    /// result received and discards the rest of the results.
+    /// Agents that poll again for active breakpoints will no longer have
+    /// the completed breakpoint in the list and should remove that breakpoint from
+    /// their attached process.
+    /// 
+    /// The Controller service does not provide a way to retrieve the results of
+    /// a completed breakpoint. This functionality is available using the Debugger
+    /// service.
+    /// </remarks>
     public sealed partial class Controller2ClientImpl : Controller2Client
     {
         private readonly gaxgrpc::ApiCall<RegisterDebuggeeRequest, RegisterDebuggeeResponse> _callRegisterDebuggee;

--- a/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2/Debugger2Client.g.cs
+++ b/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2/Debugger2Client.g.cs
@@ -189,6 +189,20 @@ namespace Google.Cloud.Debugger.V2
     }
 
     /// <summary>Debugger2 client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// The Debugger service provides the API that allows users to collect run-time
+    /// information from a running application, without stopping or slowing it down
+    /// and without modifying its state.  An application may include one or
+    /// more replicated processes performing the same work.
+    /// 
+    /// A debugged application is represented using the Debuggee concept. The
+    /// Debugger service provides a way to query for available debuggees, but does
+    /// not provide a way to create one.  A debuggee is created using the Controller
+    /// service, usually by running a debugger agent with the application.
+    /// 
+    /// The Debugger service enables the client to set one or more Breakpoints on a
+    /// Debuggee and collect the results of the set Breakpoints.
+    /// </remarks>
     public abstract partial class Debugger2Client
     {
         /// <summary>
@@ -705,6 +719,20 @@ namespace Google.Cloud.Debugger.V2
     }
 
     /// <summary>Debugger2 client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// The Debugger service provides the API that allows users to collect run-time
+    /// information from a running application, without stopping or slowing it down
+    /// and without modifying its state.  An application may include one or
+    /// more replicated processes performing the same work.
+    /// 
+    /// A debugged application is represented using the Debuggee concept. The
+    /// Debugger service provides a way to query for available debuggees, but does
+    /// not provide a way to create one.  A debuggee is created using the Controller
+    /// service, usually by running a debugger agent with the application.
+    /// 
+    /// The Debugger service enables the client to set one or more Breakpoints on a
+    /// Debuggee and collect the results of the set Breakpoints.
+    /// </remarks>
     public sealed partial class Debugger2ClientImpl : Debugger2Client
     {
         private readonly gaxgrpc::ApiCall<SetBreakpointRequest, SetBreakpointResponse> _callSetBreakpoint;

--- a/apis/Google.Cloud.Debugger.V2/synth.metadata
+++ b/apis/Google.Cloud.Debugger.V2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1/ContainerAnalysisClient.g.cs
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1/ContainerAnalysisClient.g.cs
@@ -153,6 +153,21 @@ namespace Google.Cloud.DevTools.ContainerAnalysis.V1
     }
 
     /// <summary>ContainerAnalysis client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Retrieves analysis results of Cloud components such as Docker container
+    /// images. The Container Analysis API is an implementation of the
+    /// [Grafeas](https://grafeas.io) API.
+    /// 
+    /// Analysis results are stored as a series of occurrences. An `Occurrence`
+    /// contains information about a specific analysis instance on a resource. An
+    /// occurrence refers to a `Note`. A note contains details describing the
+    /// analysis and is generally stored in a separate project, called a `Provider`.
+    /// Multiple occurrences can refer to the same note.
+    /// 
+    /// For example, an SSL vulnerability could affect multiple images. In this case,
+    /// there would be one note for the vulnerability and an occurrence for each
+    /// image with the vulnerability referring to that note.
+    /// </remarks>
     public abstract partial class ContainerAnalysisClient
     {
         /// <summary>
@@ -836,6 +851,21 @@ namespace Google.Cloud.DevTools.ContainerAnalysis.V1
     }
 
     /// <summary>ContainerAnalysis client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Retrieves analysis results of Cloud components such as Docker container
+    /// images. The Container Analysis API is an implementation of the
+    /// [Grafeas](https://grafeas.io) API.
+    /// 
+    /// Analysis results are stored as a series of occurrences. An `Occurrence`
+    /// contains information about a specific analysis instance on a resource. An
+    /// occurrence refers to a `Note`. A note contains details describing the
+    /// analysis and is generally stored in a separate project, called a `Provider`.
+    /// Multiple occurrences can refer to the same note.
+    /// 
+    /// For example, an SSL vulnerability could affect multiple images. In this case,
+    /// there would be one note for the vulnerability and an occurrence for each
+    /// image with the vulnerability referring to that note.
+    /// </remarks>
     public sealed partial class ContainerAnalysisClientImpl : ContainerAnalysisClient
     {
         private readonly gaxgrpc::ApiCall<gciv::SetIamPolicyRequest, gciv::Policy> _callSetIamPolicy;

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/synth.metadata
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/AgentsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/AgentsClient.g.cs
@@ -335,6 +335,9 @@ namespace Google.Cloud.Dialogflow.V2
     }
 
     /// <summary>Agents client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Service for managing [Agents][google.cloud.dialogflow.v2.Agent].
+    /// </remarks>
     public abstract partial class AgentsClient
     {
         /// <summary>
@@ -1372,6 +1375,9 @@ namespace Google.Cloud.Dialogflow.V2
     }
 
     /// <summary>Agents client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Service for managing [Agents][google.cloud.dialogflow.v2.Agent].
+    /// </remarks>
     public sealed partial class AgentsClientImpl : AgentsClient
     {
         private readonly gaxgrpc::ApiCall<GetAgentRequest, Agent> _callGetAgent;

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ContextsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ContextsClient.g.cs
@@ -209,6 +209,26 @@ namespace Google.Cloud.Dialogflow.V2
     }
 
     /// <summary>Contexts client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// A context represents additional information included with user input or with
+    /// an intent returned by the Dialogflow API. Contexts are helpful for
+    /// differentiating user input which may be vague or have a different meaning
+    /// depending on additional details from your application such as user setting
+    /// and preferences, previous user input, where the user is in your application,
+    /// geographic location, and so on.
+    /// 
+    /// You can include contexts as input parameters of a
+    /// [DetectIntent][google.cloud.dialogflow.v2.Sessions.DetectIntent] (or
+    /// [StreamingDetectIntent][google.cloud.dialogflow.v2.Sessions.StreamingDetectIntent]) request,
+    /// or as output contexts included in the returned intent.
+    /// Contexts expire when an intent is matched, after the number of `DetectIntent`
+    /// requests specified by the `lifespan_count` parameter, or after 20 minutes
+    /// if no intents are matched for a `DetectIntent` request.
+    /// 
+    /// For more information about contexts, see the
+    /// [Dialogflow
+    /// documentation](https://cloud.google.com/dialogflow/docs/contexts-overview).
+    /// </remarks>
     public abstract partial class ContextsClient
     {
         /// <summary>
@@ -1080,6 +1100,26 @@ namespace Google.Cloud.Dialogflow.V2
     }
 
     /// <summary>Contexts client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// A context represents additional information included with user input or with
+    /// an intent returned by the Dialogflow API. Contexts are helpful for
+    /// differentiating user input which may be vague or have a different meaning
+    /// depending on additional details from your application such as user setting
+    /// and preferences, previous user input, where the user is in your application,
+    /// geographic location, and so on.
+    /// 
+    /// You can include contexts as input parameters of a
+    /// [DetectIntent][google.cloud.dialogflow.v2.Sessions.DetectIntent] (or
+    /// [StreamingDetectIntent][google.cloud.dialogflow.v2.Sessions.StreamingDetectIntent]) request,
+    /// or as output contexts included in the returned intent.
+    /// Contexts expire when an intent is matched, after the number of `DetectIntent`
+    /// requests specified by the `lifespan_count` parameter, or after 20 minutes
+    /// if no intents are matched for a `DetectIntent` request.
+    /// 
+    /// For more information about contexts, see the
+    /// [Dialogflow
+    /// documentation](https://cloud.google.com/dialogflow/docs/contexts-overview).
+    /// </remarks>
     public sealed partial class ContextsClientImpl : ContextsClient
     {
         private readonly gaxgrpc::ApiCall<ListContextsRequest, ListContextsResponse> _callListContexts;

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/EntityTypesClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/EntityTypesClient.g.cs
@@ -369,6 +369,36 @@ namespace Google.Cloud.Dialogflow.V2
     }
 
     /// <summary>EntityTypes client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Entities are extracted from user input and represent parameters that are
+    /// meaningful to your application. For example, a date range, a proper name
+    /// such as a geographic location or landmark, and so on. Entities represent
+    /// actionable data for your application.
+    /// 
+    /// When you define an entity, you can also include synonyms that all map to
+    /// that entity. For example, "soft drink", "soda", "pop", and so on.
+    /// 
+    /// There are three types of entities:
+    /// 
+    /// *   **System** - entities that are defined by the Dialogflow API for common
+    /// data types such as date, time, currency, and so on. A system entity is
+    /// represented by the `EntityType` type.
+    /// 
+    /// *   **Custom** - entities that are defined by you that represent
+    /// actionable data that is meaningful to your application. For example,
+    /// you could define a `pizza.sauce` entity for red or white pizza sauce,
+    /// a `pizza.cheese` entity for the different types of cheese on a pizza,
+    /// a `pizza.topping` entity for different toppings, and so on. A custom
+    /// entity is represented by the `EntityType` type.
+    /// 
+    /// *   **User** - entities that are built for an individual user such as
+    /// favorites, preferences, playlists, and so on. A user entity is
+    /// represented by the [SessionEntityType][google.cloud.dialogflow.v2.SessionEntityType] type.
+    /// 
+    /// For more information about entity types, see the
+    /// [Dialogflow
+    /// documentation](https://cloud.google.com/dialogflow/docs/entities-overview).
+    /// </remarks>
     public abstract partial class EntityTypesClient
     {
         /// <summary>
@@ -2902,6 +2932,36 @@ namespace Google.Cloud.Dialogflow.V2
     }
 
     /// <summary>EntityTypes client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Entities are extracted from user input and represent parameters that are
+    /// meaningful to your application. For example, a date range, a proper name
+    /// such as a geographic location or landmark, and so on. Entities represent
+    /// actionable data for your application.
+    /// 
+    /// When you define an entity, you can also include synonyms that all map to
+    /// that entity. For example, "soft drink", "soda", "pop", and so on.
+    /// 
+    /// There are three types of entities:
+    /// 
+    /// *   **System** - entities that are defined by the Dialogflow API for common
+    /// data types such as date, time, currency, and so on. A system entity is
+    /// represented by the `EntityType` type.
+    /// 
+    /// *   **Custom** - entities that are defined by you that represent
+    /// actionable data that is meaningful to your application. For example,
+    /// you could define a `pizza.sauce` entity for red or white pizza sauce,
+    /// a `pizza.cheese` entity for the different types of cheese on a pizza,
+    /// a `pizza.topping` entity for different toppings, and so on. A custom
+    /// entity is represented by the `EntityType` type.
+    /// 
+    /// *   **User** - entities that are built for an individual user such as
+    /// favorites, preferences, playlists, and so on. A user entity is
+    /// represented by the [SessionEntityType][google.cloud.dialogflow.v2.SessionEntityType] type.
+    /// 
+    /// For more information about entity types, see the
+    /// [Dialogflow
+    /// documentation](https://cloud.google.com/dialogflow/docs/entities-overview).
+    /// </remarks>
     public sealed partial class EntityTypesClientImpl : EntityTypesClient
     {
         private readonly gaxgrpc::ApiCall<ListEntityTypesRequest, ListEntityTypesResponse> _callListEntityTypes;

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/EnvironmentsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/EnvironmentsClient.g.cs
@@ -128,6 +128,9 @@ namespace Google.Cloud.Dialogflow.V2
     }
 
     /// <summary>Environments client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Manages agent environments.
+    /// </remarks>
     public abstract partial class EnvironmentsClient
     {
         /// <summary>
@@ -226,6 +229,9 @@ namespace Google.Cloud.Dialogflow.V2
     }
 
     /// <summary>Environments client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Manages agent environments.
+    /// </remarks>
     public sealed partial class EnvironmentsClientImpl : EnvironmentsClient
     {
         private readonly gaxgrpc::ApiCall<ListEnvironmentsRequest, ListEnvironmentsResponse> _callListEnvironments;

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/IntentsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/IntentsClient.g.cs
@@ -264,6 +264,40 @@ namespace Google.Cloud.Dialogflow.V2
     }
 
     /// <summary>Intents client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// An intent represents a mapping between input from a user and an action to
+    /// be taken by your application. When you pass user input to the
+    /// [DetectIntent][google.cloud.dialogflow.v2.Sessions.DetectIntent] (or
+    /// [StreamingDetectIntent][google.cloud.dialogflow.v2.Sessions.StreamingDetectIntent]) method, the
+    /// Dialogflow API analyzes the input and searches
+    /// for a matching intent. If no match is found, the Dialogflow API returns a
+    /// fallback intent (`is_fallback` = true).
+    /// 
+    /// You can provide additional information for the Dialogflow API to use to
+    /// match user input to an intent by adding the following to your intent.
+    /// 
+    /// *   **Contexts** - provide additional context for intent analysis. For
+    /// example, if an intent is related to an object in your application that
+    /// plays music, you can provide a context to determine when to match the
+    /// intent if the user input is "turn it off". You can include a context
+    /// that matches the intent when there is previous user input of
+    /// "play music", and not when there is previous user input of
+    /// "turn on the light".
+    /// 
+    /// *   **Events** - allow for matching an intent by using an event name
+    /// instead of user input. Your application can provide an event name and
+    /// related parameters to the Dialogflow API to match an intent. For
+    /// example, when your application starts, you can send a welcome event
+    /// with a user name parameter to the Dialogflow API to match an intent with
+    /// a personalized welcome message for the user.
+    /// 
+    /// *   **Training phrases** - provide examples of user input to train the
+    /// Dialogflow API agent to better match intents.
+    /// 
+    /// For more information about intents, see the
+    /// [Dialogflow
+    /// documentation](https://cloud.google.com/dialogflow/docs/intents-overview).
+    /// </remarks>
     public abstract partial class IntentsClient
     {
         /// <summary>
@@ -1903,6 +1937,40 @@ namespace Google.Cloud.Dialogflow.V2
     }
 
     /// <summary>Intents client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// An intent represents a mapping between input from a user and an action to
+    /// be taken by your application. When you pass user input to the
+    /// [DetectIntent][google.cloud.dialogflow.v2.Sessions.DetectIntent] (or
+    /// [StreamingDetectIntent][google.cloud.dialogflow.v2.Sessions.StreamingDetectIntent]) method, the
+    /// Dialogflow API analyzes the input and searches
+    /// for a matching intent. If no match is found, the Dialogflow API returns a
+    /// fallback intent (`is_fallback` = true).
+    /// 
+    /// You can provide additional information for the Dialogflow API to use to
+    /// match user input to an intent by adding the following to your intent.
+    /// 
+    /// *   **Contexts** - provide additional context for intent analysis. For
+    /// example, if an intent is related to an object in your application that
+    /// plays music, you can provide a context to determine when to match the
+    /// intent if the user input is "turn it off". You can include a context
+    /// that matches the intent when there is previous user input of
+    /// "play music", and not when there is previous user input of
+    /// "turn on the light".
+    /// 
+    /// *   **Events** - allow for matching an intent by using an event name
+    /// instead of user input. Your application can provide an event name and
+    /// related parameters to the Dialogflow API to match an intent. For
+    /// example, when your application starts, you can send a welcome event
+    /// with a user name parameter to the Dialogflow API to match an intent with
+    /// a personalized welcome message for the user.
+    /// 
+    /// *   **Training phrases** - provide examples of user input to train the
+    /// Dialogflow API agent to better match intents.
+    /// 
+    /// For more information about intents, see the
+    /// [Dialogflow
+    /// documentation](https://cloud.google.com/dialogflow/docs/intents-overview).
+    /// </remarks>
     public sealed partial class IntentsClientImpl : IntentsClient
     {
         private readonly gaxgrpc::ApiCall<ListIntentsRequest, ListIntentsResponse> _callListIntents;

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/SessionEntityTypesClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/SessionEntityTypesClient.g.cs
@@ -199,6 +199,25 @@ namespace Google.Cloud.Dialogflow.V2
     }
 
     /// <summary>SessionEntityTypes client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Entities are extracted from user input and represent parameters that are
+    /// meaningful to your application. For example, a date range, a proper name
+    /// such as a geographic location or landmark, and so on. Entities represent
+    /// actionable data for your application.
+    /// 
+    /// Session entity types are referred to as **User** entity types and are
+    /// entities that are built for an individual user such as
+    /// favorites, preferences, playlists, and so on. You can redefine a session
+    /// entity type at the session level.
+    /// 
+    /// Session entity methods do not work with Google Assistant integration.
+    /// Contact Dialogflow support if you need to use session entities
+    /// with Google Assistant integration.
+    /// 
+    /// For more information about entity types, see the
+    /// [Dialogflow
+    /// documentation](https://cloud.google.com/dialogflow/docs/entities-overview).
+    /// </remarks>
     public abstract partial class SessionEntityTypesClient
     {
         /// <summary>
@@ -1166,6 +1185,25 @@ namespace Google.Cloud.Dialogflow.V2
     }
 
     /// <summary>SessionEntityTypes client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Entities are extracted from user input and represent parameters that are
+    /// meaningful to your application. For example, a date range, a proper name
+    /// such as a geographic location or landmark, and so on. Entities represent
+    /// actionable data for your application.
+    /// 
+    /// Session entity types are referred to as **User** entity types and are
+    /// entities that are built for an individual user such as
+    /// favorites, preferences, playlists, and so on. You can redefine a session
+    /// entity type at the session level.
+    /// 
+    /// Session entity methods do not work with Google Assistant integration.
+    /// Contact Dialogflow support if you need to use session entities
+    /// with Google Assistant integration.
+    /// 
+    /// For more information about entity types, see the
+    /// [Dialogflow
+    /// documentation](https://cloud.google.com/dialogflow/docs/entities-overview).
+    /// </remarks>
     public sealed partial class SessionEntityTypesClientImpl : SessionEntityTypesClient
     {
         private readonly gaxgrpc::ApiCall<ListSessionEntityTypesRequest, ListSessionEntityTypesResponse> _callListSessionEntityTypes;

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/SessionsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/SessionsClient.g.cs
@@ -148,6 +148,12 @@ namespace Google.Cloud.Dialogflow.V2
     }
 
     /// <summary>Sessions client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// A session represents an interaction with a user. You retrieve user input
+    /// and pass it to the [DetectIntent][google.cloud.dialogflow.v2.Sessions.DetectIntent] (or
+    /// [StreamingDetectIntent][google.cloud.dialogflow.v2.Sessions.StreamingDetectIntent]) method to determine
+    /// user intent and respond.
+    /// </remarks>
     public abstract partial class SessionsClient
     {
         /// <summary>
@@ -491,6 +497,12 @@ namespace Google.Cloud.Dialogflow.V2
     }
 
     /// <summary>Sessions client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// A session represents an interaction with a user. You retrieve user input
+    /// and pass it to the [DetectIntent][google.cloud.dialogflow.v2.Sessions.DetectIntent] (or
+    /// [StreamingDetectIntent][google.cloud.dialogflow.v2.Sessions.StreamingDetectIntent]) method to determine
+    /// user intent and respond.
+    /// </remarks>
     public sealed partial class SessionsClientImpl : SessionsClient
     {
         private readonly gaxgrpc::ApiCall<DetectIntentRequest, DetectIntentResponse> _callDetectIntent;

--- a/apis/Google.Cloud.Dialogflow.V2/synth.metadata
+++ b/apis/Google.Cloud.Dialogflow.V2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "4e8f1142ff921de8d5ad757bce9f2c09dab6ff1b"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/DlpServiceClient.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/DlpServiceClient.g.cs
@@ -625,6 +625,17 @@ namespace Google.Cloud.Dlp.V2
     }
 
     /// <summary>DlpService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// The Cloud Data Loss Prevention (DLP) API is a service that allows clients
+    /// to detect the presence of Personally Identifiable Information (PII) and other
+    /// privacy-sensitive data in user-supplied, unstructured data streams, like text
+    /// blocks or images.
+    /// The service also includes methods for sensitive data redaction and
+    /// scheduling of data scans on Google Cloud Platform based data sets.
+    /// 
+    /// To learn more about concepts and find how-to guides see
+    /// https://cloud.google.com/dlp/docs/.
+    /// </remarks>
     public abstract partial class DlpServiceClient
     {
         /// <summary>
@@ -5998,6 +6009,17 @@ namespace Google.Cloud.Dlp.V2
     }
 
     /// <summary>DlpService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// The Cloud Data Loss Prevention (DLP) API is a service that allows clients
+    /// to detect the presence of Personally Identifiable Information (PII) and other
+    /// privacy-sensitive data in user-supplied, unstructured data streams, like text
+    /// blocks or images.
+    /// The service also includes methods for sensitive data redaction and
+    /// scheduling of data scans on Google Cloud Platform based data sets.
+    /// 
+    /// To learn more about concepts and find how-to guides see
+    /// https://cloud.google.com/dlp/docs/.
+    /// </remarks>
     public sealed partial class DlpServiceClientImpl : DlpServiceClient
     {
         private readonly gaxgrpc::ApiCall<InspectContentRequest, InspectContentResponse> _callInspectContent;

--- a/apis/Google.Cloud.Dlp.V2/synth.metadata
+++ b/apis/Google.Cloud.Dlp.V2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.DocumentAI.V1Beta2/Google.Cloud.DocumentAI.V1Beta2/DocumentUnderstandingServiceClient.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta2/Google.Cloud.DocumentAI.V1Beta2/DocumentUnderstandingServiceClient.g.cs
@@ -168,6 +168,11 @@ namespace Google.Cloud.DocumentAI.V1Beta2
     }
 
     /// <summary>DocumentUnderstandingService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Service to parse structured information from unstructured or semi-structured
+    /// documents using state-of-the-art Google AI such as natural language,
+    /// computer vision, and translation.
+    /// </remarks>
     public abstract partial class DocumentUnderstandingServiceClient
     {
         /// <summary>
@@ -381,6 +386,11 @@ namespace Google.Cloud.DocumentAI.V1Beta2
     }
 
     /// <summary>DocumentUnderstandingService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Service to parse structured information from unstructured or semi-structured
+    /// documents using state-of-the-art Google AI such as natural language,
+    /// computer vision, and translation.
+    /// </remarks>
     public sealed partial class DocumentUnderstandingServiceClientImpl : DocumentUnderstandingServiceClient
     {
         private readonly gaxgrpc::ApiCall<BatchProcessDocumentsRequest, lro::Operation> _callBatchProcessDocuments;

--- a/apis/Google.Cloud.DocumentAI.V1Beta2/synth.metadata
+++ b/apis/Google.Cloud.DocumentAI.V1Beta2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "519265ce99de513ee6f1b7e8d6f23ecd7c4d83cf"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ErrorGroupServiceClient.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ErrorGroupServiceClient.g.cs
@@ -144,6 +144,9 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
     }
 
     /// <summary>ErrorGroupService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Service for retrieving and updating individual error groups.
+    /// </remarks>
     public abstract partial class ErrorGroupServiceClient
     {
         /// <summary>
@@ -429,6 +432,9 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
     }
 
     /// <summary>ErrorGroupService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Service for retrieving and updating individual error groups.
+    /// </remarks>
     public sealed partial class ErrorGroupServiceClientImpl : ErrorGroupServiceClient
     {
         private readonly gaxgrpc::ApiCall<GetGroupRequest, ErrorGroup> _callGetGroup;

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ErrorStatsServiceClient.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ErrorStatsServiceClient.g.cs
@@ -162,6 +162,10 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
     }
 
     /// <summary>ErrorStatsService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// An API for retrieving and managing error statistics as well as data for
+    /// individual events.
+    /// </remarks>
     public abstract partial class ErrorStatsServiceClient
     {
         /// <summary>
@@ -693,6 +697,10 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
     }
 
     /// <summary>ErrorStatsService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// An API for retrieving and managing error statistics as well as data for
+    /// individual events.
+    /// </remarks>
     public sealed partial class ErrorStatsServiceClientImpl : ErrorStatsServiceClient
     {
         private readonly gaxgrpc::ApiCall<ListGroupStatsRequest, ListGroupStatsResponse> _callListGroupStats;

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ReportErrorsServiceClient.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ReportErrorsServiceClient.g.cs
@@ -127,6 +127,9 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
     }
 
     /// <summary>ReportErrorsService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// An API for reporting error events.
+    /// </remarks>
     public abstract partial class ReportErrorsServiceClient
     {
         /// <summary>
@@ -431,6 +434,9 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
     }
 
     /// <summary>ReportErrorsService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// An API for reporting error events.
+    /// </remarks>
     public sealed partial class ReportErrorsServiceClientImpl : ReportErrorsServiceClient
     {
         private readonly gaxgrpc::ApiCall<ReportErrorEventRequest, ReportErrorEventResponse> _callReportErrorEvent;

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/FirestoreAdminClient.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/FirestoreAdminClient.g.cs
@@ -323,6 +323,10 @@ namespace Google.Cloud.Firestore.Admin.V1
     }
 
     /// <summary>FirestoreAdmin client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Operations are created by service `FirestoreAdmin`, but are accessed via
+    /// service `google.longrunning.Operations`.
+    /// </remarks>
     public abstract partial class FirestoreAdminClient
     {
         /// <summary>
@@ -1716,6 +1720,10 @@ namespace Google.Cloud.Firestore.Admin.V1
     }
 
     /// <summary>FirestoreAdmin client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Operations are created by service `FirestoreAdmin`, but are accessed via
+    /// service `google.longrunning.Operations`.
+    /// </remarks>
     public sealed partial class FirestoreAdminClientImpl : FirestoreAdminClient
     {
         private readonly gaxgrpc::ApiCall<CreateIndexRequest, lro::Operation> _callCreateIndex;

--- a/apis/Google.Cloud.Firestore.Admin.V1/synth.metadata
+++ b/apis/Google.Cloud.Firestore.Admin.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/FirestoreClient.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/FirestoreClient.g.cs
@@ -340,6 +340,16 @@ namespace Google.Cloud.Firestore.V1
     }
 
     /// <summary>Firestore client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// The Cloud Firestore service.
+    /// 
+    /// Cloud Firestore is a fast, fully managed, serverless, cloud-native NoSQL
+    /// document database that simplifies storing, syncing, and querying data for
+    /// your mobile, web, and IoT apps at global scale. Its client libraries provide
+    /// live synchronization and offline support, while its security features and
+    /// integrations with Firebase and Google Cloud Platform (GCP) accelerate
+    /// building truly serverless apps.
+    /// </remarks>
     public abstract partial class FirestoreClient
     {
         /// <summary>
@@ -1115,6 +1125,16 @@ namespace Google.Cloud.Firestore.V1
     }
 
     /// <summary>Firestore client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// The Cloud Firestore service.
+    /// 
+    /// Cloud Firestore is a fast, fully managed, serverless, cloud-native NoSQL
+    /// document database that simplifies storing, syncing, and querying data for
+    /// your mobile, web, and IoT apps at global scale. Its client libraries provide
+    /// live synchronization and offline support, while its security features and
+    /// integrations with Firebase and Google Cloud Platform (GCP) accelerate
+    /// building truly serverless apps.
+    /// </remarks>
     public sealed partial class FirestoreClientImpl : FirestoreClient
     {
         private readonly gaxgrpc::ApiCall<GetDocumentRequest, Document> _callGetDocument;

--- a/apis/Google.Cloud.Firestore.V1/synth.metadata
+++ b/apis/Google.Cloud.Firestore.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "0a602be7b3835b51d59daf8f6f5dc2dc22f69d7e"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/GameServerClustersServiceClient.g.cs
+++ b/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/GameServerClustersServiceClient.g.cs
@@ -301,6 +301,10 @@ namespace Google.Cloud.Gaming.V1Beta
     }
 
     /// <summary>GameServerClustersService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// The game server cluster maps to Kubernetes clusters running Agones and is
+    /// used to manage fleets within clusters.
+    /// </remarks>
     public abstract partial class GameServerClustersServiceClient
     {
         /// <summary>
@@ -1143,6 +1147,10 @@ namespace Google.Cloud.Gaming.V1Beta
     }
 
     /// <summary>GameServerClustersService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// The game server cluster maps to Kubernetes clusters running Agones and is
+    /// used to manage fleets within clusters.
+    /// </remarks>
     public sealed partial class GameServerClustersServiceClientImpl : GameServerClustersServiceClient
     {
         private readonly gaxgrpc::ApiCall<ListGameServerClustersRequest, ListGameServerClustersResponse> _callListGameServerClusters;

--- a/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/GameServerConfigsServiceClient.g.cs
+++ b/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/GameServerConfigsServiceClient.g.cs
@@ -217,6 +217,9 @@ namespace Google.Cloud.Gaming.V1Beta
     }
 
     /// <summary>GameServerConfigsService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// The game server config configures the game servers in an Agones fleet.
+    /// </remarks>
     public abstract partial class GameServerConfigsServiceClient
     {
         /// <summary>
@@ -880,6 +883,9 @@ namespace Google.Cloud.Gaming.V1Beta
     }
 
     /// <summary>GameServerConfigsService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// The game server config configures the game servers in an Agones fleet.
+    /// </remarks>
     public sealed partial class GameServerConfigsServiceClientImpl : GameServerConfigsServiceClient
     {
         private readonly gaxgrpc::ApiCall<ListGameServerConfigsRequest, ListGameServerConfigsResponse> _callListGameServerConfigs;

--- a/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/GameServerDeploymentsServiceClient.g.cs
+++ b/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/GameServerDeploymentsServiceClient.g.cs
@@ -339,6 +339,10 @@ namespace Google.Cloud.Gaming.V1Beta
     }
 
     /// <summary>GameServerDeploymentsService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// The game server deployment is used to control the deployment of Agones
+    /// fleets.
+    /// </remarks>
     public abstract partial class GameServerDeploymentsServiceClient
     {
         /// <summary>
@@ -1413,6 +1417,10 @@ namespace Google.Cloud.Gaming.V1Beta
     }
 
     /// <summary>GameServerDeploymentsService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// The game server deployment is used to control the deployment of Agones
+    /// fleets.
+    /// </remarks>
     public sealed partial class GameServerDeploymentsServiceClientImpl : GameServerDeploymentsServiceClient
     {
         private readonly gaxgrpc::ApiCall<ListGameServerDeploymentsRequest, ListGameServerDeploymentsResponse> _callListGameServerDeployments;

--- a/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/RealmsServiceClient.g.cs
+++ b/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/RealmsServiceClient.g.cs
@@ -260,6 +260,10 @@ namespace Google.Cloud.Gaming.V1Beta
     }
 
     /// <summary>RealmsService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// A realm is a grouping of game server clusters that are considered
+    /// interchangeable.
+    /// </remarks>
     public abstract partial class RealmsServiceClient
     {
         /// <summary>
@@ -1033,6 +1037,10 @@ namespace Google.Cloud.Gaming.V1Beta
     }
 
     /// <summary>RealmsService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// A realm is a grouping of game server clusters that are considered
+    /// interchangeable.
+    /// </remarks>
     public sealed partial class RealmsServiceClientImpl : RealmsServiceClient
     {
         private readonly gaxgrpc::ApiCall<ListRealmsRequest, ListRealmsResponse> _callListRealms;

--- a/apis/Google.Cloud.Gaming.V1Beta/synth.metadata
+++ b/apis/Google.Cloud.Gaming.V1Beta/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "4ee98d06ee3c88b3df924263815a170dc83c95da"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.Iam.V1/synth.metadata
+++ b/apis/Google.Cloud.Iam.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/KeyManagementServiceClient.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/KeyManagementServiceClient.g.cs
@@ -489,6 +489,20 @@ namespace Google.Cloud.Kms.V1
     }
 
     /// <summary>KeyManagementService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Google Cloud Key Management Service
+    /// 
+    /// Manages cryptographic keys and operations using those keys. Implements a REST
+    /// model with the following objects:
+    /// 
+    /// * [KeyRing][google.cloud.kms.v1.KeyRing]
+    /// * [CryptoKey][google.cloud.kms.v1.CryptoKey]
+    /// * [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion]
+    /// * [ImportJob][google.cloud.kms.v1.ImportJob]
+    /// 
+    /// If you are using manual gRPC libraries, see
+    /// [Using gRPC with Cloud KMS](https://cloud.google.com/kms/docs/grpc).
+    /// </remarks>
     public abstract partial class KeyManagementServiceClient
     {
         /// <summary>
@@ -3727,6 +3741,20 @@ namespace Google.Cloud.Kms.V1
     }
 
     /// <summary>KeyManagementService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Google Cloud Key Management Service
+    /// 
+    /// Manages cryptographic keys and operations using those keys. Implements a REST
+    /// model with the following objects:
+    /// 
+    /// * [KeyRing][google.cloud.kms.v1.KeyRing]
+    /// * [CryptoKey][google.cloud.kms.v1.CryptoKey]
+    /// * [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion]
+    /// * [ImportJob][google.cloud.kms.v1.ImportJob]
+    /// 
+    /// If you are using manual gRPC libraries, see
+    /// [Using gRPC with Cloud KMS](https://cloud.google.com/kms/docs/grpc).
+    /// </remarks>
     public sealed partial class KeyManagementServiceClientImpl : KeyManagementServiceClient
     {
         private readonly gaxgrpc::ApiCall<ListKeyRingsRequest, ListKeyRingsResponse> _callListKeyRings;

--- a/apis/Google.Cloud.Kms.V1/synth.metadata
+++ b/apis/Google.Cloud.Kms.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/LanguageServiceClient.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/LanguageServiceClient.g.cs
@@ -209,6 +209,10 @@ namespace Google.Cloud.Language.V1
     }
 
     /// <summary>LanguageService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Provides text analysis operations such as sentiment analysis and entity
+    /// recognition.
+    /// </remarks>
     public abstract partial class LanguageServiceClient
     {
         /// <summary>
@@ -826,6 +830,10 @@ namespace Google.Cloud.Language.V1
     }
 
     /// <summary>LanguageService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Provides text analysis operations such as sentiment analysis and entity
+    /// recognition.
+    /// </remarks>
     public sealed partial class LanguageServiceClientImpl : LanguageServiceClient
     {
         private readonly gaxgrpc::ApiCall<AnalyzeSentimentRequest, AnalyzeSentimentResponse> _callAnalyzeSentiment;

--- a/apis/Google.Cloud.Language.V1/synth.metadata
+++ b/apis/Google.Cloud.Language.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.Logging.Type/synth.metadata
+++ b/apis/Google.Cloud.Logging.Type/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/ConfigServiceV2Client.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/ConfigServiceV2Client.g.cs
@@ -331,6 +331,9 @@ namespace Google.Cloud.Logging.V2
     }
 
     /// <summary>ConfigServiceV2 client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Service for configuring sinks used to route log entries.
+    /// </remarks>
     public abstract partial class ConfigServiceV2Client
     {
         /// <summary>
@@ -3798,6 +3801,9 @@ namespace Google.Cloud.Logging.V2
     }
 
     /// <summary>ConfigServiceV2 client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Service for configuring sinks used to route log entries.
+    /// </remarks>
     public sealed partial class ConfigServiceV2ClientImpl : ConfigServiceV2Client
     {
         private readonly gaxgrpc::ApiCall<ListBucketsRequest, ListBucketsResponse> _callListBuckets;

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/LoggingServiceV2Client.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/LoggingServiceV2Client.g.cs
@@ -197,6 +197,9 @@ namespace Google.Cloud.Logging.V2
     }
 
     /// <summary>LoggingServiceV2 client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Service for ingesting and querying logs.
+    /// </remarks>
     public abstract partial class LoggingServiceV2Client
     {
         /// <summary>
@@ -1968,6 +1971,9 @@ namespace Google.Cloud.Logging.V2
     }
 
     /// <summary>LoggingServiceV2 client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Service for ingesting and querying logs.
+    /// </remarks>
     public sealed partial class LoggingServiceV2ClientImpl : LoggingServiceV2Client
     {
         private readonly gaxgrpc::ApiCall<DeleteLogRequest, wkt::Empty> _callDeleteLog;

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/MetricsServiceV2Client.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/MetricsServiceV2Client.g.cs
@@ -192,6 +192,9 @@ namespace Google.Cloud.Logging.V2
     }
 
     /// <summary>MetricsServiceV2 client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Service for configuring logs-based metrics.
+    /// </remarks>
     public abstract partial class MetricsServiceV2Client
     {
         /// <summary>
@@ -954,6 +957,9 @@ namespace Google.Cloud.Logging.V2
     }
 
     /// <summary>MetricsServiceV2 client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Service for configuring logs-based metrics.
+    /// </remarks>
     public sealed partial class MetricsServiceV2ClientImpl : MetricsServiceV2Client
     {
         private readonly gaxgrpc::ApiCall<ListLogMetricsRequest, ListLogMetricsResponse> _callListLogMetrics;

--- a/apis/Google.Cloud.Logging.V2/synth.metadata
+++ b/apis/Google.Cloud.Logging.V2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "aba9760d6abc15f724753c26d6f306e0f76dd11a"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1/ManagedIdentitiesServiceClient.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1/ManagedIdentitiesServiceClient.g.cs
@@ -390,6 +390,40 @@ namespace Google.Cloud.ManagedIdentities.V1
     }
 
     /// <summary>ManagedIdentitiesService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// ## API Overview
+    /// 
+    /// The `managedidentites.googleapis.com` service implements the Google Cloud
+    /// Managed Identites API for identity services
+    /// (e.g. Microsoft Active Directory).
+    /// 
+    /// The Managed Identities service provides methods to manage
+    /// (create/read/update/delete) domains, reset managed identities admin password,
+    /// add/remove domain controllers in GCP regions and add/remove VPC peering.
+    /// 
+    /// ## Data Model
+    /// 
+    /// The Managed Identities service exposes the following resources:
+    /// 
+    /// * Locations as global, named as follows:
+    /// `projects/{project_id}/locations/global`.
+    /// 
+    /// * Domains, named as follows:
+    /// `/projects/{project_id}/locations/global/domain/{domain_name}`.
+    /// 
+    /// The `{domain_name}` refers to fully qualified domain name in the customer
+    /// project e.g. mydomain.myorganization.com, with the following restrictions:
+    /// 
+    /// * Must contain only lowercase letters, numbers, periods and hyphens.
+    /// * Must start with a letter.
+    /// * Must contain between 2-64 characters.
+    /// * Must end with a number or a letter.
+    /// * Must not start with period.
+    /// * First segement length (mydomain form example above) shouldn't exceed
+    /// 15 chars.
+    /// * The last segment cannot be fully numeric.
+    /// * Must be unique within the customer project.
+    /// </remarks>
     public abstract partial class ManagedIdentitiesServiceClient
     {
         /// <summary>
@@ -2008,6 +2042,40 @@ namespace Google.Cloud.ManagedIdentities.V1
     }
 
     /// <summary>ManagedIdentitiesService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// ## API Overview
+    /// 
+    /// The `managedidentites.googleapis.com` service implements the Google Cloud
+    /// Managed Identites API for identity services
+    /// (e.g. Microsoft Active Directory).
+    /// 
+    /// The Managed Identities service provides methods to manage
+    /// (create/read/update/delete) domains, reset managed identities admin password,
+    /// add/remove domain controllers in GCP regions and add/remove VPC peering.
+    /// 
+    /// ## Data Model
+    /// 
+    /// The Managed Identities service exposes the following resources:
+    /// 
+    /// * Locations as global, named as follows:
+    /// `projects/{project_id}/locations/global`.
+    /// 
+    /// * Domains, named as follows:
+    /// `/projects/{project_id}/locations/global/domain/{domain_name}`.
+    /// 
+    /// The `{domain_name}` refers to fully qualified domain name in the customer
+    /// project e.g. mydomain.myorganization.com, with the following restrictions:
+    /// 
+    /// * Must contain only lowercase letters, numbers, periods and hyphens.
+    /// * Must start with a letter.
+    /// * Must contain between 2-64 characters.
+    /// * Must end with a number or a letter.
+    /// * Must not start with period.
+    /// * First segement length (mydomain form example above) shouldn't exceed
+    /// 15 chars.
+    /// * The last segment cannot be fully numeric.
+    /// * Must be unique within the customer project.
+    /// </remarks>
     public sealed partial class ManagedIdentitiesServiceClientImpl : ManagedIdentitiesServiceClient
     {
         private readonly gaxgrpc::ApiCall<CreateMicrosoftAdDomainRequest, lro::Operation> _callCreateMicrosoftAdDomain;

--- a/apis/Google.Cloud.ManagedIdentities.V1/synth.metadata
+++ b/apis/Google.Cloud.ManagedIdentities.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2/CloudMemcacheClient.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2/CloudMemcacheClient.g.cs
@@ -303,6 +303,23 @@ namespace Google.Cloud.Memcache.V1Beta2
     }
 
     /// <summary>CloudMemcache client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Configures and manages Cloud Memorystore for Memcached instances.
+    /// 
+    /// 
+    /// The `memcache.googleapis.com` service implements the Google Cloud Memorystore
+    /// for Memcached API and defines the following resource model for managing
+    /// Memorystore Memcached (also called Memcached below) instances:
+    /// * The service works with a collection of cloud projects, named: `/projects/*`
+    /// * Each project has a collection of available locations, named: `/locations/*`
+    /// * Each location has a collection of Memcached instances, named:
+    /// `/instances/*`
+    /// * As such, Memcached instances are resources of the form:
+    /// `/projects/{project_id}/locations/{location_id}/instances/{instance_id}`
+    /// 
+    /// Note that location_id must be refering to a GCP `region`; for example:
+    /// * `projects/my-memcached-project/locations/us-central1/instances/my-memcached`
+    /// </remarks>
     public abstract partial class CloudMemcacheClient
     {
         /// <summary>
@@ -1463,6 +1480,23 @@ namespace Google.Cloud.Memcache.V1Beta2
     }
 
     /// <summary>CloudMemcache client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Configures and manages Cloud Memorystore for Memcached instances.
+    /// 
+    /// 
+    /// The `memcache.googleapis.com` service implements the Google Cloud Memorystore
+    /// for Memcached API and defines the following resource model for managing
+    /// Memorystore Memcached (also called Memcached below) instances:
+    /// * The service works with a collection of cloud projects, named: `/projects/*`
+    /// * Each project has a collection of available locations, named: `/locations/*`
+    /// * Each location has a collection of Memcached instances, named:
+    /// `/instances/*`
+    /// * As such, Memcached instances are resources of the form:
+    /// `/projects/{project_id}/locations/{location_id}/instances/{instance_id}`
+    /// 
+    /// Note that location_id must be refering to a GCP `region`; for example:
+    /// * `projects/my-memcached-project/locations/us-central1/instances/my-memcached`
+    /// </remarks>
     public sealed partial class CloudMemcacheClientImpl : CloudMemcacheClient
     {
         private readonly gaxgrpc::ApiCall<ListInstancesRequest, ListInstancesResponse> _callListInstances;

--- a/apis/Google.Cloud.Memcache.V1Beta2/synth.metadata
+++ b/apis/Google.Cloud.Memcache.V1Beta2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/AlertPolicyServiceClient.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/AlertPolicyServiceClient.g.cs
@@ -193,6 +193,17 @@ namespace Google.Cloud.Monitoring.V3
     }
 
     /// <summary>AlertPolicyService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// The AlertPolicyService API is used to manage (list, create, delete,
+    /// edit) alert policies in Stackdriver Monitoring. An alerting policy is
+    /// a description of the conditions under which some aspect of your
+    /// system is considered to be "unhealthy" and the ways to notify
+    /// people or services about this state. In addition to using this API, alert
+    /// policies can also be managed through
+    /// [Stackdriver Monitoring](https://cloud.google.com/monitoring/docs/),
+    /// which can be reached by clicking the "Monitoring" tab in
+    /// [Cloud Console](https://console.cloud.google.com/).
+    /// </remarks>
     public abstract partial class AlertPolicyServiceClient
     {
         /// <summary>
@@ -1564,6 +1575,17 @@ namespace Google.Cloud.Monitoring.V3
     }
 
     /// <summary>AlertPolicyService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// The AlertPolicyService API is used to manage (list, create, delete,
+    /// edit) alert policies in Stackdriver Monitoring. An alerting policy is
+    /// a description of the conditions under which some aspect of your
+    /// system is considered to be "unhealthy" and the ways to notify
+    /// people or services about this state. In addition to using this API, alert
+    /// policies can also be managed through
+    /// [Stackdriver Monitoring](https://cloud.google.com/monitoring/docs/),
+    /// which can be reached by clicking the "Monitoring" tab in
+    /// [Cloud Console](https://console.cloud.google.com/).
+    /// </remarks>
     public sealed partial class AlertPolicyServiceClientImpl : AlertPolicyServiceClient
     {
         private readonly gaxgrpc::ApiCall<ListAlertPoliciesRequest, ListAlertPoliciesResponse> _callListAlertPolicies;

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/GroupServiceClient.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/GroupServiceClient.g.cs
@@ -208,6 +208,20 @@ namespace Google.Cloud.Monitoring.V3
     }
 
     /// <summary>GroupService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// The Group API lets you inspect and manage your
+    /// [groups](#google.monitoring.v3.Group).
+    /// 
+    /// A group is a named filter that is used to identify
+    /// a collection of monitored resources. Groups are typically used to
+    /// mirror the physical and/or logical topology of the environment.
+    /// Because group membership is computed dynamically, monitored
+    /// resources that are started in the future are automatically placed
+    /// in matching groups. By using a group to name monitored resources in,
+    /// for example, an alert policy, the target of that alert policy is
+    /// updated automatically as monitored resources are added and removed
+    /// from the infrastructure.
+    /// </remarks>
     public abstract partial class GroupServiceClient
     {
         /// <summary>
@@ -1463,6 +1477,20 @@ namespace Google.Cloud.Monitoring.V3
     }
 
     /// <summary>GroupService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// The Group API lets you inspect and manage your
+    /// [groups](#google.monitoring.v3.Group).
+    /// 
+    /// A group is a named filter that is used to identify
+    /// a collection of monitored resources. Groups are typically used to
+    /// mirror the physical and/or logical topology of the environment.
+    /// Because group membership is computed dynamically, monitored
+    /// resources that are started in the future are automatically placed
+    /// in matching groups. By using a group to name monitored resources in,
+    /// for example, an alert policy, the target of that alert policy is
+    /// updated automatically as monitored resources are added and removed
+    /// from the infrastructure.
+    /// </remarks>
     public sealed partial class GroupServiceClientImpl : GroupServiceClient
     {
         private readonly gaxgrpc::ApiCall<ListGroupsRequest, ListGroupsResponse> _callListGroups;

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/MetricServiceClient.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/MetricServiceClient.g.cs
@@ -242,6 +242,10 @@ namespace Google.Cloud.Monitoring.V3
     }
 
     /// <summary>MetricService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Manages metric descriptors, monitored resource descriptors, and
+    /// time series data.
+    /// </remarks>
     public abstract partial class MetricServiceClient
     {
         /// <summary>
@@ -2259,6 +2263,10 @@ namespace Google.Cloud.Monitoring.V3
     }
 
     /// <summary>MetricService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Manages metric descriptors, monitored resource descriptors, and
+    /// time series data.
+    /// </remarks>
     public sealed partial class MetricServiceClientImpl : MetricServiceClient
     {
         private readonly gaxgrpc::ApiCall<ListMonitoredResourceDescriptorsRequest, ListMonitoredResourceDescriptorsResponse> _callListMonitoredResourceDescriptors;

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/NotificationChannelServiceClient.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/NotificationChannelServiceClient.g.cs
@@ -278,6 +278,10 @@ namespace Google.Cloud.Monitoring.V3
     }
 
     /// <summary>NotificationChannelService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// The Notification Channel API provides access to configuration that
+    /// controls how messages related to incidents are sent.
+    /// </remarks>
     public abstract partial class NotificationChannelServiceClient
     {
         /// <summary>
@@ -2984,6 +2988,10 @@ namespace Google.Cloud.Monitoring.V3
     }
 
     /// <summary>NotificationChannelService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// The Notification Channel API provides access to configuration that
+    /// controls how messages related to incidents are sent.
+    /// </remarks>
     public sealed partial class NotificationChannelServiceClientImpl : NotificationChannelServiceClient
     {
         private readonly gaxgrpc::ApiCall<ListNotificationChannelDescriptorsRequest, ListNotificationChannelDescriptorsResponse> _callListNotificationChannelDescriptors;

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/ServiceMonitoringServiceClient.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/ServiceMonitoringServiceClient.g.cs
@@ -274,6 +274,12 @@ namespace Google.Cloud.Monitoring.V3
     }
 
     /// <summary>ServiceMonitoringService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// The Cloud Monitoring Service-Oriented Monitoring API has endpoints for
+    /// managing and querying aspects of a workspace's services. These include the
+    /// `Service`'s monitored resources, its Service-Level Objectives, and a taxonomy
+    /// of categorized Health Metrics.
+    /// </remarks>
     public abstract partial class ServiceMonitoringServiceClient
     {
         /// <summary>
@@ -2149,6 +2155,12 @@ namespace Google.Cloud.Monitoring.V3
     }
 
     /// <summary>ServiceMonitoringService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// The Cloud Monitoring Service-Oriented Monitoring API has endpoints for
+    /// managing and querying aspects of a workspace's services. These include the
+    /// `Service`'s monitored resources, its Service-Level Objectives, and a taxonomy
+    /// of categorized Health Metrics.
+    /// </remarks>
     public sealed partial class ServiceMonitoringServiceClientImpl : ServiceMonitoringServiceClient
     {
         private readonly gaxgrpc::ApiCall<CreateServiceRequest, Service> _callCreateService;

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/UptimeCheckServiceClient.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/UptimeCheckServiceClient.g.cs
@@ -211,6 +211,16 @@ namespace Google.Cloud.Monitoring.V3
     }
 
     /// <summary>UptimeCheckService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// The UptimeCheckService API is used to manage (list, create, delete, edit)
+    /// Uptime check configurations in the Stackdriver Monitoring product. An Uptime
+    /// check is a piece of configuration that determines which resources and
+    /// services to monitor for availability. These configurations can also be
+    /// configured interactively by navigating to the [Cloud Console]
+    /// (http://console.cloud.google.com), selecting the appropriate project,
+    /// clicking on "Monitoring" on the left-hand side to navigate to Stackdriver,
+    /// and then clicking on "Uptime".
+    /// </remarks>
     public abstract partial class UptimeCheckServiceClient
     {
         /// <summary>
@@ -1373,6 +1383,16 @@ namespace Google.Cloud.Monitoring.V3
     }
 
     /// <summary>UptimeCheckService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// The UptimeCheckService API is used to manage (list, create, delete, edit)
+    /// Uptime check configurations in the Stackdriver Monitoring product. An Uptime
+    /// check is a piece of configuration that determines which resources and
+    /// services to monitor for availability. These configurations can also be
+    /// configured interactively by navigating to the [Cloud Console]
+    /// (http://console.cloud.google.com), selecting the appropriate project,
+    /// clicking on "Monitoring" on the left-hand side to navigate to Stackdriver,
+    /// and then clicking on "Uptime".
+    /// </remarks>
     public sealed partial class UptimeCheckServiceClientImpl : UptimeCheckServiceClient
     {
         private readonly gaxgrpc::ApiCall<ListUptimeCheckConfigsRequest, ListUptimeCheckConfigsResponse> _callListUptimeCheckConfigs;

--- a/apis/Google.Cloud.Monitoring.V3/synth.metadata
+++ b/apis/Google.Cloud.Monitoring.V3/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.OrgPolicy.V1/synth.metadata
+++ b/apis/Google.Cloud.OrgPolicy.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/OsConfigServiceClient.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/OsConfigServiceClient.g.cs
@@ -263,6 +263,12 @@ namespace Google.Cloud.OsConfig.V1
     }
 
     /// <summary>OsConfigService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// OS Config API
+    /// 
+    /// The OS Config service is a server-side component that you can use to
+    /// manage package installations and patch jobs for virtual machine instances.
+    /// </remarks>
     public abstract partial class OsConfigServiceClient
     {
         /// <summary>
@@ -1261,6 +1267,12 @@ namespace Google.Cloud.OsConfig.V1
     }
 
     /// <summary>OsConfigService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// OS Config API
+    /// 
+    /// The OS Config service is a server-side component that you can use to
+    /// manage package installations and patch jobs for virtual machine instances.
+    /// </remarks>
     public sealed partial class OsConfigServiceClientImpl : OsConfigServiceClient
     {
         private readonly gaxgrpc::ApiCall<ExecutePatchJobRequest, PatchJob> _callExecutePatchJob;

--- a/apis/Google.Cloud.OsConfig.V1/synth.metadata
+++ b/apis/Google.Cloud.OsConfig.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "02c23d62c7a133608fcf6ea33aea90ed0e0d098a"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.OsLogin.Common/synth.metadata
+++ b/apis/Google.Cloud.OsLogin.Common/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1/OsLoginServiceClient.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1/OsLoginServiceClient.g.cs
@@ -210,6 +210,12 @@ namespace Google.Cloud.OsLogin.V1
     }
 
     /// <summary>OsLoginService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Cloud OS Login API
+    /// 
+    /// The Cloud OS Login API allows you to manage users and their associated SSH
+    /// public keys for logging into virtual machines on Google Cloud Platform.
+    /// </remarks>
     public abstract partial class OsLoginServiceClient
     {
         /// <summary>
@@ -1322,6 +1328,12 @@ namespace Google.Cloud.OsLogin.V1
     }
 
     /// <summary>OsLoginService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Cloud OS Login API
+    /// 
+    /// The Cloud OS Login API allows you to manage users and their associated SSH
+    /// public keys for logging into virtual machines on Google Cloud Platform.
+    /// </remarks>
     public sealed partial class OsLoginServiceClientImpl : OsLoginServiceClient
     {
         private readonly gaxgrpc::ApiCall<DeletePosixAccountRequest, wkt::Empty> _callDeletePosixAccount;

--- a/apis/Google.Cloud.OsLogin.V1/synth.metadata
+++ b/apis/Google.Cloud.OsLogin.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/OsLoginServiceClient.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/OsLoginServiceClient.g.cs
@@ -210,6 +210,12 @@ namespace Google.Cloud.OsLogin.V1Beta
     }
 
     /// <summary>OsLoginService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Cloud OS Login API
+    /// 
+    /// The Cloud OS Login API allows you to manage users and their associated SSH
+    /// public keys for logging into virtual machines on Google Cloud Platform.
+    /// </remarks>
     public abstract partial class OsLoginServiceClient
     {
         /// <summary>
@@ -1326,6 +1332,12 @@ namespace Google.Cloud.OsLogin.V1Beta
     }
 
     /// <summary>OsLoginService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Cloud OS Login API
+    /// 
+    /// The Cloud OS Login API allows you to manage users and their associated SSH
+    /// public keys for logging into virtual machines on Google Cloud Platform.
+    /// </remarks>
     public sealed partial class OsLoginServiceClientImpl : OsLoginServiceClient
     {
         private readonly gaxgrpc::ApiCall<DeletePosixAccountRequest, wkt::Empty> _callDeletePosixAccount;

--- a/apis/Google.Cloud.OsLogin.V1Beta/synth.metadata
+++ b/apis/Google.Cloud.OsLogin.V1Beta/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1/PhishingProtectionServiceV1Beta1Client.g.cs
+++ b/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1/PhishingProtectionServiceV1Beta1Client.g.cs
@@ -130,6 +130,9 @@ namespace Google.Cloud.PhishingProtection.V1Beta1
     }
 
     /// <summary>PhishingProtectionServiceV1Beta1 client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Service to report phishing URIs.
+    /// </remarks>
     public abstract partial class PhishingProtectionServiceV1Beta1Client
     {
         /// <summary>
@@ -399,6 +402,9 @@ namespace Google.Cloud.PhishingProtection.V1Beta1
     }
 
     /// <summary>PhishingProtectionServiceV1Beta1 client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Service to report phishing URIs.
+    /// </remarks>
     public sealed partial class PhishingProtectionServiceV1Beta1ClientImpl : PhishingProtectionServiceV1Beta1Client
     {
         private readonly gaxgrpc::ApiCall<ReportPhishingRequest, ReportPhishingResponse> _callReportPhishing;

--- a/apis/Google.Cloud.PhishingProtection.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.PhishingProtection.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/PublisherServiceApiClient.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/PublisherServiceApiClient.g.cs
@@ -235,6 +235,10 @@ namespace Google.Cloud.PubSub.V1
     }
 
     /// <summary>PublisherServiceApi client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// The service that an application uses to manipulate topics, and to send
+    /// messages to a topic.
+    /// </remarks>
     public abstract partial class PublisherServiceApiClient
     {
         /// <summary>
@@ -1333,6 +1337,10 @@ namespace Google.Cloud.PubSub.V1
     }
 
     /// <summary>PublisherServiceApi client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// The service that an application uses to manipulate topics, and to send
+    /// messages to a topic.
+    /// </remarks>
     public sealed partial class PublisherServiceApiClientImpl : PublisherServiceApiClient
     {
         private readonly gaxgrpc::ApiCall<Topic, Topic> _callCreateTopic;

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberServiceApiClient.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberServiceApiClient.g.cs
@@ -338,6 +338,11 @@ namespace Google.Cloud.PubSub.V1
     }
 
     /// <summary>SubscriberServiceApi client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// The service that an application uses to manipulate subscriptions and to
+    /// consume messages from a subscription via the `Pull` method or by
+    /// establishing a bi-directional stream using the `StreamingPull` method.
+    /// </remarks>
     public abstract partial class SubscriberServiceApiClient
     {
         /// <summary>
@@ -3125,6 +3130,11 @@ namespace Google.Cloud.PubSub.V1
     }
 
     /// <summary>SubscriberServiceApi client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// The service that an application uses to manipulate subscriptions and to
+    /// consume messages from a subscription via the `Pull` method or by
+    /// establishing a bi-directional stream using the `StreamingPull` method.
+    /// </remarks>
     public sealed partial class SubscriberServiceApiClientImpl : SubscriberServiceApiClient
     {
         private readonly gaxgrpc::ApiCall<Subscription, Subscription> _callCreateSubscription;

--- a/apis/Google.Cloud.PubSub.V1/synth.metadata
+++ b/apis/Google.Cloud.PubSub.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "14f0c2cc9392234707247ab2b0782c118cb179aa"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1/RecaptchaEnterpriseServiceClient.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1/RecaptchaEnterpriseServiceClient.g.cs
@@ -213,6 +213,9 @@ namespace Google.Cloud.RecaptchaEnterprise.V1
     }
 
     /// <summary>RecaptchaEnterpriseService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Service to determine the likelihood an event is legitimate.
+    /// </remarks>
     public abstract partial class RecaptchaEnterpriseServiceClient
     {
         /// <summary>
@@ -695,6 +698,9 @@ namespace Google.Cloud.RecaptchaEnterprise.V1
     }
 
     /// <summary>RecaptchaEnterpriseService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Service to determine the likelihood an event is legitimate.
+    /// </remarks>
     public sealed partial class RecaptchaEnterpriseServiceClientImpl : RecaptchaEnterpriseServiceClient
     {
         private readonly gaxgrpc::ApiCall<CreateAssessmentRequest, Assessment> _callCreateAssessment;

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/synth.metadata
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1/RecaptchaEnterpriseServiceV1Beta1Client.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1/RecaptchaEnterpriseServiceV1Beta1Client.g.cs
@@ -219,6 +219,9 @@ namespace Google.Cloud.RecaptchaEnterprise.V1Beta1
     }
 
     /// <summary>RecaptchaEnterpriseServiceV1Beta1 client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Service to determine the likelihood an event is legitimate.
+    /// </remarks>
     public abstract partial class RecaptchaEnterpriseServiceV1Beta1Client
     {
         /// <summary>
@@ -702,6 +705,9 @@ namespace Google.Cloud.RecaptchaEnterprise.V1Beta1
     }
 
     /// <summary>RecaptchaEnterpriseServiceV1Beta1 client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Service to determine the likelihood an event is legitimate.
+    /// </remarks>
     public sealed partial class RecaptchaEnterpriseServiceV1Beta1ClientImpl : RecaptchaEnterpriseServiceV1Beta1Client
     {
         private readonly gaxgrpc::ApiCall<CreateAssessmentRequest, Assessment> _callCreateAssessment;

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/RecommenderClient.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/RecommenderClient.g.cs
@@ -225,6 +225,12 @@ namespace Google.Cloud.Recommender.V1
     }
 
     /// <summary>Recommender client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Provides insights and recommendations for cloud customers for various
+    /// categories like performance optimization, cost savings, reliability, feature
+    /// discovery, etc. Insights and recommendations are generated automatically
+    /// based on analysis of user resources, configuration and monitoring metrics.
+    /// </remarks>
     public abstract partial class RecommenderClient
     {
         /// <summary>
@@ -1989,6 +1995,12 @@ namespace Google.Cloud.Recommender.V1
     }
 
     /// <summary>Recommender client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Provides insights and recommendations for cloud customers for various
+    /// categories like performance optimization, cost savings, reliability, feature
+    /// discovery, etc. Insights and recommendations are generated automatically
+    /// based on analysis of user resources, configuration and monitoring metrics.
+    /// </remarks>
     public sealed partial class RecommenderClientImpl : RecommenderClient
     {
         private readonly gaxgrpc::ApiCall<ListInsightsRequest, ListInsightsResponse> _callListInsights;

--- a/apis/Google.Cloud.Recommender.V1/synth.metadata
+++ b/apis/Google.Cloud.Recommender.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "5202cfe3e5c2907a1a21a4c6d4bd0812029b6aa3"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1/CloudRedisClient.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1/CloudRedisClient.g.cs
@@ -365,6 +365,23 @@ namespace Google.Cloud.Redis.V1
     }
 
     /// <summary>CloudRedis client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Configures and manages Cloud Memorystore for Redis instances
+    /// 
+    /// Google Cloud Memorystore for Redis v1
+    /// 
+    /// The `redis.googleapis.com` service implements the Google Cloud Memorystore
+    /// for Redis API and defines the following resource model for managing Redis
+    /// instances:
+    /// * The service works with a collection of cloud projects, named: `/projects/*`
+    /// * Each project has a collection of available locations, named: `/locations/*`
+    /// * Each location has a collection of Redis instances, named: `/instances/*`
+    /// * As such, Redis instances are resources of the form:
+    /// `/projects/{project_id}/locations/{location_id}/instances/{instance_id}`
+    /// 
+    /// Note that location_id must be referring to a GCP `region`; for example:
+    /// * `projects/redpepper-1290/locations/us-central1/instances/my-redis`
+    /// </remarks>
     public abstract partial class CloudRedisClient
     {
         /// <summary>
@@ -2005,6 +2022,23 @@ namespace Google.Cloud.Redis.V1
     }
 
     /// <summary>CloudRedis client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Configures and manages Cloud Memorystore for Redis instances
+    /// 
+    /// Google Cloud Memorystore for Redis v1
+    /// 
+    /// The `redis.googleapis.com` service implements the Google Cloud Memorystore
+    /// for Redis API and defines the following resource model for managing Redis
+    /// instances:
+    /// * The service works with a collection of cloud projects, named: `/projects/*`
+    /// * Each project has a collection of available locations, named: `/locations/*`
+    /// * Each location has a collection of Redis instances, named: `/instances/*`
+    /// * As such, Redis instances are resources of the form:
+    /// `/projects/{project_id}/locations/{location_id}/instances/{instance_id}`
+    /// 
+    /// Note that location_id must be referring to a GCP `region`; for example:
+    /// * `projects/redpepper-1290/locations/us-central1/instances/my-redis`
+    /// </remarks>
     public sealed partial class CloudRedisClientImpl : CloudRedisClient
     {
         private readonly gaxgrpc::ApiCall<ListInstancesRequest, ListInstancesResponse> _callListInstances;

--- a/apis/Google.Cloud.Redis.V1/synth.metadata
+++ b/apis/Google.Cloud.Redis.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "76905ffe7e3b0605f64ef889fb88913634f9f836"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1/CloudRedisClient.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1/CloudRedisClient.g.cs
@@ -365,6 +365,23 @@ namespace Google.Cloud.Redis.V1Beta1
     }
 
     /// <summary>CloudRedis client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Configures and manages Cloud Memorystore for Redis instances
+    /// 
+    /// Google Cloud Memorystore for Redis v1beta1
+    /// 
+    /// The `redis.googleapis.com` service implements the Google Cloud Memorystore
+    /// for Redis API and defines the following resource model for managing Redis
+    /// instances:
+    /// * The service works with a collection of cloud projects, named: `/projects/*`
+    /// * Each project has a collection of available locations, named: `/locations/*`
+    /// * Each location has a collection of Redis instances, named: `/instances/*`
+    /// * As such, Redis instances are resources of the form:
+    /// `/projects/{project_id}/locations/{location_id}/instances/{instance_id}`
+    /// 
+    /// Note that location_id must be refering to a GCP `region`; for example:
+    /// * `projects/redpepper-1290/locations/us-central1/instances/my-redis`
+    /// </remarks>
     public abstract partial class CloudRedisClient
     {
         /// <summary>
@@ -2005,6 +2022,23 @@ namespace Google.Cloud.Redis.V1Beta1
     }
 
     /// <summary>CloudRedis client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Configures and manages Cloud Memorystore for Redis instances
+    /// 
+    /// Google Cloud Memorystore for Redis v1beta1
+    /// 
+    /// The `redis.googleapis.com` service implements the Google Cloud Memorystore
+    /// for Redis API and defines the following resource model for managing Redis
+    /// instances:
+    /// * The service works with a collection of cloud projects, named: `/projects/*`
+    /// * Each project has a collection of available locations, named: `/locations/*`
+    /// * Each location has a collection of Redis instances, named: `/instances/*`
+    /// * As such, Redis instances are resources of the form:
+    /// `/projects/{project_id}/locations/{location_id}/instances/{instance_id}`
+    /// 
+    /// Note that location_id must be refering to a GCP `region`; for example:
+    /// * `projects/redpepper-1290/locations/us-central1/instances/my-redis`
+    /// </remarks>
     public sealed partial class CloudRedisClientImpl : CloudRedisClient
     {
         private readonly gaxgrpc::ApiCall<ListInstancesRequest, ListInstancesResponse> _callListInstances;

--- a/apis/Google.Cloud.Redis.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.Redis.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1/CloudSchedulerClient.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1/CloudSchedulerClient.g.cs
@@ -228,6 +228,10 @@ namespace Google.Cloud.Scheduler.V1
     }
 
     /// <summary>CloudScheduler client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// The Cloud Scheduler API allows external entities to reliably
+    /// schedule asynchronous jobs.
+    /// </remarks>
     public abstract partial class CloudSchedulerClient
     {
         /// <summary>
@@ -1396,6 +1400,10 @@ namespace Google.Cloud.Scheduler.V1
     }
 
     /// <summary>CloudScheduler client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// The Cloud Scheduler API allows external entities to reliably
+    /// schedule asynchronous jobs.
+    /// </remarks>
     public sealed partial class CloudSchedulerClientImpl : CloudSchedulerClient
     {
         private readonly gaxgrpc::ApiCall<ListJobsRequest, ListJobsResponse> _callListJobs;

--- a/apis/Google.Cloud.Scheduler.V1/synth.metadata
+++ b/apis/Google.Cloud.Scheduler.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1/SecretManagerServiceClient.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1/SecretManagerServiceClient.g.cs
@@ -322,6 +322,15 @@ namespace Google.Cloud.SecretManager.V1
     }
 
     /// <summary>SecretManagerService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Secret Manager Service
+    /// 
+    /// Manages secrets and operations using those secrets. Implements a REST
+    /// model with the following objects:
+    /// 
+    /// * [Secret][google.cloud.secretmanager.v1.Secret]
+    /// * [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]
+    /// </remarks>
     public abstract partial class SecretManagerServiceClient
     {
         /// <summary>
@@ -2088,6 +2097,15 @@ namespace Google.Cloud.SecretManager.V1
     }
 
     /// <summary>SecretManagerService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Secret Manager Service
+    /// 
+    /// Manages secrets and operations using those secrets. Implements a REST
+    /// model with the following objects:
+    /// 
+    /// * [Secret][google.cloud.secretmanager.v1.Secret]
+    /// * [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]
+    /// </remarks>
     public sealed partial class SecretManagerServiceClientImpl : SecretManagerServiceClient
     {
         private readonly gaxgrpc::ApiCall<ListSecretsRequest, ListSecretsResponse> _callListSecrets;

--- a/apis/Google.Cloud.SecretManager.V1/synth.metadata
+++ b/apis/Google.Cloud.SecretManager.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1/SecretManagerServiceClient.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1/SecretManagerServiceClient.g.cs
@@ -322,6 +322,15 @@ namespace Google.Cloud.SecretManager.V1Beta1
     }
 
     /// <summary>SecretManagerService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Secret Manager Service
+    /// 
+    /// Manages secrets and operations using those secrets. Implements a REST
+    /// model with the following objects:
+    /// 
+    /// * [Secret][google.cloud.secrets.v1beta1.Secret]
+    /// * [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion]
+    /// </remarks>
     public abstract partial class SecretManagerServiceClient
     {
         /// <summary>
@@ -2088,6 +2097,15 @@ namespace Google.Cloud.SecretManager.V1Beta1
     }
 
     /// <summary>SecretManagerService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Secret Manager Service
+    /// 
+    /// Manages secrets and operations using those secrets. Implements a REST
+    /// model with the following objects:
+    /// 
+    /// * [Secret][google.cloud.secrets.v1beta1.Secret]
+    /// * [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion]
+    /// </remarks>
     public sealed partial class SecretManagerServiceClientImpl : SecretManagerServiceClient
     {
         private readonly gaxgrpc::ApiCall<ListSecretsRequest, ListSecretsResponse> _callListSecrets;

--- a/apis/Google.Cloud.SecretManager.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1/SecurityCenterSettingsServiceClient.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1/SecurityCenterSettingsServiceClient.g.cs
@@ -339,6 +339,14 @@ namespace Google.Cloud.SecurityCenter.Settings.V1Beta1
     }
 
     /// <summary>SecurityCenterSettingsService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// ## API Overview
+    /// 
+    /// The SecurityCenterSettingsService is a sub-api of
+    /// `securitycenter.googleapis.com`. The service provides methods to manage
+    /// Security Center Settings, and Component Settings for GCP organizations,
+    /// folders, projects, and clusters.
+    /// </remarks>
     public abstract partial class SecurityCenterSettingsServiceClient
     {
         /// <summary>
@@ -1908,6 +1916,14 @@ namespace Google.Cloud.SecurityCenter.Settings.V1Beta1
     }
 
     /// <summary>SecurityCenterSettingsService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// ## API Overview
+    /// 
+    /// The SecurityCenterSettingsService is a sub-api of
+    /// `securitycenter.googleapis.com`. The service provides methods to manage
+    /// Security Center Settings, and Component Settings for GCP organizations,
+    /// folders, projects, and clusters.
+    /// </remarks>
     public sealed partial class SecurityCenterSettingsServiceClientImpl : SecurityCenterSettingsServiceClient
     {
         private readonly gaxgrpc::ApiCall<GetServiceAccountRequest, ServiceAccount> _callGetServiceAccount;

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/SecurityCenterClient.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/SecurityCenterClient.g.cs
@@ -475,6 +475,9 @@ namespace Google.Cloud.SecurityCenter.V1
     }
 
     /// <summary>SecurityCenter client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// V1 APIs for Security Center service.
+    /// </remarks>
     public abstract partial class SecurityCenterClient
     {
         /// <summary>
@@ -3334,6 +3337,9 @@ namespace Google.Cloud.SecurityCenter.V1
     }
 
     /// <summary>SecurityCenter client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// V1 APIs for Security Center service.
+    /// </remarks>
     public sealed partial class SecurityCenterClientImpl : SecurityCenterClient
     {
         private readonly gaxgrpc::ApiCall<CreateSourceRequest, Source> _callCreateSource;

--- a/apis/Google.Cloud.SecurityCenter.V1/synth.metadata
+++ b/apis/Google.Cloud.SecurityCenter.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/SecurityCenterClient.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/SecurityCenterClient.g.cs
@@ -475,6 +475,9 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1
     }
 
     /// <summary>SecurityCenter client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// V1p1Beta1 APIs for Security Center service.
+    /// </remarks>
     public abstract partial class SecurityCenterClient
     {
         /// <summary>
@@ -3922,6 +3925,9 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1
     }
 
     /// <summary>SecurityCenter client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// V1p1Beta1 APIs for Security Center service.
+    /// </remarks>
     public sealed partial class SecurityCenterClientImpl : SecurityCenterClient
     {
         private readonly gaxgrpc::ApiCall<CreateSourceRequest, Source> _callCreateSource;

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/synth.metadata
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/LookupServiceClient.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/LookupServiceClient.g.cs
@@ -128,6 +128,9 @@ namespace Google.Cloud.ServiceDirectory.V1Beta1
     }
 
     /// <summary>LookupService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Service Directory API for looking up service data at runtime.
+    /// </remarks>
     public abstract partial class LookupServiceClient
     {
         /// <summary>
@@ -239,6 +242,9 @@ namespace Google.Cloud.ServiceDirectory.V1Beta1
     }
 
     /// <summary>LookupService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Service Directory API for looking up service data at runtime.
+    /// </remarks>
     public sealed partial class LookupServiceClientImpl : LookupServiceClient
     {
         private readonly gaxgrpc::ApiCall<ResolveServiceRequest, ResolveServiceResponse> _callResolveService;

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/RegistrationServiceClient.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/RegistrationServiceClient.g.cs
@@ -405,6 +405,23 @@ namespace Google.Cloud.ServiceDirectory.V1Beta1
     }
 
     /// <summary>RegistrationService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Service Directory API for registering services. It defines the following
+    /// resource model:
+    /// 
+    /// - The API has a collection of
+    /// [Namespace][google.cloud.servicedirectory.v1beta1.Namespace]
+    /// resources, named `projects/*/locations/*/namespaces/*`.
+    /// 
+    /// - Each Namespace has a collection of
+    /// [Service][google.cloud.servicedirectory.v1beta1.Service] resources, named
+    /// `projects/*/locations/*/namespaces/*/services/*`.
+    /// 
+    /// - Each Service has a collection of
+    /// [Endpoint][google.cloud.servicedirectory.v1beta1.Endpoint]
+    /// resources, named
+    /// `projects/*/locations/*/namespaces/*/services/*/endpoints/*`.
+    /// </remarks>
     public abstract partial class RegistrationServiceClient
     {
         /// <summary>
@@ -2361,6 +2378,23 @@ namespace Google.Cloud.ServiceDirectory.V1Beta1
     }
 
     /// <summary>RegistrationService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Service Directory API for registering services. It defines the following
+    /// resource model:
+    /// 
+    /// - The API has a collection of
+    /// [Namespace][google.cloud.servicedirectory.v1beta1.Namespace]
+    /// resources, named `projects/*/locations/*/namespaces/*`.
+    /// 
+    /// - Each Namespace has a collection of
+    /// [Service][google.cloud.servicedirectory.v1beta1.Service] resources, named
+    /// `projects/*/locations/*/namespaces/*/services/*`.
+    /// 
+    /// - Each Service has a collection of
+    /// [Endpoint][google.cloud.servicedirectory.v1beta1.Endpoint]
+    /// resources, named
+    /// `projects/*/locations/*/namespaces/*/services/*/endpoints/*`.
+    /// </remarks>
     public sealed partial class RegistrationServiceClientImpl : RegistrationServiceClient
     {
         private readonly gaxgrpc::ApiCall<CreateNamespaceRequest, Namespace> _callCreateNamespace;

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/DatabaseAdminClient.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/DatabaseAdminClient.g.cs
@@ -448,6 +448,14 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
     }
 
     /// <summary>DatabaseAdmin client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Cloud Spanner Database Admin API
+    /// 
+    /// The Cloud Spanner Database Admin API can be used to create, drop, and
+    /// list databases. It also enables updating the schema of pre-existing
+    /// databases. It can be also used to create, delete and list backups for a
+    /// database and to restore from an existing backup.
+    /// </remarks>
     public abstract partial class DatabaseAdminClient
     {
         /// <summary>
@@ -3569,6 +3577,14 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
     }
 
     /// <summary>DatabaseAdmin client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Cloud Spanner Database Admin API
+    /// 
+    /// The Cloud Spanner Database Admin API can be used to create, drop, and
+    /// list databases. It also enables updating the schema of pre-existing
+    /// databases. It can be also used to create, delete and list backups for a
+    /// database and to restore from an existing backup.
+    /// </remarks>
     public sealed partial class DatabaseAdminClientImpl : DatabaseAdminClient
     {
         private readonly gaxgrpc::ApiCall<ListDatabasesRequest, ListDatabasesResponse> _callListDatabases;

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/synth.metadata
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "4d8706453bf6016ebf1bb241d78b4dc58c92064d"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/InstanceAdminClient.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/InstanceAdminClient.g.cs
@@ -304,6 +304,29 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
     }
 
     /// <summary>InstanceAdmin client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Cloud Spanner Instance Admin API
+    /// 
+    /// The Cloud Spanner Instance Admin API can be used to create, delete,
+    /// modify and list instances. Instances are dedicated Cloud Spanner serving
+    /// and storage resources to be used by Cloud Spanner databases.
+    /// 
+    /// Each instance has a "configuration", which dictates where the
+    /// serving resources for the Cloud Spanner instance are located (e.g.,
+    /// US-central, Europe). Configurations are created by Google based on
+    /// resource availability.
+    /// 
+    /// Cloud Spanner billing is based on the instances that exist and their
+    /// sizes. After an instance exists, there are no additional
+    /// per-database or per-operation charges for use of the instance
+    /// (though there may be additional network bandwidth charges).
+    /// Instances offer isolation: problems with databases in one instance
+    /// will not affect other instances. However, within an instance
+    /// databases can affect each other. For example, if one database in an
+    /// instance receives a lot of requests and consumes most of the
+    /// instance resources, fewer resources are available for other
+    /// databases in that instance, and their performance may suffer.
+    /// </remarks>
     public abstract partial class InstanceAdminClient
     {
         /// <summary>
@@ -2434,6 +2457,29 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
     }
 
     /// <summary>InstanceAdmin client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Cloud Spanner Instance Admin API
+    /// 
+    /// The Cloud Spanner Instance Admin API can be used to create, delete,
+    /// modify and list instances. Instances are dedicated Cloud Spanner serving
+    /// and storage resources to be used by Cloud Spanner databases.
+    /// 
+    /// Each instance has a "configuration", which dictates where the
+    /// serving resources for the Cloud Spanner instance are located (e.g.,
+    /// US-central, Europe). Configurations are created by Google based on
+    /// resource availability.
+    /// 
+    /// Cloud Spanner billing is based on the instances that exist and their
+    /// sizes. After an instance exists, there are no additional
+    /// per-database or per-operation charges for use of the instance
+    /// (though there may be additional network bandwidth charges).
+    /// Instances offer isolation: problems with databases in one instance
+    /// will not affect other instances. However, within an instance
+    /// databases can affect each other. For example, if one database in an
+    /// instance receives a lot of requests and consumes most of the
+    /// instance resources, fewer resources are available for other
+    /// databases in that instance, and their performance may suffer.
+    /// </remarks>
     public sealed partial class InstanceAdminClientImpl : InstanceAdminClient
     {
         private readonly gaxgrpc::ApiCall<ListInstanceConfigsRequest, ListInstanceConfigsResponse> _callListInstanceConfigs;

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/synth.metadata
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SpannerClient.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SpannerClient.g.cs
@@ -349,6 +349,12 @@ namespace Google.Cloud.Spanner.V1
     }
 
     /// <summary>Spanner client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Cloud Spanner API
+    /// 
+    /// The Cloud Spanner API can be used to manage sessions and execute
+    /// transactions on data stored in Cloud Spanner databases.
+    /// </remarks>
     public abstract partial class SpannerClient
     {
         /// <summary>
@@ -2386,6 +2392,12 @@ namespace Google.Cloud.Spanner.V1
     }
 
     /// <summary>Spanner client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Cloud Spanner API
+    /// 
+    /// The Cloud Spanner API can be used to manage sessions and execute
+    /// transactions on data stored in Cloud Spanner databases.
+    /// </remarks>
     public sealed partial class SpannerClientImpl : SpannerClient
     {
         private readonly gaxgrpc::ApiCall<CreateSessionRequest, Session> _callCreateSession;

--- a/apis/Google.Cloud.Spanner.V1/synth.metadata
+++ b/apis/Google.Cloud.Spanner.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/SpeechClient.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/SpeechClient.g.cs
@@ -176,6 +176,9 @@ namespace Google.Cloud.Speech.V1
     }
 
     /// <summary>Speech client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Service that implements Google Cloud Speech API.
+    /// </remarks>
     public abstract partial class SpeechClient
     {
         /// <summary>
@@ -494,6 +497,9 @@ namespace Google.Cloud.Speech.V1
     }
 
     /// <summary>Speech client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Service that implements Google Cloud Speech API.
+    /// </remarks>
     public sealed partial class SpeechClientImpl : SpeechClient
     {
         private readonly gaxgrpc::ApiCall<RecognizeRequest, RecognizeResponse> _callRecognize;

--- a/apis/Google.Cloud.Speech.V1/synth.metadata
+++ b/apis/Google.Cloud.Speech.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/SpeechClient.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/SpeechClient.g.cs
@@ -176,6 +176,9 @@ namespace Google.Cloud.Speech.V1P1Beta1
     }
 
     /// <summary>Speech client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Service that implements Google Cloud Speech API.
+    /// </remarks>
     public abstract partial class SpeechClient
     {
         /// <summary>
@@ -494,6 +497,9 @@ namespace Google.Cloud.Speech.V1P1Beta1
     }
 
     /// <summary>Speech client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Service that implements Google Cloud Speech API.
+    /// </remarks>
     public sealed partial class SpeechClientImpl : SpeechClient
     {
         private readonly gaxgrpc::ApiCall<RecognizeRequest, RecognizeResponse> _callRecognize;

--- a/apis/Google.Cloud.Speech.V1P1Beta1/synth.metadata
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/ApplicationServiceClient.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/ApplicationServiceClient.g.cs
@@ -191,6 +191,10 @@ namespace Google.Cloud.Talent.V4Beta1
     }
 
     /// <summary>ApplicationService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// A service that handles application management, including CRUD and
+    /// enumeration.
+    /// </remarks>
     public abstract partial class ApplicationServiceClient
     {
         /// <summary>
@@ -879,6 +883,10 @@ namespace Google.Cloud.Talent.V4Beta1
     }
 
     /// <summary>ApplicationService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// A service that handles application management, including CRUD and
+    /// enumeration.
+    /// </remarks>
     public sealed partial class ApplicationServiceClientImpl : ApplicationServiceClient
     {
         private readonly gaxgrpc::ApiCall<CreateApplicationRequest, Application> _callCreateApplication;

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/CompanyServiceClient.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/CompanyServiceClient.g.cs
@@ -189,6 +189,9 @@ namespace Google.Cloud.Talent.V4Beta1
     }
 
     /// <summary>CompanyService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// A service that handles company management, including CRUD and enumeration.
+    /// </remarks>
     public abstract partial class CompanyServiceClient
     {
         /// <summary>
@@ -1049,6 +1052,9 @@ namespace Google.Cloud.Talent.V4Beta1
     }
 
     /// <summary>CompanyService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// A service that handles company management, including CRUD and enumeration.
+    /// </remarks>
     public sealed partial class CompanyServiceClientImpl : CompanyServiceClient
     {
         private readonly gaxgrpc::ApiCall<CreateCompanyRequest, Company> _callCreateCompany;

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/CompletionClient.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/CompletionClient.g.cs
@@ -127,6 +127,9 @@ namespace Google.Cloud.Talent.V4Beta1
     }
 
     /// <summary>Completion client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// A service handles auto completion.
+    /// </remarks>
     public abstract partial class CompletionClient
     {
         /// <summary>
@@ -236,6 +239,9 @@ namespace Google.Cloud.Talent.V4Beta1
     }
 
     /// <summary>Completion client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// A service handles auto completion.
+    /// </remarks>
     public sealed partial class CompletionClientImpl : CompletionClient
     {
         private readonly gaxgrpc::ApiCall<CompleteQueryRequest, CompleteQueryResponse> _callCompleteQuery;

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/EventServiceClient.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/EventServiceClient.g.cs
@@ -125,6 +125,9 @@ namespace Google.Cloud.Talent.V4Beta1
     }
 
     /// <summary>EventService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// A service handles client event report.
+    /// </remarks>
     public abstract partial class EventServiceClient
     {
         /// <summary>
@@ -499,6 +502,9 @@ namespace Google.Cloud.Talent.V4Beta1
     }
 
     /// <summary>EventService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// A service handles client event report.
+    /// </remarks>
     public sealed partial class EventServiceClientImpl : EventServiceClient
     {
         private readonly gaxgrpc::ApiCall<CreateClientEventRequest, ClientEvent> _callCreateClientEvent;

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/JobServiceClient.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/JobServiceClient.g.cs
@@ -292,6 +292,9 @@ namespace Google.Cloud.Talent.V4Beta1
     }
 
     /// <summary>JobService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// A service handles job management, including job CRUD, enumeration and search.
+    /// </remarks>
     public abstract partial class JobServiceClient
     {
         /// <summary>
@@ -2240,6 +2243,9 @@ namespace Google.Cloud.Talent.V4Beta1
     }
 
     /// <summary>JobService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// A service handles job management, including job CRUD, enumeration and search.
+    /// </remarks>
     public sealed partial class JobServiceClientImpl : JobServiceClient
     {
         private readonly gaxgrpc::ApiCall<CreateJobRequest, Job> _callCreateJob;

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/ProfileServiceClient.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/ProfileServiceClient.g.cs
@@ -201,6 +201,10 @@ namespace Google.Cloud.Talent.V4Beta1
     }
 
     /// <summary>ProfileService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// A service that handles profile management, including profile CRUD,
+    /// enumeration and search.
+    /// </remarks>
     public abstract partial class ProfileServiceClient
     {
         /// <summary>
@@ -936,6 +940,10 @@ namespace Google.Cloud.Talent.V4Beta1
     }
 
     /// <summary>ProfileService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// A service that handles profile management, including profile CRUD,
+    /// enumeration and search.
+    /// </remarks>
     public sealed partial class ProfileServiceClientImpl : ProfileServiceClient
     {
         private readonly gaxgrpc::ApiCall<ListProfilesRequest, ListProfilesResponse> _callListProfiles;

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/TenantServiceClient.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/TenantServiceClient.g.cs
@@ -189,6 +189,9 @@ namespace Google.Cloud.Talent.V4Beta1
     }
 
     /// <summary>TenantService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// A service that handles tenant management, including CRUD and enumeration.
+    /// </remarks>
     public abstract partial class TenantServiceClient
     {
         /// <summary>
@@ -852,6 +855,9 @@ namespace Google.Cloud.Talent.V4Beta1
     }
 
     /// <summary>TenantService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// A service that handles tenant management, including CRUD and enumeration.
+    /// </remarks>
     public sealed partial class TenantServiceClientImpl : TenantServiceClient
     {
         private readonly gaxgrpc::ApiCall<CreateTenantRequest, Tenant> _callCreateTenant;

--- a/apis/Google.Cloud.Talent.V4Beta1/synth.metadata
+++ b/apis/Google.Cloud.Talent.V4Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/CloudTasksClient.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/CloudTasksClient.g.cs
@@ -347,6 +347,10 @@ namespace Google.Cloud.Tasks.V2
     }
 
     /// <summary>CloudTasks client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Cloud Tasks allows developers to manage the execution of background
+    /// work in their applications.
+    /// </remarks>
     public abstract partial class CloudTasksClient
     {
         /// <summary>
@@ -3634,6 +3638,10 @@ namespace Google.Cloud.Tasks.V2
     }
 
     /// <summary>CloudTasks client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Cloud Tasks allows developers to manage the execution of background
+    /// work in their applications.
+    /// </remarks>
     public sealed partial class CloudTasksClientImpl : CloudTasksClient
     {
         private readonly gaxgrpc::ApiCall<ListQueuesRequest, ListQueuesResponse> _callListQueues;

--- a/apis/Google.Cloud.Tasks.V2/synth.metadata
+++ b/apis/Google.Cloud.Tasks.V2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3/CloudTasksClient.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3/CloudTasksClient.g.cs
@@ -347,6 +347,10 @@ namespace Google.Cloud.Tasks.V2Beta3
     }
 
     /// <summary>CloudTasks client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Cloud Tasks allows developers to manage the execution of background
+    /// work in their applications.
+    /// </remarks>
     public abstract partial class CloudTasksClient
     {
         /// <summary>
@@ -3634,6 +3638,10 @@ namespace Google.Cloud.Tasks.V2Beta3
     }
 
     /// <summary>CloudTasks client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Cloud Tasks allows developers to manage the execution of background
+    /// work in their applications.
+    /// </remarks>
     public sealed partial class CloudTasksClientImpl : CloudTasksClient
     {
         private readonly gaxgrpc::ApiCall<ListQueuesRequest, ListQueuesResponse> _callListQueues;

--- a/apis/Google.Cloud.Tasks.V2Beta3/synth.metadata
+++ b/apis/Google.Cloud.Tasks.V2Beta3/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "eb37e688331443969eed9b969531751154a956d5"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/TextToSpeechClient.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/TextToSpeechClient.g.cs
@@ -143,6 +143,9 @@ namespace Google.Cloud.TextToSpeech.V1
     }
 
     /// <summary>TextToSpeech client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Service that implements Google Cloud Text-to-Speech API.
+    /// </remarks>
     public abstract partial class TextToSpeechClient
     {
         /// <summary>
@@ -402,6 +405,9 @@ namespace Google.Cloud.TextToSpeech.V1
     }
 
     /// <summary>TextToSpeech client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Service that implements Google Cloud Text-to-Speech API.
+    /// </remarks>
     public sealed partial class TextToSpeechClientImpl : TextToSpeechClient
     {
         private readonly gaxgrpc::ApiCall<ListVoicesRequest, ListVoicesResponse> _callListVoices;

--- a/apis/Google.Cloud.TextToSpeech.V1/synth.metadata
+++ b/apis/Google.Cloud.TextToSpeech.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/TraceServiceClient.g.cs
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/TraceServiceClient.g.cs
@@ -161,6 +161,13 @@ namespace Google.Cloud.Trace.V1
     }
 
     /// <summary>TraceService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// This file describes an API for collecting and viewing traces and spans
+    /// within a trace.  A Trace is a collection of spans corresponding to a single
+    /// operation or set of operations for an application. A span is an individual
+    /// timed event which forms a node of the trace tree. Spans for a single trace
+    /// may span multiple services.
+    /// </remarks>
     public abstract partial class TraceServiceClient
     {
         /// <summary>
@@ -487,6 +494,13 @@ namespace Google.Cloud.Trace.V1
     }
 
     /// <summary>TraceService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// This file describes an API for collecting and viewing traces and spans
+    /// within a trace.  A Trace is a collection of spans corresponding to a single
+    /// operation or set of operations for an application. A span is an individual
+    /// timed event which forms a node of the trace tree. Spans for a single trace
+    /// may span multiple services.
+    /// </remarks>
     public sealed partial class TraceServiceClientImpl : TraceServiceClient
     {
         private readonly gaxgrpc::ApiCall<ListTracesRequest, ListTracesResponse> _callListTraces;

--- a/apis/Google.Cloud.Trace.V1/synth.metadata
+++ b/apis/Google.Cloud.Trace.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "13d3b3ace10bd5a4865094ad2ba5e62b02e1e6bf"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/TraceServiceClient.g.cs
+++ b/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/TraceServiceClient.g.cs
@@ -142,6 +142,13 @@ namespace Google.Cloud.Trace.V2
     }
 
     /// <summary>TraceService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// This file describes an API for collecting and viewing traces and spans
+    /// within a trace.  A Trace is a collection of spans corresponding to a single
+    /// operation or set of operations for an application. A span is an individual
+    /// timed event which forms a node of the trace tree. A single trace may
+    /// contain span(s) from multiple services.
+    /// </remarks>
     public abstract partial class TraceServiceClient
     {
         /// <summary>
@@ -409,6 +416,13 @@ namespace Google.Cloud.Trace.V2
     }
 
     /// <summary>TraceService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// This file describes an API for collecting and viewing traces and spans
+    /// within a trace.  A Trace is a collection of spans corresponding to a single
+    /// operation or set of operations for an application. A span is an individual
+    /// timed event which forms a node of the trace tree. A single trace may
+    /// contain span(s) from multiple services.
+    /// </remarks>
     public sealed partial class TraceServiceClientImpl : TraceServiceClient
     {
         private readonly gaxgrpc::ApiCall<BatchWriteSpansRequest, wkt::Empty> _callBatchWriteSpans;

--- a/apis/Google.Cloud.Trace.V2/synth.metadata
+++ b/apis/Google.Cloud.Trace.V2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "13d3b3ace10bd5a4865094ad2ba5e62b02e1e6bf"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3/TranslationServiceClient.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3/TranslationServiceClient.g.cs
@@ -290,6 +290,9 @@ namespace Google.Cloud.Translate.V3
     }
 
     /// <summary>TranslationService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Provides natural language translation operations.
+    /// </remarks>
     public abstract partial class TranslationServiceClient
     {
         /// <summary>
@@ -2265,6 +2268,9 @@ namespace Google.Cloud.Translate.V3
     }
 
     /// <summary>TranslationService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Provides natural language translation operations.
+    /// </remarks>
     public sealed partial class TranslationServiceClientImpl : TranslationServiceClient
     {
         private readonly gaxgrpc::ApiCall<TranslateTextRequest, TranslateTextResponse> _callTranslateText;

--- a/apis/Google.Cloud.Translate.V3/synth.metadata
+++ b/apis/Google.Cloud.Translate.V3/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1/VideoIntelligenceServiceClient.g.cs
+++ b/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1/VideoIntelligenceServiceClient.g.cs
@@ -151,6 +151,9 @@ namespace Google.Cloud.VideoIntelligence.V1
     }
 
     /// <summary>VideoIntelligenceService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Service that implements Google Cloud Video Intelligence API.
+    /// </remarks>
     public abstract partial class VideoIntelligenceServiceClient
     {
         /// <summary>
@@ -386,6 +389,9 @@ namespace Google.Cloud.VideoIntelligence.V1
     }
 
     /// <summary>VideoIntelligenceService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Service that implements Google Cloud Video Intelligence API.
+    /// </remarks>
     public sealed partial class VideoIntelligenceServiceClientImpl : VideoIntelligenceServiceClient
     {
         private readonly gaxgrpc::ApiCall<AnnotateVideoRequest, lro::Operation> _callAnnotateVideo;

--- a/apis/Google.Cloud.VideoIntelligence.V1/synth.metadata
+++ b/apis/Google.Cloud.VideoIntelligence.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ImageAnnotatorClient.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ImageAnnotatorClient.g.cs
@@ -217,6 +217,11 @@ namespace Google.Cloud.Vision.V1
     }
 
     /// <summary>ImageAnnotator client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Service that performs Google Cloud Vision API detection tasks over client
+    /// images, such as face, landmark, logo, label, and text detection. The
+    /// ImageAnnotator service returns detected entities from the images.
+    /// </remarks>
     public abstract partial class ImageAnnotatorClient
     {
         /// <summary>
@@ -767,6 +772,11 @@ namespace Google.Cloud.Vision.V1
     }
 
     /// <summary>ImageAnnotator client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Service that performs Google Cloud Vision API detection tasks over client
+    /// images, such as face, landmark, logo, label, and text detection. The
+    /// ImageAnnotator service returns detected entities from the images.
+    /// </remarks>
     public sealed partial class ImageAnnotatorClientImpl : ImageAnnotatorClient
     {
         private readonly gaxgrpc::ApiCall<BatchAnnotateImagesRequest, BatchAnnotateImagesResponse> _callBatchAnnotateImages;

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ProductSearchClient.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ProductSearchClient.g.cs
@@ -461,6 +461,22 @@ namespace Google.Cloud.Vision.V1
     }
 
     /// <summary>ProductSearch client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Manages Products and ProductSets of reference images for use in product
+    /// search. It uses the following resource model:
+    /// 
+    /// - The API has a collection of [ProductSet][google.cloud.vision.v1.ProductSet] resources, named
+    /// `projects/*/locations/*/productSets/*`, which acts as a way to put different
+    /// products into groups to limit identification.
+    /// 
+    /// In parallel,
+    /// 
+    /// - The API has a collection of [Product][google.cloud.vision.v1.Product] resources, named
+    /// `projects/*/locations/*/products/*`
+    /// 
+    /// - Each [Product][google.cloud.vision.v1.Product] has a collection of [ReferenceImage][google.cloud.vision.v1.ReferenceImage] resources, named
+    /// `projects/*/locations/*/products/*/referenceImages/*`
+    /// </remarks>
     public abstract partial class ProductSearchClient
     {
         /// <summary>
@@ -4266,6 +4282,22 @@ namespace Google.Cloud.Vision.V1
     }
 
     /// <summary>ProductSearch client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Manages Products and ProductSets of reference images for use in product
+    /// search. It uses the following resource model:
+    /// 
+    /// - The API has a collection of [ProductSet][google.cloud.vision.v1.ProductSet] resources, named
+    /// `projects/*/locations/*/productSets/*`, which acts as a way to put different
+    /// products into groups to limit identification.
+    /// 
+    /// In parallel,
+    /// 
+    /// - The API has a collection of [Product][google.cloud.vision.v1.Product] resources, named
+    /// `projects/*/locations/*/products/*`
+    /// 
+    /// - Each [Product][google.cloud.vision.v1.Product] has a collection of [ReferenceImage][google.cloud.vision.v1.ReferenceImage] resources, named
+    /// `projects/*/locations/*/products/*/referenceImages/*`
+    /// </remarks>
     public sealed partial class ProductSearchClientImpl : ProductSearchClient
     {
         private readonly gaxgrpc::ApiCall<CreateProductSetRequest, ProductSet> _callCreateProductSet;

--- a/apis/Google.Cloud.Vision.V1/synth.metadata
+++ b/apis/Google.Cloud.Vision.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1/WebRiskServiceClient.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1/WebRiskServiceClient.g.cs
@@ -175,6 +175,10 @@ namespace Google.Cloud.WebRisk.V1
     }
 
     /// <summary>WebRiskService client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Web Risk API defines an interface to detect malicious URLs on your
+    /// website and in client applications.
+    /// </remarks>
     public abstract partial class WebRiskServiceClient
     {
         /// <summary>
@@ -778,6 +782,10 @@ namespace Google.Cloud.WebRisk.V1
     }
 
     /// <summary>WebRiskService client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Web Risk API defines an interface to detect malicious URLs on your
+    /// website and in client applications.
+    /// </remarks>
     public sealed partial class WebRiskServiceClientImpl : WebRiskServiceClient
     {
         private readonly gaxgrpc::ApiCall<ComputeThreatListDiffRequest, ComputeThreatListDiffResponse> _callComputeThreatListDiff;

--- a/apis/Google.Cloud.WebRisk.V1/synth.metadata
+++ b/apis/Google.Cloud.WebRisk.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "2e4b4213e174036bd02895f1eb59c47b2a41df78"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1/WebRiskServiceV1Beta1Client.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1/WebRiskServiceV1Beta1Client.g.cs
@@ -163,6 +163,10 @@ namespace Google.Cloud.WebRisk.V1Beta1
     }
 
     /// <summary>WebRiskServiceV1Beta1 client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Web Risk v1beta1 API defines an interface to detect malicious URLs on your
+    /// website and in client applications.
+    /// </remarks>
     public abstract partial class WebRiskServiceV1Beta1Client
     {
         /// <summary>
@@ -528,6 +532,10 @@ namespace Google.Cloud.WebRisk.V1Beta1
     }
 
     /// <summary>WebRiskServiceV1Beta1 client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Web Risk v1beta1 API defines an interface to detect malicious URLs on your
+    /// website and in client applications.
+    /// </remarks>
     public sealed partial class WebRiskServiceV1Beta1ClientImpl : WebRiskServiceV1Beta1Client
     {
         private readonly gaxgrpc::ApiCall<ComputeThreatListDiffRequest, ComputeThreatListDiffResponse> _callComputeThreatListDiff;

--- a/apis/Google.Cloud.WebRisk.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.WebRisk.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Identity.AccessContextManager.Type/synth.metadata
+++ b/apis/Google.Identity.AccessContextManager.Type/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.Identity.AccessContextManager.V1/synth.metadata
+++ b/apis/Google.Identity.AccessContextManager.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Google.LongRunning/Google.LongRunning/OperationsClient.g.cs
+++ b/apis/Google.LongRunning/Google.LongRunning/OperationsClient.g.cs
@@ -190,6 +190,17 @@ namespace Google.LongRunning
     }
 
     /// <summary>Operations client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// Manages long-running operations with an API service.
+    /// 
+    /// When an API method normally takes long time to complete, it can be designed
+    /// to return [Operation][google.longrunning.Operation] to the client, and the client can use this
+    /// interface to receive the real response asynchronously by polling the
+    /// operation resource, or pass the operation resource to another API (such as
+    /// Google Cloud Pub/Sub API) to receive the response.  Any API service that
+    /// returns long-running operations should implement the `Operations` interface
+    /// so developers can have a consistent client experience.
+    /// </remarks>
     public abstract partial class OperationsClient
     {
         /// <summary>
@@ -685,6 +696,17 @@ namespace Google.LongRunning
     }
 
     /// <summary>Operations client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// Manages long-running operations with an API service.
+    /// 
+    /// When an API method normally takes long time to complete, it can be designed
+    /// to return [Operation][google.longrunning.Operation] to the client, and the client can use this
+    /// interface to receive the real response asynchronously by polling the
+    /// operation resource, or pass the operation resource to another API (such as
+    /// Google Cloud Pub/Sub API) to receive the response.  Any API service that
+    /// returns long-running operations should implement the `Operations` interface
+    /// so developers can have a consistent client experience.
+    /// </remarks>
     public sealed partial class OperationsClientImpl : OperationsClient
     {
         private readonly gaxgrpc::ApiCall<ListOperationsRequest, ListOperationsResponse> _callListOperations;

--- a/apis/Google.LongRunning/synth.metadata
+++ b/apis/Google.LongRunning/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]

--- a/apis/Grafeas.V1/Grafeas.V1/GrafeasClient.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1/GrafeasClient.g.cs
@@ -313,6 +313,22 @@ namespace Grafeas.V1
     }
 
     /// <summary>Grafeas client wrapper, for convenient use.</summary>
+    /// <remarks>
+    /// [Grafeas](https://grafeas.io) API.
+    /// 
+    /// Retrieves analysis results of Cloud components such as Docker container
+    /// images.
+    /// 
+    /// Analysis results are stored as a series of occurrences. An `Occurrence`
+    /// contains information about a specific analysis instance on a resource. An
+    /// occurrence refers to a `Note`. A note contains details describing the
+    /// analysis and is generally stored in a separate project, called a `Provider`.
+    /// Multiple occurrences can refer to the same note.
+    /// 
+    /// For example, an SSL vulnerability could affect multiple images. In this case,
+    /// there would be one note for the vulnerability and an occurrence for each
+    /// image with the vulnerability referring to that note.
+    /// </remarks>
     public abstract partial class GrafeasClient
     {
 
@@ -2229,6 +2245,22 @@ namespace Grafeas.V1
     }
 
     /// <summary>Grafeas client wrapper implementation, for convenient use.</summary>
+    /// <remarks>
+    /// [Grafeas](https://grafeas.io) API.
+    /// 
+    /// Retrieves analysis results of Cloud components such as Docker container
+    /// images.
+    /// 
+    /// Analysis results are stored as a series of occurrences. An `Occurrence`
+    /// contains information about a specific analysis instance on a resource. An
+    /// occurrence refers to a `Note`. A note contains details describing the
+    /// analysis and is generally stored in a separate project, called a `Provider`.
+    /// Multiple occurrences can refer to the same note.
+    /// 
+    /// For example, an SSL vulnerability could affect multiple images. In this case,
+    /// there would be one note for the vulnerability and an occurrence for each
+    /// image with the vulnerability referring to that note.
+    /// </remarks>
     public sealed partial class GrafeasClientImpl : GrafeasClient
     {
         private readonly gaxgrpc::ApiCall<GetOccurrenceRequest, Occurrence> _callGetOccurrence;

--- a/apis/Grafeas.V1/synth.metadata
+++ b/apis/Grafeas.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7272af32a96a42fe5bb9452360e32ae95718abc2"        
+        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
       }
     }
   ]


### PR DESCRIPTION
The comments are included as they are, as a "remarks" section both the abstract base class and the concrete implementation.