### PR TITLE
Release Google.Cloud.AutoML.V1 version 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Each package name links to the documentation for that package.
 | [Google.Area120.Tables.V1Alpha1](https://googleapis.dev/dotnet/Google.Area120.Tables.V1Alpha1/1.0.0-alpha01) | 1.0.0-alpha01 | Google Area 120 Tables API |
 | [Google.Cloud.Asset.V1](https://googleapis.dev/dotnet/Google.Cloud.Asset.V1/2.5.0) | 2.5.0 | [Google Cloud Asset Inventory](https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview) |
 | [Google.Cloud.AssuredWorkloads.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.AssuredWorkloads.V1Beta1/1.0.0-beta01) | 1.0.0-beta01 | [Assured Workloads API](https://cloud.google.com/assured-workloads/docs) |
-| [Google.Cloud.AutoML.V1](https://googleapis.dev/dotnet/Google.Cloud.AutoML.V1/2.0.0) | 2.0.0 | [Google AutoML](https://cloud.google.com/automl/) |
+| [Google.Cloud.AutoML.V1](https://googleapis.dev/dotnet/Google.Cloud.AutoML.V1/2.1.0) | 2.1.0 | [Google AutoML](https://cloud.google.com/automl/) |
 | [Google.Cloud.BigQuery.Connection.V1](https://googleapis.dev/dotnet/Google.Cloud.BigQuery.Connection.V1/1.0.0) | 1.0.0 | [BigQuery Connection API](https://cloud.google.com/bigquery/docs/reference/bigqueryconnection) |
 | [Google.Cloud.BigQuery.DataTransfer.V1](https://googleapis.dev/dotnet/Google.Cloud.BigQuery.DataTransfer.V1/3.0.0) | 3.0.0 | [Google BigQuery Data Transfer](https://cloud.google.com/bigquery/transfer/) |
 | [Google.Cloud.BigQuery.Reservation.V1](https://googleapis.dev/dotnet/Google.Cloud.BigQuery.Reservation.V1/1.0.0) | 1.0.0 | [BigQuery Reservation API](https://cloud.google.com/bigquery/docs/reference/reservations) |

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.csproj
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AutoML API, which allows you to train high-quality custom machine learning models with minimal effort and machine learning expertise.</Description>

--- a/apis/Google.Cloud.AutoML.V1/docs/history.md
+++ b/apis/Google.Cloud.AutoML.V1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+# Version 2.1.0, released 2020-10-07
+
+- [Commit 0790924](https://github.com/googleapis/google-cloud-dotnet/commit/0790924): fix: Add gRPC compatibility constructors
+- [Commit 0ca05f5](https://github.com/googleapis/google-cloud-dotnet/commit/0ca05f5): chore: Regenerate all APIs using protoc 3.13 and Grpc.Tools 2.31
+- [Commit 6bde7a3](https://github.com/googleapis/google-cloud-dotnet/commit/6bde7a3): docs: Regenerate all APIs with service comments in client documentation
+- [Commit f83bdf1](https://github.com/googleapis/google-cloud-dotnet/commit/f83bdf1): fix: Regenerate all APIs with generator changes (fixes timeouts)
+- [Commit 947a573](https://github.com/googleapis/google-cloud-dotnet/commit/947a573): docs: Regenerate all clients with more explicit documentation
+- [Commit 3e2a816](https://github.com/googleapis/google-cloud-dotnet/commit/3e2a816): docs: Remove raw html from proto comments as this breaks client library documentation generators.
+
+In addition, dependencies have been updated.
+
 # Version 2.0.0, released 2020-03-17
 
 No API surface changes compared with 2.0.0-beta01, just dependencies

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -86,7 +86,7 @@
       "protoPath": "google/cloud/automl/v1",
       "productName": "Google AutoML",
       "productUrl": "https://cloud.google.com/automl/",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the AutoML API, which allows you to train high-quality custom machine learning models with minimal effort and machine learning expertise.",
       "dependencies": {

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -23,7 +23,7 @@ Each package name links to the documentation for that package.
 | [Google.Area120.Tables.V1Alpha1](Google.Area120.Tables.V1Alpha1/index.html) | 1.0.0-alpha01 | Google Area 120 Tables API |
 | [Google.Cloud.Asset.V1](Google.Cloud.Asset.V1/index.html) | 2.5.0 | [Google Cloud Asset Inventory](https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview) |
 | [Google.Cloud.AssuredWorkloads.V1Beta1](Google.Cloud.AssuredWorkloads.V1Beta1/index.html) | 1.0.0-beta01 | [Assured Workloads API](https://cloud.google.com/assured-workloads/docs) |
-| [Google.Cloud.AutoML.V1](Google.Cloud.AutoML.V1/index.html) | 2.0.0 | [Google AutoML](https://cloud.google.com/automl/) |
+| [Google.Cloud.AutoML.V1](Google.Cloud.AutoML.V1/index.html) | 2.1.0 | [Google AutoML](https://cloud.google.com/automl/) |
 | [Google.Cloud.BigQuery.Connection.V1](Google.Cloud.BigQuery.Connection.V1/index.html) | 1.0.0 | [BigQuery Connection API](https://cloud.google.com/bigquery/docs/reference/bigqueryconnection) |
 | [Google.Cloud.BigQuery.DataTransfer.V1](Google.Cloud.BigQuery.DataTransfer.V1/index.html) | 3.0.0 | [Google BigQuery Data Transfer](https://cloud.google.com/bigquery/transfer/) |
 | [Google.Cloud.BigQuery.Reservation.V1](Google.Cloud.BigQuery.Reservation.V1/index.html) | 1.0.0 | [BigQuery Reservation API](https://cloud.google.com/bigquery/docs/reference/reservations) |


### PR DESCRIPTION

Changes in this release:

- [Commit 0790924](https://github.com/googleapis/google-cloud-dotnet/commit/0790924): fix: Add gRPC compatibility constructors
- [Commit 0ca05f5](https://github.com/googleapis/google-cloud-dotnet/commit/0ca05f5): chore: Regenerate all APIs using protoc 3.13 and Grpc.Tools 2.31
- [Commit 6bde7a3](https://github.com/googleapis/google-cloud-dotnet/commit/6bde7a3): docs: Regenerate all APIs with service comments in client documentation
- [Commit f83bdf1](https://github.com/googleapis/google-cloud-dotnet/commit/f83bdf1): fix: Regenerate all APIs with generator changes (fixes timeouts)
- [Commit 947a573](https://github.com/googleapis/google-cloud-dotnet/commit/947a573): docs: Regenerate all clients with more explicit documentation
- [Commit 3e2a816](https://github.com/googleapis/google-cloud-dotnet/commit/3e2a816): docs: Remove raw html from proto comments as this breaks client library documentation generators.

In addition, dependencies have been updated.
