### PR TITLE
Release Google.Cloud.Asset.V1 version 2.5.0-beta01

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Each package name links to the documentation for that package.
 | [Google.Analytics.Admin.V1Alpha](https://googleapis.dev/dotnet/Google.Analytics.Admin.V1Alpha/1.0.0-alpha01) | 1.0.0-alpha01 | Analytics Admin API |
 | [Google.Analytics.Data.V1Alpha](https://googleapis.dev/dotnet/Google.Analytics.Data.V1Alpha/1.0.0-alpha01) | 1.0.0-alpha01 | Google Analytics Data API |
 | [Google.Area120.Tables.V1Alpha1](https://googleapis.dev/dotnet/Google.Area120.Tables.V1Alpha1/1.0.0-alpha01) | 1.0.0-alpha01 | Google Area 120 Tables API |
-| [Google.Cloud.Asset.V1](https://googleapis.dev/dotnet/Google.Cloud.Asset.V1/2.4.0) | 2.4.0 | [Google Cloud Asset Inventory](https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview) |
+| [Google.Cloud.Asset.V1](https://googleapis.dev/dotnet/Google.Cloud.Asset.V1/2.5.0-beta01) | 2.5.0-beta01 | [Google Cloud Asset Inventory](https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview) |
 | [Google.Cloud.AssuredWorkloads.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.AssuredWorkloads.V1Beta1/1.0.0-beta01) | 1.0.0-beta01 | [Assured Workloads API](https://cloud.google.com/assured-workloads/docs) |
 | [Google.Cloud.AutoML.V1](https://googleapis.dev/dotnet/Google.Cloud.AutoML.V1/2.0.0) | 2.0.0 | [Google AutoML](https://cloud.google.com/automl/) |
 | [Google.Cloud.BigQuery.Connection.V1](https://googleapis.dev/dotnet/Google.Cloud.BigQuery.Connection.V1/1.0.0) | 1.0.0 | [BigQuery Connection API](https://cloud.google.com/bigquery/docs/reference/bigqueryconnection) |

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.csproj
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.4.0</Version>
+    <Version>2.5.0-beta01</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Asset Inventory API (v1).</Description>

--- a/apis/Google.Cloud.Asset.V1/docs/history.md
+++ b/apis/Google.Cloud.Asset.V1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+# Version 2.5.0-beta01, released 2020-09-24
+
+- [Commit 0ca05f5](https://github.com/googleapis/google-cloud-dotnet/commit/0ca05f5): Regenerate all APIs using protoc 3.13 and Grpc.Tools 2.31.
+
+  Note that the change in gRPC generation is *just possibly* breaking,
+  as it changes a constructor parameter type (to a base type). This is
+  far less likely to break anyone than changing a *method* parameter,
+  as method group conversions aren't involved. It also removes the
+  dependency on Grpc.Core from the generated code.
+- [Commit 6eed2d8](https://github.com/googleapis/google-cloud-dotnet/commit/6eed2d8): feat: added support for per type and partition export for Cloud Asset API.
+
 # Version 2.4.0, released 2020-09-15
 
 - [Commit c9ca107](https://github.com/googleapis/google-cloud-dotnet/commit/c9ca107): Remove AnalyzeIamPolicy and ExportIamPolicyAnalysis RPCs

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -45,7 +45,7 @@
       "protoPath": "google/cloud/asset/v1",
       "productName": "Google Cloud Asset Inventory",
       "productUrl": "https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview",
-      "version": "2.4.0",
+      "version": "2.5.0-beta01",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Asset Inventory API (v1).",
       "dependencies": {

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -21,7 +21,7 @@ Each package name links to the documentation for that package.
 | [Google.Analytics.Admin.V1Alpha](Google.Analytics.Admin.V1Alpha/index.html) | 1.0.0-alpha01 | Analytics Admin API |
 | [Google.Analytics.Data.V1Alpha](Google.Analytics.Data.V1Alpha/index.html) | 1.0.0-alpha01 | Google Analytics Data API |
 | [Google.Area120.Tables.V1Alpha1](Google.Area120.Tables.V1Alpha1/index.html) | 1.0.0-alpha01 | Google Area 120 Tables API |
-| [Google.Cloud.Asset.V1](Google.Cloud.Asset.V1/index.html) | 2.4.0 | [Google Cloud Asset Inventory](https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview) |
+| [Google.Cloud.Asset.V1](Google.Cloud.Asset.V1/index.html) | 2.5.0-beta01 | [Google Cloud Asset Inventory](https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview) |
 | [Google.Cloud.AssuredWorkloads.V1Beta1](Google.Cloud.AssuredWorkloads.V1Beta1/index.html) | 1.0.0-beta01 | [Assured Workloads API](https://cloud.google.com/assured-workloads/docs) |
 | [Google.Cloud.AutoML.V1](Google.Cloud.AutoML.V1/index.html) | 2.0.0 | [Google AutoML](https://cloud.google.com/automl/) |
 | [Google.Cloud.BigQuery.Connection.V1](Google.Cloud.BigQuery.Connection.V1/index.html) | 1.0.0 | [BigQuery Connection API](https://cloud.google.com/bigquery/docs/reference/bigqueryconnection) |


### PR DESCRIPTION
Changes in this release:

- [Commit 0ca05f5](https://github.com/googleapis/google-cloud-dotnet/commit/0ca05f5): Regenerate all APIs using protoc 3.13 and Grpc.Tools 2.31.
Note that the change in gRPC generation is *just possibly* breaking, as it changes a constructor parameter type (to a base type). This is far less likely to break anyone than changing a *method* parameter, as method group conversions aren't involved. It also removes the dependency on Grpc.Core from the generated code.
- [Commit 6eed2d8](https://github.com/googleapis/google-cloud-dotnet/commit/6eed2d8): feat: added support for per type and partition export for Cloud Asset API.
