### PR TITLE
Release Google.Cloud.Recommender.V1 version 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.PubSub.V1](https://googleapis.dev/dotnet/Google.Cloud.PubSub.V1/2.0.0) | 2.0.0 | [Cloud Pub/Sub](https://cloud.google.com/pubsub/) |
 | [Google.Cloud.RecaptchaEnterprise.V1](https://googleapis.dev/dotnet/Google.Cloud.RecaptchaEnterprise.V1/1.0.0) | 1.0.0 | [Google Cloud reCAPTCHA Enterprise (V1 API)](https://cloud.google.com/recaptcha-enterprise/) |
 | [Google.Cloud.RecaptchaEnterprise.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.RecaptchaEnterprise.V1Beta1/1.0.0-beta02) | 1.0.0-beta02 | [Google Cloud reCAPTCHA Enterprise (V1Beta1 API)](https://cloud.google.com/recaptcha-enterprise/) |
-| [Google.Cloud.Recommender.V1](https://googleapis.dev/dotnet/Google.Cloud.Recommender.V1/2.0.0) | 2.0.0 | [Google Cloud Recommender](https://cloud.google.com/recommender/) |
+| [Google.Cloud.Recommender.V1](https://googleapis.dev/dotnet/Google.Cloud.Recommender.V1/2.1.0) | 2.1.0 | [Google Cloud Recommender](https://cloud.google.com/recommender/) |
 | [Google.Cloud.Redis.V1](https://googleapis.dev/dotnet/Google.Cloud.Redis.V1/2.0.0) | 2.0.0 | [Google Cloud Memorystore for Redis (V1 API)](https://cloud.google.com/memorystore/) |
 | [Google.Cloud.Redis.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Redis.V1Beta1/2.0.0-beta02) | 2.0.0-beta02 | [Google Cloud Memorystore for Redis (V1Beta1 API)](https://cloud.google.com/memorystore/) |
 | [Google.Cloud.Scheduler.V1](https://googleapis.dev/dotnet/Google.Cloud.Scheduler.V1/2.0.0) | 2.0.0 | [Google Cloud Scheduler](https://cloud.google.com/scheduler/) |

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.csproj
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library for the Recommender API, which provides usage recommendations for Cloud products and services.</Description>

--- a/apis/Google.Cloud.Recommender.V1/docs/history.md
+++ b/apis/Google.Cloud.Recommender.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+# Version 2.1.0, released 2020-07-09
+
+- [Commit 6bde7a3](https://github.com/googleapis/google-cloud-dotnet/commit/6bde7a3): docs: include service description in documentation for client classes
+- [Commit 518278e](https://github.com/googleapis/google-cloud-dotnet/commit/518278e): feat: adds methods for interacting with insights
+- [Commit f83bdf1](https://github.com/googleapis/google-cloud-dotnet/commit/f83bdf1): feat: apply timeouts to RPCs without retries
+- [Commit 947a573](https://github.com/googleapis/google-cloud-dotnet/commit/947a573): docs: avoid use of inheritdoc
+
 # Version 2.0.0, released 2020-03-18
 
 No API surface changes compared with 2.0.0-beta01, just dependency

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -937,7 +937,7 @@
       "protoPath": "google/cloud/recommender/v1",
       "productName": "Google Cloud Recommender",
       "productUrl": "https://cloud.google.com/recommender/",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "type": "grpc",
       "description": "Recommended Google client library for the Recommender API, which provides usage recommendations for Cloud products and services.",
       "dependencies": {

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -65,7 +65,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.PubSub.V1](Google.Cloud.PubSub.V1/index.html) | 2.0.0 | [Cloud Pub/Sub](https://cloud.google.com/pubsub/) |
 | [Google.Cloud.RecaptchaEnterprise.V1](Google.Cloud.RecaptchaEnterprise.V1/index.html) | 1.0.0 | [Google Cloud reCAPTCHA Enterprise (V1 API)](https://cloud.google.com/recaptcha-enterprise/) |
 | [Google.Cloud.RecaptchaEnterprise.V1Beta1](Google.Cloud.RecaptchaEnterprise.V1Beta1/index.html) | 1.0.0-beta02 | [Google Cloud reCAPTCHA Enterprise (V1Beta1 API)](https://cloud.google.com/recaptcha-enterprise/) |
-| [Google.Cloud.Recommender.V1](Google.Cloud.Recommender.V1/index.html) | 2.0.0 | [Google Cloud Recommender](https://cloud.google.com/recommender/) |
+| [Google.Cloud.Recommender.V1](Google.Cloud.Recommender.V1/index.html) | 2.1.0 | [Google Cloud Recommender](https://cloud.google.com/recommender/) |
 | [Google.Cloud.Redis.V1](Google.Cloud.Redis.V1/index.html) | 2.0.0 | [Google Cloud Memorystore for Redis (V1 API)](https://cloud.google.com/memorystore/) |
 | [Google.Cloud.Redis.V1Beta1](Google.Cloud.Redis.V1Beta1/index.html) | 2.0.0-beta02 | [Google Cloud Memorystore for Redis (V1Beta1 API)](https://cloud.google.com/memorystore/) |
 | [Google.Cloud.Scheduler.V1](Google.Cloud.Scheduler.V1/index.html) | 2.0.0 | [Google Cloud Scheduler](https://cloud.google.com/scheduler/) |


### PR DESCRIPTION

Changes in this release:

- [Commit 6bde7a3](https://github.com/googleapis/google-cloud-dotnet/commit/6bde7a3): docs: include service description in documentation for client classes
- [Commit 518278e](https://github.com/googleapis/google-cloud-dotnet/commit/518278e): feat: adds methods for interacting with insights
- [Commit f83bdf1](https://github.com/googleapis/google-cloud-dotnet/commit/f83bdf1): feat: apply timeouts to RPCs without retries
- [Commit 947a573](https://github.com/googleapis/google-cloud-dotnet/commit/947a573): docs: avoid use of inheritdoc
