### PR TITLE
[Diagnostics]: Associates logs to the correct trace/span if there is one.

### DIFF
--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/EntryData.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/EntryData.cs
@@ -16,7 +16,7 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
 {
     /// <summary>
     /// Class that contains data and helper methods used to include data in
-    /// <see cref="ErrorEvent"/> entries.
+    /// log entries.
     /// </summary>
     public static class EntryData
     {
@@ -27,5 +27,7 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
         /// Returns a formatted message based on the two parametes.
         /// </summary>
         public static string GetMessage(string message, string id) => $"{message} - {id}";
+
+        public static string SpanIdToHex(ulong? spanId) => spanId is null ? null : string.Format("0x{0:X}", spanId);
     }
 }

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Trace/TraceEntryPolling.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Trace/TraceEntryPolling.cs
@@ -18,7 +18,6 @@ using Google.Protobuf.WellKnownTypes;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-
 using TraceProto = Google.Cloud.Trace.V1.Trace;
 
 namespace Google.Cloud.Diagnostics.Common.IntegrationTests
@@ -35,6 +34,10 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
         private readonly TraceServiceClient _client = TraceServiceClient.Create();
 
         internal TraceEntryPolling(TimeSpan timeout = default, TimeSpan sleepInterval = default) : base(timeout, sleepInterval) { }
+
+        public TraceProto GetTrace(string traceId) => 
+            GetEntries(1, () => new[] { _client.GetTrace(_projectId, traceId) })
+                .SingleOrDefault();
 
         /// <summary>
         /// Gets a trace that contains a span with the given name.


### PR DESCRIPTION
  * Fixes #5190

(I'm running integration tests locally).