### PR TITLE
Revert "Skip URL signer test that needs to metadata access"

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Snippets/UrlSignerSnippets.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Snippets/UrlSignerSnippets.cs
@@ -181,8 +181,7 @@ namespace Google.Cloud.Storage.V1.Snippets
         }
         // End sample
 
-        [Fact(Skip = "CI can't currently get to metadata server. See https://github.com/googleapis/google-cloud-dotnet/issues/5163")]
-        //[SkippableFact]
+        [SkippableFact]
         public async Task SignedUrlWithIamServiceBlobSigner()
         {
             _fixture.SkipIf(Platform.Instance().Type == PlatformType.Unknown);


### PR DESCRIPTION
This reverts commit 4998bd9dc5aa4928f4e24b59f26670ef917f8982.

We believe the lack of metadata access was just a blip; will run the
integration tests on Windows with this PR before merging.

Closes #5163.