### PR TITLE
[Translate]: Loosens HTML translation tests to avoid flakiness.

### DIFF
--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.Snippets/TranslationClientSnippets.cs
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.Snippets/TranslationClientSnippets.cs
@@ -93,7 +93,7 @@ namespace Google.Cloud.Translation.V2.Snippets
             Console.WriteLine($"Result: {result.TranslatedText}; detected language {result.DetectedSourceLanguage}");
             // End sample
 
-            Assert.Equal("<p> <strong>Il pleut.</strong> </p>", result.TranslatedText);
+            Assert.Equal("<p> <strong>Il pleut.</strong> </p>", result.TranslatedText, ignoreWhiteSpaceDifferences:true);
             Assert.Equal("en", result.DetectedSourceLanguage);
         }
 
@@ -106,7 +106,7 @@ namespace Google.Cloud.Translation.V2.Snippets
             Console.WriteLine($"Result: {result.TranslatedText}; detected language {result.DetectedSourceLanguage}");
             // End snippet
 
-            Assert.Equal("<p> <strong>Il pleut.</strong> </p>", result.TranslatedText);
+            Assert.Equal("<p> <strong>Il pleut.</strong> </p>", result.TranslatedText, ignoreWhiteSpaceDifferences: true);
             Assert.Equal("en", result.DetectedSourceLanguage);
         }
 
@@ -151,9 +151,9 @@ namespace Google.Cloud.Translation.V2.Snippets
             }
             // End sample
 
-            Assert.Equal("<p> <strong>Il pleut.</strong> </p>", results[0].TranslatedText);
+            Assert.Equal("<p> <strong>Il pleut.</strong> </p>", results[0].TranslatedText, ignoreWhiteSpaceDifferences: true);
             Assert.Equal("en", results[0].DetectedSourceLanguage);
-            Assert.Equal("<p> <strong>C&#39;est ensoleillé.</strong> </p>", results[1].TranslatedText);
+            Assert.Equal("<p> <strong>C&#39;est ensoleillé.</strong> </p>", results[1].TranslatedText, ignoreWhiteSpaceDifferences: true);
             Assert.Equal("en", results[1].DetectedSourceLanguage);
         }
 


### PR DESCRIPTION
HTLM Translation Snippets:

- Windows build failed today because the results didn't have spaces sorrounding the paragraph elements.
- Ubuntu build (and locally) passed with the spaces sorrounding the paragraph elements.
- So, ignore whitespace diferences when checking results.