### PR TITLE
Trust SpannerClientCreationOptions to connect to the emulator

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.ExecutableCommand.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.ExecutableCommand.cs
@@ -218,9 +218,9 @@ namespace Google.Cloud.Spanner.Data
                 {
                     var databaseAdminClient = new DatabaseAdminClientBuilder
                     {
-                        CallInvoker = channel.CreateCallInvoker(),
+                        // Note: deliberately not copying EmulatorDetection, as that's handled in SpannerClientCreationOptions
+                        CallInvoker = channel?.CreateCallInvoker(),
                         Settings = s_databaseAdminSettings,
-                        EmulatorDetection = builder.EmulatorDetection
                     }.Build();
                     if (CommandTextBuilder.IsCreateDatabaseCommand)
                     {


### PR DESCRIPTION
We already have the correct channel set up - we don't need to let
DatabaseAdminClientBuilder know that we might be talking to the
emulator.

Fixes #5362.

(Note that adding an actual test for this would be really tricky. I've tested it locally with the sample code in the issue though.)