### PR TITLE
Prototype of passing server-provided fields to custom type converters

### DIFF
--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/ConverterRegistryTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/ConverterRegistryTest.cs
@@ -13,9 +13,7 @@
 // limitations under the License.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Xunit;
 using static Google.Cloud.Firestore.Tests.SerializationTestData;
 

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/ConverterRegistry.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/ConverterRegistry.cs
@@ -37,7 +37,7 @@ namespace Google.Cloud.Firestore
         /// <summary>
         /// Adds the given converter to the registry.
         /// </summary>
-        /// <typeparam name="T">The </typeparam>
+        /// <typeparam name="T">The type that <paramref name="converter"/> converts to/from.</typeparam>
         /// <param name="converter">The converter to add.</param>
         /// <exception cref="ArgumentException">There is already a converter in the registry for the given type.</exception>
         public void Add<T>(IFirestoreConverter<T> converter)

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/FirestoreDeserializationConfigurationAttribute.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/FirestoreDeserializationConfigurationAttribute.cs
@@ -1,0 +1,72 @@
+﻿// Copyright 2020, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+
+namespace Google.Cloud.Firestore
+{
+    /// <summary>
+    /// Provides additional information for how Firestore converters (types implementing <see cref="IFirestoreConverter{T}"/>)
+    /// should be called during deserialization.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+    public sealed class FirestoreDeserializationConfigurationAttribute : Attribute
+    {
+        /// <summary>
+        /// The dictionary key used to specify the document ID when deserializing,
+        /// or null if the document ID is not propagated.
+        /// </summary>        
+        public string DocumentIdKey { get; set; }
+
+        /// <summary>
+        /// The dictionary key used to specify the create timestamp when deserializing,
+        /// or null if the create timestamp is not propagated.
+        /// </summary>
+        public string CreateTimestampKey { get; set; }
+
+        /// <summary>
+        /// The dictionary key used to specify the update timestamp when deserializing,
+        /// or null if the update timestamp is not propagated.
+        /// </summary>
+        public string UpdateTimestampKey { get; set; }
+
+        /// <summary>
+        /// The dictionary key used to specify the read timestamp when deserializing,
+        /// or null if the read timestamp is not propagated.
+        /// </summary>
+        public string ReadTimestampKey { get; set; }
+
+        /// <summary>
+        /// Applies the deserialization context properties to the given map.
+        /// </summary>
+        /// <param name="context">The current deserialization context.</param>
+        /// <param name="map">The map to (possibly) update.</param>
+        internal void ApplyContext(DeserializationContext context, Dictionary<string, object> map)
+        {
+            MaybePopulate(DocumentIdKey, context.DocumentReference);
+            MaybePopulate(CreateTimestampKey, context.Snapshot.CreateTime);
+            MaybePopulate(UpdateTimestampKey, context.Snapshot.UpdateTime);
+            MaybePopulate(ReadTimestampKey, context.Snapshot.ReadTime);
+
+            void MaybePopulate(string key, object value)
+            {
+                if (key is object)
+                {
+                    map[key] = value;
+                }
+            }
+        }
+    }
+}

--- a/apis/Google.Cloud.Firestore/docs/datamodel.md
+++ b/apis/Google.Cloud.Firestore/docs/datamodel.md
@@ -228,7 +228,16 @@ value will be stored as a 64-bit integer in the same way as an `int`
 property in an attributed type, or an `int` value within a dictionary.
 
 The `FromFirestore` method receives the deserialized value using the
-default mapping, as shown in the earlier table.
+default mapping, as shown in the earlier table. However, if the
+`[FirestoreDeserializationConfigurationAttribute]` attribute is
+applied to the method, and if the value received is a dictionary
+(such as for the top-level document deserialization) then additional
+keys may be populated in the dictionary, representing the document
+ID or create/update/read timestamps. This attribute provides the
+equivalent functionality to the `[FirestoreDocumentId]`,
+`[FirestoreDocumentCreateTimestamp]`,
+`[FirestoreDocumentUpdateTimestamp]` and `[FirestoreDocumentReadTimestamp]`
+attributes, but for custom converters.
 
 ### Applying a converter to a type
 


### PR DESCRIPTION
Would fix #5470, if adopted. Needs documentation if we go ahead.

Concerns:

- Is the Firestore team happy with this?
- Should we just work out a way of making the deserialization
  context public?
- Is it okay for the attribute to allow multiple and be inherited?
  (I can imagine a TypeConverterBase specifying it, for example...
  but what if we later have extra properties on it that conflict?)
- Is it okay for this to be very tightly bound to the implementation
  type? (There's no flexibility here - you need to know the keys
  at compile-time. I think that's okay, but...)

cc @schmidt-sebastian for Firestore, @ryandl for verification that it would solve their issue.
