### PR TITLE
Release Google.Cloud.Gaming.V1Beta version 1.0.0-beta05

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Firestore.V1](https://googleapis.dev/dotnet/Google.Cloud.Firestore.V1/2.0.0) | 2.0.0 | [Firestore low-level API access](https://firebase.google.com) |
 | [Google.Cloud.Functions.V1](https://googleapis.dev/dotnet/Google.Cloud.Functions.V1/1.0.0-beta01) | 1.0.0-beta01 | [Cloud Functions API](https://cloud.google.com/functions) |
 | [Google.Cloud.Gaming.V1](https://googleapis.dev/dotnet/Google.Cloud.Gaming.V1/1.0.0-beta01) | 1.0.0-beta01 | [Game Services API](https://cloud.google.com/solutions/gaming) |
-| [Google.Cloud.Gaming.V1Beta](https://googleapis.dev/dotnet/Google.Cloud.Gaming.V1Beta/1.0.0-beta04) | 1.0.0-beta04 | [Google Cloud for Games](https://cloud.google.com/solutions/gaming) |
+| [Google.Cloud.Gaming.V1Beta](https://googleapis.dev/dotnet/Google.Cloud.Gaming.V1Beta/1.0.0-beta05) | 1.0.0-beta05 | [Google Cloud for Games](https://cloud.google.com/solutions/gaming) |
 | [Google.Cloud.Iam.V1](https://googleapis.dev/dotnet/Google.Cloud.Iam.V1/2.0.0) | 2.0.0 | [Google Cloud Identity and Access Management (IAM)](https://cloud.google.com/iam/) |
 | [Google.Cloud.Kms.V1](https://googleapis.dev/dotnet/Google.Cloud.Kms.V1/2.0.0) | 2.0.0 | [Google Cloud Key Management Service](https://cloud.google.com/kms/) |
 | [Google.Cloud.Language.V1](https://googleapis.dev/dotnet/Google.Cloud.Language.V1/2.0.0) | 2.0.0 | [Google Cloud Natural Language](https://cloud.google.com/natural-language) |

--- a/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta.csproj
+++ b/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta04</Version>
+    <Version>1.0.0-beta05</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Gaming API, version v1beta.</Description>
@@ -11,9 +11,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.0.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.1.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.0.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.27.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Gaming.V1Beta/docs/history.md
+++ b/apis/Google.Cloud.Gaming.V1Beta/docs/history.md
@@ -1,5 +1,14 @@
 # Version history
 
+# Version 1.0.0-beta05, released 2020-09-07
+
+- [Commit 6bde7a3](https://github.com/googleapis/google-cloud-dotnet/commit/6bde7a3): docs: Adds service comments to client documentation
+- [Commit 1765de9](https://github.com/googleapis/google-cloud-dotnet/commit/1765de9):
+  - fix!: Corrects return type of long running delete operations
+  - fix: Increases timeout for CreateGameServerCluster ([issue 5125](https://github.com/googleapis/google-cloud-dotnet/issues/5125))
+- [Commit 0bf565a](https://github.com/googleapis/google-cloud-dotnet/commit/0bf565a): feat: Adds retry configuration.
+- [Commit 947a573](https://github.com/googleapis/google-cloud-dotnet/commit/947a573): docs: Adds more explicit documentation.
+  
 # Version 1.0.0-beta04, released 2020-04-23
 
 No API changes; this release is for release automation testing.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -655,7 +655,7 @@
       "id": "Google.Cloud.Gaming.V1Beta",
       "generator": "micro",
       "protoPath": "google/cloud/gaming/v1beta",
-      "version": "1.0.0-beta04",
+      "version": "1.0.0-beta05",
       "type": "grpc",
       "productName": "Google Cloud for Games",
       "productUrl": "https://cloud.google.com/solutions/gaming",
@@ -665,9 +665,7 @@
         "games"
       ],
       "dependencies": {
-        "Google.LongRunning": "2.0.0",
-        "Google.Api.Gax.Grpc.GrpcCore": "3.0.0",
-        "Grpc.Core": "2.27.0"
+        "Google.LongRunning": "2.0.0"
       }
     },
     {

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -51,7 +51,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Firestore.V1](Google.Cloud.Firestore.V1/index.html) | 2.0.0 | [Firestore low-level API access](https://firebase.google.com) |
 | [Google.Cloud.Functions.V1](Google.Cloud.Functions.V1/index.html) | 1.0.0-beta01 | [Cloud Functions API](https://cloud.google.com/functions) |
 | [Google.Cloud.Gaming.V1](Google.Cloud.Gaming.V1/index.html) | 1.0.0-beta01 | [Game Services API](https://cloud.google.com/solutions/gaming) |
-| [Google.Cloud.Gaming.V1Beta](Google.Cloud.Gaming.V1Beta/index.html) | 1.0.0-beta04 | [Google Cloud for Games](https://cloud.google.com/solutions/gaming) |
+| [Google.Cloud.Gaming.V1Beta](Google.Cloud.Gaming.V1Beta/index.html) | 1.0.0-beta05 | [Google Cloud for Games](https://cloud.google.com/solutions/gaming) |
 | [Google.Cloud.Iam.V1](Google.Cloud.Iam.V1/index.html) | 2.0.0 | [Google Cloud Identity and Access Management (IAM)](https://cloud.google.com/iam/) |
 | [Google.Cloud.Kms.V1](Google.Cloud.Kms.V1/index.html) | 2.0.0 | [Google Cloud Key Management Service](https://cloud.google.com/kms/) |
 | [Google.Cloud.Language.V1](Google.Cloud.Language.V1/index.html) | 2.0.0 | [Google Cloud Natural Language](https://cloud.google.com/natural-language) |


### PR DESCRIPTION

Changes in this release:

- [Commit 6bde7a3](https://github.com/googleapis/google-cloud-dotnet/commit/6bde7a3): docs: Adds service comments to client documentation
- [Commit 1765de9](https://github.com/googleapis/google-cloud-dotnet/commit/1765de9):
  - fix!: Corrects return type of long running delete operations
  - fix: Increases timeout for CreateGameServerCluster ([issue 5125](https://github.com/googleapis/google-cloud-dotnet/issues/5125))
- [Commit 0bf565a](https://github.com/googleapis/google-cloud-dotnet/commit/0bf565a): feat: Adds retry configuration.
- [Commit 947a573](https://github.com/googleapis/google-cloud-dotnet/commit/947a573): docs: Adds more explicit documentation.
