### PR TITLE
Fix generation by removing a previous tweak

### DIFF
--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/postgeneration.sh
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/postgeneration.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-set -e
-
-# Just add a using directive in a single file; it's not worth
-# using the source manipulation code for this.
-sed -i '19 i \ \ \ \ using Grafeas.V1;' Google.Cloud.DevTools.ContainerAnalysis.V1.Snippets/ContainerAnalysisClientSnippets.g.cs
-


### PR DESCRIPTION
This is a legacy from preivous resource name generation (and API
configuration). The using directive is no longer required - and
actively interferes in this case as `ProjectName` is present in both
Grafeas.V1 and Google.Api.Gax.ResourceNames.