### PR TITLE
Release Google.Cloud.Vision.V1 version 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Translate.V3](https://googleapis.dev/dotnet/Google.Cloud.Translate.V3/2.0.0) | 2.0.0 | [Google Cloud Translation (V3 API)](https://cloud.google.com/translate/) |
 | [Google.Cloud.Translation.V2](https://googleapis.dev/dotnet/Google.Cloud.Translation.V2/2.0.0) | 2.0.0 | [Google Cloud Translation (V2 API)](https://cloud.google.com/translate/) |
 | [Google.Cloud.VideoIntelligence.V1](https://googleapis.dev/dotnet/Google.Cloud.VideoIntelligence.V1/2.0.0) | 2.0.0 | [Google Cloud Video Intelligence](https://cloud.google.com/video-intelligence) |
-| [Google.Cloud.Vision.V1](https://googleapis.dev/dotnet/Google.Cloud.Vision.V1/2.0.0) | 2.0.0 | [Google Cloud Vision](https://cloud.google.com/vision) |
+| [Google.Cloud.Vision.V1](https://googleapis.dev/dotnet/Google.Cloud.Vision.V1/2.1.0) | 2.1.0 | [Google Cloud Vision](https://cloud.google.com/vision) |
 | [Google.Cloud.WebRisk.V1](https://googleapis.dev/dotnet/Google.Cloud.WebRisk.V1/1.0.0) | 1.0.0 | [Google Cloud Web Risk (V1 API)](https://cloud.google.com/web-risk/) |
 | [Google.Cloud.WebRisk.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.WebRisk.V1Beta1/2.0.0-beta02) | 2.0.0-beta02 | [Google Cloud Web Risk (V1Beta1 API)](https://cloud.google.com/web-risk/) |
 | [Google.Identity.AccessContextManager.Type](https://googleapis.dev/dotnet/Google.Identity.AccessContextManager.Type/1.0.0) | 1.0.0 | Version-agnostic types for the Google Identity Access Context Manager API |

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.csproj
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Vision API, which integrates Google Vision features, including image labeling, face, logo, and landmark detection, optical character recognition (OCR), and detection of explicit content, into applications.</Description>

--- a/apis/Google.Cloud.Vision.V1/docs/history.md
+++ b/apis/Google.Cloud.Vision.V1/docs/history.md
@@ -1,5 +1,24 @@
 # Version history
 
+# Version 2.1.0, released 2020-09-15
+
+- [Commit 6bde7a3](https://github.com/googleapis/google-cloud-dotnet/commit/6bde7a3):
+  - Regenerate all APIs with service comments in client documentation
+  - The comments are included as they are, as a "remarks" section both the abstract base class and the concrete implementation.
+- [Commit 947a573](https://github.com/googleapis/google-cloud-dotnet/commit/947a573):
+  - Regenerate all clients with more explicit documentation
+  - The use of "inheritdoc" breaks docfx in many cases. The generator
+  - has been improved to generate more explicit documentation. This PR only
+  - contains changes due to that generator change.
+- [Commit bbccd6f](https://github.com/googleapis/google-cloud-dotnet/commit/bbccd6f):
+  - docs: change a relative URL to an absolute URL to fix broken links.
+  - https://github.com/googleapis/googleapis/commit/4a6a01ce0ead505c245d11a2ce156de34800c58f
+  - commit 4a6a01ce0ead505c245d11a2ce156de34800c58f
+  - Author: Google APIs <noreply@google.com>
+  - Date:   Fri Apr 3 09:40:35 2020 -0700
+  -     docs: change a relative URL to an absolute URL to fix broken links.
+  -     PiperOrigin-RevId: 304633630
+
 # Version 2.0.0, released 2020-03-19
 
 No API surface changes compared with 2.0.0-beta01, just dependency

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1623,7 +1623,7 @@
       "protoPath": "google/cloud/vision/v1",
       "productName": "Google Cloud Vision",
       "productUrl": "https://cloud.google.com/vision",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Vision API, which integrates Google Vision features, including image labeling, face, logo, and landmark detection, optical character recognition (OCR), and detection of explicit content, into applications.",
       "tags": [

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -100,7 +100,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Translate.V3](Google.Cloud.Translate.V3/index.html) | 2.0.0 | [Google Cloud Translation (V3 API)](https://cloud.google.com/translate/) |
 | [Google.Cloud.Translation.V2](Google.Cloud.Translation.V2/index.html) | 2.0.0 | [Google Cloud Translation (V2 API)](https://cloud.google.com/translate/) |
 | [Google.Cloud.VideoIntelligence.V1](Google.Cloud.VideoIntelligence.V1/index.html) | 2.0.0 | [Google Cloud Video Intelligence](https://cloud.google.com/video-intelligence) |
-| [Google.Cloud.Vision.V1](Google.Cloud.Vision.V1/index.html) | 2.0.0 | [Google Cloud Vision](https://cloud.google.com/vision) |
+| [Google.Cloud.Vision.V1](Google.Cloud.Vision.V1/index.html) | 2.1.0 | [Google Cloud Vision](https://cloud.google.com/vision) |
 | [Google.Cloud.WebRisk.V1](Google.Cloud.WebRisk.V1/index.html) | 1.0.0 | [Google Cloud Web Risk (V1 API)](https://cloud.google.com/web-risk/) |
 | [Google.Cloud.WebRisk.V1Beta1](Google.Cloud.WebRisk.V1Beta1/index.html) | 2.0.0-beta02 | [Google Cloud Web Risk (V1Beta1 API)](https://cloud.google.com/web-risk/) |
 | [Google.Identity.AccessContextManager.Type](Google.Identity.AccessContextManager.Type/index.html) | 1.0.0 | Version-agnostic types for the Google Identity Access Context Manager API |


### PR DESCRIPTION

Changes in this release:

- [Commit 6bde7a3](https://github.com/googleapis/google-cloud-dotnet/commit/6bde7a3):
  - Regenerate all APIs with service comments in client documentation
  - The comments are included as they are, as a "remarks" section both the abstract base class and the concrete implementation.
- [Commit 947a573](https://github.com/googleapis/google-cloud-dotnet/commit/947a573):
  - Regenerate all clients with more explicit documentation
  - The use of "inheritdoc" breaks docfx in many cases. The generator
  - has been improved to generate more explicit documentation. This PR only
  - contains changes due to that generator change.
- [Commit bbccd6f](https://github.com/googleapis/google-cloud-dotnet/commit/bbccd6f):
  - docs: change a relative URL to an absolute URL to fix broken links.
  - https://github.com/googleapis/googleapis/commit/4a6a01ce0ead505c245d11a2ce156de34800c58f
  - commit 4a6a01ce0ead505c245d11a2ce156de34800c58f
  - Author: Google APIs <noreply@google.com>
  - Date:   Fri Apr 3 09:40:35 2020 -0700
  -     docs: change a relative URL to an absolute URL to fix broken links.
  -     PiperOrigin-RevId: 304633630
