### PR TITLE
Release Google.Cloud.Bigtable.V2 version 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.BigQuery.Storage.V1](https://googleapis.dev/dotnet/Google.Cloud.BigQuery.Storage.V1/2.1.0) | 2.1.0 | [Google BigQuery Storage](https://cloud.google.com/bigquery/docs/reference/storage/) |
 | [Google.Cloud.Bigtable.Admin.V2](https://googleapis.dev/dotnet/Google.Cloud.Bigtable.Admin.V2/2.2.0) | 2.2.0 | [Google Cloud Bigtable Administration](https://cloud.google.com/bigtable/) |
 | [Google.Cloud.Bigtable.Common.V2](https://googleapis.dev/dotnet/Google.Cloud.Bigtable.Common.V2/2.0.0) | 2.0.0 | Common code used by Bigtable V2 APIs |
-| [Google.Cloud.Bigtable.V2](https://googleapis.dev/dotnet/Google.Cloud.Bigtable.V2/2.0.0) | 2.0.0 | [Google Bigtable](https://cloud.google.com/bigtable/) |
+| [Google.Cloud.Bigtable.V2](https://googleapis.dev/dotnet/Google.Cloud.Bigtable.V2/2.1.0) | 2.1.0 | [Google Bigtable](https://cloud.google.com/bigtable/) |
 | [Google.Cloud.Billing.Budgets.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Billing.Budgets.V1Beta1/1.0.0-beta01) | 1.0.0-beta01 | [Cloud Billing Budget API](https://cloud.google.com/billing/docs/how-to/budget-api-overview) |
 | [Google.Cloud.Billing.V1](https://googleapis.dev/dotnet/Google.Cloud.Billing.V1/2.0.0) | 2.0.0 | [Google Cloud Billing API](https://cloud.google.com/billing/docs/) |
 | [Google.Cloud.Container.V1](https://googleapis.dev/dotnet/Google.Cloud.Container.V1/2.0.0) | 2.0.0 | [Google Kubernetes Engine API](https://cloud.google.com/kubernetes-engine/docs/reference/rest/) |

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Bigtable API.</Description>

--- a/apis/Google.Cloud.Bigtable.V2/docs/history.md
+++ b/apis/Google.Cloud.Bigtable.V2/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+# Version 2.1.0, released 2020-10-12
+
+- [Commit 0790924](https://github.com/googleapis/google-cloud-dotnet/commit/0790924): fix: Add gRPC compatibility constructors
+- [Commit 0ca05f5](https://github.com/googleapis/google-cloud-dotnet/commit/0ca05f5): chore: Regenerate all APIs using protoc 3.13 and Grpc.Tools 2.31
+- [Commit 6bde7a3](https://github.com/googleapis/google-cloud-dotnet/commit/6bde7a3): docs: Regenerate all APIs with service comments in client documentation
+- [Commit f83bdf1](https://github.com/googleapis/google-cloud-dotnet/commit/f83bdf1): fix: Regenerate all APIs with generator changes to fix timeouts
+- [Commit 808fab8](https://github.com/googleapis/google-cloud-dotnet/commit/808fab8): chore: set Ruby namespace in proto options
+- [Commit 0c129ac](https://github.com/googleapis/google-cloud-dotnet/commit/0c129ac): chore: Update bigtable grpc service config
+- [Commit 947a573](https://github.com/googleapis/google-cloud-dotnet/commit/947a573): docs: Regenerate all clients with more explicit documentation
+
 # Version 2.0.0, released 2020-04-08
 
 No API surface changes compared with 2.0.0-beta02, just a GA release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -232,15 +232,15 @@
       "protoPath": "google/bigtable/v2",
       "productName": "Google Bigtable",
       "productUrl": "https://cloud.google.com/bigtable/",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Bigtable API.",
       "tags": [
         "Bigtable"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.2.0",
         "Google.Api.Gax.Grpc.Gcp": "3.2.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.2.0",
         "Google.Cloud.Bigtable.Common.V2": "2.0.0",
         "Grpc.Core": "2.31.0"
       },

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -31,7 +31,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.BigQuery.Storage.V1](Google.Cloud.BigQuery.Storage.V1/index.html) | 2.1.0 | [Google BigQuery Storage](https://cloud.google.com/bigquery/docs/reference/storage/) |
 | [Google.Cloud.Bigtable.Admin.V2](Google.Cloud.Bigtable.Admin.V2/index.html) | 2.2.0 | [Google Cloud Bigtable Administration](https://cloud.google.com/bigtable/) |
 | [Google.Cloud.Bigtable.Common.V2](Google.Cloud.Bigtable.Common.V2/index.html) | 2.0.0 | Common code used by Bigtable V2 APIs |
-| [Google.Cloud.Bigtable.V2](Google.Cloud.Bigtable.V2/index.html) | 2.0.0 | [Google Bigtable](https://cloud.google.com/bigtable/) |
+| [Google.Cloud.Bigtable.V2](Google.Cloud.Bigtable.V2/index.html) | 2.1.0 | [Google Bigtable](https://cloud.google.com/bigtable/) |
 | [Google.Cloud.Billing.Budgets.V1Beta1](Google.Cloud.Billing.Budgets.V1Beta1/index.html) | 1.0.0-beta01 | [Cloud Billing Budget API](https://cloud.google.com/billing/docs/how-to/budget-api-overview) |
 | [Google.Cloud.Billing.V1](Google.Cloud.Billing.V1/index.html) | 2.0.0 | [Google Cloud Billing API](https://cloud.google.com/billing/docs/) |
 | [Google.Cloud.Container.V1](Google.Cloud.Container.V1/index.html) | 2.0.0 | [Google Kubernetes Engine API](https://cloud.google.com/kubernetes-engine/docs/reference/rest/) |


### PR DESCRIPTION

Changes in this release:

- [Commit 0790924](https://github.com/googleapis/google-cloud-dotnet/commit/0790924): fix: Add gRPC compatibility constructors
- [Commit 0ca05f5](https://github.com/googleapis/google-cloud-dotnet/commit/0ca05f5): chore: Regenerate all APIs using protoc 3.13 and Grpc.Tools 2.31
- [Commit 6bde7a3](https://github.com/googleapis/google-cloud-dotnet/commit/6bde7a3): docs: Regenerate all APIs with service comments in client documentation
- [Commit f83bdf1](https://github.com/googleapis/google-cloud-dotnet/commit/f83bdf1): fix: Regenerate all APIs with generator changes to fix timeouts
- [Commit 808fab8](https://github.com/googleapis/google-cloud-dotnet/commit/808fab8): chore: set Ruby namespace in proto options
- [Commit 0c129ac](https://github.com/googleapis/google-cloud-dotnet/commit/0c129ac): chore: Update bigtable grpc service config
- [Commit 947a573](https://github.com/googleapis/google-cloud-dotnet/commit/947a573): docs: Regenerate all clients with more explicit documentation
