### PR TITLE
Allow for more flexible commit handling

### DIFF
--- a/tools/Google.Cloud.Tools.ReleaseManager/Google.Cloud.Tools.ReleaseManager.csproj
+++ b/tools/Google.Cloud.Tools.ReleaseManager/Google.Cloud.Tools.ReleaseManager.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Octokit" Version="0.32.0" />
     <ProjectReference Include="..\Google.Cloud.Tools.Common\Google.Cloud.Tools.Common.csproj" />
     <ProjectReference Include="..\Google.Cloud.Tools.VersionCompat\Google.Cloud.Tools.VersionCompat.csproj" />
+    <EmbeddedResource Include="History/*.json" />
   </ItemGroup>
 
 </Project>

--- a/tools/Google.Cloud.Tools.ReleaseManager/History/overrides.json
+++ b/tools/Google.Cloud.Tools.ReleaseManager/History/overrides.json
@@ -1,0 +1,11 @@
+﻿// This file maps commit hashes (first 7 characters) to the message
+// that should appear in the history file (after the commit link).
+// A message of "skip" indicates that the commit should be skipped.
+{
+  "0790924": "fix: Add gRPC compatibility constructors",
+  "0ca05f5": "chore: Regenerate all APIs using protoc 3.13 and Grpc.Tools 2.31",
+  "6bde7a3": "docs: Regenerate all APIs with service comments in client documentation",
+  "f83bdf1": "fix: Apply timeouts to RPCs without retry",
+  "947a573": "docs: Regenerate all clients with more explicit documentation",
+  "0b0773d": "skip", // enum generation change
+}


### PR DESCRIPTION
When we know at commit time that we want a different message, allow
that to be specified after a "Version history:" line.

When we only know after the fact (or can't change the commit), allow
overrides to be specified in a JSON file.

If the message is just "skip", the commit is skipped.

(Tested with DLP)