### PR TITLE
Bump Dataproc library version due to breaking change

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Billing.V1](https://googleapis.dev/dotnet/Google.Cloud.Billing.V1/2.0.0) | 2.0.0 | [Google Cloud Billing API](https://cloud.google.com/billing/docs/) |
 | [Google.Cloud.Container.V1](https://googleapis.dev/dotnet/Google.Cloud.Container.V1/2.0.0) | 2.0.0 | [Google Kubernetes Engine API](https://cloud.google.com/kubernetes-engine/docs/reference/rest/) |
 | [Google.Cloud.DataCatalog.V1](https://googleapis.dev/dotnet/Google.Cloud.DataCatalog.V1/1.0.0) | 1.0.0 | [Data Catalog](https://cloud.google.com/data-catalog/docs) |
-| [Google.Cloud.Dataproc.V1](https://googleapis.dev/dotnet/Google.Cloud.Dataproc.V1/2.1.0) | 2.1.0 | [Google Cloud Dataproc](https://cloud.google.com/dataproc/docs/concepts/overview) |
+| [Google.Cloud.Dataproc.V1](https://googleapis.dev/dotnet/Google.Cloud.Dataproc.V1/3.0.0-beta00) | 3.0.0-beta00 | [Google Cloud Dataproc](https://cloud.google.com/dataproc/docs/concepts/overview) |
 | [Google.Cloud.Datastore.V1](https://googleapis.dev/dotnet/Google.Cloud.Datastore.V1/3.0.0) | 3.0.0 | [Google Cloud Datastore](https://cloud.google.com/datastore/docs/concepts/overview) |
 | [Google.Cloud.Debugger.V2](https://googleapis.dev/dotnet/Google.Cloud.Debugger.V2/2.0.0) | 2.0.0 | [Google Cloud Debugger](https://cloud.google.com/debugger/) |
 | [Google.Cloud.DevTools.Common](https://googleapis.dev/dotnet/Google.Cloud.DevTools.Common/2.0.0) | 2.0.0 | Common Protocol Buffer messages for Google Cloud Developer Tools APIs |

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.csproj
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>3.0.0-beta00</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Dataproc API, which manages Hadoop-based clusters and jobs on Google Cloud Platform.</Description>

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -266,7 +266,7 @@
       "protoPath": "google/cloud/dataproc/v1",
       "productName": "Google Cloud Dataproc",
       "productUrl": "https://cloud.google.com/dataproc/docs/concepts/overview",
-      "version": "2.1.0",
+      "version": "3.0.0-beta00",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Dataproc API, which manages Hadoop-based clusters and jobs on Google Cloud Platform.",
       "tags": [

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -32,7 +32,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Billing.V1](Google.Cloud.Billing.V1/index.html) | 2.0.0 | [Google Cloud Billing API](https://cloud.google.com/billing/docs/) |
 | [Google.Cloud.Container.V1](Google.Cloud.Container.V1/index.html) | 2.0.0 | [Google Kubernetes Engine API](https://cloud.google.com/kubernetes-engine/docs/reference/rest/) |
 | [Google.Cloud.DataCatalog.V1](Google.Cloud.DataCatalog.V1/index.html) | 1.0.0 | [Data Catalog](https://cloud.google.com/data-catalog/docs) |
-| [Google.Cloud.Dataproc.V1](Google.Cloud.Dataproc.V1/index.html) | 2.1.0 | [Google Cloud Dataproc](https://cloud.google.com/dataproc/docs/concepts/overview) |
+| [Google.Cloud.Dataproc.V1](Google.Cloud.Dataproc.V1/index.html) | 3.0.0-beta00 | [Google Cloud Dataproc](https://cloud.google.com/dataproc/docs/concepts/overview) |
 | [Google.Cloud.Datastore.V1](Google.Cloud.Datastore.V1/index.html) | 3.0.0 | [Google Cloud Datastore](https://cloud.google.com/datastore/docs/concepts/overview) |
 | [Google.Cloud.Debugger.V2](Google.Cloud.Debugger.V2/index.html) | 2.0.0 | [Google Cloud Debugger](https://cloud.google.com/debugger/) |
 | [Google.Cloud.DevTools.Common](Google.Cloud.DevTools.Common/index.html) | 2.0.0 | Common Protocol Buffer messages for Google Cloud Developer Tools APIs |


### PR DESCRIPTION
bumping the version number now, we won't accidentally release a 2.2
later.