### PR TITLE
Release Google.Cloud.SecretManager.V1 version 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Redis.V1](https://googleapis.dev/dotnet/Google.Cloud.Redis.V1/2.0.0) | 2.0.0 | [Google Cloud Memorystore for Redis (V1 API)](https://cloud.google.com/memorystore/) |
 | [Google.Cloud.Redis.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Redis.V1Beta1/2.0.0-beta02) | 2.0.0-beta02 | [Google Cloud Memorystore for Redis (V1Beta1 API)](https://cloud.google.com/memorystore/) |
 | [Google.Cloud.Scheduler.V1](https://googleapis.dev/dotnet/Google.Cloud.Scheduler.V1/2.0.0) | 2.0.0 | [Google Cloud Scheduler](https://cloud.google.com/scheduler/) |
-| [Google.Cloud.SecretManager.V1](https://googleapis.dev/dotnet/Google.Cloud.SecretManager.V1/1.0.0) | 1.0.0 | [Secret Manager (V1 API)](https://cloud.google.com/secret-manager) |
+| [Google.Cloud.SecretManager.V1](https://googleapis.dev/dotnet/Google.Cloud.SecretManager.V1/1.1.0) | 1.1.0 | [Secret Manager (V1 API)](https://cloud.google.com/secret-manager) |
 | [Google.Cloud.SecretManager.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.SecretManager.V1Beta1/2.0.0-beta02) | 2.0.0-beta02 | [Secret Manager (V1Beta1 API)](https://cloud.google.com/secret-manager) |
 | [Google.Cloud.SecurityCenter.Settings.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.SecurityCenter.Settings.V1Beta1/1.0.0-beta01) | 1.0.0-beta01 | [Google Cloud Security Command Center Settings](https://cloud.google.com/security-command-center/) |
 | [Google.Cloud.SecurityCenter.V1](https://googleapis.dev/dotnet/Google.Cloud.SecurityCenter.V1/2.0.0) | 2.0.0 | [Google Cloud Security Command Center (V1 API)](https://cloud.google.com/security-command-center/) |

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.csproj
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Secret Manager API.</Description>

--- a/apis/Google.Cloud.SecretManager.V1/docs/history.md
+++ b/apis/Google.Cloud.SecretManager.V1/docs/history.md
@@ -1,5 +1,14 @@
 # Version history
 
+# Version 1.1.0, released 2020-09-10
+
+- [Commit 45c0cff](https://github.com/googleapis/google-cloud-dotnet/commit/45c0cff): New feature: customer managed encryption keys
+- [Commit 6bde7a3](https://github.com/googleapis/google-cloud-dotnet/commit/6bde7a3): Regenerate all APIs with service comments in client documentation
+- [Commit f83bdf1](https://github.com/googleapis/google-cloud-dotnet/commit/f83bdf1): Regenerate all APIs with generator changes for timeouts
+- [Commit 947a573](https://github.com/googleapis/google-cloud-dotnet/commit/947a573): Regenerate all clients with more explicit documentation
+- [Commit 028f418](https://github.com/googleapis/google-cloud-dotnet/commit/028f418): Update to SecretManager documentation
+- [Commit 617763f](https://github.com/googleapis/google-cloud-dotnet/commit/617763f): Document Secret ID character limitations
+
 # Version 1.0.0, released 2020-03-19
 
 No API surface changes compared with 1.0.0-beta01, just dependency

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1167,7 +1167,7 @@
       "protoPath": "google/cloud/secretmanager/v1",
       "productName": "Secret Manager",
       "productUrl": "https://cloud.google.com/secret-manager",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Secret Manager API.",
       "dependencies": {

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -77,7 +77,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Redis.V1](Google.Cloud.Redis.V1/index.html) | 2.0.0 | [Google Cloud Memorystore for Redis (V1 API)](https://cloud.google.com/memorystore/) |
 | [Google.Cloud.Redis.V1Beta1](Google.Cloud.Redis.V1Beta1/index.html) | 2.0.0-beta02 | [Google Cloud Memorystore for Redis (V1Beta1 API)](https://cloud.google.com/memorystore/) |
 | [Google.Cloud.Scheduler.V1](Google.Cloud.Scheduler.V1/index.html) | 2.0.0 | [Google Cloud Scheduler](https://cloud.google.com/scheduler/) |
-| [Google.Cloud.SecretManager.V1](Google.Cloud.SecretManager.V1/index.html) | 1.0.0 | [Secret Manager (V1 API)](https://cloud.google.com/secret-manager) |
+| [Google.Cloud.SecretManager.V1](Google.Cloud.SecretManager.V1/index.html) | 1.1.0 | [Secret Manager (V1 API)](https://cloud.google.com/secret-manager) |
 | [Google.Cloud.SecretManager.V1Beta1](Google.Cloud.SecretManager.V1Beta1/index.html) | 2.0.0-beta02 | [Secret Manager (V1Beta1 API)](https://cloud.google.com/secret-manager) |
 | [Google.Cloud.SecurityCenter.Settings.V1Beta1](Google.Cloud.SecurityCenter.Settings.V1Beta1/index.html) | 1.0.0-beta01 | [Google Cloud Security Command Center Settings](https://cloud.google.com/security-command-center/) |
 | [Google.Cloud.SecurityCenter.V1](Google.Cloud.SecurityCenter.V1/index.html) | 2.0.0 | [Google Cloud Security Command Center (V1 API)](https://cloud.google.com/security-command-center/) |


### PR DESCRIPTION

Changes in this release:

- [Commit 45c0cff](https://github.com/googleapis/google-cloud-dotnet/commit/45c0cff): New feature: customer managed encryption keys
- [Commit 6bde7a3](https://github.com/googleapis/google-cloud-dotnet/commit/6bde7a3): Regenerate all APIs with service comments in client documentation
- [Commit f83bdf1](https://github.com/googleapis/google-cloud-dotnet/commit/f83bdf1): Regenerate all APIs with generator changes for timeouts
- [Commit 947a573](https://github.com/googleapis/google-cloud-dotnet/commit/947a573): Regenerate all clients with more explicit documentation
- [Commit 028f418](https://github.com/googleapis/google-cloud-dotnet/commit/028f418): Update to SecretManager documentation
- [Commit 617763f](https://github.com/googleapis/google-cloud-dotnet/commit/617763f): Document Secret ID character limitations
