### PR TITLE
Create tool to show "stale" APIs

### DIFF
--- a/tools/Google.Cloud.Tools.ReleaseManager/GitHelpers.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/GitHelpers.cs
@@ -1,0 +1,61 @@
+﻿// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using LibGit2Sharp;
+using System;
+using System.Linq;
+
+namespace Google.Cloud.Tools.ReleaseManager
+{
+    internal static class GitHelpers
+    {
+        /// <summary>
+        /// Creates a predicate which determines whether or not a commit affects an API.
+        /// </summary>
+        /// <param name="id">The ID of the API to create a predicate for.</param>
+        /// <returns>The predicate.</returns>
+        internal static Func<Commit, bool> CreateCommitPredicate(Repository repo, string id)
+        {
+            var pathPrefix = $"apis/{id}/{id}/";
+            var projectFile = $"apis/{id}/{id}/{id}.csproj";
+            Func<string, bool> pathFilter = path => path.StartsWith(pathPrefix) && path != projectFile;
+            return CommitContainsApi;
+
+            bool CommitContainsApi(Commit commit)
+            {
+                if (commit.Parents.Count() != 1)
+                {
+                    return false;
+                }
+                var tree = commit.Tree;
+                var parentTree = commit.Parents.First().Tree;
+                // If nothing has changed under apis/{id}/{id}, it's definitely not relevant.
+                if (tree[pathPrefix]?.Target.Sha == parentTree[pathPrefix]?.Target.Sha)
+                {
+                    return false;
+                }
+                // Otherwise, check whether something *other* than the project file has changed.
+                var comparison = repo.Diff.Compare<TreeChanges>(parentTree, tree);
+                // Some versions return forward slashes, some return backslashes :(
+                return comparison.Select(change => change.Path.Replace('\\', '/')).Any(pathFilter);
+            }
+        }
+
+        internal static DateTimeOffset GetDate(this Tag tag) =>
+            ((Commit) tag.PeeledTarget).GetDate();
+
+        internal static DateTimeOffset GetDate(this Commit commit) =>
+            (commit.Author ?? commit.Committer).When;
+    }
+}

--- a/tools/Google.Cloud.Tools.ReleaseManager/History/Release.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/History/Release.cs
@@ -31,9 +31,7 @@ namespace Google.Cloud.Tools.ReleaseManager.History
             Version = version;
             Commits = commits.ToList().AsReadOnly();
             // Assume that if a release isn't tagged yet, it's because we're releasing it today.
-            ReleaseDate = tagCommit != null
-                ? (tagCommit.Author ?? tagCommit.Committer).When.Date
-                : DateTime.Today;
+            ReleaseDate = tagCommit?.GetDate().UtcDateTime ?? DateTime.Today;
         }
     }
 }

--- a/tools/Google.Cloud.Tools.ReleaseManager/ShowStaleCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/ShowStaleCommand.cs
@@ -1,0 +1,71 @@
+﻿// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Tools.Common;
+using LibGit2Sharp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Google.Cloud.Tools.ReleaseManager
+{
+    /// <summary>
+    /// Command to show APIs that may need re-releasing, i.e. where there are
+    /// non-project-file commits since the last release.
+    /// </summary>
+    public sealed class ShowStaleCommand : CommandBase
+    {
+        public ShowStaleCommand() : base("show-stale", "Shows stale APIs, which may need a new release")
+        {
+        }
+
+        protected override void ExecuteImpl(string[] args)
+        {
+            var root = DirectoryLayout.DetermineRootDirectory();
+            var catalog = ApiCatalog.Load();
+            using (var repo = new Repository(root))
+            {
+                var allTags = repo.Tags.OrderByDescending(GitHelpers.GetDate).ToList();
+                foreach (var api in catalog.Apis)
+                {
+                    MaybeShowStale(repo, allTags, api);
+                }
+            }
+        }
+
+        private static void MaybeShowStale(Repository repo, List<Tag> allTags, ApiMetadata api)
+        {
+            string expectedTagName = $"{api.Id}-{api.Version}";
+            var latestRelease = allTags.FirstOrDefault(tag => tag.FriendlyName == expectedTagName);
+
+            // If we don't have any releases for the API (or couldn't find the tag), skip it.
+            if (latestRelease is null)
+            {
+                return;
+            }
+
+            var laterCommits = repo.Commits.TakeWhile(commit => commit.Sha != latestRelease.Target.Sha);
+            var relevantCommits = laterCommits.Where(GitHelpers.CreateCommitPredicate(repo, api.Id)).ToList();
+
+            // No changes
+            if (relevantCommits.Count == 0)
+            {
+                return;
+            }
+
+            string changes = relevantCommits.Count == 1 ? "change" : "changes";
+            Console.WriteLine($"{api.Id,-50} {latestRelease.GetDate():yyyy-MM-dd}: {api.Version} + {relevantCommits.Count} {changes}");
+        }
+    }
+}


### PR DESCRIPTION
These are APIs where there have been commits since to prod code
other than the project file, since the last release

Start of current output (API ID, last release date, last release version, unreleased changes):

```text
Google.Analytics.Data.V1Alpha                      2020-08-18: 1.0.0-alpha01 + 1 change
Google.Cloud.AutoML.V1                             2020-03-17: 2.0.0 + 4 changes
Google.Cloud.BigQuery.Connection.V1                2020-07-06: 1.0.0 + 3 changes
Google.Cloud.BigQuery.DataTransfer.V1              2020-03-17: 2.0.0 + 5 changes
Google.Cloud.BigQuery.Reservation.V1               2020-07-06: 1.0.0 + 2 changes
Google.Cloud.BigQuery.V2                           2020-06-04: 2.0.0 + 1 change
Google.Cloud.BigQuery.Storage.V1                   2020-03-17: 2.0.0 + 4 changes
Google.Cloud.Bigtable.Admin.V2                     2020-05-05: 2.1.0 + 4 changes
Google.Cloud.Bigtable.V2                           2020-04-08: 2.0.0 + 5 changes
```