### PR TITLE
[Spanner] feat: set resource header in streaming method

### DIFF
--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/PooledSession.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/PooledSession.cs
@@ -296,6 +296,7 @@ namespace Google.Cloud.Spanner.V1
                 request.Transaction = new TransactionSelector { Id = TransactionId };
             }
             request.SessionAsSessionName = SessionName;
+            SpannerClientImpl.ApplyResourcePrefixHeaderFromSession(ref callSettings, request.Session);
 
             SqlResultStream stream = new SqlResultStream(Client, request, _session, callSettings);
             return new ReliableStreamReader(stream, Client.Settings.Logger);

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SpannerClientPartial.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SpannerClientPartial.cs
@@ -74,7 +74,7 @@ namespace Google.Cloud.Spanner.V1
         partial void Modify_PartitionReadRequest(ref PartitionReadRequest request, ref CallSettings settings) =>
             ApplyResourcePrefixHeaderFromSession(ref settings, request.Session);
 
-        private static void ApplyResourcePrefixHeaderFromDatabase(ref CallSettings settings, string resource)
+        internal static void ApplyResourcePrefixHeaderFromDatabase(ref CallSettings settings, string resource)
         {
             // If we haven't been given a resource name, just leave the request as it is.
             if (string.IsNullOrEmpty(resource))
@@ -88,7 +88,7 @@ namespace Google.Cloud.Spanner.V1
             }
         }
 
-        private static void ApplyResourcePrefixHeaderFromSession(ref CallSettings settings, string resource)
+        internal static void ApplyResourcePrefixHeaderFromSession(ref CallSettings settings, string resource)
         {
             // If we haven't been given a resource name, just leave the request as it is.
             if (string.IsNullOrEmpty(resource))


### PR DESCRIPTION
Sets the google-cloud-resource-prefix header when calling the ExecuteStreamingSql RPC in the Spanner data client so that we can support resource-based routing.

Towards #5181