### PR TITLE
Change Span ID format string to improve Trace list consistency

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/TraceContextForLogEntry.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/TraceContextForLogEntry.cs
@@ -62,7 +62,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         internal static TraceContextForLogEntry FromExternalTrace(IServiceProvider serviceProvider) =>
             serviceProvider?.GetService<IExternalTraceProvider>()?.GetCurrentTraceContext(serviceProvider);
 
-        private static string SpanIdToHex(ulong? spanId) => spanId is null ? null : string.Format("0x{0:X}", spanId);
+        private static string SpanIdToHex(ulong? spanId) => spanId is null ? null : $"{spanId:x}";
 
     }
 }

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/TraceContextForLogEntry.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Logging/TraceContextForLogEntry.cs
@@ -62,7 +62,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore
         internal static TraceContextForLogEntry FromExternalTrace(IServiceProvider serviceProvider) =>
             serviceProvider?.GetService<IExternalTraceProvider>()?.GetCurrentTraceContext(serviceProvider);
 
-        private static string SpanIdToHex(ulong? spanId) => spanId is null ? null : $"{spanId:x}";
+        private static string SpanIdToHex(ulong? spanId) => spanId is null ? null : $"{spanId:x16}";
 
     }
 }


### PR DESCRIPTION
When viewing traces in Cloud Console Trace list, the span IDs are displayed as lower-case hex strings without the "0x" prefix.
When logging using this library, the span ID is set to an upper-case hex string with a "0x" prefix. While it isn't wrong, it seems out of place in Trace list and this PR has an easy fix to improve it.

**Without this PR:**

![Before 1](https://user-images.githubusercontent.com/3020941/94227174-a5b0dd00-fec7-11ea-8bc8-99bb30ce2f46.png)

![Before 2](https://user-images.githubusercontent.com/3020941/94227175-a6497380-fec7-11ea-87d7-ce26ae736371.png)

**With this PR:**

![New 1](https://user-images.githubusercontent.com/3020941/94227181-b1040880-fec7-11ea-86fb-c855048e6c2d.png)

![New 2](https://user-images.githubusercontent.com/3020941/94227185-b1040880-fec7-11ea-936e-2b6c6c209f08.png)

As you can see, the organization is still correct, but the span ID is now consistent with the rest of the span IDs shown in Trace list.