### PR TITLE
For all but patch releases, update known dependencies

### DIFF
--- a/tools/Google.Cloud.Tools.ReleaseManager/SetVersionCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/SetVersionCommand.cs
@@ -35,6 +35,10 @@ namespace Google.Cloud.Tools.ReleaseManager
 
             string oldVersion = api.Version;
             api.Version = version;
+            if (api.StructuredVersion.Patch == 0)
+            {
+                GenerateProjectsCommand.UpdateDependencies(api);
+            }
             var layout = DirectoryLayout.ForApi(id);
             var apiNames = catalog.CreateIdHashSet();
             GenerateProjectsCommand.GenerateMetadataFile(layout.SourceDirectory, api);


### PR DESCRIPTION
This change also expands the list of known defaulted dependencies.

(We don't *downgrade* a dependency though.)