### PR TITLE
feat: retry SpannerTransaction on aborted error [WIP]

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/AbortedTransactionsTest.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/AbortedTransactionsTest.cs
@@ -1,4 +1,18 @@
-﻿using Google.Protobuf;
+﻿// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Protobuf;
 using Grpc.Core;
 using System;
 using System.Collections.Generic;

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/AbortedTransactionsTest.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/AbortedTransactionsTest.cs
@@ -1,0 +1,755 @@
+﻿using Google.Protobuf;
+using Grpc.Core;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Google.Cloud.Spanner.Data.Tests
+{
+    public class AbortedTransactionsTests : IClassFixture<SpannerMockServerFixture>
+    {
+        SpannerMockServerFixture _fixture;
+
+        public AbortedTransactionsTests(SpannerMockServerFixture service)
+        {
+            this._fixture = service;
+        }
+
+        [Fact]
+        public async void ReadWriteTransaction_AbortedDml_IsAutomaticallyRetried()
+        {
+            string sql = "UPDATE Foo SET Bar='bar' WHERE Id=1";
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateUpdateCount(1));
+            string connectionString = $"Data Source=projects/p1/instances/i1/databases/d1;Host={_fixture.Host};Port={_fixture.Port}";
+            using (var connection = new SpannerConnection(connectionString, ChannelCredentials.Insecure))
+            {
+                await connection.OpenAsync();
+                using (var transaction = await connection.BeginRetriableTransactionAsync())
+                {
+                    var originalTxId = transaction.TransactionId;
+                    // Abort the transaction on the mock server. The transaction should be able to internally retry.
+                    _fixture.SpannerMock.AbortTransaction(ByteString.FromBase64(transaction.TransactionId.Id));
+                    var cmd = connection.CreateDmlCommand(sql);
+                    cmd.Transaction = transaction;
+                    var updateCount = await cmd.ExecuteNonQueryAsync();
+                    Assert.NotEqual(originalTxId.Id, transaction.TransactionId.Id);
+                    await transaction.CommitAsync();
+                    Assert.Equal(1, updateCount);
+                    Assert.Equal(1, transaction.RetryCount);
+                }
+            }
+        }
+
+        [Fact]
+        public async void ReadWriteTransaction_ModifiedDmlUpdateCount_FailsRetry()
+        {
+            // This statement returns an update count of 1 the first time.
+            string sql = "UPDATE Foo SET Bar='baz' WHERE Id IN (1,2)";
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateUpdateCount(1));
+
+            string connectionString = $"Data Source=projects/p1/instances/i1/databases/d1;Host={_fixture.Host};Port={_fixture.Port}";
+            using (var connection = new SpannerConnection(connectionString, ChannelCredentials.Insecure))
+            {
+                await connection.OpenAsync();
+                using (var transaction = await connection.BeginRetriableTransactionAsync())
+                {
+                    // Execute an update and then change the return value for the statement before the retry is executed.
+                    var cmd = connection.CreateDmlCommand(sql);
+                    cmd.Transaction = transaction;
+                    Assert.Equal(1, await cmd.ExecuteNonQueryAsync());
+                    // The update statement will return 2 the next time it is executed.
+                    _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateUpdateCount(2));
+
+                    // Now abort the transaction and try to execute another DML statement. The retry will fail because it sees
+                    // a different update count during the retry.
+                    _fixture.SpannerMock.AbortTransaction(ByteString.FromBase64(transaction.TransactionId.Id));
+                    cmd = connection.CreateDmlCommand("UPDATE Foo SET Bar='bar' WHERE Id=1");
+                    cmd.Transaction = transaction;
+                    try
+                    {
+                        await cmd.ExecuteNonQueryAsync();
+                        Assert.True(false, "Missing expected exception");
+                    }
+                    catch (SpannerAbortedDueToConcurrentModificationException)
+                    {
+                        Assert.Equal(1, transaction.RetryCount);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public async void ReadWriteTransaction_AbortedDmlWithSameException_CanBeRetried()
+        {
+            string sql = "UPDATE Foo SET Bar='bar'";
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateException(new RpcException(new Status(StatusCode.FailedPrecondition, "UPDATE statement misses WHERE clause"))));
+            string connectionString = $"Data Source=projects/p1/instances/i1/databases/d1;Host={_fixture.Host};Port={_fixture.Port}";
+            using (var connection = new SpannerConnection(connectionString, ChannelCredentials.Insecure))
+            {
+                await connection.OpenAsync();
+                using (var transaction = await connection.BeginRetriableTransactionAsync())
+                {
+                    var cmd = connection.CreateDmlCommand(sql);
+                    cmd.Transaction = transaction;
+                    try
+                    {
+                        await cmd.ExecuteNonQueryAsync();
+                        Assert.True(false, "Missing expected exception");
+                    }
+                    catch (SpannerException e) when (e.ErrorCode == ErrorCode.FailedPrecondition)
+                    {
+                        Assert.Contains("UPDATE statement misses WHERE clause", e.InnerException?.Message);
+                    }
+                    // Abort the transaction on the mock server. The transaction should be able to internally retry.
+                    _fixture.SpannerMock.AbortTransaction(ByteString.FromBase64(transaction.TransactionId.Id));
+                    await transaction.CommitAsync();
+                    Assert.Equal(1, transaction.RetryCount);
+                }
+            }
+        }
+
+        [Fact]
+        public async void ReadWriteTransaction_AbortedDmlWithDifferentException_FailsRetry()
+        {
+            string sql = "UPDATE Foo SET Bar='bar' WHERE Id=1";
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateException(new RpcException(new Status(StatusCode.AlreadyExists, "Unique key constraint violation"))));
+            string connectionString = $"Data Source=projects/p1/instances/i1/databases/d1;Host={_fixture.Host};Port={_fixture.Port}";
+            using (var connection = new SpannerConnection(connectionString, ChannelCredentials.Insecure))
+            {
+                await connection.OpenAsync();
+                using (var transaction = await connection.BeginRetriableTransactionAsync())
+                {
+                    var cmd = connection.CreateDmlCommand(sql);
+                    cmd.Transaction = transaction;
+                    try
+                    {
+                        await cmd.ExecuteNonQueryAsync();
+                        Assert.True(false, "Missing expected exception");
+                    }
+                    catch (SpannerException e) when (e.ErrorCode == ErrorCode.AlreadyExists)
+                    {
+                        Assert.Contains("Unique key constraint violation", e.InnerException?.Message);
+                    }
+                    // Change the error for the statement on the mock server and abort the transaction.
+                    // The retry should now fail as the error has changed.
+                    _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateException(new RpcException(new Status(StatusCode.NotFound, "Table Foo not found"))));
+                    _fixture.SpannerMock.AbortTransaction(ByteString.FromBase64(transaction.TransactionId.Id));
+                    try
+                    {
+                        await transaction.CommitAsync();
+                        Assert.True(false, "Missing expected exception");
+                    }
+                    catch (SpannerAbortedDueToConcurrentModificationException)
+                    {
+                        Assert.Equal(1, transaction.RetryCount);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public async void ReadWriteTransaction_AbortedBatchDml_IsAutomaticallyRetried()
+        {
+            string sql1 = "UPDATE Foo SET Bar='bar' WHERE Id=1";
+            string sql2 = "UPDATE Foo SET Bar='baz' WHERE Id IN (2,3)";
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql1, StatementResult.CreateUpdateCount(1));
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql2, StatementResult.CreateUpdateCount(2));
+            string connectionString = $"Data Source=projects/p1/instances/i1/databases/d1;Host={_fixture.Host};Port={_fixture.Port}";
+            using (var connection = new SpannerConnection(connectionString, ChannelCredentials.Insecure))
+            {
+                await connection.OpenAsync();
+                using (var transaction = await connection.BeginRetriableTransactionAsync())
+                {
+                    var originalTxId = transaction.TransactionId;
+                    // Abort the transaction on the mock server. The transaction should be able to internally retry.
+                    _fixture.SpannerMock.AbortTransaction(ByteString.FromBase64(transaction.TransactionId.Id));
+                    var cmd = transaction.CreateBatchDmlCommand();
+                    cmd.Add(sql1);
+                    cmd.Add(sql2);
+                    var updateCounts = await cmd.ExecuteNonQueryAsync();
+                    Assert.NotEqual(originalTxId.Id, transaction.TransactionId.Id);
+                    await transaction.CommitAsync();
+                    Assert.Equal(new List<long> { 1, 2 }, updateCounts);
+                    Assert.Equal(1, transaction.RetryCount);
+                }
+            }
+        }
+
+        [Fact]
+        public async void ReadWriteTransaction_ModifiedBatchDmlUpdateCount_FailsRetry()
+        {
+            string sql1 = "UPDATE Foo SET Bar='bar' WHERE Id=1";
+            string sql2 = "UPDATE Foo SET Bar='baz' WHERE Id IN (2,3)";
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql1, StatementResult.CreateUpdateCount(1));
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql2, StatementResult.CreateUpdateCount(2));
+            string connectionString = $"Data Source=projects/p1/instances/i1/databases/d1;Host={_fixture.Host};Port={_fixture.Port}";
+            using (var connection = new SpannerConnection(connectionString, ChannelCredentials.Insecure))
+            {
+                await connection.OpenAsync();
+                using (var transaction = await connection.BeginRetriableTransactionAsync())
+                {
+                    var cmd = transaction.CreateBatchDmlCommand();
+                    cmd.Add(sql1);
+                    cmd.Add(sql2);
+                    Assert.Equal(new List<long> { 1, 2 }, await cmd.ExecuteNonQueryAsync());
+                    // Change the update count returned by one of the statements and abort the transaction.
+                    _fixture.SpannerMock.AddOrUpdateStatementResult(sql2, StatementResult.CreateUpdateCount(1));
+                    _fixture.SpannerMock.AbortTransaction(ByteString.FromBase64(transaction.TransactionId.Id));
+
+                    try
+                    {
+                        await transaction.CommitAsync();
+                        Assert.True(false, "Missing expected exception");
+                    }
+                    catch (SpannerAbortedDueToConcurrentModificationException)
+                    {
+                        Assert.Equal(1, transaction.RetryCount);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public async void ReadWriteTransaction_BatchDmlWithSameException_CanBeRetried()
+        {
+            // UPDATE statement that misses a WHERE clause.
+            string sql1 = "UPDATE Foo SET Bar='bar'";
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql1, StatementResult.CreateException(new RpcException(new Status(StatusCode.FailedPrecondition, "UPDATE statement misses WHERE clause"))));
+            string connectionString = $"Data Source=projects/p1/instances/i1/databases/d1;Host={_fixture.Host};Port={_fixture.Port}";
+            using (var connection = new SpannerConnection(connectionString, ChannelCredentials.Insecure))
+            {
+                await connection.OpenAsync();
+                using (var transaction = await connection.BeginRetriableTransactionAsync())
+                {
+                    var cmd = transaction.CreateBatchDmlCommand();
+                    cmd.Add(sql1);
+                    try
+                    {
+                        await cmd.ExecuteNonQueryAsync();
+                        Assert.True(false, "Missing expected exception");
+                    }
+                    catch (SpannerException e) when (e.ErrorCode == ErrorCode.FailedPrecondition)
+                    {
+                        Assert.Contains("UPDATE statement misses WHERE clause", e.InnerException?.Message);
+                    }
+                    // Abort the transaction and try to commit. That will trigger a retry, and the retry will receive
+                    // the same error for the BatchDML call as the original attempt.
+                    _fixture.SpannerMock.AbortTransaction(ByteString.FromBase64(transaction.TransactionId.Id));
+                    await transaction.CommitAsync();
+                    Assert.Equal(1, transaction.RetryCount);
+                }
+            }
+        }
+
+        [Fact]
+        public async void ReadWriteTransaction_BatchDmlWithDifferentException_FailsRetry()
+        {
+            string sql1 = "UPDATE Foo SET Bar='bar' WHERE Id=1";
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql1, StatementResult.CreateException(new RpcException(new Status(StatusCode.AlreadyExists, "Unique key constraint violation"))));
+            string connectionString = $"Data Source=projects/p1/instances/i1/databases/d1;Host={_fixture.Host};Port={_fixture.Port}";
+            using (var connection = new SpannerConnection(connectionString, ChannelCredentials.Insecure))
+            {
+                await connection.OpenAsync();
+                using (var transaction = await connection.BeginRetriableTransactionAsync())
+                {
+                    var cmd = transaction.CreateBatchDmlCommand();
+                    cmd.Add(sql1);
+                    try
+                    {
+                        await cmd.ExecuteNonQueryAsync();
+                        Assert.True(false, "Missing expected exception");
+                    }
+                    catch (SpannerException e) when (e.ErrorCode == ErrorCode.AlreadyExists)
+                    {
+                        Assert.Contains("Unique key constraint violation", e.InnerException?.Message);
+                    }
+
+                    // Remove the error message for the udpate statement.
+                    _fixture.SpannerMock.AddOrUpdateStatementResult(sql1, StatementResult.CreateUpdateCount(1));
+                    // Abort the transaction and try to commit. That will trigger a retry, but the retry
+                    // will not receive an error for the update statement. That will fail the retry.
+                    _fixture.SpannerMock.AbortTransaction(ByteString.FromBase64(transaction.TransactionId.Id));
+                    try
+                    {
+                        await transaction.CommitAsync();
+                        Assert.True(false, "Missing expected exception");
+                    }
+                    catch (SpannerAbortedDueToConcurrentModificationException)
+                    {
+                        Assert.Equal(1, transaction.RetryCount);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public async void ReadWriteTransaction_BatchDmlWithSameExceptionHalfwayAndSameResults_CanBeRetried()
+        {
+            string sql1 = "UPDATE Foo SET Bar='valid' WHERE Id=1";
+            string sql2 = "UPDATE Foo SET Bar='invalid'";
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql1, StatementResult.CreateUpdateCount(1));
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql2, StatementResult.CreateException(new RpcException(new Status(StatusCode.FailedPrecondition, "UPDATE statement misses WHERE clause"))));
+            string connectionString = $"Data Source=projects/p1/instances/i1/databases/d1;Host={_fixture.Host};Port={_fixture.Port}";
+            using (var connection = new SpannerConnection(connectionString, ChannelCredentials.Insecure))
+            {
+                await connection.OpenAsync();
+                using (var transaction = await connection.BeginRetriableTransactionAsync())
+                {
+                    var cmd = transaction.CreateBatchDmlCommand();
+                    cmd.Add(sql1);
+                    cmd.Add(sql2);
+                    try
+                    {
+                        await cmd.ExecuteNonQueryAsync();
+                        Assert.True(false, "Missing expected exception");
+                    }
+                    catch (SpannerBatchNonQueryException e)
+                    {
+                        Assert.Contains("UPDATE statement misses WHERE clause", e.Message);
+                        Assert.Equal(new List<long> { 1 }, e.SuccessfulCommandResults);
+                    }
+                    // Abort the transaction and try to commit. That will trigger a retry, and the retry will receive
+                    // the same error and the same results for the BatchDML call as the original attempt.
+                    _fixture.SpannerMock.AbortTransaction(ByteString.FromBase64(transaction.TransactionId.Id));
+                    await transaction.CommitAsync();
+                    Assert.Equal(1, transaction.RetryCount);
+                }
+            }
+        }
+
+        [Fact]
+        public async void ReadWriteTransaction_BatchDmlWithSameExceptionHalfwayAndDifferentResults_FailsRetry()
+        {
+            string sql1 = "UPDATE Foo SET Bar='valid' WHERE Id=1";
+            string sql2 = "UPDATE Foo SET Bar='invalid'";
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql1, StatementResult.CreateUpdateCount(1));
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql2, StatementResult.CreateException(new RpcException(new Status(StatusCode.FailedPrecondition, "UPDATE statement misses WHERE clause"))));
+            string connectionString = $"Data Source=projects/p1/instances/i1/databases/d1;Host={_fixture.Host};Port={_fixture.Port}";
+            using (var connection = new SpannerConnection(connectionString, ChannelCredentials.Insecure))
+            {
+                await connection.OpenAsync();
+                using (var transaction = await connection.BeginRetriableTransactionAsync())
+                {
+                    var cmd = transaction.CreateBatchDmlCommand();
+                    cmd.Add(sql1);
+                    cmd.Add(sql2);
+                    try
+                    {
+                        await cmd.ExecuteNonQueryAsync();
+                        Assert.True(false, "Missing expected exception");
+                    }
+                    catch (SpannerBatchNonQueryException e)
+                    {
+                        Assert.Contains("UPDATE statement misses WHERE clause", e.Message);
+                        Assert.Equal(new List<long> { 1 }, e.SuccessfulCommandResults);
+                    }
+                    // Change the result of the first statement and abort the transaction.
+                    // The retry should now fail, even though the error code and message is the same.
+                    _fixture.SpannerMock.AddOrUpdateStatementResult(sql1, StatementResult.CreateUpdateCount(2));
+                    _fixture.SpannerMock.AbortTransaction(ByteString.FromBase64(transaction.TransactionId.Id));
+                    try
+                    {
+                        await transaction.CommitAsync();
+                        Assert.True(false, "Missing expected exception");
+                    }
+                    catch (SpannerAbortedDueToConcurrentModificationException)
+                    {
+                        Assert.Equal(1, transaction.RetryCount);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public async void ReadWriteTransaction_QueryFullyConsumed_CanBeRetried()
+        {
+            string sql = "SELECT Id FROM Foo";
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateSingleColumnResultSet(SpannerDbType.Int64, "Id", 1));
+            string connectionString = $"Data Source=projects/p1/instances/i1/databases/d1;Host={_fixture.Host};Port={_fixture.Port}";
+            using (var connection = new SpannerConnection(connectionString, ChannelCredentials.Insecure))
+            {
+                await connection.OpenAsync();
+                using (var transaction = await connection.BeginRetriableTransactionAsync())
+                {
+                    var cmd = connection.CreateSelectCommand(sql);
+                    cmd.Transaction = transaction;
+                    using (var reader = await cmd.ExecuteReaderAsync())
+                    {
+                        while (await reader.ReadAsync())
+                        {
+                            Assert.Equal(1, reader.GetInt64(reader.GetOrdinal("Id")));
+                        }
+                    }
+                    // Abort the transaction on the mock server. The transaction should be able to internally retry.
+                    _fixture.SpannerMock.AbortTransaction(ByteString.FromBase64(transaction.TransactionId.Id));
+                    await transaction.CommitAsync();
+                    Assert.Equal(1, transaction.RetryCount);
+                }
+            }
+        }
+
+        [Fact]
+        public async void ReadWriteTransaction_QueryWithSameException_CanBeRetried()
+        {
+            string sql = "SELECT Id FROM Foo";
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateException(new RpcException(new Status(StatusCode.NotFound, "Table not found: Foo"))));
+            string connectionString = $"Data Source=projects/p1/instances/i1/databases/d1;Host={_fixture.Host};Port={_fixture.Port}";
+            using (var connection = new SpannerConnection(connectionString, ChannelCredentials.Insecure))
+            {
+                await connection.OpenAsync();
+                using (var transaction = await connection.BeginRetriableTransactionAsync())
+                {
+                    var cmd = connection.CreateSelectCommand(sql);
+                    cmd.Transaction = transaction;
+                    using (var reader = await cmd.ExecuteReaderAsync())
+                    {
+                        // Any query error is thrown by the first call to reader.ReadAsync();
+                        try
+                        {
+                            while (await reader.ReadAsync()) { }
+                        }
+                        catch (SpannerException e) when (e.ErrorCode == ErrorCode.NotFound)
+                        {
+                            Assert.Contains("Table not found: Foo", e.InnerException.Message);
+                        }
+                    }
+                    // Abort the transaction on the mock server. The transaction should be able to internally retry.
+                    _fixture.SpannerMock.AbortTransaction(ByteString.FromBase64(transaction.TransactionId.Id));
+                    await transaction.CommitAsync();
+                    Assert.Equal(1, transaction.RetryCount);
+                }
+            }
+        }
+
+        [Fact]
+        public async void ReadWriteTransaction_QueryFullyConsumed_WithModifiedResults_FailsRetry()
+        {
+            string sql = "SELECT Id FROM Foo";
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateSingleColumnResultSet(SpannerDbType.Int64, "Id", 1));
+            string connectionString = $"Data Source=projects/p1/instances/i1/databases/d1;Host={_fixture.Host};Port={_fixture.Port}";
+            using (var connection = new SpannerConnection(connectionString, ChannelCredentials.Insecure))
+            {
+                await connection.OpenAsync();
+                using (var transaction = await connection.BeginRetriableTransactionAsync())
+                {
+                    var cmd = connection.CreateSelectCommand(sql);
+                    cmd.Transaction = transaction;
+                    using (var reader = await cmd.ExecuteReaderAsync())
+                    {
+                        while (await reader.ReadAsync())
+                        {
+                            Assert.Equal(1, reader.GetInt64(reader.GetOrdinal("Id")));
+                        }
+                    }
+                    // Change the result of the query on the server and abort the transaction.
+                    // The retry should now fail.
+                    _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateSingleColumnResultSet(SpannerDbType.Int64, "Id", 2));
+                    _fixture.SpannerMock.AbortTransaction(ByteString.FromBase64(transaction.TransactionId.Id));
+                    try
+                    {
+                        await transaction.CommitAsync();
+                        Assert.True(false, "Missing expected exception");
+                    }
+                    catch (SpannerAbortedDueToConcurrentModificationException)
+                    {
+                        Assert.Equal(1, transaction.RetryCount);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public async void ReadWriteTransaction_QueryWithError_AndThenDifferentError_FailsRetry()
+        {
+            string sql = "SELECT Id FROM Foo";
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateException(new RpcException(new Status(StatusCode.NotFound, "Table not found: Foo"))));
+            string connectionString = $"Data Source=projects/p1/instances/i1/databases/d1;Host={_fixture.Host};Port={_fixture.Port}";
+            using (var connection = new SpannerConnection(connectionString, ChannelCredentials.Insecure))
+            {
+                await connection.OpenAsync();
+                using (var transaction = await connection.BeginRetriableTransactionAsync())
+                {
+                    var cmd = connection.CreateSelectCommand(sql);
+                    cmd.Transaction = transaction;
+                    using (var reader = await cmd.ExecuteReaderAsync())
+                    {
+                        // Any query error is thrown by the first call to reader.ReadAsync();
+                        try
+                        {
+                            while (await reader.ReadAsync()) { }
+                        }
+                        catch (SpannerException e) when (e.ErrorCode == ErrorCode.NotFound)
+                        {
+                            Assert.Contains("Table not found: Foo", e.InnerException.Message);
+                        }
+                    }
+                    // Change the error returned by the query on the server and abort the transaction.
+                    // The retry should now fail.
+                    _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateException(new RpcException(new Status(StatusCode.PermissionDenied, "Permission denied for table Foo"))));
+                    _fixture.SpannerMock.AbortTransaction(ByteString.FromBase64(transaction.TransactionId.Id));
+                    try
+                    {
+                        await transaction.CommitAsync();
+                        Assert.True(false, "Missing expected exception");
+                    }
+                    catch (SpannerAbortedDueToConcurrentModificationException)
+                    {
+                        Assert.Equal(1, transaction.RetryCount);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public async void ReadWriteTransaction_QueryWithError_AndThenNoError_FailsRetry()
+        {
+            string sql = "SELECT Id FROM Foo";
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateException(new RpcException(new Status(StatusCode.NotFound, "Table not found: Foo"))));
+            string connectionString = $"Data Source=projects/p1/instances/i1/databases/d1;Host={_fixture.Host};Port={_fixture.Port}";
+            using (var connection = new SpannerConnection(connectionString, ChannelCredentials.Insecure))
+            {
+                await connection.OpenAsync();
+                using (var transaction = await connection.BeginRetriableTransactionAsync())
+                {
+                    var cmd = connection.CreateSelectCommand(sql);
+                    cmd.Transaction = transaction;
+                    using (var reader = await cmd.ExecuteReaderAsync())
+                    {
+                        // Any query error is thrown by the first call to reader.ReadAsync();
+                        try
+                        {
+                            while (await reader.ReadAsync()) { }
+                        }
+                        catch (SpannerException e) when (e.ErrorCode == ErrorCode.NotFound)
+                        {
+                            Assert.Contains("Table not found: Foo", e.InnerException.Message);
+                        }
+                    }
+                    // Remove the error returned by the query on the server and abort the transaction.
+                    // The retry should now fail.
+                    _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateSingleColumnResultSet(SpannerDbType.Int64, "Id", 1));
+                    _fixture.SpannerMock.AbortTransaction(ByteString.FromBase64(transaction.TransactionId.Id));
+                    try
+                    {
+                        await transaction.CommitAsync();
+                        Assert.True(false, "Missing expected exception");
+                    }
+                    catch (SpannerAbortedDueToConcurrentModificationException)
+                    {
+                        Assert.Equal(1, transaction.RetryCount);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public async void ReadWriteTransaction_QueryFullyConsumed_AndThenError_FailsRetry()
+        {
+            string sql = "SELECT Id FROM Foo";
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateSingleColumnResultSet(SpannerDbType.Int64, "Id", 1));
+            string connectionString = $"Data Source=projects/p1/instances/i1/databases/d1;Host={_fixture.Host};Port={_fixture.Port}";
+            using (var connection = new SpannerConnection(connectionString, ChannelCredentials.Insecure))
+            {
+                await connection.OpenAsync();
+                using (var transaction = await connection.BeginRetriableTransactionAsync())
+                {
+                    var cmd = connection.CreateSelectCommand(sql);
+                    cmd.Transaction = transaction;
+                    using (var reader = await cmd.ExecuteReaderAsync())
+                    {
+                        while (await reader.ReadAsync())
+                        {
+                            Assert.Equal(1, reader.GetInt64(reader.GetOrdinal("Id")));
+                        }
+                    }
+                    // Replace the result returned by the query on the server with an error and abort the transaction.
+                    // The retry should now fail.
+                    _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateException(new RpcException(new Status(StatusCode.NotFound, "Table not found: Foo"))));
+                    _fixture.SpannerMock.AbortTransaction(ByteString.FromBase64(transaction.TransactionId.Id));
+                    try
+                    {
+                        await transaction.CommitAsync();
+                        Assert.True(false, "Missing expected exception");
+                    }
+                    catch (SpannerAbortedDueToConcurrentModificationException)
+                    {
+                        Assert.Equal(1, transaction.RetryCount);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public async void ReadWriteTransaction_QueryHalfConsumed_WithSameResults_CanBeRetried()
+        {
+            string sql = "SELECT Id FROM Foo";
+            // Create a result set with 2 rows.
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateSingleColumnResultSet(SpannerDbType.Int64, "Id", 1, 2));
+            string connectionString = $"Data Source=projects/p1/instances/i1/databases/d1;Host={_fixture.Host};Port={_fixture.Port}";
+            using (var connection = new SpannerConnection(connectionString, ChannelCredentials.Insecure))
+            {
+                await connection.OpenAsync();
+                using (var transaction = await connection.BeginRetriableTransactionAsync())
+                {
+                    var cmd = connection.CreateSelectCommand(sql);
+                    cmd.Transaction = transaction;
+                    using (var reader = await cmd.ExecuteReaderAsync())
+                    {
+                        // Only consume the first row of the reader.
+                        Assert.True(await reader.ReadAsync());
+                        Assert.Equal(1, reader.GetInt64(reader.GetOrdinal("Id")));
+                    }
+                    // Abort the transaction on the mock server. The transaction should be able to internally retry.
+                    _fixture.SpannerMock.AbortTransaction(ByteString.FromBase64(transaction.TransactionId.Id));
+                    await transaction.CommitAsync();
+                    Assert.Equal(1, transaction.RetryCount);
+                }
+            }
+        }
+
+        [Fact]
+        public async void ReadWriteTransaction_QueryHalfConsumed_WithDifferentUnseenResults_CanBeRetried()
+        {
+            string sql = "SELECT Id FROM Foo";
+            // Create a result set with 2 rows.
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateSingleColumnResultSet(SpannerDbType.Int64, "Id", 1, 2));
+            string connectionString = $"Data Source=projects/p1/instances/i1/databases/d1;Host={_fixture.Host};Port={_fixture.Port}";
+            using (var connection = new SpannerConnection(connectionString, ChannelCredentials.Insecure))
+            {
+                await connection.OpenAsync();
+                using (var transaction = await connection.BeginRetriableTransactionAsync())
+                {
+                    var cmd = connection.CreateSelectCommand(sql);
+                    cmd.Transaction = transaction;
+                    using (var reader = await cmd.ExecuteReaderAsync())
+                    {
+                        // Only consume the first row of the reader.
+                        Assert.True(await reader.ReadAsync());
+                        Assert.Equal(1, reader.GetInt64(reader.GetOrdinal("Id")));
+                    }
+                    // Change the second row of the result of the query. That row has never been seen by the transaction
+                    // and should therefore not cause any retry to abort.
+                    _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateSingleColumnResultSet(SpannerDbType.Int64, "Id", 1, 3));
+                    _fixture.SpannerMock.AbortTransaction(ByteString.FromBase64(transaction.TransactionId.Id));
+                    await transaction.CommitAsync();
+                    Assert.Equal(1, transaction.RetryCount);
+                }
+            }
+        }
+
+        [Fact]
+        public async void ReadWriteTransaction_QueryAbortsHalfway_WithSameResults_CanBeRetried()
+        {
+            string sql = "SELECT Id FROM Foo";
+            // Create a result set with 2 rows.
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateSingleColumnResultSet(SpannerDbType.Int64, "Id", 1, 2));
+            // The following will cause the ExecuteStreamingSql method on the mock server to return an Aborted error on stream index 1 (i.e. before the row with value 2 is returned).
+            // This simulates a transaction that is aborted while a streaming result set is still being returned to the client.
+            _fixture.SpannerMock.AddOrUpdateExecutionTime(nameof(MockSpannerService.ExecuteStreamingSql), ExecutionTime.StreamException(MockSpannerService.CreateAbortedException(), 1));
+            string connectionString = $"Data Source=projects/p1/instances/i1/databases/d1;Host={_fixture.Host};Port={_fixture.Port}";
+            using (var connection = new SpannerConnection(connectionString, ChannelCredentials.Insecure))
+            {
+                await connection.OpenAsync();
+                using (var transaction = await connection.BeginRetriableTransactionAsync())
+                {
+                    var cmd = connection.CreateSelectCommand(sql);
+                    cmd.Transaction = transaction;
+                    using (var reader = await cmd.ExecuteReaderAsync())
+                    {
+                        // Only the first row of the reader.
+                        Assert.True(await reader.ReadAsync());
+                        Assert.Equal(1, reader.GetInt64(reader.GetOrdinal("Id")));
+                        // Try to get the second row of the result. This should succeed, even though the transaction
+                        // was aborted, retried and the reader was re-initialized under the hood.
+                        Assert.True(await reader.ReadAsync());
+                        Assert.Equal(2, reader.GetInt64(reader.GetOrdinal("Id")));
+                        // Ensure that there are no more rows in the results.
+                        Assert.False(await reader.ReadAsync());
+                    }
+                    // Check that the transaction really retried.
+                    Assert.Equal(1, transaction.RetryCount);
+                }
+            }
+        }
+
+        [Fact]
+        public async void ReadWriteTransaction_QueryAbortsHalfway_WithDifferentUnseenResults_CanBeRetried()
+        {
+            string sql = "SELECT Id FROM Foo";
+            // Create a result set with 2 rows.
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateSingleColumnResultSet(SpannerDbType.Int64, "Id", 1, 2));
+            // The following will cause the ExecuteStreamingSql method on the mock server to return an Aborted error on stream index 1 (i.e. before the row with value 2 is returned).
+            // This simulates a transaction that is aborted while a streaming result set is still being returned to the client.
+            _fixture.SpannerMock.AddOrUpdateExecutionTime(nameof(MockSpannerService.ExecuteStreamingSql), ExecutionTime.StreamException(MockSpannerService.CreateAbortedException(), 1));
+            string connectionString = $"Data Source=projects/p1/instances/i1/databases/d1;Host={_fixture.Host};Port={_fixture.Port}";
+            using (var connection = new SpannerConnection(connectionString, ChannelCredentials.Insecure))
+            {
+                await connection.OpenAsync();
+                using (var transaction = await connection.BeginRetriableTransactionAsync())
+                {
+                    var cmd = connection.CreateSelectCommand(sql);
+                    cmd.Transaction = transaction;
+                    using (var reader = await cmd.ExecuteReaderAsync())
+                    {
+                        // Only the first row of the reader.
+                        Assert.True(await reader.ReadAsync());
+                        Assert.Equal(1, reader.GetInt64(reader.GetOrdinal("Id")));
+
+                        // Now change the result of the query, but only for the second row which has not yet been
+                        // seen by this transaction.
+                        _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateSingleColumnResultSet(SpannerDbType.Int64, "Id", 1, 3));
+                        // Try to get the second row of the result. This should succeed, even though the transaction
+                        // was aborted, retried and the reader was re-initialized under the hood. The retry succeeds
+                        // because only data that had not yet been seen by this transaction was changed.
+                        Assert.True(await reader.ReadAsync());
+                        Assert.Equal(3, reader.GetInt64(reader.GetOrdinal("Id")));
+                        // Ensure that there are no more rows in the results.
+                        Assert.False(await reader.ReadAsync());
+                    }
+                    // Check that the transaction really retried.
+                    Assert.Equal(1, transaction.RetryCount);
+                }
+            }
+        }
+
+        [Fact]
+        public async void ReadWriteTransaction_QueryAbortsHalfway_WithDifferentResults_FailsRetry()
+        {
+            string sql = "SELECT Id FROM Foo";
+            // Create a result set with 2 rows.
+            _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateSingleColumnResultSet(SpannerDbType.Int64, "Id", 1, 2));
+            // The following will cause the ExecuteStreamingSql method on the mock server to return an Aborted error on stream index 1 (i.e. before the row with value 2 is returned).
+            // This simulates a transaction that is aborted while a streaming result set is still being returned to the client.
+            _fixture.SpannerMock.AddOrUpdateExecutionTime(nameof(MockSpannerService.ExecuteStreamingSql), ExecutionTime.StreamException(MockSpannerService.CreateAbortedException(), 1));
+            string connectionString = $"Data Source=projects/p1/instances/i1/databases/d1;Host={_fixture.Host};Port={_fixture.Port}";
+            using (var connection = new SpannerConnection(connectionString, ChannelCredentials.Insecure))
+            {
+                await connection.OpenAsync();
+                using (var transaction = await connection.BeginRetriableTransactionAsync())
+                {
+                    var cmd = connection.CreateSelectCommand(sql);
+                    cmd.Transaction = transaction;
+                    using (var reader = await cmd.ExecuteReaderAsync())
+                    {
+                        // Only the first row of the reader.
+                        Assert.True(await reader.ReadAsync());
+                        Assert.Equal(1, reader.GetInt64(reader.GetOrdinal("Id")));
+
+                        // Now change the result of the query for the record that has already been seen.
+                        _fixture.SpannerMock.AddOrUpdateStatementResult(sql, StatementResult.CreateSingleColumnResultSet(SpannerDbType.Int64, "Id", 3, 2));
+                        // Try to get the second row of the result. This will now fail.
+                        try
+                        {
+                            await reader.ReadAsync();
+                            Assert.True(false, "Missing expected exception");
+                        } catch (SpannerAbortedDueToConcurrentModificationException)
+                        {
+                            Assert.Equal(1, transaction.RetryCount);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/MockSpannerServer.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/MockSpannerServer.cs
@@ -1,4 +1,18 @@
-﻿using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
+﻿// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
 using Google.Api.Gax.Grpc.GrpcCore;
 using Google.Cloud.Spanner.Common.V1;
 using Google.Cloud.Spanner.V1;

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/MockSpannerServer.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/MockSpannerServer.cs
@@ -1,0 +1,547 @@
+﻿using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
+using Google.Api.Gax.Grpc.GrpcCore;
+using Google.Cloud.Spanner.Common.V1;
+using Google.Cloud.Spanner.V1;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+using Google.Rpc;
+using Grpc.Core;
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Status = Google.Rpc.Status;
+
+namespace Google.Cloud.Spanner.Data.Tests
+{
+    public class StatementResult
+    {
+        public enum StatementResultType
+        {
+            RESULT_SET,
+            UPDATE_COUNT,
+            EXCEPTION
+        }
+
+        public StatementResultType Type { get; }
+        public ResultSet ResultSet { get; }
+        public long UpdateCount { get; }
+        public Exception Exception { get; }
+
+        internal static StatementResult CreateQuery(ResultSet resultSet)
+        {
+            return new StatementResult(resultSet);
+        }
+
+        internal static StatementResult CreateUpdateCount(long count)
+        {
+            return new StatementResult(count);
+        }
+
+        internal static StatementResult CreateException(Exception exception)
+        {
+            return new StatementResult(exception);
+        }
+
+        internal static StatementResult CreateSelect1ResultSet()
+        {
+            return CreateSingleColumnResultSet(SpannerConversionOptions.Default, SpannerDbType.Int64, "COL1", 1);
+        }
+
+        internal static StatementResult CreateSingleColumnResultSet(SpannerDbType type, String col, params object[] values)
+        {
+            return CreateSingleColumnResultSet(SpannerConversionOptions.Default, type, col, values);
+        }
+
+        internal static StatementResult CreateSingleColumnResultSet(SpannerConversionOptions options, SpannerDbType type, String col, params object[] values)
+        {
+            ResultSet rs = new ResultSet();
+            rs.Metadata = new ResultSetMetadata
+            {
+                RowType = new StructType()
+            };
+            rs.Metadata.RowType.Fields.Add(new StructType.Types.Field
+            {
+                Name = col,
+                Type = new V1.Type
+                {
+                    Code = type.ToProtobufType().Code
+                }
+            });
+            foreach (object val in values)
+            {
+                ListValue row = new ListValue();
+                row.Values.Add(type.ToProtobufValue(val, options));
+                rs.Rows.Add(row);
+            }
+            return CreateQuery(rs);
+        }
+
+        private StatementResult(ResultSet resultSet)
+        {
+            Type = StatementResultType.RESULT_SET;
+            ResultSet = resultSet;
+        }
+
+        private StatementResult(long updateCount)
+        {
+            Type = StatementResultType.UPDATE_COUNT;
+            UpdateCount = updateCount;
+        }
+
+        private StatementResult(Exception exception)
+        {
+            Type = StatementResultType.EXCEPTION;
+            Exception = exception;
+        }
+    }
+
+    public class ExecutionTime
+    {
+        private readonly int _executionTime;
+        // TODO: Support multiple exceptions
+        private Exception _exception;
+        private readonly int _exceptionStreamIndex;
+
+        internal bool HasExceptionAtIndex(int index)
+        {
+            return _exception != null && _exceptionStreamIndex == index;
+        }
+
+        internal Exception PopExceptionAtIndex(int index)
+        {
+            Exception res = _exceptionStreamIndex == index ? _exception : null;
+            if (res != null)
+            {
+                _exception = null;
+            }
+            return res;
+        }
+
+        internal static ExecutionTime StreamException(Exception exception, int streamIndex)
+        {
+            return new ExecutionTime(0, exception, streamIndex);
+        }
+
+        private ExecutionTime(int executionTime, Exception exception, int exceptionStreamIndex)
+        {
+            _executionTime = executionTime;
+            _exception = exception;
+            _exceptionStreamIndex = exceptionStreamIndex;
+        }
+    }
+
+    public class MockSpannerService : Google.Cloud.Spanner.V1.Spanner.SpannerBase
+    {
+        class PartialResultSetsEnumerable : IEnumerable<PartialResultSet>
+        {
+            private readonly ResultSet _resultSet;
+            public PartialResultSetsEnumerable(ResultSet resultSet)
+            {
+                this._resultSet = resultSet;
+            }
+
+            public IEnumerator<PartialResultSet> GetEnumerator()
+            {
+                return new PartialResultSetsEnumerator(_resultSet);
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return new PartialResultSetsEnumerator(_resultSet);
+            }
+        }
+
+        class PartialResultSetsEnumerator : IEnumerator<PartialResultSet>
+        {
+            private static readonly int MAX_ROWS_IN_CHUNK = 1;
+
+            private readonly ResultSet _resultSet;
+            private bool _first = true;
+            private int _currentRow = 0;
+            private PartialResultSet _current;
+
+            public PartialResultSetsEnumerator(ResultSet resultSet)
+            {
+                this._resultSet = resultSet;
+            }
+
+            PartialResultSet IEnumerator<PartialResultSet>.Current => _current;
+
+            object IEnumerator.Current => _current;
+
+            public bool MoveNext()
+            {
+                _current = new PartialResultSet();
+                _current.ResumeToken = ByteString.CopyFromUtf8($"{_currentRow}");
+                if (_first)
+                {
+                    _current.Metadata = _resultSet.Metadata;
+                    _first = false;
+                } else if (_currentRow == _resultSet.Rows.Count)
+                {
+                    return false;
+                }
+                int recordCount = 0;
+                while (recordCount < MAX_ROWS_IN_CHUNK && _currentRow < _resultSet.Rows.Count)
+                {
+                    _current.Values.Add(_resultSet.Rows.ElementAt(_currentRow).Values);
+                    recordCount++;
+                    _currentRow++;
+                }
+                return true;
+            }
+
+            public void Reset()
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Dispose()
+            {
+            }
+        }
+
+
+        private static readonly Empty EMPTY = new Empty();
+        private static readonly TransactionOptions SINGLE_USE = new TransactionOptions { ReadOnly = new TransactionOptions.Types.ReadOnly { Strong = true, ReturnReadTimestamp = false } };
+
+        private ConcurrentDictionary<string, StatementResult> _results = new ConcurrentDictionary<string, StatementResult>();
+        private ConcurrentQueue<IMessage> _requests = new ConcurrentQueue<IMessage>();
+        private int _sessionCounter;
+        private int _transactionCounter;
+        private ConcurrentDictionary<SessionName, Session> _sessions = new ConcurrentDictionary<SessionName, Session>();
+        private ConcurrentDictionary<ByteString, Transaction> _transactions = new ConcurrentDictionary<ByteString, Transaction>();
+        private ConcurrentDictionary<ByteString, TransactionOptions> _transactionOptions = new ConcurrentDictionary<ByteString, TransactionOptions>();
+        private ConcurrentDictionary<ByteString, bool> _abortedTransactions = new ConcurrentDictionary<ByteString, bool>();
+        private ConcurrentDictionary<string, ExecutionTime> _executionTimes = new ConcurrentDictionary<string, ExecutionTime>();
+
+        public void AddOrUpdateStatementResult(string sql, StatementResult result)
+        {
+            _results.AddOrUpdate(sql,
+                result,
+                (string sql, StatementResult existing) => result
+            );
+        }
+
+        public void AddOrUpdateExecutionTime(string method, ExecutionTime executionTime)
+        {
+            _executionTimes.AddOrUpdate(method,
+                executionTime,
+                (string method, ExecutionTime existing) => executionTime
+            );
+        }
+
+        internal void AbortTransaction(ByteString id)
+        {
+            _abortedTransactions.TryAdd(id, true);
+        }
+
+        public List<IMessage> Requests()
+        {
+            return new List<IMessage>(_requests);
+        }
+
+        public void Reset()
+        {
+            _requests = new ConcurrentQueue<IMessage>();
+        }
+
+        public override Task<Transaction> BeginTransaction(BeginTransactionRequest request, ServerCallContext context)
+        {
+            _requests.Enqueue(request);
+            TryFindSession(request.SessionAsSessionName);
+            Transaction tx = new Transaction();
+            var id = Interlocked.Increment(ref _transactionCounter);
+            tx.Id = ByteString.CopyFromUtf8($"{request.SessionAsSessionName}/transactions/{id}");
+            _transactions.TryAdd(tx.Id, tx);
+            return Task.FromResult(tx);
+        }
+
+        public override Task<CommitResponse> Commit(CommitRequest request, ServerCallContext context)
+        {
+            _requests.Enqueue(request);
+            TryFindSession(request.SessionAsSessionName);
+            if (request.TransactionCase == CommitRequest.TransactionOneofCase.TransactionId)
+            {
+                TryFindTransaction(request.TransactionId, true);
+            }
+            CommitResponse response = new CommitResponse();
+            Timestamp ts = Timestamp.FromDateTime(DateTime.UtcNow);
+            response.CommitTimestamp = ts;
+            return Task.FromResult(response);
+        }
+
+        private Session CreateSession(DatabaseName database)
+        {
+            var id = Interlocked.Increment(ref _sessionCounter);
+            Session session = new Session { SessionName = new SessionName(database.ProjectId, database.InstanceId, database.DatabaseId, $"session-{id}") };
+            if (!_sessions.TryAdd(session.SessionName, session))
+            {
+                throw new RpcException(new Grpc.Core.Status(StatusCode.AlreadyExists, $"Session with id session-{id} already exists"));
+            }
+            return session;
+        }
+
+        static internal RpcException CreateAbortedException()
+        {
+            return new RpcException(new Grpc.Core.Status(StatusCode.Aborted, "Transaction aborted"));
+        }
+
+        private Transaction TryFindTransaction(ByteString id, Boolean remove = false)
+        {
+            bool aborted;
+            if (_abortedTransactions.TryGetValue(id, out aborted) && aborted)
+            {
+                throw CreateAbortedException();
+            }
+            Transaction tx;
+            if (remove ? _transactions.TryRemove(id, out tx) : _transactions.TryGetValue(id, out tx))
+            {
+                return tx;
+            }
+            throw new RpcException(new Grpc.Core.Status(StatusCode.NotFound, $"Transaction not found: {id.ToBase64()}"));
+        }
+
+        private Transaction FindOrBeginTransaction(SessionName session, TransactionSelector selector)
+        {
+            if (selector == null)
+            {
+                return BeginTransaction(session, SINGLE_USE, true);
+            }
+            // TODO: Check that the selected transaction actually belongs to the given session.
+            switch (selector.SelectorCase)
+            {
+                case TransactionSelector.SelectorOneofCase.SingleUse:
+                    return BeginTransaction(session, selector.SingleUse, true);
+                case TransactionSelector.SelectorOneofCase.Begin:
+                    return BeginTransaction(session, selector.Begin, false);
+                case TransactionSelector.SelectorOneofCase.Id:
+                    return TryFindTransaction(selector.Id);
+                case TransactionSelector.SelectorOneofCase.None:
+                default:
+                    return null;
+            }
+        }
+
+        private Transaction BeginTransaction(SessionName session, TransactionOptions options, bool singleUse)
+        {
+            Transaction tx = new Transaction();
+            var id = Interlocked.Increment(ref _transactionCounter);
+            tx.Id = ByteString.CopyFromUtf8($"{session}/transactions/{id}");
+            if (options.ModeCase == TransactionOptions.ModeOneofCase.ReadOnly && options.ReadOnly.ReturnReadTimestamp)
+            {
+                tx.ReadTimestamp = Timestamp.FromDateTime(DateTime.Now);
+            }
+            if (!singleUse)
+            {
+                _transactions.TryAdd(tx.Id, tx);
+                _transactionOptions.TryAdd(tx.Id, options);
+            }
+            return tx;
+        }
+
+        public override Task<BatchCreateSessionsResponse> BatchCreateSessions(BatchCreateSessionsRequest request, ServerCallContext context)
+        {
+            _requests.Enqueue(request);
+            var database = request.DatabaseAsDatabaseName;
+            BatchCreateSessionsResponse response = new BatchCreateSessionsResponse();
+            for (int i = 0; i < request.SessionCount; i++)
+            {
+                response.Session.Add(CreateSession(database));
+            }
+            return Task.FromResult(response);
+        }
+
+        public override Task<Session> CreateSession(CreateSessionRequest request, ServerCallContext context)
+        {
+            _requests.Enqueue(request);
+            var database = request.DatabaseAsDatabaseName;
+            return Task.FromResult(CreateSession(database));
+        }
+
+        public override Task<Session> GetSession(GetSessionRequest request, ServerCallContext context)
+        {
+            _requests.Enqueue(request);
+            return Task.FromResult(TryFindSession(request.SessionName));
+        }
+
+        public override Task<ListSessionsResponse> ListSessions(ListSessionsRequest request, ServerCallContext context)
+        {
+            _requests.Enqueue(request);
+            ListSessionsResponse response = new ListSessionsResponse();
+            foreach (Session session in _sessions.Values)
+            {
+                response.Sessions.Add(session);
+            }
+            return Task.FromResult(response);
+        }
+
+        public override Task<Empty> DeleteSession(DeleteSessionRequest request, ServerCallContext context)
+        {
+            _requests.Enqueue(request);
+            _sessions.TryRemove(request.SessionName, out _);
+            return Task.FromResult(EMPTY);
+        }
+
+        private Session TryFindSession(SessionName name)
+        {
+            Session session;
+            if (_sessions.TryGetValue(name, out session))
+            {
+                return session;
+            }
+            throw new RpcException(new Grpc.Core.Status(StatusCode.NotFound, $"Session not found: {name}"));
+        }
+
+        public override Task<ExecuteBatchDmlResponse> ExecuteBatchDml(ExecuteBatchDmlRequest request, ServerCallContext context)
+        {
+            _requests.Enqueue(request);
+            Session session = TryFindSession(request.SessionAsSessionName);
+            Transaction tx = FindOrBeginTransaction(request.SessionAsSessionName, request.Transaction);
+            ExecuteBatchDmlResponse response = new ExecuteBatchDmlResponse();
+            // TODO: Return other statuses based on the mocked results.
+            response.Status = new Status();
+            response.Status.Code = (int) StatusCode.OK;
+            int index = 0;
+            foreach (var statement in request.Statements)
+            {
+                if (response.Status.Code != (int) StatusCode.OK)
+                {
+                    break;
+                }
+                StatementResult result;
+                if (_results.TryGetValue(statement.Sql, out result))
+                {
+                    switch (result.Type)
+                    {
+                        case StatementResult.StatementResultType.RESULT_SET:
+                            throw new RpcException(new Grpc.Core.Status(StatusCode.InvalidArgument, $"ResultSet is not a valid result type for BatchDml"));
+                        case StatementResult.StatementResultType.UPDATE_COUNT:
+                            response.ResultSets.Add(CreateUpdateCountResultSet(result.UpdateCount));
+                            break;
+                        case StatementResult.StatementResultType.EXCEPTION:
+                            if (index == 0)
+                            {
+                                throw result.Exception;
+                            }
+                            response.Status = StatusFromException(result.Exception);
+                            break;
+                        default:
+                            throw new RpcException(new Grpc.Core.Status(StatusCode.InvalidArgument, $"Invalid result type {result.Type} for {statement.Sql}"));
+                    }
+                }
+                else
+                {
+                    throw new RpcException(new Grpc.Core.Status(StatusCode.InvalidArgument, $"No result found for {statement.Sql}"));
+                }
+                index++;
+            }
+            return Task.FromResult(response);
+        }
+
+        private Status StatusFromException(Exception e)
+        {
+            if (e is RpcException) {
+                RpcException rpc = (RpcException)e;
+                return new Status { Code = (int) rpc.StatusCode, Message = e.Message };
+            }
+            return new Status { Code = (int) StatusCode.Unknown, Message = e.Message };
+        }
+
+        public override Task<ResultSet> ExecuteSql(ExecuteSqlRequest request, ServerCallContext context)
+        {
+            return base.ExecuteSql(request, context);
+        }
+
+        public override async Task ExecuteStreamingSql(ExecuteSqlRequest request, IServerStreamWriter<PartialResultSet> responseStream, ServerCallContext context)
+        {
+            _requests.Enqueue(request);
+            ExecutionTime executionTime;
+            _executionTimes.TryGetValue(nameof(ExecuteStreamingSql), out executionTime);
+            Session session = TryFindSession(request.SessionAsSessionName);
+            Transaction tx = FindOrBeginTransaction(request.SessionAsSessionName, request.Transaction);
+            StatementResult result;
+            if (_results.TryGetValue(request.Sql, out result))
+            {
+                switch (result.Type)
+                {
+                    case StatementResult.StatementResultType.RESULT_SET:
+                        await WriteResultSet(result.ResultSet, responseStream, executionTime);
+                        break;
+                    case StatementResult.StatementResultType.UPDATE_COUNT:
+                        await WriteUpdateCount(result.UpdateCount, responseStream);
+                        break;
+                    case StatementResult.StatementResultType.EXCEPTION:
+                        throw result.Exception;
+                    default:
+                        throw new RpcException(new Grpc.Core.Status(StatusCode.InvalidArgument, $"Invalid result type {result.Type} for {request.Sql}"));
+                }
+            }
+            else
+            {
+                throw new RpcException(new Grpc.Core.Status(StatusCode.InvalidArgument, $"No result found for {request.Sql}"));
+            }
+        }
+
+        private async Task WriteResultSet(ResultSet resultSet, IServerStreamWriter<PartialResultSet> responseStream, ExecutionTime executionTime)
+        {
+            int index = 0;
+            PartialResultSetsEnumerable enumerator = new PartialResultSetsEnumerable(resultSet);
+            foreach (PartialResultSet prs in enumerator)
+            {
+                Exception e = executionTime?.PopExceptionAtIndex(index);
+                if (e != null)
+                {
+                    throw e;
+                }
+                await responseStream.WriteAsync(prs);
+                index++;
+            }
+        }
+
+        private async Task WriteUpdateCount(long updateCount, IServerStreamWriter<PartialResultSet> responseStream)
+        {
+            PartialResultSet prs = new PartialResultSet();
+            prs.Stats = new ResultSetStats { RowCountExact = updateCount };
+            await responseStream.WriteAsync(prs);
+        }
+
+        private ResultSet CreateUpdateCountResultSet(long updateCount)
+        {
+            ResultSet rs = new ResultSet();
+            rs.Stats = new ResultSetStats { RowCountExact = updateCount };
+            return rs;
+        }
+
+        public override Task<PartitionResponse> PartitionQuery(PartitionQueryRequest request, ServerCallContext context)
+        {
+            return base.PartitionQuery(request, context);
+        }
+
+        public override Task<PartitionResponse> PartitionRead(PartitionReadRequest request, ServerCallContext context)
+        {
+            return base.PartitionRead(request, context);
+        }
+
+        public override Task<ResultSet> Read(ReadRequest request, ServerCallContext context)
+        {
+            return base.Read(request, context);
+        }
+
+        public override Task<Empty> Rollback(RollbackRequest request, ServerCallContext context)
+        {
+            return base.Rollback(request, context);
+        }
+
+        public override Task StreamingRead(ReadRequest request, IServerStreamWriter<PartialResultSet> responseStream, ServerCallContext context)
+        {
+            return base.StreamingRead(request, responseStream, context);
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/MockSpannerServerTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/MockSpannerServerTests.cs
@@ -1,4 +1,18 @@
-﻿using Google.Cloud.Spanner.V1;
+﻿// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Spanner.V1;
 using Google.Protobuf;
 using Grpc.Core;
 using System;

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/MockSpannerServiceTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/MockSpannerServiceTests.cs
@@ -1,0 +1,190 @@
+﻿using Google.Cloud.Spanner.V1;
+using Google.Protobuf;
+using Grpc.Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Transactions;
+using Xunit;
+
+namespace Google.Cloud.Spanner.Data.Tests
+{
+    public class MockSpannerServerTests : IClassFixture<SpannerMockServerFixture>
+    {
+        SpannerMockServerFixture _fixture;
+
+        public MockSpannerServerTests(SpannerMockServerFixture service)
+        {
+            this._fixture = service;
+            // Add a simple SELECT 1 result to the mock server to be available for all test cases.
+            _fixture.SpannerMock.AddOrUpdateStatementResult("SELECT 1", StatementResult.CreateSelect1ResultSet());
+        }
+
+        [Fact]
+        public void BatchCreateSessions()
+        {
+            SpannerClientBuilder builder = new SpannerClientBuilder();
+            builder.Endpoint = _fixture.Endpoint;
+            builder.ChannelCredentials = ChannelCredentials.Insecure;
+            SpannerClient client = builder.Build();
+            BatchCreateSessionsRequest request = new BatchCreateSessionsRequest();
+            request.Database = "projects/p1/instances/i1/databases/d1";
+            request.SessionCount = 25;
+            request.SessionTemplate = new Session();
+            BatchCreateSessionsResponse response = client.BatchCreateSessions(request);
+            Assert.Equal(25, response.Session.Count);
+        }
+
+        [Fact]
+        public async void SingleUseSelect()
+        {
+            string connectionString = $"Data Source=projects/p1/instances/i1/databases/d1;Host={_fixture.Host};Port={_fixture.Port}";
+            // Create connection to Cloud Spanner.
+            using (var connection = new SpannerConnection(connectionString, ChannelCredentials.Insecure))
+            {
+                SpannerCommand cmd = connection.CreateSelectCommand("SELECT 1");
+                using (var reader = await cmd.ExecuteReaderAsync())
+                {
+                    while (await reader.ReadAsync())
+                    {
+                        Assert.Equal(1, reader.GetInt64(0));
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public async void ReadOnlyTxSelect()
+        {
+            string connectionString = $"Data Source=projects/p1/instances/i1/databases/d1;Host={_fixture.Host};Port={_fixture.Port}";
+            using (var connection = new SpannerConnection(connectionString, ChannelCredentials.Insecure))
+            {
+                using (var transaction = await connection.BeginReadOnlyTransactionAsync())
+                {
+                    SpannerCommand cmd = connection.CreateSelectCommand("SELECT 1");
+                    cmd.Transaction = transaction;
+                    using (var reader = await cmd.ExecuteReaderAsync())
+                    {
+                        while (await reader.ReadAsync())
+                        {
+                            Assert.Equal(1, reader.GetInt64(0));
+                        }
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public async void WriteMutations()
+        {
+            string connectionString = $"Data Source=projects/p1/instances/i1/databases/d1;Host={_fixture.Host};Port={_fixture.Port}";
+            using (var connection = new SpannerConnection(connectionString, ChannelCredentials.Insecure))
+            {
+                SpannerCommand cmd = connection.CreateInsertOrUpdateCommand("Singers", new SpannerParameterCollection {
+                        {"SingerId", SpannerDbType.Int64, 1},
+                        {"FirstName", SpannerDbType.String, "FirstName1"},
+                        {"LastName", SpannerDbType.String, "LastName1"},
+                    });
+                await cmd.ExecuteNonQueryAsync();
+            }
+            List<IMessage> requests = _fixture.SpannerMock.Requests();
+            CommitRequest commit = (CommitRequest)requests.Last();
+            Assert.Equal(Mutation.OperationOneofCase.InsertOrUpdate, commit.Mutations.First().OperationCase);
+            Assert.Equal("Singers", commit.Mutations.First().InsertOrUpdate.Table);
+        }
+
+        [Fact]
+        public async void ReadWriteTransaction()
+        {
+            decimal initialBudget1 = 1225250.00m;
+            decimal initialBudget2 = 2250198.28m;
+            _fixture.SpannerMock.AddOrUpdateStatementResult(
+                "SELECT MarketingBudget FROM Albums WHERE SingerId = 1 AND AlbumId = 1",
+                StatementResult.CreateSingleColumnResultSet(SpannerDbType.Numeric, "MarketingBudget", initialBudget1));
+            _fixture.SpannerMock.AddOrUpdateStatementResult(
+                "SELECT MarketingBudget FROM Albums WHERE SingerId = 2 AND AlbumId = 2",
+                StatementResult.CreateSingleColumnResultSet(SpannerDbType.Numeric, "MarketingBudget", initialBudget2));
+            string connectionString = $"Data Source=projects/p1/instances/i1/databases/d1;Host={_fixture.Host};Port={_fixture.Port}";
+
+            decimal transferAmount = 200000;
+            decimal secondBudget = 0;
+            decimal firstBudget = 0;
+
+            using (var connection = new SpannerConnection(connectionString, ChannelCredentials.Insecure))
+            {
+                await connection.OpenAsync();
+                using (var transaction = await connection.BeginTransactionAsync())
+                {
+                    // Create statement to select the second album's data.
+                    var cmdLookup = connection.CreateSelectCommand(
+                        "SELECT MarketingBudget FROM Albums WHERE SingerId = 2 AND AlbumId = 2");
+                    cmdLookup.Transaction = transaction;
+                    // Excecute the select query.
+                    using (var reader = await cmdLookup.ExecuteReaderAsync())
+                    {
+                        while (await reader.ReadAsync())
+                        {
+                            secondBudget = reader.GetNumeric(reader.GetOrdinal("MarketingBudget")).ToDecimal(LossOfPrecisionHandling.Throw);
+                        }
+                    }
+                    // Read the first album's budget.
+                    cmdLookup = connection.CreateSelectCommand(
+                        "SELECT MarketingBudget FROM Albums WHERE SingerId = 1 AND AlbumId = 1");
+                    cmdLookup.Transaction = transaction;
+                    using (var reader = await cmdLookup.ExecuteReaderAsync())
+                    {
+                        while (await reader.ReadAsync())
+                        {
+                            firstBudget = reader.GetNumeric(reader.GetOrdinal("MarketingBudget")).ToDecimal(LossOfPrecisionHandling.Throw);
+                        }
+                    }
+                    // Specify update command parameters.
+                    var cmd = connection.CreateUpdateCommand("Albums",
+                        new SpannerParameterCollection
+                        {
+                            {"SingerId", SpannerDbType.Int64},
+                            {"AlbumId", SpannerDbType.Int64},
+                            {"MarketingBudget", SpannerDbType.Numeric},
+                        });
+                    cmd.Transaction = transaction;
+                    // Update second album to remove the transfer amount.
+                    secondBudget -= transferAmount;
+                    cmd.Parameters["SingerId"].Value = 2;
+                    cmd.Parameters["AlbumId"].Value = 2;
+                    cmd.Parameters["MarketingBudget"].Value = secondBudget;
+                    await cmd.ExecuteNonQueryAsync();
+                    // Update first album to add the transfer amount.
+                    firstBudget += transferAmount;
+                    cmd.Parameters["SingerId"].Value = 1;
+                    cmd.Parameters["AlbumId"].Value = 1;
+                    cmd.Parameters["MarketingBudget"].Value = firstBudget;
+                    await cmd.ExecuteNonQueryAsync();
+
+                    await transaction.CommitAsync();
+                }
+                // Assert that the correct updates were sent.
+                Stack<IMessage> requests = new Stack<IMessage>(_fixture.SpannerMock.Requests());
+                Assert.Equal(typeof(CommitRequest), requests.Peek().GetType());
+                CommitRequest commit = (CommitRequest)requests.Pop();
+                Assert.Equal(2, commit.Mutations.Count);
+
+                Mutation update1 = commit.Mutations.Last();
+                Assert.Equal(Mutation.OperationOneofCase.Update, update1.OperationCase);
+                Assert.Equal("Albums", update1.Update.Table);
+                Assert.Equal("1", update1.Update.Values.ElementAt(0).Values.ElementAt(0).StringValue);
+                Assert.Equal(
+                    SpannerNumeric.FromDecimal(initialBudget1 + transferAmount, LossOfPrecisionHandling.Throw),
+                    SpannerNumeric.Parse(update1.Update.Values.ElementAt(0).Values.ElementAt(2).StringValue));
+
+                Mutation update2 = commit.Mutations.First();
+                Assert.Equal(Mutation.OperationOneofCase.Update, update2.OperationCase);
+                Assert.Equal("Albums", update2.Update.Table);
+                Assert.Equal("2", update2.Update.Values.ElementAt(0).Values.ElementAt(0).StringValue);
+                Assert.Equal(
+                    SpannerNumeric.FromDecimal(initialBudget2 - transferAmount, LossOfPrecisionHandling.Throw),
+                    SpannerNumeric.Parse(update2.Update.Values.ElementAt(0).Values.ElementAt(2).StringValue));
+            }
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerMockServerFixture.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerMockServerFixture.cs
@@ -1,4 +1,18 @@
-﻿using Grpc.Core;
+﻿// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Grpc.Core;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerMockServerFixture.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerMockServerFixture.cs
@@ -1,0 +1,39 @@
+﻿using Grpc.Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Google.Cloud.Spanner.Data.Tests
+{
+    public class SpannerMockServerFixture : IDisposable
+    {
+        private readonly Server _server;
+        public MockSpannerService SpannerMock { get; }
+        public string Endpoint
+        {
+            get
+            {
+                return $"{_server.Ports.ElementAt(0).Host}:{_server.Ports.ElementAt(0).BoundPort}";
+            }
+        }
+        public string Host { get { return _server.Ports.ElementAt(0).Host; } }
+        public int Port { get { return _server.Ports.ElementAt(0).BoundPort; } }
+
+        public SpannerMockServerFixture()
+        {
+            SpannerMock = new MockSpannerService();
+            _server = new Server
+            {
+                Services = { Google.Cloud.Spanner.V1.Spanner.BindService(SpannerMock) },
+                Ports = { new ServerPort("localhost", 0, ServerCredentials.Insecure) }
+            };
+            _server.Start();
+        }
+
+        public void Dispose()
+        {
+            _server.ShutdownAsync().Wait();
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/EphemeralTransaction.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/EphemeralTransaction.cs
@@ -14,6 +14,7 @@
 
 using Google.Api.Gax;
 using Google.Cloud.Spanner.V1;
+using Google.Cloud.Spanner.V1.Internal.Logging;
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -142,6 +143,18 @@ namespace Google.Cloud.Spanner.Data
                 reader.StreamClosed += delegate { session.ReleaseToPool(forceDelete: false); };
                 return reader;
             }
+        }
+
+        SpannerDataReader ISpannerTransaction.CreateDataReader(
+            ExecuteSqlRequest request,
+            Logger logger,
+            ReliableStreamReader resultSet,
+            IDisposable resourceToClose,
+            SpannerConversionOptions conversionOptions,
+            bool provideSchemaTable,
+            int readTimeoutSeconds)
+        {
+            return new SpannerDataReader(logger, resultSet, resourceToClose, conversionOptions, provideSchemaTable, readTimeoutSeconds);
         }
     }
 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/ISpannerTransaction.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/ISpannerTransaction.cs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 using Google.Cloud.Spanner.V1;
+using Google.Cloud.Spanner.V1.Internal.Logging;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -35,5 +37,14 @@ namespace Google.Cloud.Spanner.Data
         // Note: the timeout here is *not* used for the streaming result set; it's used by VolatileResourceManager to set the commit timeout.
         // (We may wish to improve this abstraction, but it works for now...)
         Task<ReliableStreamReader> ExecuteQueryAsync(ExecuteSqlRequest request, CancellationToken cancellationToken, int timeoutSeconds);
+
+        SpannerDataReader CreateDataReader(
+            ExecuteSqlRequest request,
+            Logger logger,
+            ReliableStreamReader resultSet,
+            IDisposable resourceToClose,
+            SpannerConversionOptions conversionOptions,
+            bool provideSchemaTable,
+            int readTimeoutSeconds);
     }
 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/RetriableSpannerTransaction.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/RetriableSpannerTransaction.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2019 Google LLC
+﻿// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/RetriableSpannerTransaction.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/RetriableSpannerTransaction.cs
@@ -1,0 +1,374 @@
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using Google.Apis.Auth.OAuth2.Requests;
+using Google.Cloud.Spanner.V1;
+using Google.Cloud.Spanner.V1.Internal.Logging;
+using Google.Protobuf;
+using Google.Rpc;
+using Grpc.Core;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Status = Grpc.Core.Status;
+
+namespace Google.Cloud.Spanner.Data
+{
+    internal interface IRetriableStatement
+    {
+        internal Task Retry(RetriableSpannerTransaction transaction, CancellationToken cancellationToken, int timeoutSeconds);
+    }
+
+    internal sealed class RetriableDmlStatement : IRetriableStatement
+    {
+        private readonly ExecuteSqlRequest _request;
+        private readonly long _updateCount;
+
+        internal RetriableDmlStatement(ExecuteSqlRequest request, long updateCount)
+        {
+            this._request = request;
+            this._updateCount = updateCount;
+        }
+
+        async Task IRetriableStatement.Retry(RetriableSpannerTransaction transaction, CancellationToken cancellationToken, int timeoutSeconds)
+        {
+            try
+            {
+                if (await transaction.DoExecuteDmlAsync(_request, cancellationToken, timeoutSeconds).ConfigureAwait(false) != _updateCount)
+                {
+                    throw new SpannerAbortedDueToConcurrentModificationException();
+                }
+            }
+            catch (SpannerException e) when (e.ErrorCode != ErrorCode.Aborted)
+            {
+                throw new SpannerAbortedDueToConcurrentModificationException();
+            }
+        }
+    }
+
+    internal sealed class FailedDmlStatement : IRetriableStatement
+    {
+        private readonly ExecuteSqlRequest _request;
+        private readonly SpannerException _exception;
+
+        internal FailedDmlStatement(ExecuteSqlRequest request, SpannerException exception)
+        {
+            this._request = request;
+            this._exception = exception;
+        }
+
+        async Task IRetriableStatement.Retry(RetriableSpannerTransaction transaction, CancellationToken cancellationToken, int timeoutSeconds)
+        {
+            try
+            {
+                await transaction.DoExecuteDmlAsync(_request, cancellationToken, timeoutSeconds).ConfigureAwait(false);
+                // Fallthrough and throw the exception at the end of the method.
+            }
+            catch (SpannerException e) when (e.ErrorCode != ErrorCode.Aborted)
+            {
+                // Check that we got the exact same exception this time as the previous time.
+                if (RetriableSpannerTransaction.SpannerExceptionsEqualForRetry(e, _exception))
+                {
+                    return;
+                }
+            }
+            throw new SpannerAbortedDueToConcurrentModificationException();
+        }
+    }
+
+    internal sealed class RetriableBatchDmlStatement : IRetriableStatement
+    {
+        private readonly ExecuteBatchDmlRequest _request;
+        private readonly IEnumerable<long> _updateCounts;
+
+        internal RetriableBatchDmlStatement(ExecuteBatchDmlRequest request, IEnumerable<long> updateCounts)
+        {
+            this._request = request;
+            this._updateCounts = updateCounts;
+        }
+
+        async Task IRetriableStatement.Retry(RetriableSpannerTransaction transaction, CancellationToken cancellationToken, int timeoutSeconds)
+        {
+            try
+            {
+                if (!_updateCounts.SequenceEqual(await transaction.DoExecuteBatchDmlAsync(_request, cancellationToken, timeoutSeconds).ConfigureAwait(false)))
+                {
+                    throw new SpannerAbortedDueToConcurrentModificationException();
+                }
+            }
+            catch (SpannerException e) when (e.ErrorCode != ErrorCode.Aborted)
+            {
+                throw new SpannerAbortedDueToConcurrentModificationException();
+            }
+        }
+    }
+
+    internal sealed class FailedBatchDmlStatement : IRetriableStatement
+    {
+        private readonly ExecuteBatchDmlRequest _request;
+        private readonly SpannerException _exception;
+
+        internal FailedBatchDmlStatement(ExecuteBatchDmlRequest request, SpannerException exception)
+        {
+            this._request = request;
+            this._exception = exception;
+        }
+
+        async Task IRetriableStatement.Retry(RetriableSpannerTransaction transaction, CancellationToken cancellationToken, int timeoutSeconds)
+        {
+            try
+            {
+                await transaction.DoExecuteBatchDmlAsync(_request, cancellationToken, timeoutSeconds).ConfigureAwait(false);
+                // Fallthrough and throw the exception at the end of the method.
+            }
+            catch (SpannerBatchNonQueryException e)
+            {
+                // Check that we got the exact same exception and results this time as the previous time.
+                if (_exception is SpannerBatchNonQueryException
+                    && e.ErrorCode == _exception.ErrorCode
+                    && e.Message.Equals(_exception.Message)
+                    && e.SuccessfulCommandResults.SequenceEqual(((SpannerBatchNonQueryException) _exception).SuccessfulCommandResults)
+                    )
+                {
+                    return;
+                }
+            }
+            catch (SpannerException e) when (e.ErrorCode != ErrorCode.Aborted)
+            {
+                // Check that we got the exact same exception this time as the previous time.
+                if (!(_exception is SpannerBatchNonQueryException) && RetriableSpannerTransaction.SpannerExceptionsEqualForRetry(e, _exception))
+                {
+                    return;
+                }
+            }
+            throw new SpannerAbortedDueToConcurrentModificationException();
+        }
+    }
+
+    /// <summary>
+    /// Represents a SQL transaction to be made in a Spanner database.
+    /// A transaction in Cloud Spanner is a set of reads and writes that execute
+    /// atomically at a single logical point in time across columns, rows, and
+    /// tables in a database.
+    /// 
+    /// This transaction will automatically be retried if it is aborted by the
+    /// Cloud Spanner backend.
+    /// </summary>
+    public sealed class RetriableSpannerTransaction : SpannerTransaction, ISpannerTransaction
+    {
+        internal static bool SpannerExceptionsEqualForRetry(SpannerException e1, SpannerException e2)
+        {
+            // Quick return for the most common case.
+            if (e1 == null && e2 == null)
+            {
+                return true;
+            }
+            if (!Object.Equals(e1?.ErrorCode, e2?.ErrorCode))
+            {
+                return false;
+            }
+            if (!Object.Equals(e1?.Message, e2?.Message))
+            {
+                return false;
+            }
+            if (!Object.Equals(e1?.InnerException?.GetType(), e2?.InnerException?.GetType()))
+            {
+                return false;
+            }
+            if(e1?.InnerException is RpcException)
+            {
+                Status status1 = ((RpcException)e1.InnerException).Status;
+                Status status2 = ((RpcException)e2.InnerException).Status;
+                if(!(Object.Equals(status1.StatusCode, status2.StatusCode) && Object.Equals(status1.Detail, status2.Detail)))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private const int MAX_RETRIES = 1000;
+        private const int MAX_TIMEOUT_SECONDS = Int32.MaxValue / 1000; // Max is Int32.MaxValue milliseconds.
+        private readonly IClock _clock;
+        private readonly IScheduler _scheduler;
+        private readonly RetriableTransactionOptions _options;
+        private readonly List<IRetriableStatement> _retriableStatements = new List<IRetriableStatement>();
+        private int _retryCount;
+        internal int RetryCount { get => _retryCount; }
+
+        internal RetriableSpannerTransaction(
+            SpannerConnection connection,
+            PooledSession session,
+            IClock clock,
+            IScheduler scheduler,
+            RetriableTransactionOptions options = null)
+            : base(connection, TransactionMode.ReadWrite, session, null)
+        {
+            _clock = GaxPreconditions.CheckNotNull(clock, nameof(clock));
+            _scheduler = GaxPreconditions.CheckNotNull(scheduler, nameof(scheduler));
+            _options = options ?? RetriableTransactionOptions.CreateDefault();
+        }
+
+        internal void Retry(int timeoutSeconds = MAX_TIMEOUT_SECONDS)
+        {
+            RetryAsync(CancellationToken.None, timeoutSeconds).WaitWithUnwrappedExceptions();
+        }
+
+        internal async Task RetryAsync(CancellationToken cancellationToken, int timeoutSeconds = MAX_TIMEOUT_SECONDS)
+        {
+            while (true)
+            {
+                _retryCount++;
+                Session = await (Session?.WithFreshTransactionOrNewAsync(SpannerConnection.s_readWriteTransactionOptions, cancellationToken) ?? SpannerConnection.AcquireReadWriteSessionAsync(cancellationToken)).ConfigureAwait(false);
+                try
+                {
+                    foreach (IRetriableStatement statement in _retriableStatements)
+                    {
+                        await statement.Retry(this, cancellationToken, timeoutSeconds).ConfigureAwait(false);
+                    }
+                    break;
+                } catch (SpannerAbortedDueToConcurrentModificationException e)
+                {
+                    // Retry failed because of a concurrent modification.
+                    throw e;
+                } catch (SpannerException e) when (e.ErrorCode == ErrorCode.Aborted)
+                {
+                    // Ignore and retry.
+                    if (_retryCount >= MAX_RETRIES)
+                    {
+                        throw new SpannerException(ErrorCode.Aborted, "Transaction was aborted because it aborted and retried too many times");
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Commits the database transaction asynchronously.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token used for this task.</param>
+        /// <returns>Returns the UTC timestamp when the data was written to the database.</returns>
+        public async override Task<DateTime> CommitAsync(CancellationToken cancellationToken = default)
+        {
+            while (true)
+            {
+                try
+                {
+                    return await base.CommitAsync(cancellationToken).ConfigureAwait(false);
+                }
+                catch (SpannerException e) when (e.ErrorCode == ErrorCode.Aborted)
+                {
+                    await RetryAsync(cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public override void Commit()
+        {
+            while (true)
+            {
+                try
+                {
+                    base.Commit();
+                }
+                catch (SpannerException e) when (e.ErrorCode == ErrorCode.Aborted)
+                {
+                    Retry();
+                }
+            }
+        }
+
+        Task<int> ISpannerTransaction.ExecuteMutationsAsync(List<Mutation> mutations, CancellationToken cancellationToken, int timeoutSeconds)
+        {
+            return DoExecuteMutationsAsync(mutations, cancellationToken, timeoutSeconds);
+        }
+
+        async Task<long> ISpannerTransaction.ExecuteDmlAsync(ExecuteSqlRequest request, CancellationToken cancellationToken, int timeoutSeconds)
+        {
+            while (true)
+            { 
+                try
+                {
+                    long res = await DoExecuteDmlAsync(request, cancellationToken, timeoutSeconds).ConfigureAwait(false);
+                    _retriableStatements.Add(new RetriableDmlStatement(request, res));
+                    return res;
+                }
+                catch (SpannerException e) when (e.ErrorCode == ErrorCode.Aborted)
+                {
+                    await RetryAsync(cancellationToken, timeoutSeconds).ConfigureAwait(false);
+                }
+                catch (SpannerException e)
+                {
+                    _retriableStatements.Add(new FailedDmlStatement(request, e));
+                    throw e;
+                }
+            }
+        }
+
+        async Task<IEnumerable<long>> ISpannerTransaction.ExecuteBatchDmlAsync(ExecuteBatchDmlRequest request, CancellationToken cancellationToken, int timeoutSeconds)
+        {
+            while (true)
+            {
+                try
+                {
+                    var res = await DoExecuteBatchDmlAsync(request, cancellationToken, timeoutSeconds).ConfigureAwait(false);
+                    _retriableStatements.Add(new RetriableBatchDmlStatement(request, res));
+                    return res;
+                }
+                catch (SpannerException e) when (e.ErrorCode == ErrorCode.Aborted)
+                {
+                    await RetryAsync(cancellationToken, timeoutSeconds).ConfigureAwait(false);
+                }
+                catch (SpannerException e)
+                {
+                    _retriableStatements.Add(new FailedBatchDmlStatement(request, e));
+                    throw e;
+                }
+            }
+        }
+
+        Task<ReliableStreamReader> ISpannerTransaction.ExecuteQueryAsync(ExecuteSqlRequest request, CancellationToken cancellationToken, int timeoutSeconds)
+        {
+            return DoExecuteQueryAsync(request, cancellationToken, timeoutSeconds);
+        }
+
+        SpannerDataReader ISpannerTransaction.CreateDataReader(
+            ExecuteSqlRequest request,
+            Logger logger,
+            ReliableStreamReader resultSet,
+            IDisposable resourceToClose,
+            SpannerConversionOptions conversionOptions,
+            bool provideSchemaTable,
+            int readTimeoutSeconds)
+        {
+            SpannerDataReaderWithChecksum res = new SpannerDataReaderWithChecksum(
+                this,
+                request,
+                logger,
+                resultSet,
+                resourceToClose,
+                conversionOptions,
+                provideSchemaTable,
+                readTimeoutSeconds);
+            _retriableStatements.Add(res);
+            return res;
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerAbortedDueToConcurrentModificationException.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerAbortedDueToConcurrentModificationException.cs
@@ -1,0 +1,32 @@
+﻿// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Rpc;
+using System.Collections.Generic;
+
+namespace Google.Cloud.Spanner.Data
+{
+    /// <summary>
+    /// Represents an error that will be thrown if a SpannerRetriableTransaction executes a retry and
+    /// determines that the data that the transaction is operating on has been modified by a different
+    /// transaction and must therefore abort the retry attempt.
+    /// </summary>
+    public class SpannerAbortedDueToConcurrentModificationException : SpannerException
+    {
+        internal SpannerAbortedDueToConcurrentModificationException()
+            : base(ErrorCode.Aborted, "Transaction aborted due to a concurrent modification")
+        {
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.ExecutableCommand.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.ExecutableCommand.cs
@@ -136,7 +136,7 @@ namespace Google.Cloud.Spanner.Data
                 // When the data reader is closed, we may need to dispose of the connection.
                 IDisposable resourceToClose = (behavior & CommandBehavior.CloseConnection) == CommandBehavior.CloseConnection ? Connection : null;
 
-                return new SpannerDataReader(Connection.Logger, resultSet, resourceToClose, conversionOptions, enableGetSchemaTable, CommandTimeout);
+                return effectiveTransaction.CreateDataReader(request, Connection.Logger, resultSet, resourceToClose, conversionOptions, enableGetSchemaTable, CommandTimeout);
             }
 
             internal async Task<IReadOnlyList<CommandPartition>> GetReaderPartitionsAsync(long? partitionSizeBytes, long? maxPartitions, CancellationToken cancellationToken)

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDataReaderWithChecksum.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDataReaderWithChecksum.cs
@@ -1,4 +1,18 @@
-﻿using Google.Api.Gax;
+﻿// Copyright 2020 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
 using Google.Cloud.Spanner.V1;
 using Google.Cloud.Spanner.V1.Internal.Logging;
 using Google.Protobuf;

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDataReaderWithChecksum.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDataReaderWithChecksum.cs
@@ -1,0 +1,162 @@
+﻿using Google.Api.Gax;
+using Google.Cloud.Spanner.V1;
+using Google.Cloud.Spanner.V1.Internal.Logging;
+using Google.Protobuf;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Cloud.Spanner.Data
+{
+    /// <summary>
+    /// Reads a forward-only stream of rows from a data source and keeps track of a running
+    /// checksum for all data that have been seen.
+    /// </summary>
+    public sealed class SpannerDataReaderWithChecksum : SpannerDataReader, IRetriableStatement
+    {
+        private readonly RetriableSpannerTransaction _transaction;
+        private readonly ExecuteSqlRequest _request;
+        private int _numberOfReadCalls;
+        private byte[] _currentChecksum = new byte[0];
+        private SpannerException _firstException;
+
+        internal SpannerDataReaderWithChecksum(
+            RetriableSpannerTransaction transaction,
+            ExecuteSqlRequest request,
+            Logger logger,
+            ReliableStreamReader resultSet,
+            IDisposable resourceToClose,
+            SpannerConversionOptions conversionOptions,
+            bool provideSchemaTable,
+            int readTimeoutSeconds) : base(
+                logger,
+                resultSet,
+                resourceToClose,
+                conversionOptions,
+                provideSchemaTable,
+                readTimeoutSeconds
+            )
+        {
+            _transaction = transaction;
+            _request = request;
+        }
+
+        /// <inheritdoc />
+        public override bool Read() => Task.Run(() => ReadAsync(CancellationToken.None)).ResultWithUnwrappedExceptions();
+
+        /// <inheritdoc />
+        public override Task<bool> ReadAsync(CancellationToken cancellationToken) =>
+            ExecuteHelper.WithErrorTranslationAndProfiling(async () =>
+            {
+                while (true)
+                {
+                    try
+                    {
+                        bool res = await base.ReadAsync(cancellationToken).ConfigureAwait(false);
+                        if (res)
+                        {
+                            _currentChecksum = CalculateNextChecksum(this, _currentChecksum);
+                        }
+                        _numberOfReadCalls++;
+                        return res;
+                    } catch (SpannerException e) when (e.ErrorCode == ErrorCode.Aborted)
+                    {
+                        // Retry the transaction and then retry the ReadAsync call.
+                        await _transaction.RetryAsync(cancellationToken).ConfigureAwait(false);
+                    } catch (SpannerException e)
+                    {
+                        if (_firstException == null)
+                        {
+                            _firstException = e;
+                        }
+                        _numberOfReadCalls++;
+                        throw e;
+                    }
+                }
+            }, "SpannerDataReaderWithChecksum.Read", Logger);
+
+        internal static byte[] CalculateNextChecksum(SpannerDataReader reader, byte[] currentChecksum)
+        {
+            int size = currentChecksum.Length;
+            for(int i=0; i<reader.FieldCount; i++)
+            {
+                size += reader.GetJsonValue(i).CalculateSize();
+            }
+            using (MemoryStream ms = new MemoryStream(size))
+            {
+                ms.Write(currentChecksum, 0, currentChecksum.Length);
+                using (CodedOutputStream cos = new CodedOutputStream(ms))
+                {
+                    for (int i = 0; i < reader.FieldCount; i++)
+                    {
+                        reader.GetJsonValue(i).WriteTo(cos);
+                    }
+                    // Flush the protobuf stream so everything is written to the memory stream.
+                    cos.Flush();
+                    // Then reset the memory stream to the start so the hash is calculated over all the bytes in the buffer.
+                    ms.Position = 0;
+                    SHA256 checksum = SHA256.Create();
+                    return checksum.ComputeHash(ms);
+                }
+            }
+        }
+
+        async Task IRetriableStatement.Retry(RetriableSpannerTransaction transaction, CancellationToken cancellationToken, int timeoutSeconds)
+        {
+            ReliableStreamReader streamReader = await transaction.DoExecuteQueryAsync(_request, cancellationToken, timeoutSeconds).ConfigureAwait(false);
+            SpannerDataReader reader = new SpannerDataReader(Logger, streamReader, null, ConversionOptions, false, timeoutSeconds);
+            int counter = 0;
+            bool read = true;
+            byte[] newChecksum = new byte[0];
+            SpannerException newException = null;
+            while (counter < _numberOfReadCalls && read)
+            {
+                try
+                {
+                    read = await reader.ReadAsync().ConfigureAwait(false);
+                    if (read)
+                    {
+                        newChecksum = CalculateNextChecksum(reader, newChecksum);
+                    }
+                    counter++;
+                }
+                catch (SpannerException e) when (e.ErrorCode == ErrorCode.Aborted)
+                {
+                    // Propagate Aborted errors to trigger a new retry.
+                    throw e;
+                }
+                catch (SpannerException e)
+                {
+                    newException = e;
+                    counter++;
+                    break;
+                }
+            }
+            if (counter == _numberOfReadCalls
+                && newChecksum.SequenceEqual(_currentChecksum)
+                && RetriableSpannerTransaction.SpannerExceptionsEqualForRetry(newException, _firstException))
+            {
+                // Checksum is ok, we only need to replace the delegate result set if it's still open.
+                if (IsClosed)
+                {
+                    reader.Close();
+                }
+                else
+                {
+                    ResultSet = streamReader;
+                }
+            }
+            else
+            {
+                // The results are not equal, there is an actual concurrent modification, so we cannot
+                // continue the transaction.
+                throw new SpannerAbortedDueToConcurrentModificationException();
+            }
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/VolatileResourceManager.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/VolatileResourceManager.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Api.Gax;
 using Google.Cloud.Spanner.V1;
 using Google.Cloud.Spanner.V1.Internal.Logging;
 using System;
@@ -194,6 +195,19 @@ namespace Google.Cloud.Spanner.Data
         {
             ISpannerTransaction transaction = await GetTransactionAsync(cancellationToken, timeoutSeconds).ConfigureAwait(false);
             return await transaction.ExecuteBatchDmlAsync(request, cancellationToken, timeoutSeconds).ConfigureAwait(false);
+        }
+
+        SpannerDataReader ISpannerTransaction.CreateDataReader(
+            ExecuteSqlRequest request,
+            Logger logger,
+            ReliableStreamReader resultSet,
+            IDisposable resourceToClose,
+            SpannerConversionOptions conversionOptions,
+            bool provideSchemaTable,
+            int readTimeoutSeconds)
+        {
+            ISpannerTransaction transaction = GetTransactionAsync(CancellationToken.None, 0).ResultWithUnwrappedExceptions();
+            return transaction.CreateDataReader(request, logger, resultSet, resourceToClose, conversionOptions, provideSchemaTable, readTimeoutSeconds);
         }
 
         private async Task<SpannerTransaction> GetTransactionAsync(CancellationToken cancellationToken, int timeoutSeconds)


### PR DESCRIPTION
Adds automatic retries of `Aborted` transactions when using the normal ADO.NET transactions (i.e. not using `SpannerConnection.RunWithRetriableTransactionAsync(..)`).