### PR TITLE
Release Google.Cloud.Firestore version 2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.DocumentAI.V1Beta2](https://googleapis.dev/dotnet/Google.Cloud.DocumentAI.V1Beta2/1.0.0-beta01) | 1.0.0-beta01 | [Cloud Document AI](https://cloud.google.com/solutions/document-ai) |
 | [Google.Cloud.ErrorReporting.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.ErrorReporting.V1Beta1/2.0.0-beta02) | 2.0.0-beta02 | [Google Cloud Error Reporting](https://cloud.google.com/error-reporting/) |
 | [Google.Cloud.Firestore.Admin.V1](https://googleapis.dev/dotnet/Google.Cloud.Firestore.Admin.V1/2.0.0) | 2.0.0 | [Firestore Administration (e.g. index management)](https://firebase.google.com) |
-| [Google.Cloud.Firestore](https://googleapis.dev/dotnet/Google.Cloud.Firestore/2.1.0) | 2.1.0 | [Firestore high-level library](https://firebase.google.com/docs/firestore/) |
-| [Google.Cloud.Firestore.V1](https://googleapis.dev/dotnet/Google.Cloud.Firestore.V1/2.0.0) | 2.0.0 | [Firestore low-level API access](https://firebase.google.com) |
+| [Google.Cloud.Firestore](https://googleapis.dev/dotnet/Google.Cloud.Firestore/2.2.0) | 2.2.0 | [Firestore high-level library](https://firebase.google.com/docs/firestore/) |
+| [Google.Cloud.Firestore.V1](https://googleapis.dev/dotnet/Google.Cloud.Firestore.V1/2.1.0) | 2.1.0 | [Firestore low-level API access](https://firebase.google.com) |
 | [Google.Cloud.Functions.V1](https://googleapis.dev/dotnet/Google.Cloud.Functions.V1/1.0.0-beta01) | 1.0.0-beta01 | [Cloud Functions API](https://cloud.google.com/functions) |
 | [Google.Cloud.Gaming.V1](https://googleapis.dev/dotnet/Google.Cloud.Gaming.V1/1.0.0-beta01) | 1.0.0-beta01 | [Game Services API](https://cloud.google.com/solutions/gaming) |
 | [Google.Cloud.Gaming.V1Beta](https://googleapis.dev/dotnet/Google.Cloud.Gaming.V1Beta/1.0.0-beta05) | 1.0.0-beta05 | [Google Cloud for Games](https://cloud.google.com/solutions/gaming) |

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.csproj
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Low-level Google client library to access the Firestore API. Users are recommended to use the Google.Cloud.Firestore package instead.</Description>

--- a/apis/Google.Cloud.Firestore.V1/docs/history.md
+++ b/apis/Google.Cloud.Firestore.V1/docs/history.md
@@ -4,6 +4,18 @@ This package is primarily a dependency of Google.Cloud.Firestore. See the
 [Google.Cloud.Firestore version history](https://googleapis.dev/dotnet/Google.Cloud.Firestore/latest/history.html)
 for more details.
 
+# Version 2.1.0, released 2020-10-05
+
+- [Commit 0790924](https://github.com/googleapis/google-cloud-dotnet/commit/0790924): fix: Add gRPC compatibility constructors
+- [Commit 0ca05f5](https://github.com/googleapis/google-cloud-dotnet/commit/0ca05f5): chore: Regenerate all APIs using protoc 3.13 and Grpc.Tools 2.31
+- [Commit afbd7c4](https://github.com/googleapis/google-cloud-dotnet/commit/afbd7c4): feat: firestore: add `!=` support
+- [Commit 6bde7a3](https://github.com/googleapis/google-cloud-dotnet/commit/6bde7a3): docs: Regenerate all APIs with service comments in client documentation
+- [Commit c39c12c](https://github.com/googleapis/google-cloud-dotnet/commit/c39c12c): chore: add BatchWrite to service config
+- [Commit f83bdf1](https://github.com/googleapis/google-cloud-dotnet/commit/f83bdf1): fix: Regenerate all APIs with generator changes (fixes retries)
+- [Commit 71492d2](https://github.com/googleapis/google-cloud-dotnet/commit/71492d2): feat: retry CommitRequests that fail with UNAVAILABLE
+- [Commit 8264d69](https://github.com/googleapis/google-cloud-dotnet/commit/8264d69): feat: add BatchWrite and PartitionQuery ([issue 5013](https://github.com/googleapis/google-cloud-dotnet/issues/5013))
+- [Commit 947a573](https://github.com/googleapis/google-cloud-dotnet/commit/947a573): docs: Regenerate all clients with more explicit documentation
+
 # Version 2.0.0, released 2020-05-12
 
 No API surface changes.

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Google.Cloud.Firestore.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Google.Cloud.Firestore.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Firestore API.</Description>

--- a/apis/Google.Cloud.Firestore/docs/history.md
+++ b/apis/Google.Cloud.Firestore/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+# Version 2.2.0, released 2020-10-05
+
+- [Commit 8698c6e](https://github.com/googleapis/google-cloud-dotnet/commit/8698c6e): docs: Improve "where in/not-in" documentation slightly
+- [Commit e35d18b](https://github.com/googleapis/google-cloud-dotnet/commit/e35d18b): feat: Add "where not in" Firestore query support
+- [Commit 1f3168e](https://github.com/googleapis/google-cloud-dotnet/commit/1f3168e): feat: Add "where not equal" support for Firestore
+- [Commit ef55349](https://github.com/googleapis/google-cloud-dotnet/commit/ef55349): chore: Simplify WriteBatch implementation in line with internal guidance
+- [Commit 310a1cb](https://github.com/googleapis/google-cloud-dotnet/commit/310a1cb): chore: Refactor WriteBatch now that every update is just a single Write
+- [Commit 94375e9](https://github.com/googleapis/google-cloud-dotnet/commit/94375e9): chore: Fix conformance tests, by using update transforms
+- [Commit eddc395](https://github.com/googleapis/google-cloud-dotnet/commit/eddc395): fix: Fix WhereIn filters being used in implicit orderings
+- [Commit bb09597](https://github.com/googleapis/google-cloud-dotnet/commit/bb09597): feat: Allow general iterable objects to be serialized (but not deserialized) in Firestore
+
 # Version 2.1.0, released 2020-06-02
 
 - [Commit 48cef0e](https://github.com/googleapis/google-cloud-dotnet/commit/48cef0e): Allow nested arrays to be constructed client-side, relying on server-side validation

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -603,7 +603,7 @@
       "productName": "Firestore",
       "productUrl": "https://firebase.google.com/docs/firestore/",
       "listingDescription": "Firestore high-level library",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "type": "other",
       "targetFrameworks": "netstandard2.0;net461",
       "testTargetFrameworks": "netcoreapp2.1;net461",
@@ -619,8 +619,8 @@
         "System.Linq.Async": "4.0.0"
       },
       "testDependencies": {
-        "Google.Api.Gax.Testing": "3.2.0",
         "Google.Api.Gax.Grpc.Testing": "3.2.0",
+        "Google.Api.Gax.Testing": "3.2.0",
         "Grpc.Core.Testing": "2.31.0",
         "System.ValueTuple": "4.5.0",
         "Xunit.Combinatorial": "1.2.7"
@@ -633,7 +633,7 @@
       "productName": "Firestore",
       "productUrl": "https://firebase.google.com",
       "listingDescription": "Firestore low-level API access",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "type": "grpc",
       "targetFrameworks": "netstandard2.0;net461",
       "testTargetFrameworks": "netcoreapp2.1;net461",
@@ -643,8 +643,8 @@
         "firebase"
       ],
       "dependencies": {
-        "Google.LongRunning": "2.0.0",
         "Google.Api.Gax.Grpc.GrpcCore": "3.2.0",
+        "Google.LongRunning": "2.0.0",
         "Grpc.Core": "2.31.0"
       }
     },

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -49,8 +49,8 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.DocumentAI.V1Beta2](Google.Cloud.DocumentAI.V1Beta2/index.html) | 1.0.0-beta01 | [Cloud Document AI](https://cloud.google.com/solutions/document-ai) |
 | [Google.Cloud.ErrorReporting.V1Beta1](Google.Cloud.ErrorReporting.V1Beta1/index.html) | 2.0.0-beta02 | [Google Cloud Error Reporting](https://cloud.google.com/error-reporting/) |
 | [Google.Cloud.Firestore.Admin.V1](Google.Cloud.Firestore.Admin.V1/index.html) | 2.0.0 | [Firestore Administration (e.g. index management)](https://firebase.google.com) |
-| [Google.Cloud.Firestore](Google.Cloud.Firestore/index.html) | 2.1.0 | [Firestore high-level library](https://firebase.google.com/docs/firestore/) |
-| [Google.Cloud.Firestore.V1](Google.Cloud.Firestore.V1/index.html) | 2.0.0 | [Firestore low-level API access](https://firebase.google.com) |
+| [Google.Cloud.Firestore](Google.Cloud.Firestore/index.html) | 2.2.0 | [Firestore high-level library](https://firebase.google.com/docs/firestore/) |
+| [Google.Cloud.Firestore.V1](Google.Cloud.Firestore.V1/index.html) | 2.1.0 | [Firestore low-level API access](https://firebase.google.com) |
 | [Google.Cloud.Functions.V1](Google.Cloud.Functions.V1/index.html) | 1.0.0-beta01 | [Cloud Functions API](https://cloud.google.com/functions) |
 | [Google.Cloud.Gaming.V1](Google.Cloud.Gaming.V1/index.html) | 1.0.0-beta01 | [Game Services API](https://cloud.google.com/solutions/gaming) |
 | [Google.Cloud.Gaming.V1Beta](Google.Cloud.Gaming.V1Beta/index.html) | 1.0.0-beta05 | [Google Cloud for Games](https://cloud.google.com/solutions/gaming) |


### PR DESCRIPTION

Changes to Google.Cloud.Firestore since version 2.1.0:

- [Commit 8698c6e](https://github.com/googleapis/google-cloud-dotnet/commit/8698c6e): docs: Improve "where in/not-in" documentation slightly
- [Commit e35d18b](https://github.com/googleapis/google-cloud-dotnet/commit/e35d18b): feat: Add "where not in" Firestore query support
- [Commit 1f3168e](https://github.com/googleapis/google-cloud-dotnet/commit/1f3168e): feat: Add "where not equal" support for Firestore
- [Commit ef55349](https://github.com/googleapis/google-cloud-dotnet/commit/ef55349): chore: Simplify WriteBatch implementation in line with internal guidance
- [Commit 310a1cb](https://github.com/googleapis/google-cloud-dotnet/commit/310a1cb): chore: Refactor WriteBatch now that every update is just a single Write
- [Commit 94375e9](https://github.com/googleapis/google-cloud-dotnet/commit/94375e9): chore: Fix conformance tests, by using update transforms
- [Commit eddc395](https://github.com/googleapis/google-cloud-dotnet/commit/eddc395): fix: Fix WhereIn filters being used in implicit orderings
- [Commit bb09597](https://github.com/googleapis/google-cloud-dotnet/commit/bb09597): feat: Allow general iterable objects to be serialized (but not deserialized) in Firestore

(Also releases Google.Cloud.Firestore.V1 version 2.1.0, to enable new features.)

Releases:

- Release Google.Cloud.Firestore version 2.2.0
- Release Google.Cloud.Firstore.V1 version 2.1.0
