### PR TITLE
Order the service directory entries by proto path

### DIFF
--- a/tools/Google.Cloud.Tools.Common/ServiceDirectory.cs
+++ b/tools/Google.Cloud.Tools.Common/ServiceDirectory.cs
@@ -30,10 +30,14 @@ namespace Google.Cloud.Tools.Common
         private static readonly Regex ServiceVersionPattern = new Regex(@"^v\d+.*");
         public List<Service> Services { get; set; }
 
-        internal static ServiceDirectory FromServiceConfigs(string googleapisRoot, IEnumerable<ServiceConfig> configs)
-        {
-            return new ServiceDirectory { Services = configs.Select(config => Service.FromServiceConfig(googleapisRoot, config)).ToList() };
-        }
+        internal static ServiceDirectory FromServiceConfigs(string googleapisRoot, IEnumerable<ServiceConfig> configs) =>
+            new ServiceDirectory
+            {
+                Services = configs
+                    .Select(config => Service.FromServiceConfig(googleapisRoot, config))
+                    .OrderBy(config => config.ServiceDirectory, StringComparer.Ordinal)
+                    .ToList() 
+            };
 
         /// <summary>
         /// Loads the service directory from service config files in the "googleapis"


### PR DESCRIPTION
(Previously it was only by luck that we were getting some kind of ordering - but it wasn't fully deterministic.)