### PR TITLE
Release Google.Cloud.BigQuery.Reservation.V1 version 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.AutoML.V1](https://googleapis.dev/dotnet/Google.Cloud.AutoML.V1/2.1.0) | 2.1.0 | [Google AutoML](https://cloud.google.com/automl/) |
 | [Google.Cloud.BigQuery.Connection.V1](https://googleapis.dev/dotnet/Google.Cloud.BigQuery.Connection.V1/1.1.0) | 1.1.0 | [BigQuery Connection API](https://cloud.google.com/bigquery/docs/reference/bigqueryconnection) |
 | [Google.Cloud.BigQuery.DataTransfer.V1](https://googleapis.dev/dotnet/Google.Cloud.BigQuery.DataTransfer.V1/3.0.0) | 3.0.0 | [Google BigQuery Data Transfer](https://cloud.google.com/bigquery/transfer/) |
-| [Google.Cloud.BigQuery.Reservation.V1](https://googleapis.dev/dotnet/Google.Cloud.BigQuery.Reservation.V1/1.0.0) | 1.0.0 | [BigQuery Reservation API](https://cloud.google.com/bigquery/docs/reference/reservations) |
+| [Google.Cloud.BigQuery.Reservation.V1](https://googleapis.dev/dotnet/Google.Cloud.BigQuery.Reservation.V1/1.1.0) | 1.1.0 | [BigQuery Reservation API](https://cloud.google.com/bigquery/docs/reference/reservations) |
 | [Google.Cloud.BigQuery.V2](https://googleapis.dev/dotnet/Google.Cloud.BigQuery.V2/2.1.0) | 2.1.0 | [Google BigQuery](https://cloud.google.com/bigquery/) |
 | [Google.Cloud.BigQuery.Storage.V1](https://googleapis.dev/dotnet/Google.Cloud.BigQuery.Storage.V1/2.0.0) | 2.0.0 | [Google BigQuery Storage](https://cloud.google.com/bigquery/docs/reference/storage/) |
 | [Google.Cloud.Bigtable.Admin.V2](https://googleapis.dev/dotnet/Google.Cloud.Bigtable.Admin.V2/2.1.0) | 2.1.0 | [Google Cloud Bigtable Administration](https://cloud.google.com/bigtable/) |

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery Reservation API, which allows you to modify your BigQuery flat-rate reservations.</Description>

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+# Version 1.1.0, released 2020-10-07
+
+- [Commit 0790924](https://github.com/googleapis/google-cloud-dotnet/commit/0790924): fix: Add gRPC compatibility constructors
+- [Commit 0ca05f5](https://github.com/googleapis/google-cloud-dotnet/commit/0ca05f5): chore: Regenerate all APIs using protoc 3.13 and Grpc.Tools 2.31
+- [Commit 6bde7a3](https://github.com/googleapis/google-cloud-dotnet/commit/6bde7a3): docs: Regenerate all APIs with service comments in client documentation
+
 # Version 1.0.0, released 2020-07-06
 
 - [Commit f83bdf1](https://github.com/googleapis/google-cloud-dotnet/commit/f83bdf1): Regenerate all APIs with generator changes (enabled timeouts for non-retried RPCs)

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -138,7 +138,7 @@
     },
     {
       "id": "Google.Cloud.BigQuery.Reservation.V1",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "grpc",
       "productName": "BigQuery Reservation API",
       "productUrl": "https://cloud.google.com/bigquery/docs/reference/reservations",

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -26,7 +26,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.AutoML.V1](Google.Cloud.AutoML.V1/index.html) | 2.1.0 | [Google AutoML](https://cloud.google.com/automl/) |
 | [Google.Cloud.BigQuery.Connection.V1](Google.Cloud.BigQuery.Connection.V1/index.html) | 1.1.0 | [BigQuery Connection API](https://cloud.google.com/bigquery/docs/reference/bigqueryconnection) |
 | [Google.Cloud.BigQuery.DataTransfer.V1](Google.Cloud.BigQuery.DataTransfer.V1/index.html) | 3.0.0 | [Google BigQuery Data Transfer](https://cloud.google.com/bigquery/transfer/) |
-| [Google.Cloud.BigQuery.Reservation.V1](Google.Cloud.BigQuery.Reservation.V1/index.html) | 1.0.0 | [BigQuery Reservation API](https://cloud.google.com/bigquery/docs/reference/reservations) |
+| [Google.Cloud.BigQuery.Reservation.V1](Google.Cloud.BigQuery.Reservation.V1/index.html) | 1.1.0 | [BigQuery Reservation API](https://cloud.google.com/bigquery/docs/reference/reservations) |
 | [Google.Cloud.BigQuery.V2](Google.Cloud.BigQuery.V2/index.html) | 2.1.0 | [Google BigQuery](https://cloud.google.com/bigquery/) |
 | [Google.Cloud.BigQuery.Storage.V1](Google.Cloud.BigQuery.Storage.V1/index.html) | 2.0.0 | [Google BigQuery Storage](https://cloud.google.com/bigquery/docs/reference/storage/) |
 | [Google.Cloud.Bigtable.Admin.V2](Google.Cloud.Bigtable.Admin.V2/index.html) | 2.1.0 | [Google Cloud Bigtable Administration](https://cloud.google.com/bigtable/) |


### PR DESCRIPTION

Changes in this release:

- [Commit 0790924](https://github.com/googleapis/google-cloud-dotnet/commit/0790924): fix: Add gRPC compatibility constructors
- [Commit 0ca05f5](https://github.com/googleapis/google-cloud-dotnet/commit/0ca05f5): chore: Regenerate all APIs using protoc 3.13 and Grpc.Tools 2.31
- [Commit 6bde7a3](https://github.com/googleapis/google-cloud-dotnet/commit/6bde7a3): docs: Regenerate all APIs with service comments in client documentation
