### PR TITLE
Fix the "clean test data" script

### DIFF
--- a/.kokoro/cleantestdata.sh
+++ b/.kokoro/cleantestdata.sh
@@ -8,6 +8,14 @@ SCRIPT_DIR=$(dirname "$SCRIPT")
 cd $SCRIPT_DIR
 cd ..
 
+# We don't really need the submodules, but it prevents some warnings in logs.
+echo "Cloning submodules"
+git submodule init
+git submodule update
+
+# Use the explicitly-provided credentials rather than relying on default compute credentials
+export GOOGLE_APPLICATION_CREDENTIALS="$KOKORO_KEYSTORE_DIR/73609_cloud-sharp-jenkins-compute-service-account"
+
 ./cleantestdata.sh
 
 ./processbuildtiminglog.sh


### PR DESCRIPTION
We need to work out why this has just started failing (we appear not
to be able to reach the metadata server from CI) but it's probably
better to be explicit with the credentials anyway.