### PR TITLE
feat: log CommitStats if requested by the client application

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.CommonTesting/SpannerFixtureBase.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.CommonTesting/SpannerFixtureBase.cs
@@ -14,6 +14,7 @@
 
 using Google.Cloud.ClientTesting;
 using Google.Cloud.Spanner.Common.V1;
+using Google.Cloud.Spanner.V1.Internal.Logging;
 
 namespace Google.Cloud.Spanner.Data.CommonTesting
 {
@@ -33,6 +34,7 @@ namespace Google.Cloud.Spanner.Data.CommonTesting
         public DatabaseName DatabaseName => Database.DatabaseName;
         public SpannerConnection GetConnection() => Database.GetConnection();
         public string ConnectionString => Database.ConnectionString;
+        public SpannerConnection GetConnection(Logger logger) => Database.GetConnection(logger);
         public bool RunningOnEmulator => SpannerClientCreationOptions.UsesEmulator;
         internal SpannerClientCreationOptions SpannerClientCreationOptions => Database.SpannerClientCreationOptions;
     }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.CommonTesting/SpannerTestDatabase.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.CommonTesting/SpannerTestDatabase.cs
@@ -116,6 +116,10 @@ namespace Google.Cloud.Spanner.Data.CommonTesting
             return string.IsNullOrEmpty(value) ? defaultValue : value;
         }
         
-        public SpannerConnection GetConnection() => new SpannerConnection(ConnectionString);        
+        public SpannerConnection GetConnection() => new SpannerConnection(ConnectionString);
+
+        // Creates a SpannerConnection with a specific logger.
+        public SpannerConnection GetConnection(Logger logger) =>
+            new SpannerConnection(new SpannerConnectionStringBuilder(ConnectionString) { SessionPoolManager = SessionPoolManager.Create(new V1.SessionPoolOptions(), logger) });
     }
 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerConnectionStringBuilderTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerConnectionStringBuilderTests.cs
@@ -174,6 +174,19 @@ namespace Google.Cloud.Spanner.Data.Tests
         }
 
         [Fact]
+        public void LogCommitStats()
+        {
+            var connectionStringBuilder = new SpannerConnectionStringBuilder("LogCommitStats=true");
+            Assert.True(connectionStringBuilder.LogCommitStats);
+            connectionStringBuilder.LogCommitStats = false;
+            Assert.False(connectionStringBuilder.LogCommitStats);
+            // DbConnectionStringBuilder lower-cases keywords, annoyingly.
+            Assert.Equal("logcommitstats=False", connectionStringBuilder.ToString());
+            connectionStringBuilder = new SpannerConnectionStringBuilder("");
+            Assert.False(connectionStringBuilder.LogCommitStats);
+        }
+
+        [Fact]
         public void EmulatorDetectionProperty()
         {
             var connectionStringBuilder = new SpannerConnectionStringBuilder("EmulatorDetection=EmulatorOnly");

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnection.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnection.cs
@@ -124,7 +124,7 @@ namespace Google.Cloud.Spanner.Data
         /// a transaction.
         /// </summary>
         /// <remarks>
-        /// CommitStats that are returned for a transaction are logged using the
+        /// Commit statistics that are returned for a transaction are logged using the
         /// logger of this connection. Applications can set a custom logger on the
         /// connection to log the output to a different destination.
         /// <see cref="Google.Cloud.Spanner.V1.Internal.Logging.Logger.LogCommitStats(CommitRequest, CommitResponse)"/>

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnection.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnection.cs
@@ -117,6 +117,21 @@ namespace Google.Cloud.Spanner.Data
         public QueryOptions QueryOptions { get; set; }
 
         /// <summary>
+        /// Request CommitStats for all read/write transactions throughout the
+        /// lifetime of the connection and log these. This value is set as the
+        /// default for read/write transaction created by this connection, and
+        /// is used for statements that are executed on this connection without
+        /// a transaction.
+        /// </summary>
+        /// <remarks>
+        /// CommitStats that are returned for a transaction are logged using the
+        /// logger of this connection. Applications can set a custom logger on the
+        /// connection to log the output to a different destination.
+        /// <see cref="Google.Cloud.Spanner.V1.Internal.Logging.Logger.LogCommitStats(CommitRequest, CommitResponse)"/>
+        /// </remarks>
+        public bool LogCommitStats => Builder.LogCommitStats;
+
+        /// <summary>
         /// Creates a SpannerConnection with no datasource or credential specified.
         /// </summary>
         public SpannerConnection() : this(new SpannerConnectionStringBuilder())
@@ -772,7 +787,7 @@ namespace Google.Cloud.Spanner.Data
                 {
                     await OpenAsync(cancellationToken).ConfigureAwait(false);
                     var session = await AcquireSessionAsync(transactionOptions, cancellationToken).ConfigureAwait(false);
-                    return new SpannerTransaction(this, transactionMode, session, targetReadTimestamp);
+                    return new SpannerTransaction(this, transactionMode, session, targetReadTimestamp) { LogCommitStats = LogCommitStats };
                 }, "SpannerConnection.BeginTransaction", Logger);
         }
 

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnection.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnection.cs
@@ -119,7 +119,7 @@ namespace Google.Cloud.Spanner.Data
         /// <summary>
         /// Request CommitStats for all read/write transactions throughout the
         /// lifetime of the connection and log these. This value is set as the
-        /// default for read/write transaction created by this connection, and
+        /// default for read/write transactions created by this connection, and
         /// is used for statements that are executed on this connection without
         /// a transaction.
         /// </summary>

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnection.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnection.cs
@@ -117,7 +117,7 @@ namespace Google.Cloud.Spanner.Data
         public QueryOptions QueryOptions { get; set; }
 
         /// <summary>
-        /// Request CommitStats for all read/write transactions throughout the
+        /// Request commit statistics for all read/write transactions throughout the
         /// lifetime of the connection and log these. This value is set as the
         /// default for read/write transactions created by this connection, and
         /// is used for statements that are executed on this connection without

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnectionStringBuilder.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnectionStringBuilder.cs
@@ -292,11 +292,11 @@ namespace Google.Cloud.Spanner.Data
         }
 
         /// <summary>
-        /// Request CommitStats for all read/write transactions throughout the
+        /// Request commit statistics for all read/write transactions throughout the
         /// lifetime of the connection and log these.
         /// </summary>
         /// <remarks>
-        /// CommitStats that are returned for a transaction are logged using the
+        /// Commit statistics that are returned for a transaction are logged using the
         /// logger of the connection. Applications can set a custom logger on the
         /// connection to log the output to a different destination.
         /// <see cref="Google.Cloud.Spanner.V1.Internal.Logging.Logger.LogCommitStats(CommitRequest, CommitResponse)"/>

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnectionStringBuilder.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnectionStringBuilder.cs
@@ -50,6 +50,7 @@ namespace Google.Cloud.Spanner.Data
         private const string DataSourceKeyword = "Data Source";
         private const string UseClrDefaultForNullKeyword = "UseClrDefaultForNull";
         private const string EnableGetSchemaTableKeyword = "EnableGetSchemaTable";
+        private const string LogCommitStatsKeyword = "LogCommitStats";
         private const string EmulatorDetectionKeyword = "EmulatorDetection";
 
         private InstanceName _instanceName;
@@ -288,6 +289,22 @@ namespace Google.Cloud.Spanner.Data
         {
             get => GetInt32OrDefault(nameof(Timeout), 0, int.MaxValue, DefaultTimeout);
             set => SetInt32WithValidation(nameof(Timeout), 0, int.MaxValue, value);
+        }
+
+        /// <summary>
+        /// Request CommitStats for all read/write transactions throughout the
+        /// lifetime of the connection and log these.
+        /// </summary>
+        /// <remarks>
+        /// CommitStats that are returned for a transaction are logged using the
+        /// logger of the connection. Applications can set a custom logger on the
+        /// connection to log the output to a different destination.
+        /// <see cref="Google.Cloud.Spanner.V1.Internal.Logging.Logger.LogCommitStats(CommitRequest, CommitResponse)"/>
+        /// </remarks>
+        public bool LogCommitStats
+        {
+            get => GetValueOrDefault(LogCommitStatsKeyword).Equals("True", StringComparison.OrdinalIgnoreCase);
+            set => this[LogCommitStatsKeyword] = value.ToString(); // Always "True" or "False", regardless of culture.
         }
 
         /// <summary>

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Internal/Logging/Logger.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Internal/Logging/Logger.cs
@@ -119,7 +119,6 @@ namespace Google.Cloud.Spanner.V1.Internal.Logging
             if (response.CommitStats != null)
             {
                 Info(() => $"Transaction {request.TransactionId?.ToBase64() ?? ""} mutation count: {response.CommitStats.MutationCount}");
-                Info(() => $"Transaction {request.TransactionId?.ToBase64() ?? ""} overload delay: {response.CommitStats.OverloadDelay}");
             }
         }
 

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Internal/Logging/Logger.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Internal/Logging/Logger.cs
@@ -107,6 +107,23 @@ namespace Google.Cloud.Spanner.V1.Internal.Logging
         protected abstract void LogPerformanceEntries(IEnumerable<string> entries);
 
         /// <summary>
+        /// This method is called when a transaction that requested CommitStats is committed.
+        /// The default implementation logs the commit stats at log level Info. Derived classes
+        /// can override this method to log the statistics at a different level, or to a different
+        /// destination.
+        /// </summary>
+        /// <param name="request">The commit request that requested commit statistics</param>
+        /// <param name="response">The response with commit statistics</param>
+        public virtual void LogCommitStats(CommitRequest request, CommitResponse response)
+        {
+            if (response.CommitStats != null)
+            {
+                Info(() => $"Transaction {request.TransactionId?.ToBase64() ?? ""} mutation count: {response.CommitStats.MutationCount}");
+                Info(() => $"Transaction {request.TransactionId?.ToBase64() ?? ""} overload delay: {response.CommitStats.OverloadDelay}");
+            }
+        }
+
+        /// <summary>
         /// Logs a message at a level of <see cref="LogLevel.Debug"/>.
         /// </summary>
         /// <param name="message">The message to log. May be null, in which case this method is a no-op.</param>


### PR DESCRIPTION
Adds support for requesting `CommitStats` for read/write transactions. `CommitStats` that are returned by the backend are logged using the default logger of the connection.

The PR currently also includes the necessary proto changes in the [first commit ](https://github.com/googleapis/google-cloud-dotnet/pull/5506/commits/82d0c63002f07b1fa0563c2979b636dc6ec4b715), as the proto changes has not yet been published.

Replaces #5480 