### PR TITLE
Regenerate all APIs with updated generator

### DIFF
--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/ResourcesResourceNames.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/ResourcesResourceNames.g.cs
@@ -30,7 +30,7 @@ namespace Google.Analytics.Admin.V1Alpha
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>accounts/{account}</c>.</summary>
-            Account = 1
+            Account = 1,
         }
 
         private static gax::PathTemplate s_account = new gax::PathTemplate("accounts/{account}");
@@ -223,7 +223,7 @@ namespace Google.Analytics.Admin.V1Alpha
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>properties/{property}</c>.</summary>
-            Property = 1
+            Property = 1,
         }
 
         private static gax::PathTemplate s_property = new gax::PathTemplate("properties/{property}");
@@ -420,7 +420,7 @@ namespace Google.Analytics.Admin.V1Alpha
             /// A resource name with pattern <c>properties/{property}/androidAppDataStreams/{android_app_data_stream}</c>
             /// .
             /// </summary>
-            PropertyAndroidAppDataStream = 1
+            PropertyAndroidAppDataStream = 1,
         }
 
         private static gax::PathTemplate s_propertyAndroidAppDataStream = new gax::PathTemplate("properties/{property}/androidAppDataStreams/{android_app_data_stream}");
@@ -665,7 +665,7 @@ namespace Google.Analytics.Admin.V1Alpha
             /// <summary>
             /// A resource name with pattern <c>properties/{property}/iosAppDataStreams/{ios_app_data_stream}</c>.
             /// </summary>
-            PropertyIosAppDataStream = 1
+            PropertyIosAppDataStream = 1,
         }
 
         private static gax::PathTemplate s_propertyIosAppDataStream = new gax::PathTemplate("properties/{property}/iosAppDataStreams/{ios_app_data_stream}");
@@ -897,7 +897,7 @@ namespace Google.Analytics.Admin.V1Alpha
             /// <summary>
             /// A resource name with pattern <c>properties/{property}/webDataStreams/{web_data_stream}</c>.
             /// </summary>
-            PropertyWebDataStream = 1
+            PropertyWebDataStream = 1,
         }
 
         private static gax::PathTemplate s_propertyWebDataStream = new gax::PathTemplate("properties/{property}/webDataStreams/{web_data_stream}");
@@ -1122,7 +1122,7 @@ namespace Google.Analytics.Admin.V1Alpha
             AccountUserLink = 1,
 
             /// <summary>A resource name with pattern <c>properties/{property}/userLinks/{user_link}</c>.</summary>
-            PropertyUserLink = 2
+            PropertyUserLink = 2,
         }
 
         private static gax::PathTemplate s_accountUserLink = new gax::PathTemplate("accounts/{account}/userLinks/{user_link}");
@@ -1381,7 +1381,7 @@ namespace Google.Analytics.Admin.V1Alpha
             /// A resource name with pattern
             /// <c>properties/{property}/webDataStreams/{web_data_stream}/enhancedMeasurementSettings</c>.
             /// </summary>
-            PropertyWebDataStream = 1
+            PropertyWebDataStream = 1,
         }
 
         private static gax::PathTemplate s_propertyWebDataStream = new gax::PathTemplate("properties/{property}/webDataStreams/{web_data_stream}/enhancedMeasurementSettings");
@@ -1637,7 +1637,7 @@ namespace Google.Analytics.Admin.V1Alpha
             /// <summary>
             /// A resource name with pattern <c>properties/{property}/firebaseLinks/{firebase_link}</c>.
             /// </summary>
-            PropertyFirebaseLink = 1
+            PropertyFirebaseLink = 1,
         }
 
         private static gax::PathTemplate s_propertyFirebaseLink = new gax::PathTemplate("properties/{property}/firebaseLinks/{firebase_link}");
@@ -1857,7 +1857,7 @@ namespace Google.Analytics.Admin.V1Alpha
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>properties/{property}/globalSiteTag</c>.</summary>
-            Property = 1
+            Property = 1,
         }
 
         private static gax::PathTemplate s_property = new gax::PathTemplate("properties/{property}/globalSiteTag");
@@ -2068,7 +2068,7 @@ namespace Google.Analytics.Admin.V1Alpha
             /// <summary>
             /// A resource name with pattern <c>properties/{property}/googleAdsLinks/{google_ads_link}</c>.
             /// </summary>
-            PropertyGoogleAdsLink = 1
+            PropertyGoogleAdsLink = 1,
         }
 
         private static gax::PathTemplate s_propertyGoogleAdsLink = new gax::PathTemplate("properties/{property}/googleAdsLinks/{google_ads_link}");
@@ -2290,7 +2290,7 @@ namespace Google.Analytics.Admin.V1Alpha
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>accounts/{account}/dataSharingSettings</c>.</summary>
-            Account = 1
+            Account = 1,
         }
 
         private static gax::PathTemplate s_account = new gax::PathTemplate("accounts/{account}/dataSharingSettings");

--- a/apis/Google.Analytics.Admin.V1Alpha/synth.metadata
+++ b/apis/Google.Analytics.Admin.V1Alpha/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "b70bedf8081c80a9a0606564c00eccd358d77502"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Analytics.Data.V1Alpha/Google.Analytics.Data.V1Alpha/AnalyticsDataApiResourceNames.g.cs
+++ b/apis/Google.Analytics.Data.V1Alpha/Google.Analytics.Data.V1Alpha/AnalyticsDataApiResourceNames.g.cs
@@ -33,7 +33,7 @@ namespace Google.Analytics.Data.V1Alpha
             Metadata = 1,
 
             /// <summary>A resource name with pattern <c>properties/{property}/metadata</c>.</summary>
-            Property = 2
+            Property = 2,
         }
 
         private static gax::PathTemplate s_metadata = new gax::PathTemplate("metadata");

--- a/apis/Google.Analytics.Data.V1Alpha/synth.metadata
+++ b/apis/Google.Analytics.Data.V1Alpha/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "32cd28cc67e8f644856471573821bf930b7ee513"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/AssetServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/AssetServiceResourceNames.g.cs
@@ -36,7 +36,7 @@ namespace Google.Cloud.Asset.V1
             FolderFeed = 2,
 
             /// <summary>A resource name with pattern <c>organizations/{organization}/feeds/{feed}</c>.</summary>
-            OrganizationFeed = 3
+            OrganizationFeed = 3,
         }
 
         private static gax::PathTemplate s_projectFeed = new gax::PathTemplate("projects/{project}/feeds/{feed}");

--- a/apis/Google.Cloud.Asset.V1/synth.metadata
+++ b/apis/Google.Cloud.Asset.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "ef03f63f2f2d3b2dd936e46595c0f746cb10c43c"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1/AssuredworkloadsV1Beta1ResourceNames.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1/AssuredworkloadsV1Beta1ResourceNames.g.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.AssuredWorkloads.V1Beta1
             /// A resource name with pattern <c>organizations/{organization}/locations/{location}/workloads/{workload}</c>
             /// .
             /// </summary>
-            OrganizationLocationWorkload = 1
+            OrganizationLocationWorkload = 1,
         }
 
         private static gax::PathTemplate s_organizationLocationWorkload = new gax::PathTemplate("organizations/{organization}/locations/{location}/workloads/{workload}");
@@ -272,7 +272,7 @@ namespace Google.Cloud.AssuredWorkloads.V1Beta1
             /// <summary>
             /// A resource name with pattern <c>organizations/{organization}/locations/{location}</c>.
             /// </summary>
-            OrganizationLocation = 1
+            OrganizationLocation = 1,
         }
 
         private static gax::PathTemplate s_organizationLocation = new gax::PathTemplate("organizations/{organization}/locations/{location}");

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7e1a21195ede14f97f7da30efcff4c6bac599bb5"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/AnnotationSpecResourceNames.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/AnnotationSpecResourceNames.g.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.AutoML.V1
             /// A resource name with pattern
             /// <c>projects/{project}/locations/{location}/datasets/{dataset}/annotationSpecs/{annotation_spec}</c>.
             /// </summary>
-            ProjectLocationDatasetAnnotationSpec = 1
+            ProjectLocationDatasetAnnotationSpec = 1,
         }
 
         private static gax::PathTemplate s_projectLocationDatasetAnnotationSpec = new gax::PathTemplate("projects/{project}/locations/{location}/datasets/{dataset}/annotationSpecs/{annotation_spec}");

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/DatasetResourceNames.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/DatasetResourceNames.g.cs
@@ -32,7 +32,7 @@ namespace Google.Cloud.AutoML.V1
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/locations/{location}/datasets/{dataset}</c>.
             /// </summary>
-            ProjectLocationDataset = 1
+            ProjectLocationDataset = 1,
         }
 
         private static gax::PathTemplate s_projectLocationDataset = new gax::PathTemplate("projects/{project}/locations/{location}/datasets/{dataset}");

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/ModelEvaluationResourceNames.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/ModelEvaluationResourceNames.g.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.AutoML.V1
             /// A resource name with pattern
             /// <c>projects/{project}/locations/{location}/models/{model}/modelEvaluations/{model_evaluation}</c>.
             /// </summary>
-            ProjectLocationModelModelEvaluation = 1
+            ProjectLocationModelModelEvaluation = 1,
         }
 
         private static gax::PathTemplate s_projectLocationModelModelEvaluation = new gax::PathTemplate("projects/{project}/locations/{location}/models/{model}/modelEvaluations/{model_evaluation}");

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/ModelResourceNames.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/ModelResourceNames.g.cs
@@ -32,7 +32,7 @@ namespace Google.Cloud.AutoML.V1
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/locations/{location}/models/{model}</c>.
             /// </summary>
-            ProjectLocationModel = 1
+            ProjectLocationModel = 1,
         }
 
         private static gax::PathTemplate s_projectLocationModel = new gax::PathTemplate("projects/{project}/locations/{location}/models/{model}");

--- a/apis/Google.Cloud.AutoML.V1/synth.metadata
+++ b/apis/Google.Cloud.AutoML.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1/ConnectionResourceNames.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1/ConnectionResourceNames.g.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.BigQuery.Connection.V1
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/locations/{location}/connections/{connection}</c>.
             /// </summary>
-            ProjectLocationConnection = 1
+            ProjectLocationConnection = 1,
         }
 
         private static gax::PathTemplate s_projectLocationConnection = new gax::PathTemplate("projects/{project}/locations/{location}/connections/{connection}");

--- a/apis/Google.Cloud.BigQuery.Connection.V1/synth.metadata
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "c1b9289be1be876ef494f31c9662bc49b4f906e0"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/DatatransferResourceNames.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/DatatransferResourceNames.g.cs
@@ -36,7 +36,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/locations/{location}/dataSources/{data_source}</c>.
             /// </summary>
-            ProjectLocationDataSource = 2
+            ProjectLocationDataSource = 2,
         }
 
         private static gax::PathTemplate s_projectDataSource = new gax::PathTemplate("projects/{project}/dataSources/{data_source}");

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/TransferResourceNames.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/TransferResourceNames.g.cs
@@ -38,7 +38,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             /// A resource name with pattern
             /// <c>projects/{project}/locations/{location}/transferConfigs/{transfer_config}</c>.
             /// </summary>
-            ProjectLocationTransferConfig = 2
+            ProjectLocationTransferConfig = 2,
         }
 
         private static gax::PathTemplate s_projectTransferConfig = new gax::PathTemplate("projects/{project}/transferConfigs/{transfer_config}");
@@ -319,7 +319,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             /// A resource name with pattern
             /// <c>projects/{project}/locations/{location}/transferConfigs/{transfer_config}/runs/{run}</c>.
             /// </summary>
-            ProjectLocationTransferConfigRun = 2
+            ProjectLocationTransferConfigRun = 2,
         }
 
         private static gax::PathTemplate s_projectTransferConfigRun = new gax::PathTemplate("projects/{project}/transferConfigs/{transfer_config}/runs/{run}");

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/synth.metadata
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1/ReservationResourceNames.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1/ReservationResourceNames.g.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.BigQuery.Reservation.V1
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/locations/{location}/reservations/{reservation}</c>.
             /// </summary>
-            ProjectLocationReservation = 1
+            ProjectLocationReservation = 1,
         }
 
         private static gax::PathTemplate s_projectLocationReservation = new gax::PathTemplate("projects/{project}/locations/{location}/reservations/{reservation}");
@@ -273,7 +273,7 @@ namespace Google.Cloud.BigQuery.Reservation.V1
             /// A resource name with pattern
             /// <c>projects/{project}/locations/{location}/capacityCommitments/{capacity_commitment}</c>.
             /// </summary>
-            ProjectLocationCapacityCommitment = 1
+            ProjectLocationCapacityCommitment = 1,
         }
 
         private static gax::PathTemplate s_projectLocationCapacityCommitment = new gax::PathTemplate("projects/{project}/locations/{location}/capacityCommitments/{capacity_commitment}");
@@ -532,7 +532,7 @@ namespace Google.Cloud.BigQuery.Reservation.V1
             /// A resource name with pattern
             /// <c>projects/{project}/locations/{location}/reservations/{reservation}/assignments/{assignment}</c>.
             /// </summary>
-            ProjectLocationReservationAssignment = 1
+            ProjectLocationReservationAssignment = 1,
         }
 
         private static gax::PathTemplate s_projectLocationReservationAssignment = new gax::PathTemplate("projects/{project}/locations/{location}/reservations/{reservation}/assignments/{assignment}");
@@ -789,7 +789,7 @@ namespace Google.Cloud.BigQuery.Reservation.V1
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/locations/{location}/bireservation</c>.
             /// </summary>
-            ProjectLocation = 1
+            ProjectLocation = 1,
         }
 
         private static gax::PathTemplate s_projectLocation = new gax::PathTemplate("projects/{project}/locations/{location}/bireservation");

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/synth.metadata
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "0c6a73081373ff3ff3d470efe554f2f1efd64041"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/StorageResourceNames.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/StorageResourceNames.g.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.BigQuery.Storage.V1
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/datasets/{dataset}/tables/{table}</c>.
             /// </summary>
-            ProjectDatasetTable = 1
+            ProjectDatasetTable = 1,
         }
 
         private static gax::PathTemplate s_projectDatasetTable = new gax::PathTemplate("projects/{project}/datasets/{dataset}/tables/{table}");

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/StreamResourceNames.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/StreamResourceNames.g.cs
@@ -32,7 +32,7 @@ namespace Google.Cloud.BigQuery.Storage.V1
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/locations/{location}/sessions/{session}</c>.
             /// </summary>
-            ProjectLocationSession = 1
+            ProjectLocationSession = 1,
         }
 
         private static gax::PathTemplate s_projectLocationSession = new gax::PathTemplate("projects/{project}/locations/{location}/sessions/{session}");
@@ -264,7 +264,7 @@ namespace Google.Cloud.BigQuery.Storage.V1
             /// A resource name with pattern
             /// <c>projects/{project}/locations/{location}/sessions/{session}/streams/{stream}</c>.
             /// </summary>
-            ProjectLocationSessionStream = 1
+            ProjectLocationSessionStream = 1,
         }
 
         private static gax::PathTemplate s_projectLocationSessionStream = new gax::PathTemplate("projects/{project}/locations/{location}/sessions/{session}/streams/{stream}");

--- a/apis/Google.Cloud.BigQuery.Storage.V1/synth.metadata
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/InstanceResourceNames.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/InstanceResourceNames.g.cs
@@ -31,7 +31,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>projects/{project}/instances/{instance}</c>.</summary>
-            ProjectInstance = 1
+            ProjectInstance = 1,
         }
 
         private static gax::PathTemplate s_projectInstance = new gax::PathTemplate("projects/{project}/instances/{instance}");
@@ -249,7 +249,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/instances/{instance}/clusters/{cluster}</c>.
             /// </summary>
-            ProjectInstanceCluster = 1
+            ProjectInstanceCluster = 1,
         }
 
         private static gax::PathTemplate s_projectInstanceCluster = new gax::PathTemplate("projects/{project}/instances/{instance}/clusters/{cluster}");
@@ -478,7 +478,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/instances/{instance}/appProfiles/{app_profile}</c>.
             /// </summary>
-            ProjectInstanceAppProfile = 1
+            ProjectInstanceAppProfile = 1,
         }
 
         private static gax::PathTemplate s_projectInstanceAppProfile = new gax::PathTemplate("projects/{project}/instances/{instance}/appProfiles/{app_profile}");

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/TableResourceNames.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/TableResourceNames.g.cs
@@ -34,7 +34,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             /// A resource name with pattern
             /// <c>projects/{project}/instances/{instance}/clusters/{cluster}/snapshots/{snapshot}</c>.
             /// </summary>
-            ProjectInstanceClusterSnapshot = 1
+            ProjectInstanceClusterSnapshot = 1,
         }
 
         private static gax::PathTemplate s_projectInstanceClusterSnapshot = new gax::PathTemplate("projects/{project}/instances/{instance}/clusters/{cluster}/snapshots/{snapshot}");
@@ -291,7 +291,7 @@ namespace Google.Cloud.Bigtable.Admin.V2
             /// A resource name with pattern
             /// <c>projects/{project}/instances/{instance}/clusters/{cluster}/backups/{backup}</c>.
             /// </summary>
-            ProjectInstanceClusterBackup = 1
+            ProjectInstanceClusterBackup = 1,
         }
 
         private static gax::PathTemplate s_projectInstanceClusterBackup = new gax::PathTemplate("projects/{project}/instances/{instance}/clusters/{cluster}/backups/{backup}");

--- a/apis/Google.Cloud.Bigtable.Admin.V2/synth.metadata
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Bigtable.V2/synth.metadata
+++ b/apis/Google.Cloud.Bigtable.V2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1/BudgetModelResourceNames.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1/BudgetModelResourceNames.g.cs
@@ -32,7 +32,7 @@ namespace Google.Cloud.Billing.Budgets.V1Beta1
             /// <summary>
             /// A resource name with pattern <c>billingAccounts/{billing_account}/budgets/{budget}</c>.
             /// </summary>
-            BillingAccountBudget = 1
+            BillingAccountBudget = 1,
         }
 
         private static gax::PathTemplate s_billingAccountBudget = new gax::PathTemplate("billingAccounts/{billing_account}/budgets/{budget}");

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/CloudCatalogResourceNames.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/CloudCatalogResourceNames.g.cs
@@ -30,7 +30,7 @@ namespace Google.Cloud.Billing.V1
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>services/{service}</c>.</summary>
-            Service = 1
+            Service = 1,
         }
 
         private static gax::PathTemplate s_service = new gax::PathTemplate("services/{service}");
@@ -223,7 +223,7 @@ namespace Google.Cloud.Billing.V1
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>services/{service}/skus/{sku}</c>.</summary>
-            ServiceSku = 1
+            ServiceSku = 1,
         }
 
         private static gax::PathTemplate s_serviceSku = new gax::PathTemplate("services/{service}/skus/{sku}");

--- a/apis/Google.Cloud.Billing.V1/synth.metadata
+++ b/apis/Google.Cloud.Billing.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Container.V1/synth.metadata
+++ b/apis/Google.Cloud.Container.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/DatacatalogResourceNames.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/DatacatalogResourceNames.g.cs
@@ -34,7 +34,7 @@ namespace Google.Cloud.DataCatalog.V1
             /// A resource name with pattern
             /// <c>projects/{project}/locations/{location}/entryGroups/{entry_group}/entries/{entry}</c>.
             /// </summary>
-            ProjectLocationEntryGroupEntry = 1
+            ProjectLocationEntryGroupEntry = 1,
         }
 
         private static gax::PathTemplate s_projectLocationEntryGroupEntry = new gax::PathTemplate("projects/{project}/locations/{location}/entryGroups/{entry_group}/entries/{entry}");
@@ -289,7 +289,7 @@ namespace Google.Cloud.DataCatalog.V1
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/locations/{location}/entryGroups/{entry_group}</c>.
             /// </summary>
-            ProjectLocationEntryGroup = 1
+            ProjectLocationEntryGroup = 1,
         }
 
         private static gax::PathTemplate s_projectLocationEntryGroup = new gax::PathTemplate("projects/{project}/locations/{location}/entryGroups/{entry_group}");

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/TagsResourceNames.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/TagsResourceNames.g.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.DataCatalog.V1
             /// A resource name with pattern
             /// <c>projects/{project}/locations/{location}/entryGroups/{entry_group}/entries/{entry}/tags/{tag}</c>.
             /// </summary>
-            ProjectLocationEntryGroupEntryTag = 1
+            ProjectLocationEntryGroupEntryTag = 1,
         }
 
         private static gax::PathTemplate s_projectLocationEntryGroupEntryTag = new gax::PathTemplate("projects/{project}/locations/{location}/entryGroups/{entry_group}/entries/{entry}/tags/{tag}");
@@ -296,7 +296,7 @@ namespace Google.Cloud.DataCatalog.V1
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/locations/{location}/tagTemplates/{tag_template}</c>.
             /// </summary>
-            ProjectLocationTagTemplate = 1
+            ProjectLocationTagTemplate = 1,
         }
 
         private static gax::PathTemplate s_projectLocationTagTemplate = new gax::PathTemplate("projects/{project}/locations/{location}/tagTemplates/{tag_template}");
@@ -536,7 +536,7 @@ namespace Google.Cloud.DataCatalog.V1
             /// A resource name with pattern
             /// <c>projects/{project}/locations/{location}/tagTemplates/{tag_template}/fields/{field}</c>.
             /// </summary>
-            ProjectLocationTagTemplateField = 1
+            ProjectLocationTagTemplateField = 1,
         }
 
         private static gax::PathTemplate s_projectLocationTagTemplateField = new gax::PathTemplate("projects/{project}/locations/{location}/tagTemplates/{tag_template}/fields/{field}");

--- a/apis/Google.Cloud.DataCatalog.V1/synth.metadata
+++ b/apis/Google.Cloud.DataCatalog.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/AutoscalingPoliciesResourceNames.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/AutoscalingPoliciesResourceNames.g.cs
@@ -40,7 +40,7 @@ namespace Google.Cloud.Dataproc.V1
             /// A resource name with pattern
             /// <c>projects/{project}/regions/{region}/autoscalingPolicies/{autoscaling_policy}</c>.
             /// </summary>
-            ProjectRegionAutoscalingPolicy = 2
+            ProjectRegionAutoscalingPolicy = 2,
         }
 
         private static gax::PathTemplate s_projectLocationAutoscalingPolicy = new gax::PathTemplate("projects/{project}/locations/{location}/autoscalingPolicies/{autoscaling_policy}");
@@ -347,7 +347,7 @@ namespace Google.Cloud.Dataproc.V1
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>projects/{project}/regions/{region}</c>.</summary>
-            ProjectRegion = 1
+            ProjectRegion = 1,
         }
 
         private static gax::PathTemplate s_projectRegion = new gax::PathTemplate("projects/{project}/regions/{region}");

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/WorkflowTemplatesResourceNames.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/WorkflowTemplatesResourceNames.g.cs
@@ -40,7 +40,7 @@ namespace Google.Cloud.Dataproc.V1
             /// A resource name with pattern
             /// <c>projects/{project}/locations/{location}/workflowTemplates/{workflow_template}</c>.
             /// </summary>
-            ProjectLocationWorkflowTemplate = 2
+            ProjectLocationWorkflowTemplate = 2,
         }
 
         private static gax::PathTemplate s_projectRegionWorkflowTemplate = new gax::PathTemplate("projects/{project}/regions/{region}/workflowTemplates/{workflow_template}");

--- a/apis/Google.Cloud.Dataproc.V1/synth.metadata
+++ b/apis/Google.Cloud.Dataproc.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "6fd07563a2f1a6785066f5955ad9659a315e4492"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Datastore.Admin.V1/synth.metadata
+++ b/apis/Google.Cloud.Datastore.Admin.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "2db5725bf898b544a0cf951e1694d3b0fce5eda3"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Datastore.V1/synth.metadata
+++ b/apis/Google.Cloud.Datastore.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Debugger.V2/synth.metadata
+++ b/apis/Google.Cloud.Debugger.V2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/synth.metadata
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/AgentResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/AgentResourceNames.g.cs
@@ -30,7 +30,7 @@ namespace Google.Cloud.Dialogflow.V2
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>projects/{project}/agent</c>.</summary>
-            Project = 1
+            Project = 1,
         }
 
         private static gax::PathTemplate s_project = new gax::PathTemplate("projects/{project}/agent");

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ContextResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ContextResourceNames.g.cs
@@ -40,7 +40,7 @@ namespace Google.Cloud.Dialogflow.V2
             /// projects/{project}/agent/environments/{environment}/users/{user}/sessions/{session}/contexts/{context}</c>
             /// .
             /// </summary>
-            ProjectEnvironmentUserSessionContext = 2
+            ProjectEnvironmentUserSessionContext = 2,
         }
 
         private static gax::PathTemplate s_projectSessionContext = new gax::PathTemplate("projects/{project}/agent/sessions/{session}/contexts/{context}");

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/EntityTypeResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/EntityTypeResourceNames.g.cs
@@ -32,7 +32,7 @@ namespace Google.Cloud.Dialogflow.V2
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/agent/entityTypes/{entity_type}</c>.
             /// </summary>
-            ProjectEntityType = 1
+            ProjectEntityType = 1,
         }
 
         private static gax::PathTemplate s_projectEntityType = new gax::PathTemplate("projects/{project}/agent/entityTypes/{entity_type}");

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/EnvironmentResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/EnvironmentResourceNames.g.cs
@@ -32,7 +32,7 @@ namespace Google.Cloud.Dialogflow.V2
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/agent/environments/{environment}</c>.
             /// </summary>
-            ProjectEnvironment = 1
+            ProjectEnvironment = 1,
         }
 
         private static gax::PathTemplate s_projectEnvironment = new gax::PathTemplate("projects/{project}/agent/environments/{environment}");

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/IntentResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/IntentResourceNames.g.cs
@@ -30,7 +30,7 @@ namespace Google.Cloud.Dialogflow.V2
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>projects/{project}/agent/intents/{intent}</c>.</summary>
-            ProjectIntent = 1
+            ProjectIntent = 1,
         }
 
         private static gax::PathTemplate s_projectIntent = new gax::PathTemplate("projects/{project}/agent/intents/{intent}");

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/SessionEntityTypeResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/SessionEntityTypeResourceNames.g.cs
@@ -41,7 +41,7 @@ namespace Google.Cloud.Dialogflow.V2
             /// projects/{project}/agent/environments/{environment}/users/{user}/sessions/{session}/entityTypes/{entity_type}</c>
             /// .
             /// </summary>
-            ProjectEnvironmentUserSessionEntityType = 2
+            ProjectEnvironmentUserSessionEntityType = 2,
         }
 
         private static gax::PathTemplate s_projectSessionEntityType = new gax::PathTemplate("projects/{project}/agent/sessions/{session}/entityTypes/{entity_type}");

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/SessionResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/SessionResourceNames.g.cs
@@ -35,7 +35,7 @@ namespace Google.Cloud.Dialogflow.V2
             /// A resource name with pattern
             /// <c>projects/{project}/agent/environments/{environment}/users/{user}/sessions/{session}</c>.
             /// </summary>
-            ProjectEnvironmentUserSession = 2
+            ProjectEnvironmentUserSession = 2,
         }
 
         private static gax::PathTemplate s_projectSession = new gax::PathTemplate("projects/{project}/agent/sessions/{session}");

--- a/apis/Google.Cloud.Dialogflow.V2/synth.metadata
+++ b/apis/Google.Cloud.Dialogflow.V2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "b100ad424293ce5d5378e9067d9d83c4973a115a"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/DlpResourceNames.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/DlpResourceNames.g.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.Dlp.V2
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/locations/{location}/findings/{finding}</c>.
             /// </summary>
-            ProjectLocationFinding = 1
+            ProjectLocationFinding = 1,
         }
 
         private static gax::PathTemplate s_projectLocationFinding = new gax::PathTemplate("projects/{project}/locations/{location}/findings/{finding}");
@@ -279,7 +279,7 @@ namespace Google.Cloud.Dlp.V2
             /// A resource name with pattern
             /// <c>projects/{project}/locations/{location}/inspectTemplates/{inspect_template}</c>.
             /// </summary>
-            ProjectLocationInspectTemplate = 4
+            ProjectLocationInspectTemplate = 4,
         }
 
         private static gax::PathTemplate s_organizationInspectTemplate = new gax::PathTemplate("organizations/{organization}/inspectTemplates/{inspect_template}");
@@ -683,7 +683,7 @@ namespace Google.Cloud.Dlp.V2
             /// A resource name with pattern
             /// <c>projects/{project}/locations/{location}/deidentifyTemplates/{deidentify_template}</c>.
             /// </summary>
-            ProjectLocationDeidentifyTemplate = 4
+            ProjectLocationDeidentifyTemplate = 4,
         }
 
         private static gax::PathTemplate s_organizationDeidentifyTemplate = new gax::PathTemplate("organizations/{organization}/deidentifyTemplates/{deidentify_template}");
@@ -1092,7 +1092,7 @@ namespace Google.Cloud.Dlp.V2
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/locations/{location}/jobTriggers/{job_trigger}</c>.
             /// </summary>
-            ProjectLocationJobTrigger = 2
+            ProjectLocationJobTrigger = 2,
         }
 
         private static gax::PathTemplate s_projectJobTrigger = new gax::PathTemplate("projects/{project}/jobTriggers/{job_trigger}");
@@ -1366,7 +1366,7 @@ namespace Google.Cloud.Dlp.V2
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/locations/{location}/dlpJobs/{dlp_job}</c>.
             /// </summary>
-            ProjectLocationDlpJob = 2
+            ProjectLocationDlpJob = 2,
         }
 
         private static gax::PathTemplate s_projectDlpJob = new gax::PathTemplate("projects/{project}/dlpJobs/{dlp_job}");
@@ -1643,7 +1643,7 @@ namespace Google.Cloud.Dlp.V2
             /// A resource name with pattern
             /// <c>projects/{project}/locations/{location}/storedInfoTypes/{stored_info_type}</c>.
             /// </summary>
-            ProjectLocationStoredInfoType = 4
+            ProjectLocationStoredInfoType = 4,
         }
 
         private static gax::PathTemplate s_organizationStoredInfoType = new gax::PathTemplate("organizations/{organization}/storedInfoTypes/{stored_info_type}");
@@ -2032,7 +2032,7 @@ namespace Google.Cloud.Dlp.V2
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/locations/{location}/dlpContent</c>.
             /// </summary>
-            ProjectLocation = 2
+            ProjectLocation = 2,
         }
 
         private static gax::PathTemplate s_project = new gax::PathTemplate("projects/{project}/dlpContent");
@@ -2282,7 +2282,7 @@ namespace Google.Cloud.Dlp.V2
             /// <summary>
             /// A resource name with pattern <c>organizations/{organization}/locations/{location}</c>.
             /// </summary>
-            OrganizationLocation = 1
+            OrganizationLocation = 1,
         }
 
         private static gax::PathTemplate s_organizationLocation = new gax::PathTemplate("organizations/{organization}/locations/{location}");

--- a/apis/Google.Cloud.Dlp.V2/synth.metadata
+++ b/apis/Google.Cloud.Dlp.V2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "1ee015d872d003637eb47b890930bf3d0d410c61"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.DocumentAI.V1Beta2/synth.metadata
+++ b/apis/Google.Cloud.DocumentAI.V1Beta2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/CommonResourceNames.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/CommonResourceNames.g.cs
@@ -30,7 +30,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>projects/{project}/groups/{group}</c>.</summary>
-            ProjectGroup = 1
+            ProjectGroup = 1,
         }
 
         private static gax::PathTemplate s_projectGroup = new gax::PathTemplate("projects/{project}/groups/{group}");

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/FieldResourceNames.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/FieldResourceNames.g.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.Firestore.Admin.V1
             /// A resource name with pattern
             /// <c>projects/{project}/databases/{database}/collectionGroups/{collection}/fields/{field}</c>.
             /// </summary>
-            ProjectDatabaseCollectionField = 1
+            ProjectDatabaseCollectionField = 1,
         }
 
         private static gax::PathTemplate s_projectDatabaseCollectionField = new gax::PathTemplate("projects/{project}/databases/{database}/collectionGroups/{collection}/fields/{field}");

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/FirestoreAdminResourceNames.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/FirestoreAdminResourceNames.g.cs
@@ -30,7 +30,7 @@ namespace Google.Cloud.Firestore.Admin.V1
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>projects/{project}/databases/{database}</c>.</summary>
-            ProjectDatabase = 1
+            ProjectDatabase = 1,
         }
 
         private static gax::PathTemplate s_projectDatabase = new gax::PathTemplate("projects/{project}/databases/{database}");
@@ -249,7 +249,7 @@ namespace Google.Cloud.Firestore.Admin.V1
             /// A resource name with pattern <c>projects/{project}/databases/{database}/collectionGroups/{collection}</c>
             /// .
             /// </summary>
-            ProjectDatabaseCollection = 1
+            ProjectDatabaseCollection = 1,
         }
 
         private static gax::PathTemplate s_projectDatabaseCollection = new gax::PathTemplate("projects/{project}/databases/{database}/collectionGroups/{collection}");

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/IndexResourceNames.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/IndexResourceNames.g.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.Firestore.Admin.V1
             /// A resource name with pattern
             /// <c>projects/{project}/databases/{database}/collectionGroups/{collection}/indexes/{index}</c>.
             /// </summary>
-            ProjectDatabaseCollectionIndex = 1
+            ProjectDatabaseCollectionIndex = 1,
         }
 
         private static gax::PathTemplate s_projectDatabaseCollectionIndex = new gax::PathTemplate("projects/{project}/databases/{database}/collectionGroups/{collection}/indexes/{index}");

--- a/apis/Google.Cloud.Firestore.Admin.V1/synth.metadata
+++ b/apis/Google.Cloud.Firestore.Admin.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Firestore.V1/synth.metadata
+++ b/apis/Google.Cloud.Firestore.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "17de2b31f9450385e739bedeeaac6e1ec4f239a8"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1/FunctionsResourceNames.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1/FunctionsResourceNames.g.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.Functions.V1
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/locations/{location}/functions/{function}</c>.
             /// </summary>
-            ProjectLocationFunction = 1
+            ProjectLocationFunction = 1,
         }
 
         private static gax::PathTemplate s_projectLocationFunction = new gax::PathTemplate("projects/{project}/locations/{location}/functions/{function}");

--- a/apis/Google.Cloud.Functions.V1/synth.metadata
+++ b/apis/Google.Cloud.Functions.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "b375ae2941150f950b8561bbfcd8fc8908d30599"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Gaming.V1/Google.Cloud.Gaming.V1/GameServerClustersResourceNames.g.cs
+++ b/apis/Google.Cloud.Gaming.V1/Google.Cloud.Gaming.V1/GameServerClustersResourceNames.g.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.Gaming.V1
             /// A resource name with pattern
             /// <c>projects/{project}/locations/{location}/realms/{realm}/gameServerClusters/{cluster}</c>.
             /// </summary>
-            ProjectLocationRealmCluster = 1
+            ProjectLocationRealmCluster = 1,
         }
 
         private static gax::PathTemplate s_projectLocationRealmCluster = new gax::PathTemplate("projects/{project}/locations/{location}/realms/{realm}/gameServerClusters/{cluster}");

--- a/apis/Google.Cloud.Gaming.V1/Google.Cloud.Gaming.V1/GameServerConfigsResourceNames.g.cs
+++ b/apis/Google.Cloud.Gaming.V1/Google.Cloud.Gaming.V1/GameServerConfigsResourceNames.g.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.Gaming.V1
             /// A resource name with pattern
             /// <c>projects/{project}/locations/{location}/gameServerDeployments/{deployment}/configs/{config}</c>.
             /// </summary>
-            ProjectLocationDeploymentConfig = 1
+            ProjectLocationDeploymentConfig = 1,
         }
 
         private static gax::PathTemplate s_projectLocationDeploymentConfig = new gax::PathTemplate("projects/{project}/locations/{location}/gameServerDeployments/{deployment}/configs/{config}");

--- a/apis/Google.Cloud.Gaming.V1/Google.Cloud.Gaming.V1/GameServerDeploymentsResourceNames.g.cs
+++ b/apis/Google.Cloud.Gaming.V1/Google.Cloud.Gaming.V1/GameServerDeploymentsResourceNames.g.cs
@@ -34,7 +34,7 @@ namespace Google.Cloud.Gaming.V1
             /// A resource name with pattern
             /// <c>projects/{project}/locations/{location}/gameServerDeployments/{deployment}</c>.
             /// </summary>
-            ProjectLocationDeployment = 1
+            ProjectLocationDeployment = 1,
         }
 
         private static gax::PathTemplate s_projectLocationDeployment = new gax::PathTemplate("projects/{project}/locations/{location}/gameServerDeployments/{deployment}");
@@ -289,7 +289,7 @@ namespace Google.Cloud.Gaming.V1
             /// A resource name with pattern
             /// <c>projects/{project}/locations/{location}/gameServerDeployments/{deployment}/rollout</c>.
             /// </summary>
-            ProjectLocationDeployment = 1
+            ProjectLocationDeployment = 1,
         }
 
         private static gax::PathTemplate s_projectLocationDeployment = new gax::PathTemplate("projects/{project}/locations/{location}/gameServerDeployments/{deployment}/rollout");

--- a/apis/Google.Cloud.Gaming.V1/Google.Cloud.Gaming.V1/RealmsResourceNames.g.cs
+++ b/apis/Google.Cloud.Gaming.V1/Google.Cloud.Gaming.V1/RealmsResourceNames.g.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.Gaming.V1
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/locations/{location}/realms/{realm}</c>.
             /// </summary>
-            ProjectLocationRealm = 1
+            ProjectLocationRealm = 1,
         }
 
         private static gax::PathTemplate s_projectLocationRealm = new gax::PathTemplate("projects/{project}/locations/{location}/realms/{realm}");

--- a/apis/Google.Cloud.Gaming.V1/synth.metadata
+++ b/apis/Google.Cloud.Gaming.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "4d52dfb72078000b13de923c1dadec19f3a64ad1"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/GameServerClustersResourceNames.g.cs
+++ b/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/GameServerClustersResourceNames.g.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.Gaming.V1Beta
             /// A resource name with pattern
             /// <c>projects/{project}/locations/{location}/realms/{realm}/gameServerClusters/{cluster}</c>.
             /// </summary>
-            ProjectLocationRealmCluster = 1
+            ProjectLocationRealmCluster = 1,
         }
 
         private static gax::PathTemplate s_projectLocationRealmCluster = new gax::PathTemplate("projects/{project}/locations/{location}/realms/{realm}/gameServerClusters/{cluster}");

--- a/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/GameServerConfigsResourceNames.g.cs
+++ b/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/GameServerConfigsResourceNames.g.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.Gaming.V1Beta
             /// A resource name with pattern
             /// <c>projects/{project}/locations/{location}/gameServerDeployments/{deployment}/configs/{config}</c>.
             /// </summary>
-            ProjectLocationDeploymentConfig = 1
+            ProjectLocationDeploymentConfig = 1,
         }
 
         private static gax::PathTemplate s_projectLocationDeploymentConfig = new gax::PathTemplate("projects/{project}/locations/{location}/gameServerDeployments/{deployment}/configs/{config}");

--- a/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/GameServerDeploymentsResourceNames.g.cs
+++ b/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/GameServerDeploymentsResourceNames.g.cs
@@ -34,7 +34,7 @@ namespace Google.Cloud.Gaming.V1Beta
             /// A resource name with pattern
             /// <c>projects/{project}/locations/{location}/gameServerDeployments/{deployment}</c>.
             /// </summary>
-            ProjectLocationDeployment = 1
+            ProjectLocationDeployment = 1,
         }
 
         private static gax::PathTemplate s_projectLocationDeployment = new gax::PathTemplate("projects/{project}/locations/{location}/gameServerDeployments/{deployment}");
@@ -289,7 +289,7 @@ namespace Google.Cloud.Gaming.V1Beta
             /// A resource name with pattern
             /// <c>projects/{project}/locations/{location}/gameServerDeployments/{deployment}/rollout</c>.
             /// </summary>
-            ProjectLocationDeployment = 1
+            ProjectLocationDeployment = 1,
         }
 
         private static gax::PathTemplate s_projectLocationDeployment = new gax::PathTemplate("projects/{project}/locations/{location}/gameServerDeployments/{deployment}/rollout");

--- a/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/RealmsResourceNames.g.cs
+++ b/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/RealmsResourceNames.g.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.Gaming.V1Beta
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/locations/{location}/realms/{realm}</c>.
             /// </summary>
-            ProjectLocationRealm = 1
+            ProjectLocationRealm = 1,
         }
 
         private static gax::PathTemplate s_projectLocationRealm = new gax::PathTemplate("projects/{project}/locations/{location}/realms/{realm}");

--- a/apis/Google.Cloud.Gaming.V1Beta/synth.metadata
+++ b/apis/Google.Cloud.Gaming.V1Beta/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Iam.V1/synth.metadata
+++ b/apis/Google.Cloud.Iam.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/ResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/ResourcesResourceNames.g.cs
@@ -32,7 +32,7 @@ namespace Google.Cloud.Kms.V1
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/locations/{location}/keyRings/{key_ring}</c>.
             /// </summary>
-            ProjectLocationKeyRing = 1
+            ProjectLocationKeyRing = 1,
         }
 
         private static gax::PathTemplate s_projectLocationKeyRing = new gax::PathTemplate("projects/{project}/locations/{location}/keyRings/{key_ring}");
@@ -262,7 +262,7 @@ namespace Google.Cloud.Kms.V1
             /// A resource name with pattern
             /// <c>projects/{project}/locations/{location}/keyRings/{key_ring}/cryptoKeys/{crypto_key}</c>.
             /// </summary>
-            ProjectLocationKeyRingCryptoKey = 1
+            ProjectLocationKeyRingCryptoKey = 1,
         }
 
         private static gax::PathTemplate s_projectLocationKeyRingCryptoKey = new gax::PathTemplate("projects/{project}/locations/{location}/keyRings/{key_ring}/cryptoKeys/{crypto_key}");
@@ -521,7 +521,7 @@ namespace Google.Cloud.Kms.V1
             /// projects/{project}/locations/{location}/keyRings/{key_ring}/cryptoKeys/{crypto_key}/cryptoKeyVersions/{crypto_key_version}</c>
             /// .
             /// </summary>
-            ProjectLocationKeyRingCryptoKeyCryptoKeyVersion = 1
+            ProjectLocationKeyRingCryptoKeyCryptoKeyVersion = 1,
         }
 
         private static gax::PathTemplate s_projectLocationKeyRingCryptoKeyCryptoKeyVersion = new gax::PathTemplate("projects/{project}/locations/{location}/keyRings/{key_ring}/cryptoKeys/{crypto_key}/cryptoKeyVersions/{crypto_key_version}");
@@ -809,7 +809,7 @@ namespace Google.Cloud.Kms.V1
             /// projects/{project}/locations/{location}/keyRings/{key_ring}/cryptoKeys/{crypto_key}/cryptoKeyVersions/{crypto_key_version}/publicKey</c>
             /// .
             /// </summary>
-            ProjectLocationKeyRingCryptoKeyCryptoKeyVersion = 1
+            ProjectLocationKeyRingCryptoKeyCryptoKeyVersion = 1,
         }
 
         private static gax::PathTemplate s_projectLocationKeyRingCryptoKeyCryptoKeyVersion = new gax::PathTemplate("projects/{project}/locations/{location}/keyRings/{key_ring}/cryptoKeys/{crypto_key}/cryptoKeyVersions/{crypto_key_version}/publicKey");
@@ -1092,7 +1092,7 @@ namespace Google.Cloud.Kms.V1
             /// A resource name with pattern
             /// <c>projects/{project}/locations/{location}/keyRings/{key_ring}/importJobs/{import_job}</c>.
             /// </summary>
-            ProjectLocationKeyRingImportJob = 1
+            ProjectLocationKeyRingImportJob = 1,
         }
 
         private static gax::PathTemplate s_projectLocationKeyRingImportJob = new gax::PathTemplate("projects/{project}/locations/{location}/keyRings/{key_ring}/importJobs/{import_job}");

--- a/apis/Google.Cloud.Kms.V1/synth.metadata
+++ b/apis/Google.Cloud.Kms.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "b40e4533f841c96aac1d9d7d342514d146b5b4cb"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Language.V1/synth.metadata
+++ b/apis/Google.Cloud.Language.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Logging.Type/synth.metadata
+++ b/apis/Google.Cloud.Logging.Type/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/LogEntryResourceNames.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/LogEntryResourceNames.g.cs
@@ -39,7 +39,7 @@ namespace Google.Cloud.Logging.V2
             FolderLog = 3,
 
             /// <summary>A resource name with pattern <c>billingAccounts/{billing_account}/logs/{log}</c>.</summary>
-            BillingAccountLog = 4
+            BillingAccountLog = 4,
         }
 
         private static gax::PathTemplate s_projectLog = new gax::PathTemplate("projects/{project}/logs/{log}");

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/LoggingConfigResourceNames.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/LoggingConfigResourceNames.g.cs
@@ -49,7 +49,7 @@ namespace Google.Cloud.Logging.V2
             /// A resource name with pattern <c>billingAccounts/{billing_account}/locations/{location}/buckets/{bucket}</c>
             /// .
             /// </summary>
-            BillingAccountLocationBucket = 4
+            BillingAccountLocationBucket = 4,
         }
 
         private static gax::PathTemplate s_projectLocationBucket = new gax::PathTemplate("projects/{project}/locations/{location}/buckets/{bucket}");
@@ -433,7 +433,7 @@ namespace Google.Cloud.Logging.V2
             FolderSink = 3,
 
             /// <summary>A resource name with pattern <c>billingAccounts/{billing_account}/sinks/{sink}</c>.</summary>
-            BillingAccountSink = 4
+            BillingAccountSink = 4,
         }
 
         private static gax::PathTemplate s_projectSink = new gax::PathTemplate("projects/{project}/sinks/{sink}");
@@ -783,7 +783,7 @@ namespace Google.Cloud.Logging.V2
             /// <summary>
             /// A resource name with pattern <c>billingAccounts/{billing_account}/exclusions/{exclusion}</c>.
             /// </summary>
-            BillingAccountExclusion = 4
+            BillingAccountExclusion = 4,
         }
 
         private static gax::PathTemplate s_projectExclusion = new gax::PathTemplate("projects/{project}/exclusions/{exclusion}");
@@ -1133,7 +1133,7 @@ namespace Google.Cloud.Logging.V2
             Folder = 3,
 
             /// <summary>A resource name with pattern <c>billingAccounts/{billing_account}/cmekSettings</c>.</summary>
-            BillingAccount = 4
+            BillingAccount = 4,
         }
 
         private static gax::PathTemplate s_project = new gax::PathTemplate("projects/{project}/cmekSettings");
@@ -1459,7 +1459,7 @@ namespace Google.Cloud.Logging.V2
             /// <summary>
             /// A resource name with pattern <c>organizations/{organization}/locations/{location}</c>.
             /// </summary>
-            OrganizationLocation = 1
+            OrganizationLocation = 1,
         }
 
         private static gax::PathTemplate s_organizationLocation = new gax::PathTemplate("organizations/{organization}/locations/{location}");
@@ -1686,7 +1686,7 @@ namespace Google.Cloud.Logging.V2
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>folders/{folder}/locations/{location}</c>.</summary>
-            FolderLocation = 1
+            FolderLocation = 1,
         }
 
         private static gax::PathTemplate s_folderLocation = new gax::PathTemplate("folders/{folder}/locations/{location}");
@@ -1907,7 +1907,7 @@ namespace Google.Cloud.Logging.V2
             /// <summary>
             /// A resource name with pattern <c>billingAccounts/{billing_account}/locations/{location}</c>.
             /// </summary>
-            BillingAccountLocation = 1
+            BillingAccountLocation = 1,
         }
 
         private static gax::PathTemplate s_billingAccountLocation = new gax::PathTemplate("billingAccounts/{billing_account}/locations/{location}");

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/LoggingMetricsResourceNames.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/LoggingMetricsResourceNames.g.cs
@@ -31,7 +31,7 @@ namespace Google.Cloud.Logging.V2
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>projects/{project}/metrics/{metric}</c>.</summary>
-            ProjectMetric = 1
+            ProjectMetric = 1,
         }
 
         private static gax::PathTemplate s_projectMetric = new gax::PathTemplate("projects/{project}/metrics/{metric}");

--- a/apis/Google.Cloud.Logging.V2/synth.metadata
+++ b/apis/Google.Cloud.Logging.V2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1/ResourceResourceNames.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1/ResourceResourceNames.g.cs
@@ -32,7 +32,7 @@ namespace Google.Cloud.ManagedIdentities.V1
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/locations/{location}/domains/{domain}</c>.
             /// </summary>
-            ProjectLocationDomain = 1
+            ProjectLocationDomain = 1,
         }
 
         private static gax::PathTemplate s_projectLocationDomain = new gax::PathTemplate("projects/{project}/locations/{location}/domains/{domain}");

--- a/apis/Google.Cloud.ManagedIdentities.V1/synth.metadata
+++ b/apis/Google.Cloud.ManagedIdentities.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2/CloudMemcacheResourceNames.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2/CloudMemcacheResourceNames.g.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.Memcache.V1Beta2
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/locations/{location}/instances/{instance}</c>.
             /// </summary>
-            ProjectLocationInstance = 1
+            ProjectLocationInstance = 1,
         }
 
         private static gax::PathTemplate s_projectLocationInstance = new gax::PathTemplate("projects/{project}/locations/{location}/instances/{instance}");

--- a/apis/Google.Cloud.Memcache.V1Beta2/synth.metadata
+++ b/apis/Google.Cloud.Memcache.V1Beta2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/AlertResourceNames.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/AlertResourceNames.g.cs
@@ -45,7 +45,7 @@ namespace Google.Cloud.Monitoring.V3
             /// A resource name with pattern <c>folders/{folder}/alertPolicies/{alert_policy}/conditions/{condition}</c>
             /// .
             /// </summary>
-            FolderAlertPolicyCondition = 3
+            FolderAlertPolicyCondition = 3,
         }
 
         private static gax::PathTemplate s_projectAlertPolicyCondition = new gax::PathTemplate("projects/{project}/alertPolicies/{alert_policy}/conditions/{condition}");
@@ -413,7 +413,7 @@ namespace Google.Cloud.Monitoring.V3
             OrganizationAlertPolicy = 2,
 
             /// <summary>A resource name with pattern <c>folders/{folder}/alertPolicies/{alert_policy}</c>.</summary>
-            FolderAlertPolicy = 3
+            FolderAlertPolicy = 3,
         }
 
         private static gax::PathTemplate s_projectAlertPolicy = new gax::PathTemplate("projects/{project}/alertPolicies/{alert_policy}");

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/GroupResourceNames.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/GroupResourceNames.g.cs
@@ -36,7 +36,7 @@ namespace Google.Cloud.Monitoring.V3
             OrganizationGroup = 2,
 
             /// <summary>A resource name with pattern <c>folders/{folder}/groups/{group}</c>.</summary>
-            FolderGroup = 3
+            FolderGroup = 3,
         }
 
         private static gax::PathTemplate s_projectGroup = new gax::PathTemplate("projects/{project}/groups/{group}");

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/MetricServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/MetricServiceResourceNames.g.cs
@@ -44,7 +44,7 @@ namespace Google.Cloud.Monitoring.V3
             /// <summary>
             /// A resource name with pattern <c>folders/{folder}/metricDescriptors/{metric_descriptor=**}</c>.
             /// </summary>
-            FolderMetricDescriptor = 3
+            FolderMetricDescriptor = 3,
         }
 
         private static gax::PathTemplate s_projectMetricDescriptor = new gax::PathTemplate("projects/{project}/metricDescriptors/{metric_descriptor=**}");
@@ -372,7 +372,7 @@ namespace Google.Cloud.Monitoring.V3
             /// A resource name with pattern
             /// <c>folders/{folder}/monitoredResourceDescriptors/{monitored_resource_descriptor}</c>.
             /// </summary>
-            FolderMonitoredResourceDescriptor = 3
+            FolderMonitoredResourceDescriptor = 3,
         }
 
         private static gax::PathTemplate s_projectMonitoredResourceDescriptor = new gax::PathTemplate("projects/{project}/monitoredResourceDescriptors/{monitored_resource_descriptor}");

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/NotificationResourceNames.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/NotificationResourceNames.g.cs
@@ -45,7 +45,7 @@ namespace Google.Cloud.Monitoring.V3
             /// A resource name with pattern <c>folders/{folder}/notificationChannelDescriptors/{channel_descriptor}</c>
             /// .
             /// </summary>
-            FolderChannelDescriptor = 3
+            FolderChannelDescriptor = 3,
         }
 
         private static gax::PathTemplate s_projectChannelDescriptor = new gax::PathTemplate("projects/{project}/notificationChannelDescriptors/{channel_descriptor}");
@@ -415,7 +415,7 @@ namespace Google.Cloud.Monitoring.V3
             /// <summary>
             /// A resource name with pattern <c>folders/{folder}/notificationChannels/{notification_channel}</c>.
             /// </summary>
-            FolderNotificationChannel = 3
+            FolderNotificationChannel = 3,
         }
 
         private static gax::PathTemplate s_projectNotificationChannel = new gax::PathTemplate("projects/{project}/notificationChannels/{notification_channel}");

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/ServiceResourceNames.g.cs
@@ -36,7 +36,7 @@ namespace Google.Cloud.Monitoring.V3
             OrganizationService = 2,
 
             /// <summary>A resource name with pattern <c>folders/{folder}/services/{service}</c>.</summary>
-            FolderService = 3
+            FolderService = 3,
         }
 
         private static gax::PathTemplate s_projectService = new gax::PathTemplate("projects/{project}/services/{service}");
@@ -347,7 +347,7 @@ namespace Google.Cloud.Monitoring.V3
             /// A resource name with pattern
             /// <c>folders/{folder}/services/{service}/serviceLevelObjectives/{service_level_objective}</c>.
             /// </summary>
-            FolderServiceServiceLevelObjective = 3
+            FolderServiceServiceLevelObjective = 3,
         }
 
         private static gax::PathTemplate s_projectServiceServiceLevelObjective = new gax::PathTemplate("projects/{project}/services/{service}/serviceLevelObjectives/{service_level_objective}");

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/UptimeResourceNames.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/UptimeResourceNames.g.cs
@@ -43,7 +43,7 @@ namespace Google.Cloud.Monitoring.V3
             /// <summary>
             /// A resource name with pattern <c>folders/{folder}/uptimeCheckConfigs/{uptime_check_config}</c>.
             /// </summary>
-            FolderUptimeCheckConfig = 3
+            FolderUptimeCheckConfig = 3,
         }
 
         private static gax::PathTemplate s_projectUptimeCheckConfig = new gax::PathTemplate("projects/{project}/uptimeCheckConfigs/{uptime_check_config}");

--- a/apis/Google.Cloud.Monitoring.V3/synth.metadata
+++ b/apis/Google.Cloud.Monitoring.V3/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1/EnvironmentResourceNames.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1/EnvironmentResourceNames.g.cs
@@ -30,7 +30,7 @@ namespace Google.Cloud.Notebooks.V1Beta1
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>projects/{project}/environments/{environment}</c>.</summary>
-            ProjectEnvironment = 1
+            ProjectEnvironment = 1,
         }
 
         private static gax::PathTemplate s_projectEnvironment = new gax::PathTemplate("projects/{project}/environments/{environment}");

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1/InstanceResourceNames.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1/InstanceResourceNames.g.cs
@@ -30,7 +30,7 @@ namespace Google.Cloud.Notebooks.V1Beta1
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>projects/{project}/instances/{instance}</c>.</summary>
-            ProjectInstance = 1
+            ProjectInstance = 1,
         }
 
         private static gax::PathTemplate s_projectInstance = new gax::PathTemplate("projects/{project}/instances/{instance}");

--- a/apis/Google.Cloud.Notebooks.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "8ed61110e12ee3ef734c6a11e3f3e714c43bf09a"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.OrgPolicy.V1/synth.metadata
+++ b/apis/Google.Cloud.OrgPolicy.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/OsconfigServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/OsconfigServiceResourceNames.g.cs
@@ -31,7 +31,7 @@ namespace Google.Cloud.OsConfig.V1
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/zones/{zone}/instances/{instance}</c>.
             /// </summary>
-            ProjectZoneInstance = 1
+            ProjectZoneInstance = 1,
         }
 
         private static gax::PathTemplate s_projectZoneInstance = new gax::PathTemplate("projects/{project}/zones/{zone}/instances/{instance}");

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/PatchDeploymentsResourceNames.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/PatchDeploymentsResourceNames.g.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.OsConfig.V1
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/patchDeployments/{patch_deployment}</c>.
             /// </summary>
-            ProjectPatchDeployment = 1
+            ProjectPatchDeployment = 1,
         }
 
         private static gax::PathTemplate s_projectPatchDeployment = new gax::PathTemplate("projects/{project}/patchDeployments/{patch_deployment}");

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/PatchJobsResourceNames.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/PatchJobsResourceNames.g.cs
@@ -31,7 +31,7 @@ namespace Google.Cloud.OsConfig.V1
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>projects/{project}/patchJobs/{patch_job}</c>.</summary>
-            ProjectPatchJob = 1
+            ProjectPatchJob = 1,
         }
 
         private static gax::PathTemplate s_projectPatchJob = new gax::PathTemplate("projects/{project}/patchJobs/{patch_job}");

--- a/apis/Google.Cloud.OsConfig.V1/synth.metadata
+++ b/apis/Google.Cloud.OsConfig.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.OsLogin.Common/Google.Cloud.OsLogin.Common/CommonResourceNames.g.cs
+++ b/apis/Google.Cloud.OsLogin.Common/Google.Cloud.OsLogin.Common/CommonResourceNames.g.cs
@@ -30,7 +30,7 @@ namespace Google.Cloud.OsLogin.Common
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>users/{user}/projects/{project}</c>.</summary>
-            UserProject = 1
+            UserProject = 1,
         }
 
         private static gax::PathTemplate s_userProject = new gax::PathTemplate("users/{user}/projects/{project}");
@@ -239,7 +239,7 @@ namespace Google.Cloud.OsLogin.Common
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>users/{user}/sshPublicKeys/{fingerprint}</c>.</summary>
-            UserFingerprint = 1
+            UserFingerprint = 1,
         }
 
         private static gax::PathTemplate s_userFingerprint = new gax::PathTemplate("users/{user}/sshPublicKeys/{fingerprint}");
@@ -456,7 +456,7 @@ namespace Google.Cloud.OsLogin.Common
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>users/{user}</c>.</summary>
-            User = 1
+            User = 1,
         }
 
         private static gax::PathTemplate s_user = new gax::PathTemplate("users/{user}");

--- a/apis/Google.Cloud.OsLogin.Common/synth.metadata
+++ b/apis/Google.Cloud.OsLogin.Common/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.OsLogin.V1/synth.metadata
+++ b/apis/Google.Cloud.OsLogin.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.OsLogin.V1Beta/synth.metadata
+++ b/apis/Google.Cloud.OsLogin.V1Beta/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.PhishingProtection.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.PhishingProtection.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.PolicyTroubleshooter.V1/synth.metadata
+++ b/apis/Google.Cloud.PolicyTroubleshooter.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "1a85976e6bcecdaee1242f6e7fd8b3db81904f56"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/PubsubResourceNames.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/PubsubResourceNames.g.cs
@@ -34,7 +34,7 @@ namespace Google.Cloud.PubSub.V1
             ProjectTopic = 1,
 
             /// <summary>A resource name with pattern <c>_deleted-topic_</c>.</summary>
-            DeletedTopic = 2
+            DeletedTopic = 2,
         }
 
         private static gax::PathTemplate s_projectTopic = new gax::PathTemplate("projects/{project}/topics/{topic}");
@@ -274,7 +274,7 @@ namespace Google.Cloud.PubSub.V1
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>projects/{project}/subscriptions/{subscription}</c>.</summary>
-            ProjectSubscription = 1
+            ProjectSubscription = 1,
         }
 
         private static gax::PathTemplate s_projectSubscription = new gax::PathTemplate("projects/{project}/subscriptions/{subscription}");
@@ -494,7 +494,7 @@ namespace Google.Cloud.PubSub.V1
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>projects/{project}/snapshots/{snapshot}</c>.</summary>
-            ProjectSnapshot = 1
+            ProjectSnapshot = 1,
         }
 
         private static gax::PathTemplate s_projectSnapshot = new gax::PathTemplate("projects/{project}/snapshots/{snapshot}");

--- a/apis/Google.Cloud.PubSub.V1/synth.metadata
+++ b/apis/Google.Cloud.PubSub.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "4d52dfb72078000b13de923c1dadec19f3a64ad1"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1/RecaptchaenterpriseResourceNames.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1/RecaptchaenterpriseResourceNames.g.cs
@@ -31,7 +31,7 @@ namespace Google.Cloud.RecaptchaEnterprise.V1
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>projects/{project}/assessments/{assessment}</c>.</summary>
-            ProjectAssessment = 1
+            ProjectAssessment = 1,
         }
 
         private static gax::PathTemplate s_projectAssessment = new gax::PathTemplate("projects/{project}/assessments/{assessment}");
@@ -248,7 +248,7 @@ namespace Google.Cloud.RecaptchaEnterprise.V1
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>projects/{project}/keys/{key}</c>.</summary>
-            ProjectKey = 1
+            ProjectKey = 1,
         }
 
         private static gax::PathTemplate s_projectKey = new gax::PathTemplate("projects/{project}/keys/{key}");

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/synth.metadata
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1/RecaptchaenterpriseResourceNames.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1/RecaptchaenterpriseResourceNames.g.cs
@@ -31,7 +31,7 @@ namespace Google.Cloud.RecaptchaEnterprise.V1Beta1
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>projects/{project}/assessments/{assessment}</c>.</summary>
-            ProjectAssessment = 1
+            ProjectAssessment = 1,
         }
 
         private static gax::PathTemplate s_projectAssessment = new gax::PathTemplate("projects/{project}/assessments/{assessment}");
@@ -248,7 +248,7 @@ namespace Google.Cloud.RecaptchaEnterprise.V1Beta1
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>projects/{project}/keys/{key}</c>.</summary>
-            ProjectKey = 1
+            ProjectKey = 1,
         }
 
         private static gax::PathTemplate s_projectKey = new gax::PathTemplate("projects/{project}/keys/{key}");

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/InsightResourceNames.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/InsightResourceNames.g.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.Recommender.V1
             /// A resource name with pattern
             /// <c>projects/{project}/locations/{location}/insightTypes/{insight_type}/insights/{insight}</c>.
             /// </summary>
-            ProjectLocationInsightTypeInsight = 1
+            ProjectLocationInsightTypeInsight = 1,
         }
 
         private static gax::PathTemplate s_projectLocationInsightTypeInsight = new gax::PathTemplate("projects/{project}/locations/{location}/insightTypes/{insight_type}/insights/{insight}");
@@ -288,7 +288,7 @@ namespace Google.Cloud.Recommender.V1
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/locations/{location}/insightTypes/{insight_type}</c>.
             /// </summary>
-            ProjectLocationInsightType = 1
+            ProjectLocationInsightType = 1,
         }
 
         private static gax::PathTemplate s_projectLocationInsightType = new gax::PathTemplate("projects/{project}/locations/{location}/insightTypes/{insight_type}");

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/RecommendationResourceNames.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/RecommendationResourceNames.g.cs
@@ -34,7 +34,7 @@ namespace Google.Cloud.Recommender.V1
             /// <c>projects/{project}/locations/{location}/recommenders/{recommender}/recommendations/{recommendation}</c>
             /// .
             /// </summary>
-            ProjectLocationRecommenderRecommendation = 1
+            ProjectLocationRecommenderRecommendation = 1,
         }
 
         private static gax::PathTemplate s_projectLocationRecommenderRecommendation = new gax::PathTemplate("projects/{project}/locations/{location}/recommenders/{recommender}/recommendations/{recommendation}");
@@ -294,7 +294,7 @@ namespace Google.Cloud.Recommender.V1
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/locations/{location}/recommenders/{recommender}</c>.
             /// </summary>
-            ProjectLocationRecommender = 1
+            ProjectLocationRecommender = 1,
         }
 
         private static gax::PathTemplate s_projectLocationRecommender = new gax::PathTemplate("projects/{project}/locations/{location}/recommenders/{recommender}");

--- a/apis/Google.Cloud.Recommender.V1/synth.metadata
+++ b/apis/Google.Cloud.Recommender.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1/CloudRedisResourceNames.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1/CloudRedisResourceNames.g.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.Redis.V1
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/locations/{location}/instances/{instance}</c>.
             /// </summary>
-            ProjectLocationInstance = 1
+            ProjectLocationInstance = 1,
         }
 
         private static gax::PathTemplate s_projectLocationInstance = new gax::PathTemplate("projects/{project}/locations/{location}/instances/{instance}");

--- a/apis/Google.Cloud.Redis.V1/synth.metadata
+++ b/apis/Google.Cloud.Redis.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1/CloudRedisResourceNames.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1/CloudRedisResourceNames.g.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.Redis.V1Beta1
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/locations/{location}/instances/{instance}</c>.
             /// </summary>
-            ProjectLocationInstance = 1
+            ProjectLocationInstance = 1,
         }
 
         private static gax::PathTemplate s_projectLocationInstance = new gax::PathTemplate("projects/{project}/locations/{location}/instances/{instance}");

--- a/apis/Google.Cloud.Redis.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.Redis.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1/JobResourceNames.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1/JobResourceNames.g.cs
@@ -32,7 +32,7 @@ namespace Google.Cloud.Scheduler.V1
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/locations/{location}/jobs/{job}</c>.
             /// </summary>
-            ProjectLocationJob = 1
+            ProjectLocationJob = 1,
         }
 
         private static gax::PathTemplate s_projectLocationJob = new gax::PathTemplate("projects/{project}/locations/{location}/jobs/{job}");

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1/TargetResourceNames.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1/TargetResourceNames.g.cs
@@ -30,7 +30,7 @@ namespace Google.Cloud.Scheduler.V1
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>projects/{project}/topics/{topic}</c>.</summary>
-            ProjectTopic = 1
+            ProjectTopic = 1,
         }
 
         private static gax::PathTemplate s_projectTopic = new gax::PathTemplate("projects/{project}/topics/{topic}");

--- a/apis/Google.Cloud.Scheduler.V1/synth.metadata
+++ b/apis/Google.Cloud.Scheduler.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1/ResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1/ResourcesResourceNames.g.cs
@@ -30,7 +30,7 @@ namespace Google.Cloud.SecretManager.V1
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>projects/{project}/secrets/{secret}</c>.</summary>
-            ProjectSecret = 1
+            ProjectSecret = 1,
         }
 
         private static gax::PathTemplate s_projectSecret = new gax::PathTemplate("projects/{project}/secrets/{secret}");
@@ -247,7 +247,7 @@ namespace Google.Cloud.SecretManager.V1
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/secrets/{secret}/versions/{secret_version}</c>.
             /// </summary>
-            ProjectSecretSecretVersion = 1
+            ProjectSecretSecretVersion = 1,
         }
 
         private static gax::PathTemplate s_projectSecretSecretVersion = new gax::PathTemplate("projects/{project}/secrets/{secret}/versions/{secret_version}");

--- a/apis/Google.Cloud.SecretManager.V1/synth.metadata
+++ b/apis/Google.Cloud.SecretManager.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "f17ea338b502b967101ca71e4ff0f11d8d1e4518"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1/ResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1/ResourcesResourceNames.g.cs
@@ -30,7 +30,7 @@ namespace Google.Cloud.SecretManager.V1Beta1
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>projects/{project}/secrets/{secret}</c>.</summary>
-            ProjectSecret = 1
+            ProjectSecret = 1,
         }
 
         private static gax::PathTemplate s_projectSecret = new gax::PathTemplate("projects/{project}/secrets/{secret}");
@@ -247,7 +247,7 @@ namespace Google.Cloud.SecretManager.V1Beta1
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/secrets/{secret}/versions/{secret_version}</c>.
             /// </summary>
-            ProjectSecretSecretVersion = 1
+            ProjectSecretSecretVersion = 1,
         }
 
         private static gax::PathTemplate s_projectSecretSecretVersion = new gax::PathTemplate("projects/{project}/secrets/{secret}/versions/{secret_version}");

--- a/apis/Google.Cloud.SecretManager.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Security.PrivateCA.V1Beta1/Google.Cloud.Security.PrivateCA.V1Beta1/ResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1Beta1/Google.Cloud.Security.PrivateCA.V1Beta1/ResourcesResourceNames.g.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.Security.PrivateCA.V1Beta1
             /// A resource name with pattern
             /// <c>projects/{project}/locations/{location}/certificateAuthorities/{certificate_authority}</c>.
             /// </summary>
-            ProjectLocationCertificateAuthority = 1
+            ProjectLocationCertificateAuthority = 1,
         }
 
         private static gax::PathTemplate s_projectLocationCertificateAuthority = new gax::PathTemplate("projects/{project}/locations/{location}/certificateAuthorities/{certificate_authority}");
@@ -299,7 +299,7 @@ namespace Google.Cloud.Security.PrivateCA.V1Beta1
             /// projects/{project}/locations/{location}/certificateAuthorities/{certificate_authority}/certificateRevocationLists/{certificate_revocation_list}</c>
             /// .
             /// </summary>
-            ProjectLocationCertificateAuthorityCertificateRevocationList = 1
+            ProjectLocationCertificateAuthorityCertificateRevocationList = 1,
         }
 
         private static gax::PathTemplate s_projectLocationCertificateAuthorityCertificateRevocationList = new gax::PathTemplate("projects/{project}/locations/{location}/certificateAuthorities/{certificate_authority}/certificateRevocationLists/{certificate_revocation_list}");
@@ -613,7 +613,7 @@ namespace Google.Cloud.Security.PrivateCA.V1Beta1
             /// projects/{project}/locations/{location}/certificateAuthorities/{certificate_authority}/certificates/{certificate}</c>
             /// .
             /// </summary>
-            ProjectLocationCertificateAuthorityCertificate = 1
+            ProjectLocationCertificateAuthorityCertificate = 1,
         }
 
         private static gax::PathTemplate s_projectLocationCertificateAuthorityCertificate = new gax::PathTemplate("projects/{project}/locations/{location}/certificateAuthorities/{certificate_authority}/certificates/{certificate}");
@@ -895,7 +895,7 @@ namespace Google.Cloud.Security.PrivateCA.V1Beta1
             /// A resource name with pattern
             /// <c>projects/{project}/locations/{location}/reusableConfigs/{reusable_config}</c>.
             /// </summary>
-            ProjectLocationReusableConfig = 1
+            ProjectLocationReusableConfig = 1,
         }
 
         private static gax::PathTemplate s_projectLocationReusableConfig = new gax::PathTemplate("projects/{project}/locations/{location}/reusableConfigs/{reusable_config}");

--- a/apis/Google.Cloud.Security.PrivateCA.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.Security.PrivateCA.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a8c73212a73d460b1edcd0830c4c3e31de33bdc5"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1/ComponentSettingsResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1/ComponentSettingsResourceNames.g.cs
@@ -58,7 +58,7 @@ namespace Google.Cloud.SecurityCenter.Settings.V1Beta1
             /// A resource name with pattern
             /// <c>projects/{project}/zones/{zone}/clusters/{cluster}/components/{component}/settings</c>.
             /// </summary>
-            ProjectZoneClusterComponent = 6
+            ProjectZoneClusterComponent = 6,
         }
 
         private static gax::PathTemplate s_organizationComponent = new gax::PathTemplate("organizations/{organization}/components/{component}/settings");

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1/SecuritycenterSettingsServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1/SecuritycenterSettingsServiceResourceNames.g.cs
@@ -31,7 +31,7 @@ namespace Google.Cloud.SecurityCenter.Settings.V1Beta1
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>organizations/{organization}/serviceAccount</c>.</summary>
-            Organization = 1
+            Organization = 1,
         }
 
         private static gax::PathTemplate s_organization = new gax::PathTemplate("organizations/{organization}/serviceAccount");

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1/SettingsResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1/SettingsResourceNames.g.cs
@@ -51,7 +51,7 @@ namespace Google.Cloud.SecurityCenter.Settings.V1Beta1
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/zones/{zone}/clusters/{cluster}/settings</c>.
             /// </summary>
-            ProjectZoneCluster = 6
+            ProjectZoneCluster = 6,
         }
 
         private static gax::PathTemplate s_organization = new gax::PathTemplate("organizations/{organization}/settings");

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/AssetResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/AssetResourceNames.g.cs
@@ -30,7 +30,7 @@ namespace Google.Cloud.SecurityCenter.V1
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>organizations/{organization}/assets/{asset}</c>.</summary>
-            OrganizationAsset = 1
+            OrganizationAsset = 1,
         }
 
         private static gax::PathTemplate s_organizationAsset = new gax::PathTemplate("organizations/{organization}/assets/{asset}");

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/FindingResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/FindingResourceNames.g.cs
@@ -32,7 +32,7 @@ namespace Google.Cloud.SecurityCenter.V1
             /// <summary>
             /// A resource name with pattern <c>organizations/{organization}/sources/{source}/findings/{finding}</c>.
             /// </summary>
-            OrganizationSourceFinding = 1
+            OrganizationSourceFinding = 1,
         }
 
         private static gax::PathTemplate s_organizationSourceFinding = new gax::PathTemplate("organizations/{organization}/sources/{source}/findings/{finding}");

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/NotificationConfigResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/NotificationConfigResourceNames.g.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.SecurityCenter.V1
             /// A resource name with pattern <c>organizations/{organization}/notificationConfigs/{notification_config}</c>
             /// .
             /// </summary>
-            OrganizationNotificationConfig = 1
+            OrganizationNotificationConfig = 1,
         }
 
         private static gax::PathTemplate s_organizationNotificationConfig = new gax::PathTemplate("organizations/{organization}/notificationConfigs/{notification_config}");
@@ -272,7 +272,7 @@ namespace Google.Cloud.SecurityCenter.V1
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>projects/{project}/topics/{topic}</c>.</summary>
-            ProjectTopic = 1
+            ProjectTopic = 1,
         }
 
         private static gax::PathTemplate s_projectTopic = new gax::PathTemplate("projects/{project}/topics/{topic}");

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/OrganizationSettingsResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/OrganizationSettingsResourceNames.g.cs
@@ -32,7 +32,7 @@ namespace Google.Cloud.SecurityCenter.V1
             /// <summary>
             /// A resource name with pattern <c>organizations/{organization}/organizationSettings</c>.
             /// </summary>
-            Organization = 1
+            Organization = 1,
         }
 
         private static gax::PathTemplate s_organization = new gax::PathTemplate("organizations/{organization}/organizationSettings");

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/SecurityMarksResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/SecurityMarksResourceNames.g.cs
@@ -38,7 +38,7 @@ namespace Google.Cloud.SecurityCenter.V1
             /// A resource name with pattern
             /// <c>organizations/{organization}/sources/{source}/findings/{finding}/securityMarks</c>.
             /// </summary>
-            OrganizationSourceFinding = 2
+            OrganizationSourceFinding = 2,
         }
 
         private static gax::PathTemplate s_organizationAsset = new gax::PathTemplate("organizations/{organization}/assets/{asset}/securityMarks");

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/SourceResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/SourceResourceNames.g.cs
@@ -30,7 +30,7 @@ namespace Google.Cloud.SecurityCenter.V1
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>organizations/{organization}/sources/{source}</c>.</summary>
-            OrganizationSource = 1
+            OrganizationSource = 1,
         }
 
         private static gax::PathTemplate s_organizationSource = new gax::PathTemplate("organizations/{organization}/sources/{source}");

--- a/apis/Google.Cloud.SecurityCenter.V1/synth.metadata
+++ b/apis/Google.Cloud.SecurityCenter.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "623a1aa03ae7a031b50be54df78263da2f22e981"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/AssetResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/AssetResourceNames.g.cs
@@ -30,7 +30,7 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>organizations/{organization}/assets/{asset}</c>.</summary>
-            OrganizationAsset = 1
+            OrganizationAsset = 1,
         }
 
         private static gax::PathTemplate s_organizationAsset = new gax::PathTemplate("organizations/{organization}/assets/{asset}");

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/FindingResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/FindingResourceNames.g.cs
@@ -32,7 +32,7 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1
             /// <summary>
             /// A resource name with pattern <c>organizations/{organization}/sources/{source}/findings/{finding}</c>.
             /// </summary>
-            OrganizationSourceFinding = 1
+            OrganizationSourceFinding = 1,
         }
 
         private static gax::PathTemplate s_organizationSourceFinding = new gax::PathTemplate("organizations/{organization}/sources/{source}/findings/{finding}");

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/NotificationConfigResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/NotificationConfigResourceNames.g.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1
             /// A resource name with pattern <c>organizations/{organization}/notificationConfigs/{notification_config}</c>
             /// .
             /// </summary>
-            OrganizationNotificationConfig = 1
+            OrganizationNotificationConfig = 1,
         }
 
         private static gax::PathTemplate s_organizationNotificationConfig = new gax::PathTemplate("organizations/{organization}/notificationConfigs/{notification_config}");
@@ -272,7 +272,7 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>projects/{project}/topics/{topic}</c>.</summary>
-            ProjectTopic = 1
+            ProjectTopic = 1,
         }
 
         private static gax::PathTemplate s_projectTopic = new gax::PathTemplate("projects/{project}/topics/{topic}");

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/OrganizationSettingsResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/OrganizationSettingsResourceNames.g.cs
@@ -32,7 +32,7 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1
             /// <summary>
             /// A resource name with pattern <c>organizations/{organization}/organizationSettings</c>.
             /// </summary>
-            Organization = 1
+            Organization = 1,
         }
 
         private static gax::PathTemplate s_organization = new gax::PathTemplate("organizations/{organization}/organizationSettings");

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/SecurityMarksResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/SecurityMarksResourceNames.g.cs
@@ -38,7 +38,7 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1
             /// A resource name with pattern
             /// <c>organizations/{organization}/sources/{source}/findings/{finding}/securityMarks</c>.
             /// </summary>
-            OrganizationSourceFinding = 2
+            OrganizationSourceFinding = 2,
         }
 
         private static gax::PathTemplate s_organizationAsset = new gax::PathTemplate("organizations/{organization}/assets/{asset}/securityMarks");

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/SourceResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/SourceResourceNames.g.cs
@@ -30,7 +30,7 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>organizations/{organization}/sources/{source}</c>.</summary>
-            OrganizationSource = 1
+            OrganizationSource = 1,
         }
 
         private static gax::PathTemplate s_organizationSource = new gax::PathTemplate("organizations/{organization}/sources/{source}");

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/synth.metadata
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "623a1aa03ae7a031b50be54df78263da2f22e981"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/EndpointResourceNames.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/EndpointResourceNames.g.cs
@@ -35,7 +35,7 @@ namespace Google.Cloud.ServiceDirectory.V1Beta1
             /// projects/{project}/locations/{location}/namespaces/{namespace}/services/{service}/endpoints/{endpoint}</c>
             /// .
             /// </summary>
-            ProjectLocationNamespaceServiceEndpoint = 1
+            ProjectLocationNamespaceServiceEndpoint = 1,
         }
 
         private static gax::PathTemplate s_projectLocationNamespaceServiceEndpoint = new gax::PathTemplate("projects/{project}/locations/{location}/namespaces/{namespace}/services/{service}/endpoints/{endpoint}");

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/NamespaceResourceNames.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/NamespaceResourceNames.g.cs
@@ -32,7 +32,7 @@ namespace Google.Cloud.ServiceDirectory.V1Beta1
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/locations/{location}/namespaces/{namespace}</c>.
             /// </summary>
-            ProjectLocationNamespace = 1
+            ProjectLocationNamespace = 1,
         }
 
         private static gax::PathTemplate s_projectLocationNamespace = new gax::PathTemplate("projects/{project}/locations/{location}/namespaces/{namespace}");

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/ServiceResourceNames.g.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.ServiceDirectory.V1Beta1
             /// A resource name with pattern
             /// <c>projects/{project}/locations/{location}/namespaces/{namespace}/services/{service}</c>.
             /// </summary>
-            ProjectLocationNamespaceService = 1
+            ProjectLocationNamespaceService = 1,
         }
 
         private static gax::PathTemplate s_projectLocationNamespaceService = new gax::PathTemplate("projects/{project}/locations/{location}/namespaces/{namespace}/services/{service}");

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/BackupResourceNames.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/BackupResourceNames.g.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/instances/{instance}/backups/{backup}</c>.
             /// </summary>
-            ProjectInstanceBackup = 1
+            ProjectInstanceBackup = 1,
         }
 
         private static gax::PathTemplate s_projectInstanceBackup = new gax::PathTemplate("projects/{project}/instances/{instance}/backups/{backup}");

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/synth.metadata
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "8f2eda119e11c8bd0c189b545da18bba9019c83e"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/SpannerInstanceAdminResourceNames.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/SpannerInstanceAdminResourceNames.g.cs
@@ -34,7 +34,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/instanceConfigs/{instance_config}</c>.
             /// </summary>
-            ProjectInstanceConfig = 1
+            ProjectInstanceConfig = 1,
         }
 
         private static gax::PathTemplate s_projectInstanceConfig = new gax::PathTemplate("projects/{project}/instanceConfigs/{instance_config}");

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/synth.metadata
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SpannerResourceNames.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SpannerResourceNames.g.cs
@@ -34,7 +34,7 @@ namespace Google.Cloud.Spanner.V1
             /// A resource name with pattern
             /// <c>projects/{project}/instances/{instance}/databases/{database}/sessions/{session}</c>.
             /// </summary>
-            ProjectInstanceDatabaseSession = 1
+            ProjectInstanceDatabaseSession = 1,
         }
 
         private static gax::PathTemplate s_projectInstanceDatabaseSession = new gax::PathTemplate("projects/{project}/instances/{instance}/databases/{database}/sessions/{session}");

--- a/apis/Google.Cloud.Spanner.V1/synth.metadata
+++ b/apis/Google.Cloud.Spanner.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "59f97e6044a1275f83427ab7962a154c00d915b5"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Speech.V1/synth.metadata
+++ b/apis/Google.Cloud.Speech.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/ResourceResourceNames.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/ResourceResourceNames.g.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.Speech.V1P1Beta1
             /// A resource name with pattern <c>projects/{project}/locations/{location}/customClasses/{custom_class}</c>
             /// .
             /// </summary>
-            ProjectLocationCustomClass = 1
+            ProjectLocationCustomClass = 1,
         }
 
         private static gax::PathTemplate s_projectLocationCustomClass = new gax::PathTemplate("projects/{project}/locations/{location}/customClasses/{custom_class}");
@@ -272,7 +272,7 @@ namespace Google.Cloud.Speech.V1P1Beta1
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/locations/{location}/phraseSets/{phrase_set}</c>.
             /// </summary>
-            ProjectLocationPhraseSet = 1
+            ProjectLocationPhraseSet = 1,
         }
 
         private static gax::PathTemplate s_projectLocationPhraseSet = new gax::PathTemplate("projects/{project}/locations/{location}/phraseSets/{phrase_set}");

--- a/apis/Google.Cloud.Speech.V1P1Beta1/synth.metadata
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/CompanyResourceNames.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/CompanyResourceNames.g.cs
@@ -32,7 +32,7 @@ namespace Google.Cloud.Talent.V4
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/tenants/{tenant}/companies/{company}</c>.
             /// </summary>
-            ProjectTenantCompany = 1
+            ProjectTenantCompany = 1,
         }
 
         private static gax::PathTemplate s_projectTenantCompany = new gax::PathTemplate("projects/{project}/tenants/{tenant}/companies/{company}");

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/JobResourceNames.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/JobResourceNames.g.cs
@@ -30,7 +30,7 @@ namespace Google.Cloud.Talent.V4
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>projects/{project}/tenants/{tenant}/jobs/{job}</c>.</summary>
-            ProjectTenantJob = 1
+            ProjectTenantJob = 1,
         }
 
         private static gax::PathTemplate s_projectTenantJob = new gax::PathTemplate("projects/{project}/tenants/{tenant}/jobs/{job}");

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/TenantResourceNames.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/TenantResourceNames.g.cs
@@ -30,7 +30,7 @@ namespace Google.Cloud.Talent.V4
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>projects/{project}/tenants/{tenant}</c>.</summary>
-            ProjectTenant = 1
+            ProjectTenant = 1,
         }
 
         private static gax::PathTemplate s_projectTenant = new gax::PathTemplate("projects/{project}/tenants/{tenant}");

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/ApplicationResourceNames.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/ApplicationResourceNames.g.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.Talent.V4Beta1
             /// A resource name with pattern
             /// <c>projects/{project}/tenants/{tenant}/profiles/{profile}/applications/{application}</c>.
             /// </summary>
-            ProjectTenantProfileApplication = 1
+            ProjectTenantProfileApplication = 1,
         }
 
         private static gax::PathTemplate s_projectTenantProfileApplication = new gax::PathTemplate("projects/{project}/tenants/{tenant}/profiles/{profile}/applications/{application}");

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/CompanyResourceNames.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/CompanyResourceNames.g.cs
@@ -35,7 +35,7 @@ namespace Google.Cloud.Talent.V4Beta1
             ProjectTenantCompany = 1,
 
             /// <summary>A resource name with pattern <c>projects/{project}/companies/{company}</c>.</summary>
-            ProjectCompany = 2
+            ProjectCompany = 2,
         }
 
         private static gax::PathTemplate s_projectTenantCompany = new gax::PathTemplate("projects/{project}/tenants/{tenant}/companies/{company}");

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/JobResourceNames.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/JobResourceNames.g.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.Talent.V4Beta1
             ProjectTenantJob = 1,
 
             /// <summary>A resource name with pattern <c>projects/{project}/jobs/{job}</c>.</summary>
-            ProjectJob = 2
+            ProjectJob = 2,
         }
 
         private static gax::PathTemplate s_projectTenantJob = new gax::PathTemplate("projects/{project}/tenants/{tenant}/jobs/{job}");

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/ProfileResourceNames.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/ProfileResourceNames.g.cs
@@ -32,7 +32,7 @@ namespace Google.Cloud.Talent.V4Beta1
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/tenants/{tenant}/profiles/{profile}</c>.
             /// </summary>
-            ProjectTenantProfile = 1
+            ProjectTenantProfile = 1,
         }
 
         private static gax::PathTemplate s_projectTenantProfile = new gax::PathTemplate("projects/{project}/tenants/{tenant}/profiles/{profile}");

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/TenantResourceNames.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/TenantResourceNames.g.cs
@@ -30,7 +30,7 @@ namespace Google.Cloud.Talent.V4Beta1
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>projects/{project}/tenants/{tenant}</c>.</summary>
-            ProjectTenant = 1
+            ProjectTenant = 1,
         }
 
         private static gax::PathTemplate s_projectTenant = new gax::PathTemplate("projects/{project}/tenants/{tenant}");

--- a/apis/Google.Cloud.Talent.V4Beta1/synth.metadata
+++ b/apis/Google.Cloud.Talent.V4Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/QueueResourceNames.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/QueueResourceNames.g.cs
@@ -32,7 +32,7 @@ namespace Google.Cloud.Tasks.V2
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/locations/{location}/queues/{queue}</c>.
             /// </summary>
-            ProjectLocationQueue = 1
+            ProjectLocationQueue = 1,
         }
 
         private static gax::PathTemplate s_projectLocationQueue = new gax::PathTemplate("projects/{project}/locations/{location}/queues/{queue}");

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/TaskResourceNames.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/TaskResourceNames.g.cs
@@ -32,7 +32,7 @@ namespace Google.Cloud.Tasks.V2
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/locations/{location}/queues/{queue}/tasks/{task}</c>.
             /// </summary>
-            ProjectLocationQueueTask = 1
+            ProjectLocationQueueTask = 1,
         }
 
         private static gax::PathTemplate s_projectLocationQueueTask = new gax::PathTemplate("projects/{project}/locations/{location}/queues/{queue}/tasks/{task}");

--- a/apis/Google.Cloud.Tasks.V2/synth.metadata
+++ b/apis/Google.Cloud.Tasks.V2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3/QueueResourceNames.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3/QueueResourceNames.g.cs
@@ -32,7 +32,7 @@ namespace Google.Cloud.Tasks.V2Beta3
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/locations/{location}/queues/{queue}</c>.
             /// </summary>
-            ProjectLocationQueue = 1
+            ProjectLocationQueue = 1,
         }
 
         private static gax::PathTemplate s_projectLocationQueue = new gax::PathTemplate("projects/{project}/locations/{location}/queues/{queue}");

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3/TaskResourceNames.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3/TaskResourceNames.g.cs
@@ -32,7 +32,7 @@ namespace Google.Cloud.Tasks.V2Beta3
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/locations/{location}/queues/{queue}/tasks/{task}</c>.
             /// </summary>
-            ProjectLocationQueueTask = 1
+            ProjectLocationQueueTask = 1,
         }
 
         private static gax::PathTemplate s_projectLocationQueueTask = new gax::PathTemplate("projects/{project}/locations/{location}/queues/{queue}/tasks/{task}");

--- a/apis/Google.Cloud.Tasks.V2Beta3/synth.metadata
+++ b/apis/Google.Cloud.Tasks.V2Beta3/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.TextToSpeech.V1/synth.metadata
+++ b/apis/Google.Cloud.TextToSpeech.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "9b0c7b1a4665909bd18a0e0fd33004945b5c9c13"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Trace.V1/synth.metadata
+++ b/apis/Google.Cloud.Trace.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/TraceResourceNames.g.cs
+++ b/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/TraceResourceNames.g.cs
@@ -30,7 +30,7 @@ namespace Google.Cloud.Trace.V2
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>projects/{project}/traces/{trace}/spans/{span}</c>.</summary>
-            ProjectTraceSpan = 1
+            ProjectTraceSpan = 1,
         }
 
         private static gax::PathTemplate s_projectTraceSpan = new gax::PathTemplate("projects/{project}/traces/{trace}/spans/{span}");

--- a/apis/Google.Cloud.Trace.V2/synth.metadata
+++ b/apis/Google.Cloud.Trace.V2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3/TranslationServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3/TranslationServiceResourceNames.g.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.Translate.V3
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/locations/{location}/glossaries/{glossary}</c>.
             /// </summary>
-            ProjectLocationGlossary = 1
+            ProjectLocationGlossary = 1,
         }
 
         private static gax::PathTemplate s_projectLocationGlossary = new gax::PathTemplate("projects/{project}/locations/{location}/glossaries/{glossary}");

--- a/apis/Google.Cloud.Translate.V3/synth.metadata
+++ b/apis/Google.Cloud.Translate.V3/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "d399c754bdea83297877ab49e5f66b257a957a78"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.VideoIntelligence.V1/synth.metadata
+++ b/apis/Google.Cloud.VideoIntelligence.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ProductSearchServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ProductSearchServiceResourceNames.g.cs
@@ -33,7 +33,7 @@ namespace Google.Cloud.Vision.V1
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/locations/{location}/products/{product}</c>.
             /// </summary>
-            ProjectLocationProduct = 1
+            ProjectLocationProduct = 1,
         }
 
         private static gax::PathTemplate s_projectLocationProduct = new gax::PathTemplate("projects/{project}/locations/{location}/products/{product}");
@@ -262,7 +262,7 @@ namespace Google.Cloud.Vision.V1
             /// <summary>
             /// A resource name with pattern <c>projects/{project}/locations/{location}/productSets/{product_set}</c>.
             /// </summary>
-            ProjectLocationProductSet = 1
+            ProjectLocationProductSet = 1,
         }
 
         private static gax::PathTemplate s_projectLocationProductSet = new gax::PathTemplate("projects/{project}/locations/{location}/productSets/{product_set}");
@@ -502,7 +502,7 @@ namespace Google.Cloud.Vision.V1
             /// A resource name with pattern
             /// <c>projects/{project}/locations/{location}/products/{product}/referenceImages/{reference_image}</c>.
             /// </summary>
-            ProjectLocationProductReferenceImage = 1
+            ProjectLocationProductReferenceImage = 1,
         }
 
         private static gax::PathTemplate s_projectLocationProductReferenceImage = new gax::PathTemplate("projects/{project}/locations/{location}/products/{product}/referenceImages/{reference_image}");

--- a/apis/Google.Cloud.Vision.V1/synth.metadata
+++ b/apis/Google.Cloud.Vision.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.WebRisk.V1/synth.metadata
+++ b/apis/Google.Cloud.WebRisk.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Cloud.WebRisk.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.WebRisk.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Identity.AccessContextManager.Type/synth.metadata
+++ b/apis/Google.Identity.AccessContextManager.Type/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.Identity.AccessContextManager.V1/synth.metadata
+++ b/apis/Google.Identity.AccessContextManager.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Google.LongRunning/synth.metadata
+++ b/apis/Google.LongRunning/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]

--- a/apis/Grafeas.V1/Grafeas.V1/GrafeasResourceNames.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1/GrafeasResourceNames.g.cs
@@ -30,7 +30,7 @@ namespace Grafeas.V1
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>projects/{project}/occurrences/{occurrence}</c>.</summary>
-            ProjectOccurrence = 1
+            ProjectOccurrence = 1,
         }
 
         private static gax::PathTemplate s_projectOccurrence = new gax::PathTemplate("projects/{project}/occurrences/{occurrence}");
@@ -247,7 +247,7 @@ namespace Grafeas.V1
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>projects/{project}/notes/{note}</c>.</summary>
-            ProjectNote = 1
+            ProjectNote = 1,
         }
 
         private static gax::PathTemplate s_projectNote = new gax::PathTemplate("projects/{project}/notes/{note}");
@@ -450,7 +450,7 @@ namespace Grafeas.V1
             Unparsed = 0,
 
             /// <summary>A resource name with pattern <c>projects/{project}</c>.</summary>
-            Project = 1
+            Project = 1,
         }
 
         private static gax::PathTemplate s_project = new gax::PathTemplate("projects/{project}");

--- a/apis/Grafeas.V1/synth.metadata
+++ b/apis/Grafeas.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "07460951fc07dd2b3f172d01b04e2a5fefd13ccc"        
+        "sha": "921ce41f94a74905ca753c72a4d4cc43600003d3"        
       }
     }
   ]


### PR DESCRIPTION
The only relevant change is to enums: we now generate a comma after all enum members, including the last one.