### PR TITLE
Release Google.LongRunning version 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Workflows.V1Beta](https://googleapis.dev/dotnet/Google.Cloud.Workflows.V1Beta/1.0.0-beta01) | 1.0.0-beta01 | [Workflows API](https://cloud.google.com/workflows/docs/apis) |
 | [Google.Identity.AccessContextManager.Type](https://googleapis.dev/dotnet/Google.Identity.AccessContextManager.Type/1.0.0) | 1.0.0 | Version-agnostic types for the Google Identity Access Context Manager API |
 | [Google.Identity.AccessContextManager.V1](https://googleapis.dev/dotnet/Google.Identity.AccessContextManager.V1/1.0.0) | 1.0.0 | Protocol buffer types for the Google Identity Access Context Manager API V1 |
-| [Google.LongRunning](https://googleapis.dev/dotnet/Google.LongRunning/2.0.0) | 2.0.0 | Support for the Long-Running Operations API pattern |
+| [Google.LongRunning](https://googleapis.dev/dotnet/Google.LongRunning/2.1.0) | 2.1.0 | Support for the Long-Running Operations API pattern |
 | [Grafeas.V1](https://googleapis.dev/dotnet/Grafeas.V1/2.0.0) | 2.0.0 | [Grafeas](https://grafeas.io/) |
 
 If you need support for other Google APIs, check out the

--- a/apis/Google.LongRunning/Google.LongRunning/Google.LongRunning.csproj
+++ b/apis/Google.LongRunning/Google.LongRunning/Google.LongRunning.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>gRPC services for the Google Long Running Operations API. This library is typically used as a dependency for other API client libraries.</Description>

--- a/apis/Google.LongRunning/docs/history.md
+++ b/apis/Google.LongRunning/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+# Version 2.1.0, released 2020-10-19
+
+- [Commit 0790924](https://github.com/googleapis/google-cloud-dotnet/commit/0790924): fix: Add gRPC compatibility constructors
+- [Commit 0ca05f5](https://github.com/googleapis/google-cloud-dotnet/commit/0ca05f5): chore: Regenerate all APIs using protoc 3.13 and Grpc.Tools 2.31
+- [Commit 6bde7a3](https://github.com/googleapis/google-cloud-dotnet/commit/6bde7a3): docs: Regenerate all APIs with service comments in client documentation
+- [Commit 947a573](https://github.com/googleapis/google-cloud-dotnet/commit/947a573): docs: Regenerate all clients with more explicit documentation
+
 # Version 2.0.0, released 2020-03-16
 
 No API surface changes compared with 2.0.0-beta01, just dependencies

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1867,7 +1867,7 @@
       "generator": "micro",
       "protoPath": "google/longrunning",
       "listingDescription": "Support for the Long-Running Operations API pattern",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "type": "grpc",
       "description": "gRPC services for the Google Long Running Operations API. This library is typically used as a dependency for other API client libraries.",
       "tags": [

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -116,5 +116,5 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Workflows.V1Beta](Google.Cloud.Workflows.V1Beta/index.html) | 1.0.0-beta01 | [Workflows API](https://cloud.google.com/workflows/docs/apis) |
 | [Google.Identity.AccessContextManager.Type](Google.Identity.AccessContextManager.Type/index.html) | 1.0.0 | Version-agnostic types for the Google Identity Access Context Manager API |
 | [Google.Identity.AccessContextManager.V1](Google.Identity.AccessContextManager.V1/index.html) | 1.0.0 | Protocol buffer types for the Google Identity Access Context Manager API V1 |
-| [Google.LongRunning](Google.LongRunning/index.html) | 2.0.0 | Support for the Long-Running Operations API pattern |
+| [Google.LongRunning](Google.LongRunning/index.html) | 2.1.0 | Support for the Long-Running Operations API pattern |
 | [Grafeas.V1](Grafeas.V1/index.html) | 2.0.0 | [Grafeas](https://grafeas.io/) |


### PR DESCRIPTION

Changes in this release:

- [Commit 0790924](https://github.com/googleapis/google-cloud-dotnet/commit/0790924): fix: Add gRPC compatibility constructors
- [Commit 0ca05f5](https://github.com/googleapis/google-cloud-dotnet/commit/0ca05f5): chore: Regenerate all APIs using protoc 3.13 and Grpc.Tools 2.31
- [Commit 6bde7a3](https://github.com/googleapis/google-cloud-dotnet/commit/6bde7a3): docs: Regenerate all APIs with service comments in client documentation
- [Commit 947a573](https://github.com/googleapis/google-cloud-dotnet/commit/947a573): docs: Regenerate all clients with more explicit documentation
