### PR TITLE
Release Google.Cloud.Security.PrivateCA.V1Beta1 version 1.0.0-beta01

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Scheduler.V1](https://googleapis.dev/dotnet/Google.Cloud.Scheduler.V1/2.0.0) | 2.0.0 | [Google Cloud Scheduler](https://cloud.google.com/scheduler/) |
 | [Google.Cloud.SecretManager.V1](https://googleapis.dev/dotnet/Google.Cloud.SecretManager.V1/1.1.0) | 1.1.0 | [Secret Manager (V1 API)](https://cloud.google.com/secret-manager) |
 | [Google.Cloud.SecretManager.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.SecretManager.V1Beta1/2.0.0-beta02) | 2.0.0-beta02 | [Secret Manager (V1Beta1 API)](https://cloud.google.com/secret-manager) |
+| [Google.Cloud.Security.PrivateCA.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Security.PrivateCA.V1Beta1/1.0.0-beta01) | 1.0.0-beta01 | [Certificate Authority API](https://cloud.google.com/certificate-authority-service/) |
 | [Google.Cloud.SecurityCenter.Settings.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.SecurityCenter.Settings.V1Beta1/1.0.0-beta01) | 1.0.0-beta01 | [Google Cloud Security Command Center Settings](https://cloud.google.com/security-command-center/) |
 | [Google.Cloud.SecurityCenter.V1](https://googleapis.dev/dotnet/Google.Cloud.SecurityCenter.V1/2.0.0) | 2.0.0 | [Google Cloud Security Command Center (V1 API)](https://cloud.google.com/security-command-center/) |
 | [Google.Cloud.SecurityCenter.V1P1Beta1](https://googleapis.dev/dotnet/Google.Cloud.SecurityCenter.V1P1Beta1/2.0.0-beta03) | 2.0.0-beta03 | [Google Cloud Security Command Center (V1P1Beta1 API)](https://cloud.google.com/security-command-center/) |

--- a/apis/Google.Cloud.Security.PrivateCA.V1Beta1/.repo-metadata.json
+++ b/apis/Google.Cloud.Security.PrivateCA.V1Beta1/.repo-metadata.json
@@ -1,0 +1,5 @@
+{
+  "distribution_name": "Google.Cloud.Security.PrivateCA.V1Beta1",
+  "release_level": "beta",
+  "client_documentation": "https://googleapis.dev/dotnet/Google.Cloud.Security.PrivateCA.V1Beta1/latest"
+}

--- a/apis/Google.Cloud.Security.PrivateCA.V1Beta1/Google.Cloud.Security.PrivateCA.V1Beta1/Google.Cloud.Security.PrivateCA.V1Beta1.csproj
+++ b/apis/Google.Cloud.Security.PrivateCA.V1Beta1/Google.Cloud.Security.PrivateCA.V1Beta1/Google.Cloud.Security.PrivateCA.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta00</Version>
+    <Version>1.0.0-beta01</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Certificate Authority Service API version v1beta1</Description>

--- a/apis/Google.Cloud.Security.PrivateCA.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.Security.PrivateCA.V1Beta1/docs/history.md
@@ -1,0 +1,5 @@
+# Version history
+
+# Version 1.0.0-beta01, released 2020-10-06
+
+First beta release.

--- a/apis/Google.Cloud.Security.PrivateCA.V1Beta1/smoketests.json
+++ b/apis/Google.Cloud.Security.PrivateCA.V1Beta1/smoketests.json
@@ -1,0 +1,16 @@
+[
+  {
+    "method": "ListReusableConfigs",
+    "client": "CertificateAuthorityServiceClient",
+    "arguments": {
+      "parent": "projects/${PROJECT_ID}/locations/us-east1"
+    }
+  },
+  {
+    "method": "ListCertificateAuthorities",
+    "client": "CertificateAuthorityServiceClient",
+    "arguments": {
+      "parent": "projects/${PROJECT_ID}/locations/us-east1"
+    }
+  }
+]

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1231,7 +1231,7 @@
     },
     {
       "id": "Google.Cloud.Security.PrivateCA.V1Beta1",
-      "version": "1.0.0-beta00",
+      "version": "1.0.0-beta01",
       "type": "grpc",
       "productName": "Certificate Authority API",
       "productUrl": "https://cloud.google.com/certificate-authority-service/",

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -81,6 +81,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Scheduler.V1](Google.Cloud.Scheduler.V1/index.html) | 2.0.0 | [Google Cloud Scheduler](https://cloud.google.com/scheduler/) |
 | [Google.Cloud.SecretManager.V1](Google.Cloud.SecretManager.V1/index.html) | 1.1.0 | [Secret Manager (V1 API)](https://cloud.google.com/secret-manager) |
 | [Google.Cloud.SecretManager.V1Beta1](Google.Cloud.SecretManager.V1Beta1/index.html) | 2.0.0-beta02 | [Secret Manager (V1Beta1 API)](https://cloud.google.com/secret-manager) |
+| [Google.Cloud.Security.PrivateCA.V1Beta1](Google.Cloud.Security.PrivateCA.V1Beta1/index.html) | 1.0.0-beta01 | [Certificate Authority API](https://cloud.google.com/certificate-authority-service/) |
 | [Google.Cloud.SecurityCenter.Settings.V1Beta1](Google.Cloud.SecurityCenter.Settings.V1Beta1/index.html) | 1.0.0-beta01 | [Google Cloud Security Command Center Settings](https://cloud.google.com/security-command-center/) |
 | [Google.Cloud.SecurityCenter.V1](Google.Cloud.SecurityCenter.V1/index.html) | 2.0.0 | [Google Cloud Security Command Center (V1 API)](https://cloud.google.com/security-command-center/) |
 | [Google.Cloud.SecurityCenter.V1P1Beta1](Google.Cloud.SecurityCenter.V1P1Beta1/index.html) | 2.0.0-beta03 | [Google Cloud Security Command Center (V1P1Beta1 API)](https://cloud.google.com/security-command-center/) |


### PR DESCRIPTION

Changes in this release:

First beta release.
