### PR TITLE
[Speech]: Fixes Speech smoke tests.

### DIFF
--- a/apis/Google.Cloud.Speech.V1/smoketests.json
+++ b/apis/Google.Cloud.Speech.V1/smoketests.json
@@ -6,7 +6,7 @@
       	"language_code": "en-US",
       	"sample_rate_hertz": 44100,
               "encoding": "FLAC",
-        "audio_channel_count": 2
+              "audio_channel_count": 2
       },
       "audio": {
       	"uri": "gs://cloud-samples-data/speech/hello.flac"

--- a/apis/Google.Cloud.Speech.V1/smoketests.json
+++ b/apis/Google.Cloud.Speech.V1/smoketests.json
@@ -5,7 +5,7 @@
       "config": {
       	"language_code": "en-US",
       	"sample_rate_hertz": 44100,
-        "encoding": "FLAC",
+              "encoding": "FLAC",
         "audio_channel_count": 2
       },
       "audio": {

--- a/apis/Google.Cloud.Speech.V1/smoketests.json
+++ b/apis/Google.Cloud.Speech.V1/smoketests.json
@@ -5,10 +5,11 @@
       "config": {
       	"language_code": "en-US",
       	"sample_rate_hertz": 44100,
-      	"encoding": "FLAC"
+        "encoding": "FLAC",
+        "audio_channel_count": 2
       },
       "audio": {
-      	"uri": "gs://gapic-toolkit/hello.flac"
+      	"uri": "gs://cloud-samples-data/speech/hello.flac"
       }
     }
   }

--- a/apis/Google.Cloud.Speech.V1P1Beta1/smoketests.json
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/smoketests.json
@@ -3,12 +3,13 @@
     "method": "Recognize",
     "arguments": {
       "config": {
-      	"language_code": "en-US",
-      	"sample_rate_hertz": 44100,
-      	"encoding": "FLAC"
+        "language_code": "en-US",
+        "sample_rate_hertz": 44100,
+        "encoding": "FLAC",
+        "audio_channel_count": 2
       },
       "audio": {
-      	"uri": "gs://gapic-toolkit/hello.flac"
+        "uri": "gs://cloud-samples-data/speech/hello.flac"
       }
     }
   }

--- a/apis/Google.Cloud.Speech.V1P1Beta1/smoketests.json
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/smoketests.json
@@ -9,7 +9,7 @@
         "audio_channel_count": 2
       },
       "audio": {
-        "uri": "gs://cloud-samples-data/speech/hello.flac"
+              "uri": "gs://cloud-samples-data/speech/hello.flac"
       }
     }
   }


### PR DESCRIPTION
The audio files we used to use have been removed. I've pointed to ones in the samples data bucket that we use for some other smoke tests.