### PR TITLE
Release Google.Cloud.Dlp.V2 version 3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Diagnostics.AspNetCore3](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.AspNetCore3/4.0.0-beta01) | 4.0.0-beta01 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core 3 |
 | [Google.Cloud.Diagnostics.Common](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.Common/4.2.0-beta02) | 4.2.0-beta02 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries Common Components |
 | [Google.Cloud.Dialogflow.V2](https://googleapis.dev/dotnet/Google.Cloud.Dialogflow.V2/3.1.0) | 3.1.0 | [Google Cloud Dialogflow](https://cloud.google.com/dialogflow-enterprise/) |
-| [Google.Cloud.Dlp.V2](https://googleapis.dev/dotnet/Google.Cloud.Dlp.V2/3.0.0) | 3.0.0 | [Google Cloud Data Loss Prevention](https://cloud.google.com/dlp/) |
+| [Google.Cloud.Dlp.V2](https://googleapis.dev/dotnet/Google.Cloud.Dlp.V2/3.1.0) | 3.1.0 | [Google Cloud Data Loss Prevention](https://cloud.google.com/dlp/) |
 | [Google.Cloud.DocumentAI.V1Beta2](https://googleapis.dev/dotnet/Google.Cloud.DocumentAI.V1Beta2/1.0.0-beta01) | 1.0.0-beta01 | [Cloud Document AI](https://cloud.google.com/solutions/document-ai) |
 | [Google.Cloud.ErrorReporting.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.ErrorReporting.V1Beta1/2.0.0-beta02) | 2.0.0-beta02 | [Google Cloud Error Reporting](https://cloud.google.com/error-reporting/) |
 | [Google.Cloud.Firestore.Admin.V1](https://googleapis.dev/dotnet/Google.Cloud.Firestore.Admin.V1/2.0.0) | 2.0.0 | [Firestore Administration (e.g. index management)](https://firebase.google.com) |

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.csproj
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0</Version>
+    <Version>3.1.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Data Loss Prevention API, which provides methods for detection of privacy-sensitive fragments in text, images, and Google Cloud Platform storage repositories.</Description>

--- a/apis/Google.Cloud.Dlp.V2/docs/history.md
+++ b/apis/Google.Cloud.Dlp.V2/docs/history.md
@@ -1,5 +1,20 @@
 # Version history
 
+# Version 3.1.0, released 2020-10-19
+
+- [Commit 18f5adb](https://github.com/googleapis/google-cloud-dotnet/commit/18f5adb): Fix: retrieve job config for risk analysis jobs. Docs: clarify timespan config for BigQuery and Datastore.
+- [Commit 0790924](https://github.com/googleapis/google-cloud-dotnet/commit/0790924): fix: Add gRPC compatibility constructors
+- [Commit 0ca05f5](https://github.com/googleapis/google-cloud-dotnet/commit/0ca05f5): chore: Regenerate all APIs using protoc 3.13 and Grpc.Tools 2.31
+- [Commit 381929c](https://github.com/googleapis/google-cloud-dotnet/commit/381929c): docs: correct the links for parent fields
+- [Commit 2722f39](https://github.com/googleapis/google-cloud-dotnet/commit/2722f39): docs: expand parent field format, and BigQuery sampling options. Also describing which transformations are allowed for ReidentifyContent API calls, and the custom alphabet allowed for format-preserving encryption (FPE).
+- [Commit f38e102](https://github.com/googleapis/google-cloud-dotnet/commit/f38e102):
+  - feat: Add CSV and TSV to file types.
+  - fix: Cleaned up resource_reference annotations for correct semantics and improved client library generation
+  - fix: BucketingConfig.replacement_value marked as required ([issue 5153](https://github.com/googleapis/google-cloud-dotnet/issues/5153))
+- [Commit 6bde7a3](https://github.com/googleapis/google-cloud-dotnet/commit/6bde7a3): docs: Regenerate all APIs with service comments in client documentation
+- [Commit f83bdf1](https://github.com/googleapis/google-cloud-dotnet/commit/f83bdf1): fix: Apply timeouts to RPCs without retry
+- [Commit f4f2b5f](https://github.com/googleapis/google-cloud-dotnet/commit/f4f2b5f): docs: fix several broken links in the docs.
+
 # Version 3.0.0, released 2020-06-01
 
 - [Commit dee878e](https://github.com/googleapis/google-cloud-dotnet/commit/dee878e): Fix routing by including location resource names

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -547,7 +547,7 @@
       "protoPath": "google/privacy/dlp/v2",
       "productName": "Google Cloud Data Loss Prevention",
       "productUrl": "https://cloud.google.com/dlp/",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Data Loss Prevention API, which provides methods for detection of privacy-sensitive fragments in text, images, and Google Cloud Platform storage repositories.",
       "dependencies": {

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -46,7 +46,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Diagnostics.AspNetCore3](Google.Cloud.Diagnostics.AspNetCore3/index.html) | 4.0.0-beta01 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core 3 |
 | [Google.Cloud.Diagnostics.Common](Google.Cloud.Diagnostics.Common/index.html) | 4.2.0-beta02 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries Common Components |
 | [Google.Cloud.Dialogflow.V2](Google.Cloud.Dialogflow.V2/index.html) | 3.1.0 | [Google Cloud Dialogflow](https://cloud.google.com/dialogflow-enterprise/) |
-| [Google.Cloud.Dlp.V2](Google.Cloud.Dlp.V2/index.html) | 3.0.0 | [Google Cloud Data Loss Prevention](https://cloud.google.com/dlp/) |
+| [Google.Cloud.Dlp.V2](Google.Cloud.Dlp.V2/index.html) | 3.1.0 | [Google Cloud Data Loss Prevention](https://cloud.google.com/dlp/) |
 | [Google.Cloud.DocumentAI.V1Beta2](Google.Cloud.DocumentAI.V1Beta2/index.html) | 1.0.0-beta01 | [Cloud Document AI](https://cloud.google.com/solutions/document-ai) |
 | [Google.Cloud.ErrorReporting.V1Beta1](Google.Cloud.ErrorReporting.V1Beta1/index.html) | 2.0.0-beta02 | [Google Cloud Error Reporting](https://cloud.google.com/error-reporting/) |
 | [Google.Cloud.Firestore.Admin.V1](Google.Cloud.Firestore.Admin.V1/index.html) | 2.0.0 | [Firestore Administration (e.g. index management)](https://firebase.google.com) |


### PR DESCRIPTION

Changes in this release:

- [Commit 18f5adb](https://github.com/googleapis/google-cloud-dotnet/commit/18f5adb): Fix: retrieve job config for risk analysis jobs. Docs: clarify timespan config for BigQuery and Datastore.
- [Commit 0790924](https://github.com/googleapis/google-cloud-dotnet/commit/0790924): fix: Add gRPC compatibility constructors
- [Commit 0ca05f5](https://github.com/googleapis/google-cloud-dotnet/commit/0ca05f5): chore: Regenerate all APIs using protoc 3.13 and Grpc.Tools 2.31
- [Commit 381929c](https://github.com/googleapis/google-cloud-dotnet/commit/381929c): docs: correct the links for parent fields
- [Commit 2722f39](https://github.com/googleapis/google-cloud-dotnet/commit/2722f39): docs: expand parent field format, and BigQuery sampling options. Also describing which transformations are allowed for ReidentifyContent API calls, and the custom alphabet allowed for format-preserving encryption (FPE).
- [Commit f38e102](https://github.com/googleapis/google-cloud-dotnet/commit/f38e102):
  - feat: Add CSV and TSV to file types.
  - fix: Cleaned up resource_reference annotations for correct semantics and improved client library generation
  - fix: BucketingConfig.replacement_value marked as required ([issue 5153](https://github.com/googleapis/google-cloud-dotnet/issues/5153))
- [Commit 6bde7a3](https://github.com/googleapis/google-cloud-dotnet/commit/6bde7a3): docs: Regenerate all APIs with service comments in client documentation
- [Commit f83bdf1](https://github.com/googleapis/google-cloud-dotnet/commit/f83bdf1): fix: Apply timeouts to RPCs without retry
- [Commit f4f2b5f](https://github.com/googleapis/google-cloud-dotnet/commit/f4f2b5f): docs: fix several broken links in the docs.
