### PR TITLE
Disable pretty printing in BigQuery unless explicitly requested

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryClientImplTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryClientImplTest.cs
@@ -32,6 +32,25 @@ namespace Google.Cloud.BigQuery.V2.Tests
         private const string DefaultLocation = "default-location";
 
         [Fact]
+        public void PrettyPrintEnabledOnClientIsPropagatedToRequest()
+        {
+            var projectId = "project";
+            var datasetId = "dataset";
+            var service = new FakeBigqueryService();
+            var client = new BigQueryClientBuilder
+            {
+                Service = service,
+                PrettyPrint = true,
+                ProjectId = projectId
+            }.Build();
+            var reference = client.GetDatasetReference(projectId, datasetId);
+            var expectedRequest = service.Datasets.Delete(projectId, datasetId);
+            expectedRequest.PrettyPrint = true;
+            service.ExpectRequest(expectedRequest, "OK");
+            client.DeleteDataset(reference);
+        }
+
+        [Fact]
         public void Constructor_DefaultLocations()
         {
             var projectId = "project";

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/FakeBigqueryService.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/FakeBigqueryService.cs
@@ -40,6 +40,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
 
         public void ExpectRequest<TResponse>(ClientServiceRequest<TResponse> request, TResponse response)
         {
+            MaybeDisablePrettyPrint(request);
             string requestContent = SerializeObject(request);
             var httpRequest = request.CreateRequest();
             string responseContent = SerializeObject(response);            
@@ -48,11 +49,20 @@ namespace Google.Cloud.BigQuery.V2.Tests
 
         public void ExpectRequest<TResponse>(ClientServiceRequest<TResponse> request, HttpStatusCode statusCode, RequestError error)
         {
+            MaybeDisablePrettyPrint(request);
             string requestContent = SerializeObject(request);
             var httpRequest = request.CreateRequest();
             string responseContent = SerializeObject(new StandardResponse<object> { Error = error });
             var responseMessage = new HttpResponseMessage(statusCode) { Content = new StringContent(responseContent) };
             handler.ExpectRequest(httpRequest.RequestUri, httpRequest.Content?.ReadAsStringAsync()?.Result, responseMessage);
+        }
+
+        private void MaybeDisablePrettyPrint(dynamic request)
+        {
+            // Almost all our tests using FakeBigqueryService will have prettyPrint=false, and the requests will all
+            // be derived from the generic BigqueryServiceBaseRequest which has a PrettyPrint property.
+            // We use ??= so that if the request already has PrettyPrint set, we don't change that.
+            request.PrettyPrint ??= false;
         }
 
         public void Verify() => handler.Verify();

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClient.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClient.cs
@@ -83,6 +83,11 @@ namespace Google.Cloud.BigQuery.V2
         public virtual string DefaultLocation => throw new NotImplementedException();
 
         /// <summary>
+        /// Determines whether or not responses should be formatted with whitespace for readability.
+        /// </summary>
+        public virtual bool PrettyPrint => throw new NotImplementedException();
+
+        /// <summary>
         /// Asynchronously creates a <see cref="BigQueryClient"/>, using application default credentials if
         /// no credentials are specified.
         /// </summary>

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientBuilder.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientBuilder.cs
@@ -36,24 +36,48 @@ namespace Google.Cloud.BigQuery.V2
         /// </summary>
         public string DefaultLocation { get; set; }
 
+        /// <summary>
+        /// If set, overrides the default pretty-print setting.
+        /// </summary>
+        public bool? PrettyPrint { get; set; }
+
+        // Note: we may want to make this public in the future. If we do, we should check that no credentials
+        // are set in Validate().
+        /// <summary>
+        /// If set, this is used as the underlying service for the client.
+        /// Note that this should rarely be used outside testing, unless the service comes from another <see cref="BigQueryClient"/>.
+        /// Usually this library constructs a service using specific settings such as the JSON serializer settings provided by
+        /// <see cref="BigQueryClient.CreateJsonSerializersSettings"/>; if a service is constructed in user code, the client
+        /// may not function as expected.
+        /// </summary>
+        internal BigqueryService Service { get; set; }
+
         /// <inheritdoc />
         public override BigQueryClient Build()
         {
             Validate();
-            var initializer = CreateServiceInitializer();
-            initializer.Serializer = new NewtonsoftJsonSerializer(BigQueryClient.CreateJsonSerializersSettings());
-            var service = new BigqueryService(initializer);
-            return new BigQueryClientImpl(ProjectId, service, DefaultLocation);
+            var service = Service;
+            if (service is null)
+            {
+                var initializer = CreateServiceInitializer();
+                initializer.Serializer = new NewtonsoftJsonSerializer(BigQueryClient.CreateJsonSerializersSettings());
+                service = new BigqueryService(initializer);
+            }
+            return new BigQueryClientImpl(ProjectId, service, DefaultLocation, PrettyPrint ?? false);
         }
 
         /// <inheritdoc />
         public override async Task<BigQueryClient> BuildAsync(CancellationToken cancellationToken = default)
         {
             Validate();
-            var initializer = await CreateServiceInitializerAsync(cancellationToken).ConfigureAwait(false);
-            initializer.Serializer = new NewtonsoftJsonSerializer(BigQueryClient.CreateJsonSerializersSettings());
-            var service = new BigqueryService(initializer);
-            return new BigQueryClientImpl(ProjectId, service, DefaultLocation);
+            var service = Service;
+            if (service is null)
+            {
+                var initializer = await CreateServiceInitializerAsync(cancellationToken).ConfigureAwait(false);
+                initializer.Serializer = new NewtonsoftJsonSerializer(BigQueryClient.CreateJsonSerializersSettings());
+                service = new BigqueryService(initializer);
+            }
+            return new BigQueryClientImpl(ProjectId, service, DefaultLocation, PrettyPrint ?? false);
         }
 
         /// <inheritdoc />

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.DatasetCrud.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.DatasetCrud.cs
@@ -176,6 +176,7 @@ namespace Google.Cloud.BigQuery.V2
             var request = Service.Datasets.Get(datasetReference.ProjectId, datasetReference.DatasetId);
             options?.ModifyRequest(request);
             RetryHandler.MarkAsRetriable(request);
+            request.PrettyPrint = PrettyPrint;
             return request;
         }
 
@@ -184,6 +185,7 @@ namespace Google.Cloud.BigQuery.V2
             var request = Service.Datasets.List(projectReference.ProjectId);
             options?.ModifyRequest(request);
             RetryHandler.MarkAsRetriable(request);
+            request.PrettyPrint = PrettyPrint;
             return request;
         }
 
@@ -201,6 +203,7 @@ namespace Google.Cloud.BigQuery.V2
 
             var request = Service.Datasets.Insert(resource, datasetReference.ProjectId);
             options?.ModifyRequest(request);
+            request.PrettyPrint = PrettyPrint;
             return request;
         }
 
@@ -209,6 +212,7 @@ namespace Google.Cloud.BigQuery.V2
             GaxPreconditions.CheckNotNull(datasetReference, nameof(datasetReference));
             var request = Service.Datasets.Delete(datasetReference.ProjectId, datasetReference.DatasetId);
             options?.ModifyRequest(request);
+            request.PrettyPrint = PrettyPrint;
             return request;
         }
 
@@ -219,6 +223,7 @@ namespace Google.Cloud.BigQuery.V2
             var request = Service.Datasets.Update(resource, datasetReference.ProjectId, datasetReference.DatasetId);
             options?.ModifyRequest(request);
             RetryIfETagPresent(request, resource);
+            request.PrettyPrint = PrettyPrint;
             return request;
         }
 
@@ -229,6 +234,7 @@ namespace Google.Cloud.BigQuery.V2
             var request = Service.Datasets.Patch(resource, datasetReference.ProjectId, datasetReference.DatasetId);
             options?.ModifyRequest(request);
             RetryIfETagPresent(request, resource);
+            request.PrettyPrint = PrettyPrint;
             return request;
         }
     }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.InsertData.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.InsertData.cs
@@ -319,6 +319,7 @@ namespace Google.Cloud.BigQuery.V2
             // needs to explicitly allow for empty InsertId and should be aware that doing so will be at
             // the expense of de-duplication efforts.
             RetryHandler.MarkAsRetriable(request);
+            request.PrettyPrint = PrettyPrint;
             return request;
         }
 

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.JobCrud.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.JobCrud.cs
@@ -203,6 +203,7 @@ namespace Google.Cloud.BigQuery.V2
             request.Location = jobReference.Location;
             options?.ModifyRequest(request);
             RetryHandler.MarkAsRetriable(request);
+            request.PrettyPrint = PrettyPrint;
             return request;
         }
 
@@ -211,6 +212,7 @@ namespace Google.Cloud.BigQuery.V2
             var request = Service.Jobs.List(projectReference.ProjectId);
             options?.ModifyRequest(request);
             RetryHandler.MarkAsRetriable(request);
+            request.PrettyPrint = PrettyPrint;
             return request;
         }
 
@@ -221,6 +223,7 @@ namespace Google.Cloud.BigQuery.V2
             request.Location = jobReference.Location;
             options?.ModifyRequest(request);
             RetryHandler.MarkAsRetriable(request);
+            request.PrettyPrint = PrettyPrint;
             return request;
         }
 
@@ -268,6 +271,7 @@ namespace Google.Cloud.BigQuery.V2
 
             // It's safe to retry job inserts when they include a job ID, which ours always do.
             RetryHandler.MarkAsRetriable(request);
+            request.PrettyPrint = PrettyPrint;
             return request;
         }
     }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.ModelCrud.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.ModelCrud.cs
@@ -116,6 +116,7 @@ namespace Google.Cloud.BigQuery.V2
             var request = Service.Models.Get(modelReference.ProjectId, modelReference.DatasetId, modelReference.ModelId);
             options?.ModifyRequest(request);
             RetryHandler.MarkAsRetriable(request);
+            request.PrettyPrint = PrettyPrint;
             return request;
         }
 
@@ -124,6 +125,7 @@ namespace Google.Cloud.BigQuery.V2
             GaxPreconditions.CheckNotNull(modelReference, nameof(modelReference));
             var request = Service.Models.Delete(modelReference.ProjectId, modelReference.DatasetId, modelReference.ModelId);
             options?.ModifyRequest(request);
+            request.PrettyPrint = PrettyPrint;
             return request;
         }
 
@@ -134,6 +136,7 @@ namespace Google.Cloud.BigQuery.V2
             var request = Service.Models.Patch(resource, modelReference.ProjectId, modelReference.DatasetId, modelReference.ModelId);
             options?.ModifyRequest(request);
             RetryIfETagPresent(request, resource);
+            request.PrettyPrint = PrettyPrint;
             return request;
         }
 
@@ -142,6 +145,7 @@ namespace Google.Cloud.BigQuery.V2
             var request = Service.Models.List(datasetReference.ProjectId, datasetReference.DatasetId);
             options?.ModifyRequest(request);
             RetryHandler.MarkAsRetriable(request);
+            request.PrettyPrint = PrettyPrint;
             return request;
         }
     }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.ProjectCrud.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.ProjectCrud.cs
@@ -63,6 +63,7 @@ namespace Google.Cloud.BigQuery.V2
             var request = Service.Projects.List();
             options?.ModifyRequest(request);
             RetryHandler.MarkAsRetriable(request);
+            request.PrettyPrint = PrettyPrint;
             return request;
         }
     }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.Queries.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.Queries.cs
@@ -200,6 +200,7 @@ namespace Google.Cloud.BigQuery.V2
             // but both values mean the same, and that is to return whole rows.
             request.SelectedFields = schema.BuildSelectedFields();
             RetryHandler.MarkAsRetriable(request);
+            request.PrettyPrint = PrettyPrint;
             return request;
         }
 
@@ -220,6 +221,7 @@ namespace Google.Cloud.BigQuery.V2
             request.TimeoutMs = requestTimeoutMs;
             options?.ModifyRequest(request);
             RetryHandler.MarkAsRetriable(request);
+            request.PrettyPrint = PrettyPrint;
             return request;
         }
     }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.RoutineCrud.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.RoutineCrud.cs
@@ -163,6 +163,7 @@ namespace Google.Cloud.BigQuery.V2
             var request = Service.Routines.Get(routineReference.ProjectId, routineReference.DatasetId, routineReference.RoutineId);
             options?.ModifyRequest(request);
             RetryHandler.MarkAsRetriable(request);
+            request.PrettyPrint = PrettyPrint;
             return request;
         }
 
@@ -171,6 +172,7 @@ namespace Google.Cloud.BigQuery.V2
             var request = Service.Routines.List(datasetReference.ProjectId, datasetReference.DatasetId);
             options?.ModifyRequest(request);
             RetryHandler.MarkAsRetriable(request);
+            request.PrettyPrint = PrettyPrint;
             return request;
         }
 
@@ -182,6 +184,7 @@ namespace Google.Cloud.BigQuery.V2
 
             var request = Service.Routines.Insert(resource, routineReference.ProjectId, routineReference.DatasetId);
             options?.ModifyRequest(request);
+            request.PrettyPrint = PrettyPrint;
             return request;
         }
 
@@ -190,6 +193,7 @@ namespace Google.Cloud.BigQuery.V2
             GaxPreconditions.CheckNotNull(routineReference, nameof(routineReference));
             var request = Service.Routines.Delete(routineReference.ProjectId, routineReference.DatasetId, routineReference.RoutineId);
             options?.ModifyRequest(request);
+            request.PrettyPrint = PrettyPrint;
             return request;
         }
 
@@ -199,6 +203,7 @@ namespace Google.Cloud.BigQuery.V2
             var request = Service.Routines.Update(resource, routineReference.ProjectId, routineReference.DatasetId, routineReference.RoutineId);
             options?.ModifyRequest(request);
             RetryIfETagPresent(request, resource);
+            request.PrettyPrint = PrettyPrint;
             return request;
         }
 

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.ServiceAccount.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.ServiceAccount.cs
@@ -41,6 +41,7 @@ namespace Google.Cloud.BigQuery.V2
             var request = Service.Projects.GetServiceAccount(projectReference.ProjectId);
             options?.ModifyRequest(request);
             RetryHandler.MarkAsRetriable(request);
+            request.PrettyPrint = PrettyPrint;
             return request;
         }
     }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.TableCrud.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.TableCrud.cs
@@ -218,6 +218,7 @@ namespace Google.Cloud.BigQuery.V2
             var request = Service.Tables.Get(tableReference.ProjectId, tableReference.DatasetId, tableReference.TableId);
             options?.ModifyRequest(request);
             RetryHandler.MarkAsRetriable(request);
+            request.PrettyPrint = PrettyPrint;
             return request;
         }
 
@@ -227,6 +228,7 @@ namespace Google.Cloud.BigQuery.V2
             var request = Service.Tables.List(datasetReference.ProjectId, datasetReference.DatasetId);
             options?.ModifyRequest(request);
             RetryHandler.MarkAsRetriable(request);
+            request.PrettyPrint = PrettyPrint;
             return request;
         }
 
@@ -238,6 +240,7 @@ namespace Google.Cloud.BigQuery.V2
 
             var request = Service.Tables.Insert(resource, tableReference.ProjectId, tableReference.DatasetId);
             options?.ModifyRequest(request);
+            request.PrettyPrint = PrettyPrint;
             return request;
         }
 
@@ -260,6 +263,7 @@ namespace Google.Cloud.BigQuery.V2
             GaxPreconditions.CheckNotNull(tableReference, nameof(tableReference));
             var request = Service.Tables.Delete(tableReference.ProjectId, tableReference.DatasetId, tableReference.TableId);
             options?.ModifyRequest(request);
+            request.PrettyPrint = PrettyPrint;
             return request;
         }
 
@@ -270,6 +274,7 @@ namespace Google.Cloud.BigQuery.V2
             var request = Service.Tables.Update(resource, tableReference.ProjectId, tableReference.DatasetId, tableReference.TableId);
             options?.ModifyRequest(request);
             RetryIfETagPresent(request, resource);
+            request.PrettyPrint = PrettyPrint;
             return request;
         }
 
@@ -280,6 +285,7 @@ namespace Google.Cloud.BigQuery.V2
             var request = Service.Tables.Patch(resource, tableReference.ProjectId, tableReference.DatasetId, tableReference.TableId);
             options?.ModifyRequest(request);
             RetryIfETagPresent(request, resource);
+            request.PrettyPrint = PrettyPrint;
             return request;
         }
     }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.cs
@@ -76,6 +76,17 @@ namespace Google.Cloud.BigQuery.V2
         /// <inheritdoc />
         public override string DefaultLocation { get; }
 
+        /// <inheritdoc />
+        public override bool PrettyPrint { get; }
+
+        internal BigQueryClientImpl(string projectId, BigqueryService service, string defaultLocation, bool prettyPrint)
+        {
+            ProjectId = GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
+            Service = GaxPreconditions.CheckNotNull(service, nameof(service));
+            DefaultLocation = defaultLocation;
+            PrettyPrint = prettyPrint;
+        }
+
         /// <summary>
         /// Constructs a new client wrapping the given <see cref="BigqueryService"/>, with a specified default location
         /// for location-specific operations.
@@ -90,10 +101,8 @@ namespace Google.Cloud.BigQuery.V2
         /// <param name="service">The service to wrap. Must not be null.</param>
         /// <param name="defaultLocation">The default location to use for location-specific operations. May be null.</param>
         public BigQueryClientImpl(string projectId, BigqueryService service, string defaultLocation)
+            : this(projectId, service, defaultLocation, prettyPrint: false)
         {
-            ProjectId = GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
-            Service = GaxPreconditions.CheckNotNull(service, nameof(service));
-            DefaultLocation = defaultLocation;
         }
 
         /// <summary>


### PR DESCRIPTION
This is client-wide, and can only be set on the BigQueryClientBuilder (to avoid an explosion of BigQueryClientImpl constructors in the long run). It is then propagated to all requests. It defaults to false.

In order to test this change properly, I've had to also add a Service property to BigQueryClientBuilder, but that seems appropriate anyway.

Fixes #5330.