### PR TITLE
Release Spanner libraries version 3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.SecurityCenter.V1](https://googleapis.dev/dotnet/Google.Cloud.SecurityCenter.V1/2.0.0) | 2.0.0 | [Google Cloud Security Command Center (V1 API)](https://cloud.google.com/security-command-center/) |
 | [Google.Cloud.SecurityCenter.V1P1Beta1](https://googleapis.dev/dotnet/Google.Cloud.SecurityCenter.V1P1Beta1/2.0.0-beta02) | 2.0.0-beta02 | [Google Cloud Security Command Center (V1P1Beta1 API)](https://cloud.google.com/security-command-center/) |
 | [Google.Cloud.ServiceDirectory.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.ServiceDirectory.V1Beta1/1.0.0-beta02) | 1.0.0-beta02 | [Service Directory](https://cloud.google.com/service-directory/) |
-| [Google.Cloud.Spanner.Admin.Database.V1](https://googleapis.dev/dotnet/Google.Cloud.Spanner.Admin.Database.V1/3.1.0-beta01) | 3.1.0-beta01 | [Google Cloud Spanner Database Administration](https://cloud.google.com/spanner/) |
-| [Google.Cloud.Spanner.Admin.Instance.V1](https://googleapis.dev/dotnet/Google.Cloud.Spanner.Admin.Instance.V1/3.1.0-beta01) | 3.1.0-beta01 | [Google Cloud Spanner Instance Administration](https://cloud.google.com/spanner/) |
-| [Google.Cloud.Spanner.Data](https://googleapis.dev/dotnet/Google.Cloud.Spanner.Data/3.1.0-beta01) | 3.1.0-beta01 | Google ADO.NET Provider for Google Cloud Spanner |
-| [Google.Cloud.Spanner.Common.V1](https://googleapis.dev/dotnet/Google.Cloud.Spanner.Common.V1/3.1.0-beta01) | 3.1.0-beta01 | Common resource names used by all Spanner V1 APIs |
-| [Google.Cloud.Spanner.V1](https://googleapis.dev/dotnet/Google.Cloud.Spanner.V1/3.1.0-beta01) | 3.1.0-beta01 | [Google Cloud Spanner](https://cloud.google.com/spanner/) |
+| [Google.Cloud.Spanner.Admin.Database.V1](https://googleapis.dev/dotnet/Google.Cloud.Spanner.Admin.Database.V1/3.1.0) | 3.1.0 | [Google Cloud Spanner Database Administration](https://cloud.google.com/spanner/) |
+| [Google.Cloud.Spanner.Admin.Instance.V1](https://googleapis.dev/dotnet/Google.Cloud.Spanner.Admin.Instance.V1/3.1.0) | 3.1.0 | [Google Cloud Spanner Instance Administration](https://cloud.google.com/spanner/) |
+| [Google.Cloud.Spanner.Data](https://googleapis.dev/dotnet/Google.Cloud.Spanner.Data/3.1.0) | 3.1.0 | Google ADO.NET Provider for Google Cloud Spanner |
+| [Google.Cloud.Spanner.Common.V1](https://googleapis.dev/dotnet/Google.Cloud.Spanner.Common.V1/3.1.0) | 3.1.0 | Common resource names used by all Spanner V1 APIs |
+| [Google.Cloud.Spanner.V1](https://googleapis.dev/dotnet/Google.Cloud.Spanner.V1/3.1.0) | 3.1.0 | [Google Cloud Spanner](https://cloud.google.com/spanner/) |
 | [Google.Cloud.Speech.V1](https://googleapis.dev/dotnet/Google.Cloud.Speech.V1/2.0.0) | 2.0.0 | [Google Cloud Speech (V1 API)](https://cloud.google.com/speech) |
 | [Google.Cloud.Speech.V1P1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Speech.V1P1Beta1/2.0.0-beta02) | 2.0.0-beta02 | [Google Cloud Speech (V1P1Beta1 API)](https://cloud.google.com/speech) |
 | [Google.Cloud.Storage.V1](https://googleapis.dev/dotnet/Google.Cloud.Storage.V1/3.2.0) | 3.2.0 | [Google Cloud Storage](https://cloud.google.com/storage/) |

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.csproj
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.1.0-beta01</Version>
+    <Version>3.1.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Spanner Database Admin API.</Description>

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.csproj
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.1.0-beta01</Version>
+    <Version>3.1.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Spanner Instance Admin API.</Description>

--- a/apis/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1.csproj
+++ b/apis/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.1.0-beta01</Version>
+    <Version>3.1.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Common resource names used by all Spanner V1 APIs</Description>

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.csproj
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.1.0-beta01</Version>
+    <Version>3.1.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google ADO.NET Provider for Google Cloud Spanner.</Description>

--- a/apis/Google.Cloud.Spanner.Data/docs/history.md
+++ b/apis/Google.Cloud.Spanner.Data/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+# Version 3.1.0, released 2020-07-14
+
+- [Commit 6bde7a3](https://github.com/googleapis/google-cloud-dotnet/commit/6bde7a3): Regenerate all APIs with service comments in client documentation
+- [Commit 2db277b](https://github.com/googleapis/google-cloud-dotnet/commit/2db277b):
+  - Improvements to GetOrdinal behavior
+  - Fixes [issue 5114](https://github.com/googleapis/google-cloud-dotnet/issues/5114)
+- [Commit f83bdf1](https://github.com/googleapis/google-cloud-dotnet/commit/f83bdf1): Regenerate APIs with timeouts for RPCs that don't have retries
+
 # Version 3.1.0-beta01, released 2020-06-16
 
 - [Commit 5b07f5a](https://github.com/googleapis/google-cloud-dotnet/commit/5b07f5a): fix: Roll back uncommitted (and not-rolled-back) read/write transactions on session release

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.csproj
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.1.0-beta01</Version>
+    <Version>3.1.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Low-level Google client library to access the Google Cloud Spanner API. The ADO.NET provider (Google.Cloud.Spanner.Data) which depends on this package is generally preferred for Spanner access.</Description>

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1140,7 +1140,7 @@
       "testTargetFrameworks": "netcoreapp2.0;net461",
       "productName": "Google Cloud Spanner Database Administration",
       "productUrl": "https://cloud.google.com/spanner/",
-      "version": "3.1.0-beta01",
+      "version": "3.1.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Spanner Database Admin API.",
       "tags": [
@@ -1162,7 +1162,7 @@
       "testTargetFrameworks": "netcoreapp2.0;net461",
       "productName": "Google Cloud Spanner Instance Administration",
       "productUrl": "https://cloud.google.com/spanner/",
-      "version": "3.1.0-beta01",
+      "version": "3.1.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Spanner Instance Admin API.",
       "tags": [
@@ -1180,7 +1180,7 @@
       "id": "Google.Cloud.Spanner.Data",
       "targetFrameworks": "netstandard2.0;net461",
       "testTargetFrameworks": "netcoreapp2.1;net461",
-      "version": "3.1.0-beta01",
+      "version": "3.1.0",
       "type": "other",
       "description": "Google ADO.NET Provider for Google Cloud Spanner.",
       "tags": [
@@ -1205,7 +1205,7 @@
       "id": "Google.Cloud.Spanner.Common.V1",
       "type": "other",
       "targetFrameworks": "netstandard2.0;net461",
-      "version": "3.1.0-beta01",
+      "version": "3.1.0",
       "description": "Common resource names used by all Spanner V1 APIs",
       "tags": [
         "Spanner"
@@ -1222,7 +1222,7 @@
       "testTargetFrameworks": "netcoreapp2.0;net461",
       "productName": "Google Cloud Spanner",
       "productUrl": "https://cloud.google.com/spanner/",
-      "version": "3.1.0-beta01",
+      "version": "3.1.0",
       "type": "grpc",
       "description": "Low-level Google client library to access the Google Cloud Spanner API. The ADO.NET provider (Google.Cloud.Spanner.Data) which depends on this package is generally preferred for Spanner access.",
       "tags": [

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -76,11 +76,11 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.SecurityCenter.V1](Google.Cloud.SecurityCenter.V1/index.html) | 2.0.0 | [Google Cloud Security Command Center (V1 API)](https://cloud.google.com/security-command-center/) |
 | [Google.Cloud.SecurityCenter.V1P1Beta1](Google.Cloud.SecurityCenter.V1P1Beta1/index.html) | 2.0.0-beta02 | [Google Cloud Security Command Center (V1P1Beta1 API)](https://cloud.google.com/security-command-center/) |
 | [Google.Cloud.ServiceDirectory.V1Beta1](Google.Cloud.ServiceDirectory.V1Beta1/index.html) | 1.0.0-beta02 | [Service Directory](https://cloud.google.com/service-directory/) |
-| [Google.Cloud.Spanner.Admin.Database.V1](Google.Cloud.Spanner.Admin.Database.V1/index.html) | 3.1.0-beta01 | [Google Cloud Spanner Database Administration](https://cloud.google.com/spanner/) |
-| [Google.Cloud.Spanner.Admin.Instance.V1](Google.Cloud.Spanner.Admin.Instance.V1/index.html) | 3.1.0-beta01 | [Google Cloud Spanner Instance Administration](https://cloud.google.com/spanner/) |
-| [Google.Cloud.Spanner.Data](Google.Cloud.Spanner.Data/index.html) | 3.1.0-beta01 | Google ADO.NET Provider for Google Cloud Spanner |
-| [Google.Cloud.Spanner.Common.V1](Google.Cloud.Spanner.Common.V1/index.html) | 3.1.0-beta01 | Common resource names used by all Spanner V1 APIs |
-| [Google.Cloud.Spanner.V1](Google.Cloud.Spanner.V1/index.html) | 3.1.0-beta01 | [Google Cloud Spanner](https://cloud.google.com/spanner/) |
+| [Google.Cloud.Spanner.Admin.Database.V1](Google.Cloud.Spanner.Admin.Database.V1/index.html) | 3.1.0 | [Google Cloud Spanner Database Administration](https://cloud.google.com/spanner/) |
+| [Google.Cloud.Spanner.Admin.Instance.V1](Google.Cloud.Spanner.Admin.Instance.V1/index.html) | 3.1.0 | [Google Cloud Spanner Instance Administration](https://cloud.google.com/spanner/) |
+| [Google.Cloud.Spanner.Data](Google.Cloud.Spanner.Data/index.html) | 3.1.0 | Google ADO.NET Provider for Google Cloud Spanner |
+| [Google.Cloud.Spanner.Common.V1](Google.Cloud.Spanner.Common.V1/index.html) | 3.1.0 | Common resource names used by all Spanner V1 APIs |
+| [Google.Cloud.Spanner.V1](Google.Cloud.Spanner.V1/index.html) | 3.1.0 | [Google Cloud Spanner](https://cloud.google.com/spanner/) |
 | [Google.Cloud.Speech.V1](Google.Cloud.Speech.V1/index.html) | 2.0.0 | [Google Cloud Speech (V1 API)](https://cloud.google.com/speech) |
 | [Google.Cloud.Speech.V1P1Beta1](Google.Cloud.Speech.V1P1Beta1/index.html) | 2.0.0-beta02 | [Google Cloud Speech (V1P1Beta1 API)](https://cloud.google.com/speech) |
 | [Google.Cloud.Storage.V1](Google.Cloud.Storage.V1/index.html) | 3.2.0 | [Google Cloud Storage](https://cloud.google.com/storage/) |


### PR DESCRIPTION

Changes since 3.1.0-beta01:

- [Commit 6bde7a3](https://github.com/googleapis/google-cloud-dotnet/commit/6bde7a3): Regenerate all APIs with service comments in client documentation
- [Commit 2db277b](https://github.com/googleapis/google-cloud-dotnet/commit/2db277b):
  - Improvements to GetOrdinal behavior
  - Fixes [issue 5114](https://github.com/googleapis/google-cloud-dotnet/issues/5114)
- [Commit f83bdf1](https://github.com/googleapis/google-cloud-dotnet/commit/f83bdf1): Regenerate APIs with timeouts for RPCs that don't have retries

Packages in this release:

- Release Google.Cloud.Spanner.V1 version 3.1.0
- Release Google.Cloud.Spanner.Data version 3.1.0
- Release Google.Cloud.Spanner.Common.V1 version 3.1.0
- Release Google.Cloud.Spanner.Admin.Database.V1 version 3.1.0
- Release Google.Cloud.Spanner.Admin.Instance.V1 version 3.1.0
