### PR TITLE
Release Google.Cloud.BigQuery.V2 version 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.BigQuery.Connection.V1](https://googleapis.dev/dotnet/Google.Cloud.BigQuery.Connection.V1/1.0.0) | 1.0.0 | [BigQuery Connection API](https://cloud.google.com/bigquery/docs/reference/bigqueryconnection) |
 | [Google.Cloud.BigQuery.DataTransfer.V1](https://googleapis.dev/dotnet/Google.Cloud.BigQuery.DataTransfer.V1/2.0.0) | 2.0.0 | [Google BigQuery Data Transfer](https://cloud.google.com/bigquery/transfer/) |
 | [Google.Cloud.BigQuery.Reservation.V1](https://googleapis.dev/dotnet/Google.Cloud.BigQuery.Reservation.V1/1.0.0) | 1.0.0 | [BigQuery Reservation API](https://cloud.google.com/bigquery/docs/reference/reservations) |
-| [Google.Cloud.BigQuery.V2](https://googleapis.dev/dotnet/Google.Cloud.BigQuery.V2/2.0.0) | 2.0.0 | [Google BigQuery](https://cloud.google.com/bigquery/) |
+| [Google.Cloud.BigQuery.V2](https://googleapis.dev/dotnet/Google.Cloud.BigQuery.V2/2.1.0) | 2.1.0 | [Google BigQuery](https://cloud.google.com/bigquery/) |
 | [Google.Cloud.BigQuery.Storage.V1](https://googleapis.dev/dotnet/Google.Cloud.BigQuery.Storage.V1/2.0.0) | 2.0.0 | [Google BigQuery Storage](https://cloud.google.com/bigquery/docs/reference/storage/) |
 | [Google.Cloud.Bigtable.Admin.V2](https://googleapis.dev/dotnet/Google.Cloud.Bigtable.Admin.V2/2.1.0) | 2.1.0 | [Google Cloud Bigtable Administration](https://cloud.google.com/bigtable/) |
 | [Google.Cloud.Bigtable.Common.V2](https://googleapis.dev/dotnet/Google.Cloud.Bigtable.Common.V2/2.0.0) | 2.0.0 | Common code used by Bigtable V2 APIs |

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery API. It wraps the Google.Apis.Bigquery.v2 client library, making common operations simpler in client code. BigQuery is a data platform for customers to create, manage, share and query data.</Description>
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Rest" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Google.Apis.Bigquery.v2" Version="[1.46.0.1969, 2.0.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Rest" Version="[3.1.0, 4.0.0)" />
+    <PackageReference Include="Google.Apis.Bigquery.v2" Version="[1.49.0.2077, 2.0.0.0)" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.BigQuery.V2/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.V2/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+# Version 2.1.0, released 2020-09-23
+
+- [Commit 14be654](https://github.com/googleapis/google-cloud-dotnet/commit/14be654): feat: Disable pretty printing in BigQuery unless explicitly requested. Fixes [issue 5330](https://github.com/googleapis/google-cloud-dotnet/issues/5330).
+- [Commit 909f568](https://github.com/googleapis/google-cloud-dotnet/commit/909f568): docs: Clarify the scopes used by BigQueryClient.Create and CreateAsync
+
 # Version 2.0.0, released 2020-06-04
 
 - [Commit 0970dff](https://github.com/googleapis/google-cloud-dotnet/commit/0970dff): Fix: Propagates some cancellation tokens that weren't being propagated before.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -158,12 +158,12 @@
       "id": "Google.Cloud.BigQuery.V2",
       "productName": "Google BigQuery",
       "productUrl": "https://cloud.google.com/bigquery/",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "type": "rest",
       "description": "Recommended Google client library to access the BigQuery API. It wraps the Google.Apis.Bigquery.v2 client library, making common operations simpler in client code. BigQuery is a data platform for customers to create, manage, share and query data.",
       "dependencies": {
-        "Google.Apis.Bigquery.v2": "1.46.0.1969",
-        "Google.Api.Gax.Rest": "3.0.0"
+        "Google.Apis.Bigquery.v2": "1.49.0.2077",
+        "Google.Api.Gax.Rest": "3.1.0"
       },
       "testDependencies": {
         "Google.Cloud.Storage.V1": "project"

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -27,7 +27,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.BigQuery.Connection.V1](Google.Cloud.BigQuery.Connection.V1/index.html) | 1.0.0 | [BigQuery Connection API](https://cloud.google.com/bigquery/docs/reference/bigqueryconnection) |
 | [Google.Cloud.BigQuery.DataTransfer.V1](Google.Cloud.BigQuery.DataTransfer.V1/index.html) | 2.0.0 | [Google BigQuery Data Transfer](https://cloud.google.com/bigquery/transfer/) |
 | [Google.Cloud.BigQuery.Reservation.V1](Google.Cloud.BigQuery.Reservation.V1/index.html) | 1.0.0 | [BigQuery Reservation API](https://cloud.google.com/bigquery/docs/reference/reservations) |
-| [Google.Cloud.BigQuery.V2](Google.Cloud.BigQuery.V2/index.html) | 2.0.0 | [Google BigQuery](https://cloud.google.com/bigquery/) |
+| [Google.Cloud.BigQuery.V2](Google.Cloud.BigQuery.V2/index.html) | 2.1.0 | [Google BigQuery](https://cloud.google.com/bigquery/) |
 | [Google.Cloud.BigQuery.Storage.V1](Google.Cloud.BigQuery.Storage.V1/index.html) | 2.0.0 | [Google BigQuery Storage](https://cloud.google.com/bigquery/docs/reference/storage/) |
 | [Google.Cloud.Bigtable.Admin.V2](Google.Cloud.Bigtable.Admin.V2/index.html) | 2.1.0 | [Google Cloud Bigtable Administration](https://cloud.google.com/bigtable/) |
 | [Google.Cloud.Bigtable.Common.V2](Google.Cloud.Bigtable.Common.V2/index.html) | 2.0.0 | Common code used by Bigtable V2 APIs |


### PR DESCRIPTION

Changes in this release:

- [Commit 14be654](https://github.com/googleapis/google-cloud-dotnet/commit/14be654): feat: Disable pretty printing in BigQuery unless explicitly requested. Fixes [issue 5330](https://github.com/googleapis/google-cloud-dotnet/issues/5330).
- [Commit 909f568](https://github.com/googleapis/google-cloud-dotnet/commit/909f568): docs: Clarify the scopes used by BigQueryClient.Create and CreateAsync
