### PR TITLE
Release Google.Cloud.Talent.V4 version 1.0.0-beta02

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Speech.V1](https://googleapis.dev/dotnet/Google.Cloud.Speech.V1/2.0.0) | 2.0.0 | [Google Cloud Speech (V1 API)](https://cloud.google.com/speech) |
 | [Google.Cloud.Speech.V1P1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Speech.V1P1Beta1/2.0.0-beta02) | 2.0.0-beta02 | [Google Cloud Speech (V1P1Beta1 API)](https://cloud.google.com/speech) |
 | [Google.Cloud.Storage.V1](https://googleapis.dev/dotnet/Google.Cloud.Storage.V1/3.4.0-beta01) | 3.4.0-beta01 | [Google Cloud Storage](https://cloud.google.com/storage/) |
-| [Google.Cloud.Talent.V4](https://googleapis.dev/dotnet/Google.Cloud.Talent.V4/1.0.0-beta01) | 1.0.0-beta01 | [Google Cloud Talent Solution (V4 API)](https://cloud.google.com/talent-solution/) |
+| [Google.Cloud.Talent.V4](https://googleapis.dev/dotnet/Google.Cloud.Talent.V4/1.0.0-beta02) | 1.0.0-beta02 | [Google Cloud Talent Solution (V4 API)](https://cloud.google.com/talent-solution/) |
 | [Google.Cloud.Talent.V4Beta1](https://googleapis.dev/dotnet/Google.Cloud.Talent.V4Beta1/2.0.0-beta03) | 2.0.0-beta03 | [Google Cloud Talent Solution (V4Beta1 API)](https://cloud.google.com/talent-solution/) |
 | [Google.Cloud.Tasks.V2](https://googleapis.dev/dotnet/Google.Cloud.Tasks.V2/2.0.0) | 2.0.0 | [Google Cloud Tasks (V2 API)](https://cloud.google.com/tasks/) |
 | [Google.Cloud.Tasks.V2Beta3](https://googleapis.dev/dotnet/Google.Cloud.Tasks.V2Beta3/2.0.0-beta02) | 2.0.0-beta02 | [Google Cloud Tasks (V2Beta3 API)](https://cloud.google.com/tasks/) |

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.csproj
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Talent solution API (v4) which provides the capability to create, read, update, and delete job postings, as well as search jobs based on keywords and filters.</Description>

--- a/apis/Google.Cloud.Talent.V4/docs/history.md
+++ b/apis/Google.Cloud.Talent.V4/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+# Version 1.0.0-beta02, released 2020-10-01
+
+- [Commit f4c1f60](https://github.com/googleapis/google-cloud-dotnet/commit/f4c1f60): fix!: removed Cycling and Walking elements from CommuteMethod enum
+- [Commit 0ca05f5](https://github.com/googleapis/google-cloud-dotnet/commit/0ca05f5): Regenerate all APIs using protoc 3.13 and Grpc.Tools 2.31
+
+Please note the breaking change of removing CommuteMethod.Cycling and CommuteMethod.Walking. (No major version bump as the library is still in beta.)
+
 # Version 1.0.0-beta01, released 2020-09-15
 
 First beta release of GA v4 API.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1487,7 +1487,7 @@
     },
     {
       "id": "Google.Cloud.Talent.V4",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Google Cloud Talent Solution",
       "productUrl": "https://cloud.google.com/talent-solution/",

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -93,7 +93,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Speech.V1](Google.Cloud.Speech.V1/index.html) | 2.0.0 | [Google Cloud Speech (V1 API)](https://cloud.google.com/speech) |
 | [Google.Cloud.Speech.V1P1Beta1](Google.Cloud.Speech.V1P1Beta1/index.html) | 2.0.0-beta02 | [Google Cloud Speech (V1P1Beta1 API)](https://cloud.google.com/speech) |
 | [Google.Cloud.Storage.V1](Google.Cloud.Storage.V1/index.html) | 3.4.0-beta01 | [Google Cloud Storage](https://cloud.google.com/storage/) |
-| [Google.Cloud.Talent.V4](Google.Cloud.Talent.V4/index.html) | 1.0.0-beta01 | [Google Cloud Talent Solution (V4 API)](https://cloud.google.com/talent-solution/) |
+| [Google.Cloud.Talent.V4](Google.Cloud.Talent.V4/index.html) | 1.0.0-beta02 | [Google Cloud Talent Solution (V4 API)](https://cloud.google.com/talent-solution/) |
 | [Google.Cloud.Talent.V4Beta1](Google.Cloud.Talent.V4Beta1/index.html) | 2.0.0-beta03 | [Google Cloud Talent Solution (V4Beta1 API)](https://cloud.google.com/talent-solution/) |
 | [Google.Cloud.Tasks.V2](Google.Cloud.Tasks.V2/index.html) | 2.0.0 | [Google Cloud Tasks (V2 API)](https://cloud.google.com/tasks/) |
 | [Google.Cloud.Tasks.V2Beta3](Google.Cloud.Tasks.V2Beta3/index.html) | 2.0.0-beta02 | [Google Cloud Tasks (V2Beta3 API)](https://cloud.google.com/tasks/) |


### PR DESCRIPTION

Changes in this release:

- [Commit f4c1f60](https://github.com/googleapis/google-cloud-dotnet/commit/f4c1f60): fix!: removed Cycling and Walking elements from CommuteMethod enum
- [Commit 0ca05f5](https://github.com/googleapis/google-cloud-dotnet/commit/0ca05f5): Regenerate all APIs using protoc 3.13 and Grpc.Tools 2.31

Please note the breaking change of removing CommuteMethod.Cycling and CommuteMethod.Walking. (No major version bump as the library is still in beta.)
