### PR TITLE
feat(spanner): set resource header in database admin client

### DIFF
--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.Tests/ResourcePrefixHeaderTest.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.Tests/ResourcePrefixHeaderTest.cs
@@ -1,0 +1,249 @@
+// Copyright 2020, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Grpc.Core;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace Google.Cloud.Spanner.Admin.Database.V1.Tests
+{
+    public class ResourcePrefixHeaderTest
+    {
+        private const string ResourcePrefixHeader = "google-cloud-resource-prefix";
+        private const string SampleInstanceName = "projects/proj/instances/inst";
+        private const string SampleDatabaseName = "projects/proj/instances/inst/databases/db";
+        private const string SampleBackupName = "projects/proj/instances/inst/backups/backup";
+
+        [Fact]
+        public void NoHeaderOnCreateDatabaseIfEmptyInstanceName()
+        {
+            var invoker = new FakeCallInvoker();
+            var client = new DatabaseAdminClientBuilder { CallInvoker = invoker }.Build();
+            client.CreateDatabase(new CreateDatabaseRequest());
+            Assert.Null(invoker.Metadata.FirstOrDefault(e => e.Key == ResourcePrefixHeader));
+        }
+
+        [Fact]
+        public void NoHeaderOnCreateDatabaseIfInvalidInstanceName()
+        {
+            var invoker = new FakeCallInvoker();
+            var client = new DatabaseAdminClientBuilder { CallInvoker = invoker }.Build();
+            client.CreateDatabase(new CreateDatabaseRequest { Parent = "projects/instances" });
+            Assert.Null(invoker.Metadata.FirstOrDefault(e => e.Key == ResourcePrefixHeader));
+        }
+
+        [Fact]
+        public void NoHeaderOnGetDatabaseIfEmptyDatabaseName()
+        {
+            var invoker = new FakeCallInvoker();
+            var client = new DatabaseAdminClientBuilder { CallInvoker = invoker }.Build();
+            client.GetDatabase(new GetDatabaseRequest());
+            Assert.Null(invoker.Metadata.FirstOrDefault(e => e.Key == ResourcePrefixHeader));
+        }
+
+        [Fact]
+        public void NoHeaderOnGetDatabaseIfInvalidDatabaseName()
+        {
+            var invoker = new FakeCallInvoker();
+            var client = new DatabaseAdminClientBuilder { CallInvoker = invoker }.Build();
+            client.GetDatabase(new GetDatabaseRequest { Name = "projects/proj/instances/inst/databases" });
+            Assert.Null(invoker.Metadata.FirstOrDefault(e => e.Key == ResourcePrefixHeader));
+        }
+
+        [Fact]
+        public void NoHeaderOnGetBackupIfEmptyBackupName()
+        {
+            var invoker = new FakeCallInvoker();
+            var client = new DatabaseAdminClientBuilder { CallInvoker = invoker }.Build();
+            client.GetBackup(new GetBackupRequest());
+            Assert.Null(invoker.Metadata.FirstOrDefault(e => e.Key == ResourcePrefixHeader));
+        }
+
+        [Fact]
+        public void NoHeaderOnGetBackupIfInvalidBackupName()
+        {
+            var invoker = new FakeCallInvoker();
+            var client = new DatabaseAdminClientBuilder { CallInvoker = invoker }.Build();
+            client.GetBackup(new GetBackupRequest { Name = "projects/proj/instances/inst/backups" });
+            Assert.Null(invoker.Metadata.FirstOrDefault(e => e.Key == ResourcePrefixHeader));
+        }
+
+        [Fact]
+        public void SetsHeaderOnListDatabases()
+        {
+            var invoker = new FakeCallInvoker();
+            var client = new DatabaseAdminClientBuilder { CallInvoker = invoker }.Build();
+            client.ListDatabases(new ListDatabasesRequest { Parent = SampleInstanceName }).AsRawResponses().First();
+            Metadata.Entry entry = Assert.Single(invoker.Metadata, e => e.Key == ResourcePrefixHeader);
+            Assert.Equal(SampleInstanceName, entry.Value);
+        }
+
+        [Fact]
+        public void SetsHeaderOnCreateDatabase()
+        {
+            var invoker = new FakeCallInvoker();
+            var client = new DatabaseAdminClientBuilder { CallInvoker = invoker }.Build();
+            client.CreateDatabase(new CreateDatabaseRequest { Parent = SampleInstanceName });
+            Metadata.Entry entry = Assert.Single(invoker.Metadata, e => e.Key == ResourcePrefixHeader);
+            Assert.Equal(SampleInstanceName, entry.Value);
+        }
+
+        [Fact]
+        public void SetsHeaderOnGetDatabase()
+        {
+            var invoker = new FakeCallInvoker();
+            var client = new DatabaseAdminClientBuilder { CallInvoker = invoker }.Build();
+            client.GetDatabase(new GetDatabaseRequest { Name = SampleDatabaseName });
+            Metadata.Entry entry = Assert.Single(invoker.Metadata, e => e.Key == ResourcePrefixHeader);
+            Assert.Equal(SampleDatabaseName, entry.Value);
+        }
+
+        [Fact]
+        public void SetsHeaderOnUpdateDatabaseDdl()
+        {
+            var invoker = new FakeCallInvoker();
+            var client = new DatabaseAdminClientBuilder { CallInvoker = invoker }.Build();
+            client.UpdateDatabaseDdl(new UpdateDatabaseDdlRequest { Database = SampleDatabaseName });
+            Metadata.Entry entry = Assert.Single(invoker.Metadata, e => e.Key == ResourcePrefixHeader);
+            Assert.Equal(SampleDatabaseName, entry.Value);
+        }
+
+        [Fact]
+        public void SetsHeaderOnDropDatabase()
+        {
+            var invoker = new FakeCallInvoker();
+            var client = new DatabaseAdminClientBuilder { CallInvoker = invoker }.Build();
+            client.DropDatabase(new DropDatabaseRequest { Database = SampleDatabaseName });
+            Metadata.Entry entry = Assert.Single(invoker.Metadata, e => e.Key == ResourcePrefixHeader);
+            Assert.Equal(SampleDatabaseName, entry.Value);
+        }
+
+        [Fact]
+        public void SetsHeaderOnGetDatabaseDdl()
+        {
+            var invoker = new FakeCallInvoker();
+            var client = new DatabaseAdminClientBuilder { CallInvoker = invoker }.Build();
+            client.GetDatabaseDdl(new GetDatabaseDdlRequest { Database = SampleDatabaseName });
+            Metadata.Entry entry = Assert.Single(invoker.Metadata, e => e.Key == ResourcePrefixHeader);
+            Assert.Equal(SampleDatabaseName, entry.Value);
+        }
+
+        [Fact]
+        public void SetsHeaderOnCreateBackup()
+        {
+            var invoker = new FakeCallInvoker();
+            var client = new DatabaseAdminClientBuilder { CallInvoker = invoker }.Build();
+            client.CreateBackup(new CreateBackupRequest { Parent = SampleInstanceName });
+            Metadata.Entry entry = Assert.Single(invoker.Metadata, e => e.Key == ResourcePrefixHeader);
+            Assert.Equal(SampleInstanceName, entry.Value);
+        }
+
+        [Fact]
+        public void SetsHeaderOnGetBackup()
+        {
+            var invoker = new FakeCallInvoker();
+            var client = new DatabaseAdminClientBuilder { CallInvoker = invoker }.Build();
+            client.GetBackup(new GetBackupRequest { Name = SampleBackupName });
+            Metadata.Entry entry = Assert.Single(invoker.Metadata, e => e.Key == ResourcePrefixHeader);
+            Assert.Equal(SampleInstanceName, entry.Value);
+        }
+
+        [Fact]
+        public void SetsHeaderOnUpdateBackup()
+        {
+            var invoker = new FakeCallInvoker();
+            var client = new DatabaseAdminClientBuilder { CallInvoker = invoker }.Build();
+            client.UpdateBackup(new UpdateBackupRequest
+            {
+                Backup = new Backup { Name = SampleBackupName }
+            });
+            Metadata.Entry entry = Assert.Single(invoker.Metadata, e => e.Key == ResourcePrefixHeader);
+            Assert.Equal(SampleInstanceName, entry.Value);
+        }
+
+        [Fact]
+        public void SetsHeaderOnDeleteBackup()
+        {
+            var invoker = new FakeCallInvoker();
+            var client = new DatabaseAdminClientBuilder { CallInvoker = invoker }.Build();
+            client.DeleteBackup(new DeleteBackupRequest { Name = SampleBackupName });
+            Metadata.Entry entry = Assert.Single(invoker.Metadata, e => e.Key == ResourcePrefixHeader);
+            Assert.Equal(SampleInstanceName, entry.Value);
+        }
+
+        [Fact]
+        public void SetsHeaderOnListBackups()
+        {
+            var invoker = new FakeCallInvoker();
+            var client = new DatabaseAdminClientBuilder { CallInvoker = invoker }.Build();
+            client.ListBackups(new ListBackupsRequest { Parent = SampleInstanceName }).AsRawResponses().First();
+            Metadata.Entry entry = Assert.Single(invoker.Metadata, e => e.Key == ResourcePrefixHeader);
+            Assert.Equal(SampleInstanceName, entry.Value);
+        }
+
+        [Fact]
+        public void SetsHeaderOnRestoreDatabase()
+        {
+            var invoker = new FakeCallInvoker();
+            var client = new DatabaseAdminClientBuilder { CallInvoker = invoker }.Build();
+            client.RestoreDatabase(new RestoreDatabaseRequest { Parent = SampleInstanceName });
+            Metadata.Entry entry = Assert.Single(invoker.Metadata, e => e.Key == ResourcePrefixHeader);
+            Assert.Equal(SampleInstanceName, entry.Value);
+        }
+
+        [Fact]
+        public void SetsHeaderOnListDatabaseOperations()
+        {
+            var invoker = new FakeCallInvoker();
+            var client = new DatabaseAdminClientBuilder { CallInvoker = invoker }.Build();
+            client.ListDatabaseOperations(new ListDatabaseOperationsRequest { Parent = SampleInstanceName }).AsRawResponses().First();
+            Metadata.Entry entry = Assert.Single(invoker.Metadata, e => e.Key == ResourcePrefixHeader);
+            Assert.Equal(SampleInstanceName, entry.Value);
+        }
+
+        [Fact]
+        public void SetsHeaderOnListBackupOperations()
+        {
+            var invoker = new FakeCallInvoker();
+            var client = new DatabaseAdminClientBuilder { CallInvoker = invoker }.Build();
+            client.ListBackupOperations(new ListBackupOperationsRequest { Parent = SampleInstanceName }).AsRawResponses().First();
+            Metadata.Entry entry = Assert.Single(invoker.Metadata, e => e.Key == ResourcePrefixHeader);
+            Assert.Equal(SampleInstanceName, entry.Value);
+        }
+
+        private class FakeCallInvoker : CallInvoker
+        {
+            public Metadata Metadata { get; private set; }
+
+            public override AsyncClientStreamingCall<TRequest, TResponse> AsyncClientStreamingCall<TRequest, TResponse>(Method<TRequest, TResponse> method, string host, CallOptions options) =>
+                throw new NotImplementedException();
+
+            public override AsyncDuplexStreamingCall<TRequest, TResponse> AsyncDuplexStreamingCall<TRequest, TResponse>(Method<TRequest, TResponse> method, string host, CallOptions options) =>
+                throw new NotImplementedException();
+
+            public override AsyncServerStreamingCall<TResponse> AsyncServerStreamingCall<TRequest, TResponse>(Method<TRequest, TResponse> method, string host, CallOptions options, TRequest request) =>
+                throw new NotImplementedException();
+
+            public override AsyncUnaryCall<TResponse> AsyncUnaryCall<TRequest, TResponse>(Method<TRequest, TResponse> method, string host, CallOptions options, TRequest request) =>
+                throw new NotImplementedException();
+
+            public override TResponse BlockingUnaryCall<TRequest, TResponse>(Method<TRequest, TResponse> method, string host, CallOptions options, TRequest request)
+            {
+                Metadata = options.Headers;
+                return (TResponse) Activator.CreateInstance(typeof(TResponse));
+            }
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/DatabaseAdminClientPartial.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/DatabaseAdminClientPartial.cs
@@ -1,0 +1,124 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using Google.Api.Gax.Grpc;
+using Google.Cloud.Spanner.Common.V1;
+using System;
+
+namespace Google.Cloud.Spanner.Admin.Database.V1
+{
+    // Partial class to set up resource-based routing.
+    public partial class DatabaseAdminClientImpl
+    {
+        /// <summary>
+        /// The name of the header used for efficiently routing requests.
+        /// </summary>
+        /// <remarks>
+        /// This should be set to the instance resource name ("projects/{projectId}/instances/{instanceId}") for some RPCs
+        /// and to the database resource name for others ("projects/{projectId}/instances/{instanceId}/databases/{databaseId}").
+        /// For non-streaming calls, <see cref="DatabaseAdminClientImpl"/> performs this automatically. This cannot be performed
+        /// automatically for streaming calls due to the separation between initializing the stream and sending requests, so
+        /// client code should set the value in a <see cref="CallSettings"/>. Typically this is performed with either the
+        /// <see cref="CallSettings.FromHeader(string, string)"/> factory method or the
+        /// <see cref="CallSettingsExtensions.WithHeader(CallSettings, string, string)"/> extension method.
+        /// </remarks>
+        public const string ResourcePrefixHeader = "google-cloud-resource-prefix";
+
+        partial void Modify_ListDatabasesRequest(ref ListDatabasesRequest request, ref CallSettings settings) =>
+            ApplyResourcePrefixHeaderFromInstance(ref settings, request.Parent);
+
+        partial void Modify_CreateDatabaseRequest(ref CreateDatabaseRequest request, ref CallSettings settings) =>
+            ApplyResourcePrefixHeaderFromInstance(ref settings, request.Parent);
+
+        partial void Modify_GetDatabaseRequest(ref GetDatabaseRequest request, ref CallSettings settings) =>
+            ApplyResourcePrefixHeaderFromDatabase(ref settings, request.Name);
+
+        partial void Modify_UpdateDatabaseDdlRequest(ref UpdateDatabaseDdlRequest request, ref CallSettings settings) =>
+            ApplyResourcePrefixHeaderFromDatabase(ref settings, request.Database);
+
+        partial void Modify_DropDatabaseRequest(ref DropDatabaseRequest request, ref CallSettings settings) =>
+            ApplyResourcePrefixHeaderFromDatabase(ref settings, request.Database);
+
+        partial void Modify_GetDatabaseDdlRequest(ref GetDatabaseDdlRequest request, ref CallSettings settings) =>
+            ApplyResourcePrefixHeaderFromDatabase(ref settings, request.Database);
+
+        partial void Modify_CreateBackupRequest(ref CreateBackupRequest request, ref CallSettings settings) =>
+            ApplyResourcePrefixHeaderFromInstance(ref settings, request.Parent);
+
+        partial void Modify_GetBackupRequest(ref GetBackupRequest request, ref CallSettings settings) =>
+            ApplyResourcePrefixHeaderFromBackup(ref settings, request.Name);
+
+        partial void Modify_UpdateBackupRequest(ref UpdateBackupRequest request, ref CallSettings settings) =>
+            ApplyResourcePrefixHeaderFromBackup(ref settings, request.Backup.Name);
+
+        partial void Modify_DeleteBackupRequest(ref DeleteBackupRequest request, ref CallSettings settings) =>
+            ApplyResourcePrefixHeaderFromBackup(ref settings, request.Name);
+
+        partial void Modify_ListBackupsRequest(ref ListBackupsRequest request, ref CallSettings settings) =>
+            ApplyResourcePrefixHeaderFromInstance(ref settings, request.Parent);
+
+        partial void Modify_RestoreDatabaseRequest(ref RestoreDatabaseRequest request, ref CallSettings settings) =>
+            ApplyResourcePrefixHeaderFromInstance(ref settings, request.Parent);
+
+        partial void Modify_ListDatabaseOperationsRequest(ref ListDatabaseOperationsRequest request, ref CallSettings settings) =>
+            ApplyResourcePrefixHeaderFromInstance(ref settings, request.Parent);
+
+        partial void Modify_ListBackupOperationsRequest(ref ListBackupOperationsRequest request, ref CallSettings settings) =>
+            ApplyResourcePrefixHeaderFromInstance(ref settings, request.Parent);
+
+        private static void ApplyResourcePrefixHeaderFromInstance(ref CallSettings settings, string resource)
+        {
+            // If we haven't been given a resource name, just leave the request as it is.
+            if (string.IsNullOrEmpty(resource))
+            {
+                return;
+            }
+
+            if (InstanceName.TryParse(resource, out InstanceName instance))
+            {
+                settings = settings.WithHeader(ResourcePrefixHeader, instance.ToString());
+            }
+        }
+
+        private static void ApplyResourcePrefixHeaderFromDatabase(ref CallSettings settings, string resource)
+        {
+            // If we haven't been given a resource name, just leave the request as it is.
+            if (string.IsNullOrEmpty(resource))
+            {
+                return;
+            }
+
+            if (DatabaseName.TryParse(resource, out DatabaseName database))
+            {
+                settings = settings.WithHeader(ResourcePrefixHeader, database.ToString());
+            }
+        }
+
+        private static void ApplyResourcePrefixHeaderFromBackup(ref CallSettings settings, string resource)
+        {
+            // If we haven't been given a resource name, just leave the request as it is.
+            if (string.IsNullOrEmpty(resource))
+            {
+                return;
+            }
+
+            if (BackupName.TryParse(resource, out BackupName backup))
+            {
+                var instance = InstanceName.FromProjectInstance(backup.ProjectId, backup.InstanceId);
+                settings = settings.WithHeader(ResourcePrefixHeader, instance.ToString());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Sets the google-cloud-resource-prefix header in the Spanner database admin client so that we can support resource-based routing.

Towards #5181