### PR TITLE
feat(spanner): set resource header in instance admin client

### DIFF
--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.Tests/ResourcePrefixHeaderTest.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.Tests/ResourcePrefixHeaderTest.cs
@@ -1,0 +1,179 @@
+// Copyright 2020, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Grpc.Core;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace Google.Cloud.Spanner.Admin.Instance.V1.Tests
+{
+    public class ResourcePrefixHeaderTest
+    {
+        private const string ResourcePrefixHeader = "google-cloud-resource-prefix";
+        private const string SampleInstanceName = "projects/proj/instances/inst";
+        private const string SampleProjectName = "projects/proj";
+        private const string SampleInstanceConfigName = "projects/proj/instanceConfigs/cfg";
+
+        [Fact]
+        public void NoHeaderOnGetInstanceIfEmptyInstanceName()
+        {
+            var invoker = new FakeCallInvoker();
+            var client = new InstanceAdminClientBuilder { CallInvoker = invoker }.Build();
+            client.GetInstance(new GetInstanceRequest());
+            Assert.Null(invoker.Metadata.FirstOrDefault(e => e.Key == ResourcePrefixHeader));
+        }
+
+        [Fact]
+        public void NoHeaderOnGetInstanceIfInvalidInstanceName()
+        {
+            var invoker = new FakeCallInvoker();
+            var client = new InstanceAdminClientBuilder { CallInvoker = invoker }.Build();
+            client.GetInstance(new GetInstanceRequest { Name = "projects/instances" });
+            Assert.Null(invoker.Metadata.FirstOrDefault(e => e.Key == ResourcePrefixHeader));
+        }
+
+        [Fact]
+        public void NoHeaderOnGetInstanceConfigIfEmptyInstanceConfigName()
+        {
+            var invoker = new FakeCallInvoker();
+            var client = new InstanceAdminClientBuilder { CallInvoker = invoker }.Build();
+            client.GetInstanceConfig(new GetInstanceConfigRequest());
+            Assert.Null(invoker.Metadata.FirstOrDefault(e => e.Key == ResourcePrefixHeader));
+        }
+
+        [Fact]
+        public void NoHeaderOnGetInstanceConfigIfInvalidInstanceConfigName()
+        {
+            var invoker = new FakeCallInvoker();
+            var client = new InstanceAdminClientBuilder { CallInvoker = invoker }.Build();
+            client.GetInstanceConfig(new GetInstanceConfigRequest { Name = "projects/proj/instanceConfigs" });
+            Assert.Null(invoker.Metadata.FirstOrDefault(e => e.Key == ResourcePrefixHeader));
+        }
+
+        [Fact]
+        public void NoHeaderOnCreateInstanceIfEmptyProjectName()
+        {
+            var invoker = new FakeCallInvoker();
+            var client = new InstanceAdminClientBuilder { CallInvoker = invoker }.Build();
+            client.CreateInstance(new CreateInstanceRequest());
+            Assert.Null(invoker.Metadata.FirstOrDefault(e => e.Key == ResourcePrefixHeader));
+        }
+
+        [Fact]
+        public void NoHeaderOnCreateInstanceIfInvalidProjectName()
+        {
+            var invoker = new FakeCallInvoker();
+            var client = new InstanceAdminClientBuilder { CallInvoker = invoker }.Build();
+            client.CreateInstance(new CreateInstanceRequest { Parent = "projects" });
+            Assert.Null(invoker.Metadata.FirstOrDefault(e => e.Key == ResourcePrefixHeader));
+        }
+
+        [Fact]
+        public void SetsHeaderOnListInstanceConfigs()
+        {
+            var invoker = new FakeCallInvoker();
+            var client = new InstanceAdminClientBuilder { CallInvoker = invoker }.Build();
+            client.ListInstanceConfigs(new ListInstanceConfigsRequest { Parent = SampleProjectName }).AsRawResponses().First();
+            Metadata.Entry entry = Assert.Single(invoker.Metadata, e => e.Key == ResourcePrefixHeader);
+            Assert.Equal(SampleProjectName, entry.Value);
+        }
+
+        [Fact]
+        public void SetsHeaderOnGetInstanceConfig()
+        {
+            var invoker = new FakeCallInvoker();
+            var client = new InstanceAdminClientBuilder { CallInvoker = invoker }.Build();
+            client.GetInstanceConfig(new GetInstanceConfigRequest { Name = SampleInstanceConfigName });
+            Metadata.Entry entry = Assert.Single(invoker.Metadata, e => e.Key == ResourcePrefixHeader);
+            Assert.Equal(SampleProjectName, entry.Value);
+        }
+
+        [Fact]
+        public void SetsHeaderOnListInstances()
+        {
+            var invoker = new FakeCallInvoker();
+            var client = new InstanceAdminClientBuilder { CallInvoker = invoker }.Build();
+            client.ListInstances(new ListInstancesRequest { Parent = SampleProjectName }).AsRawResponses().First();
+            Metadata.Entry entry = Assert.Single(invoker.Metadata, e => e.Key == ResourcePrefixHeader);
+            Assert.Equal(SampleProjectName, entry.Value);
+        }
+
+        [Fact]
+        public void SetsHeaderOnGetInstance()
+        {
+            var invoker = new FakeCallInvoker();
+            var client = new InstanceAdminClientBuilder { CallInvoker = invoker }.Build();
+            client.GetInstance(new GetInstanceRequest { Name = SampleInstanceName });
+            Metadata.Entry entry = Assert.Single(invoker.Metadata, e => e.Key == ResourcePrefixHeader);
+            Assert.Equal(SampleInstanceName, entry.Value);
+        }
+
+        [Fact]
+        public void SetsHeaderOnCreateInstance()
+        {
+            var invoker = new FakeCallInvoker();
+            var client = new InstanceAdminClientBuilder { CallInvoker = invoker }.Build();
+            client.CreateInstance(new CreateInstanceRequest { Parent = SampleProjectName });
+            Metadata.Entry entry = Assert.Single(invoker.Metadata, e => e.Key == ResourcePrefixHeader);
+            Assert.Equal(SampleProjectName, entry.Value);
+        }
+
+        [Fact]
+        public void SetsHeaderOnUpdateInstance()
+        {
+            var invoker = new FakeCallInvoker();
+            var client = new InstanceAdminClientBuilder { CallInvoker = invoker }.Build();
+            client.UpdateInstance(new UpdateInstanceRequest
+            {
+                Instance = new Instance { Name = SampleInstanceName }
+            });
+            Metadata.Entry entry = Assert.Single(invoker.Metadata, e => e.Key == ResourcePrefixHeader);
+            Assert.Equal(SampleInstanceName, entry.Value);
+        }
+
+        [Fact]
+        public void SetsHeaderOnDeleteInstance()
+        {
+            var invoker = new FakeCallInvoker();
+            var client = new InstanceAdminClientBuilder { CallInvoker = invoker }.Build();
+            client.DeleteInstance(new DeleteInstanceRequest { Name = SampleInstanceName });
+            Metadata.Entry entry = Assert.Single(invoker.Metadata, e => e.Key == ResourcePrefixHeader);
+            Assert.Equal(SampleInstanceName, entry.Value);
+        }
+
+        private class FakeCallInvoker : CallInvoker
+        {
+            public Metadata Metadata { get; private set; }
+
+            public override AsyncClientStreamingCall<TRequest, TResponse> AsyncClientStreamingCall<TRequest, TResponse>(Method<TRequest, TResponse> method, string host, CallOptions options) =>
+                throw new NotImplementedException();
+
+            public override AsyncDuplexStreamingCall<TRequest, TResponse> AsyncDuplexStreamingCall<TRequest, TResponse>(Method<TRequest, TResponse> method, string host, CallOptions options) =>
+                throw new NotImplementedException();
+
+            public override AsyncServerStreamingCall<TResponse> AsyncServerStreamingCall<TRequest, TResponse>(Method<TRequest, TResponse> method, string host, CallOptions options, TRequest request) =>
+                throw new NotImplementedException();
+
+            public override AsyncUnaryCall<TResponse> AsyncUnaryCall<TRequest, TResponse>(Method<TRequest, TResponse> method, string host, CallOptions options, TRequest request) =>
+                throw new NotImplementedException();
+
+            public override TResponse BlockingUnaryCall<TRequest, TResponse>(Method<TRequest, TResponse> method, string host, CallOptions options, TRequest request)
+            {
+                Metadata = options.Headers;
+                return (TResponse) Activator.CreateInstance(typeof(TResponse));
+            }
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/InstanceAdminClientPartial.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/InstanceAdminClientPartial.cs
@@ -1,0 +1,104 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using Google.Api.Gax.Grpc;
+using Google.Api.Gax.ResourceNames;
+using Google.Cloud.Spanner.Common.V1;
+using System;
+
+namespace Google.Cloud.Spanner.Admin.Instance.V1
+{
+    // Partial class to set up resource-based routing.
+    public partial class InstanceAdminClientImpl
+    {
+        /// <summary>
+        /// The name of the header used for efficiently routing requests.
+        /// </summary>
+        /// <remarks>
+        /// This should be set to the instance resource name ("projects/{projectId}/instances/{instanceId}") for some RPCs
+        /// and to the project resource name for others ("projects/{projectId}").
+        /// For non-streaming calls, <see cref="InstanceAdminClientImpl"/> performs this automatically. This cannot be performed
+        /// automatically for streaming calls due to the separation between initializing the stream and sending requests, so
+        /// client code should set the value in a <see cref="CallSettings"/>. Typically this is performed with either the
+        /// <see cref="CallSettings.FromHeader(string, string)"/> factory method or the
+        /// <see cref="CallSettingsExtensions.WithHeader(CallSettings, string, string)"/> extension method.
+        /// </remarks>
+        public const string ResourcePrefixHeader = "google-cloud-resource-prefix";
+
+        partial void Modify_ListInstanceConfigsRequest(ref ListInstanceConfigsRequest request, ref CallSettings settings) =>
+            ApplyResourcePrefixHeaderFromProject(ref settings, request.Parent);
+
+        partial void Modify_GetInstanceConfigRequest(ref GetInstanceConfigRequest request, ref CallSettings settings) =>
+            ApplyResourcePrefixHeaderFromInstanceConfig(ref settings, request.Name);
+
+        partial void Modify_ListInstancesRequest(ref ListInstancesRequest request, ref CallSettings settings) =>
+            ApplyResourcePrefixHeaderFromProject(ref settings, request.Parent);
+
+        partial void Modify_GetInstanceRequest(ref GetInstanceRequest request, ref CallSettings settings) =>
+            ApplyResourcePrefixHeaderFromInstance(ref settings, request.Name);
+
+        partial void Modify_CreateInstanceRequest(ref CreateInstanceRequest request, ref CallSettings settings) =>
+            ApplyResourcePrefixHeaderFromProject(ref settings, request.Parent);
+
+        partial void Modify_UpdateInstanceRequest(ref UpdateInstanceRequest request, ref CallSettings settings) =>
+            ApplyResourcePrefixHeaderFromInstance(ref settings, request.Instance.Name);
+
+        partial void Modify_DeleteInstanceRequest(ref DeleteInstanceRequest request, ref CallSettings settings) =>
+            ApplyResourcePrefixHeaderFromInstance(ref settings, request.Name);
+
+        private static void ApplyResourcePrefixHeaderFromInstance(ref CallSettings settings, string resource)
+        {
+            // If we haven't been given a resource name, just leave the request as it is.
+            if (string.IsNullOrEmpty(resource))
+            {
+                return;
+            }
+
+            if (InstanceName.TryParse(resource, out InstanceName instance))
+            {
+                settings = settings.WithHeader(ResourcePrefixHeader, instance.ToString());
+            }
+        }
+
+        private static void ApplyResourcePrefixHeaderFromProject(ref CallSettings settings, string resource)
+        {
+            // If we haven't been given a resource name, just leave the request as it is.
+            if (string.IsNullOrEmpty(resource))
+            {
+                return;
+            }
+
+            if (ProjectName.TryParse(resource, out ProjectName project))
+            {
+                settings = settings.WithHeader(ResourcePrefixHeader, project.ToString());
+            }
+        }
+
+        private static void ApplyResourcePrefixHeaderFromInstanceConfig(ref CallSettings settings, string resource)
+        {
+            // If we haven't been given a resource name, just leave the request as it is.
+            if (string.IsNullOrEmpty(resource))
+            {
+                return;
+            }
+
+            if (InstanceConfigName.TryParse(resource, out InstanceConfigName instanceConfig))
+            {
+                var project = ProjectName.FromProject(instanceConfig.ProjectId);
+                settings = settings.WithHeader(ResourcePrefixHeader, project.ToString());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Sets the google-cloud-resource-prefix header in the Spanner instance admin client so that we can support resource-based routing.

Fixes #5181