### PR TITLE
Avoid unnecessarily problematic language

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,12 @@ dotnet: 3.1.301
 dist: xenial
 
 # We really don't need to see "Welcome to .NET Core" everywhere,
-# and setting the TERM variable to "dumb" fixes some odd console
+# and setting the TERM variable to "plain" fixes some odd console
 # output where dotnet appears to issue control characters (^[[?1h^[=) that
 # Travis doesn't support.
 env:
   global:
-    - DOTNET_NOLOGO=true TERM=dumb
+    - DOTNET_NOLOGO=true TERM=plain
 
 jobs:
   include:


### PR DESCRIPTION
It looks like TERM can be anything that dotnet doesn't understand,
so "plain" should be fine.

(I'll review Travis output before merging.)