### PR TITLE
Release Google.Cloud.Diagnostics packages version 4.2.0-beta01

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Debugger.V2](https://googleapis.dev/dotnet/Google.Cloud.Debugger.V2/2.0.0) | 2.0.0 | [Google Cloud Debugger](https://cloud.google.com/debugger/) |
 | [Google.Cloud.DevTools.Common](https://googleapis.dev/dotnet/Google.Cloud.DevTools.Common/2.0.0) | 2.0.0 | Common Protocol Buffer messages for Google Cloud Developer Tools APIs |
 | [Google.Cloud.DevTools.ContainerAnalysis.V1](https://googleapis.dev/dotnet/Google.Cloud.DevTools.ContainerAnalysis.V1/2.0.0) | 2.0.0 | [Google Container Analysis](https://cloud.google.com/container-registry/docs/container-analysis/) |
-| [Google.Cloud.Diagnostics.AspNetCore](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.AspNetCore/4.1.0) | 4.1.0 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core |
-| [Google.Cloud.Diagnostics.Common](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.Common/4.1.0) | 4.1.0 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries Common Components |
+| [Google.Cloud.Diagnostics.AspNetCore](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.AspNetCore/4.2.0-beta01) | 4.2.0-beta01 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core |
+| [Google.Cloud.Diagnostics.Common](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.Common/4.2.0-beta01) | 4.2.0-beta01 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries Common Components |
 | [Google.Cloud.Dialogflow.V2](https://googleapis.dev/dotnet/Google.Cloud.Dialogflow.V2/3.0.0) | 3.0.0 | [Google Cloud Dialogflow](https://cloud.google.com/dialogflow-enterprise/) |
 | [Google.Cloud.Dlp.V2](https://googleapis.dev/dotnet/Google.Cloud.Dlp.V2/3.0.0) | 3.0.0 | [Google Cloud Data Loss Prevention](https://cloud.google.com/dlp/) |
 | [Google.Cloud.DocumentAI.V1Beta2](https://googleapis.dev/dotnet/Google.Cloud.DocumentAI.V1Beta2/1.0.0-beta01) | 1.0.0-beta01 | [Cloud Document AI](https://cloud.google.com/solutions/document-ai) |

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.1.0</Version>
+    <Version>4.2.0-beta01</Version>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core.</Description>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/docs/history.md
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+# Version 4.2.0-beta01, released 2020-09-29
+
+- [Commit 5710321](https://github.com/googleapis/google-cloud-dotnet/commit/5710321): feat: Adds GoogleTraceProvider to be used by Logging when Tracing is not configured. Closes [issue 5359](https://github.com/googleapis/google-cloud-dotnet/issues/5359).
+- [Commit f46b1c6](https://github.com/googleapis/google-cloud-dotnet/commit/f46b1c6): fix: Corrects Span ID format for adding to Log Entries. Fixes [issue 5358](https://github.com/googleapis/google-cloud-dotnet/issues/5358).
+- [Commit 924c503](https://github.com/googleapis/google-cloud-dotnet/commit/924c503): docs: Adds documentation about environments that limit background activities. Closes [issue 5275](https://github.com/googleapis/google-cloud-dotnet/issues/5275).
+- [Commit 7480149](https://github.com/googleapis/google-cloud-dotnet/commit/7480149): fix: Sets LogEntry.TraceSampled to true if tracing information is adding to the entry. Fixes [issue 5307](https://github.com/googleapis/google-cloud-dotnet/issues/5307).
+
 # Version 4.1.0, released 2020-08-18
 
 No changes compared with 4.1.0-beta01

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.1.0</Version>
+    <Version>4.2.0-beta01</Version>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries Common Components.</Description>

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -434,7 +434,7 @@
     },
     {
       "id": "Google.Cloud.Diagnostics.AspNetCore",
-      "version": "4.1.0",
+      "version": "4.2.0-beta01",
       "type": "other",
       "targetFrameworks": "netstandard2.0",
       "testTargetFrameworks": "netcoreapp2.1;net461",
@@ -470,7 +470,7 @@
     },
     {
       "id": "Google.Cloud.Diagnostics.Common",
-      "version": "4.1.0",
+      "version": "4.2.0-beta01",
       "type": "other",
       "targetFrameworks": "netstandard2.0",
       "testTargetFrameworks": "netcoreapp2.1;net461",

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -42,8 +42,8 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Debugger.V2](Google.Cloud.Debugger.V2/index.html) | 2.0.0 | [Google Cloud Debugger](https://cloud.google.com/debugger/) |
 | [Google.Cloud.DevTools.Common](Google.Cloud.DevTools.Common/index.html) | 2.0.0 | Common Protocol Buffer messages for Google Cloud Developer Tools APIs |
 | [Google.Cloud.DevTools.ContainerAnalysis.V1](Google.Cloud.DevTools.ContainerAnalysis.V1/index.html) | 2.0.0 | [Google Container Analysis](https://cloud.google.com/container-registry/docs/container-analysis/) |
-| [Google.Cloud.Diagnostics.AspNetCore](Google.Cloud.Diagnostics.AspNetCore/index.html) | 4.1.0 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core |
-| [Google.Cloud.Diagnostics.Common](Google.Cloud.Diagnostics.Common/index.html) | 4.1.0 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries Common Components |
+| [Google.Cloud.Diagnostics.AspNetCore](Google.Cloud.Diagnostics.AspNetCore/index.html) | 4.2.0-beta01 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core |
+| [Google.Cloud.Diagnostics.Common](Google.Cloud.Diagnostics.Common/index.html) | 4.2.0-beta01 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries Common Components |
 | [Google.Cloud.Dialogflow.V2](Google.Cloud.Dialogflow.V2/index.html) | 3.0.0 | [Google Cloud Dialogflow](https://cloud.google.com/dialogflow-enterprise/) |
 | [Google.Cloud.Dlp.V2](Google.Cloud.Dlp.V2/index.html) | 3.0.0 | [Google Cloud Data Loss Prevention](https://cloud.google.com/dlp/) |
 | [Google.Cloud.DocumentAI.V1Beta2](Google.Cloud.DocumentAI.V1Beta2/index.html) | 1.0.0-beta01 | [Cloud Document AI](https://cloud.google.com/solutions/document-ai) |


### PR DESCRIPTION

Changes in this release:
- [Commit 5710321](https://github.com/googleapis/google-cloud-dotnet/commit/5710321): feat: Adds GoogleTraceProvider to be used by Logging when Tracing is not configured. Closes [issue 5359](https://github.com/googleapis/google-cloud-dotnet/issues/5359).
- [Commit f46b1c6](https://github.com/googleapis/google-cloud-dotnet/commit/f46b1c6): fix: Corrects Span ID format for adding to Log Entries. Fixes [issue 5358](https://github.com/googleapis/google-cloud-dotnet/issues/5358).
- [Commit 924c503](https://github.com/googleapis/google-cloud-dotnet/commit/924c503): docs: Adds documentation about environments that limit background activities. Closes [issue 5275](https://github.com/googleapis/google-cloud-dotnet/issues/5275).
- [Commit 7480149](https://github.com/googleapis/google-cloud-dotnet/commit/7480149): fix: Sets LogEntry.TraceSampled to true if tracing information is adding to the entry. Fixes [issue 5307](https://github.com/googleapis/google-cloud-dotnet/issues/5307).

Packages in this release:

- Release Google.Cloud.Diagnostics.Common version 4.2.0-beta01
- Release Google.Cloud.Diagnostics.AspNetCore version 4.2.0-beta01
