### PR TITLE
Add tool to detect misconfigured proto namespaces

### DIFF
--- a/tools/Google.Cloud.Tools.ReleaseManager/DetectNamingAnomaliesCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/DetectNamingAnomaliesCommand.cs
@@ -1,0 +1,120 @@
+﻿// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Tools.Common;
+using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Google.Cloud.Tools.ReleaseManager
+{
+    public sealed class DetectNamingAnomaliesCommand : CommandBase
+    {
+        public DetectNamingAnomaliesCommand() : base("detect-naming-anomalies", "Detects oddities in API naming")
+        {
+        }
+
+        protected override void ExecuteImpl(string[] args)
+        {
+            var directory = ServiceDirectory.LoadFromGoogleapis();
+            foreach (var api in directory.Services)
+            {
+                ReportAnomalies(api);
+            }
+        }
+
+        private static void ReportAnomalies(Service api)
+        {
+            var titleWords = GetTitleWords(api);
+
+            var csharpNs = api.CSharpNamespaceFromProtos;
+
+            // First detect the occasional problem of misconfiguration to "V1beta1" or "v1beta1" instead of "V1Beta1".
+            if (Regex.IsMatch(csharpNs, @"\.V\d+[a-z][^.]*$") || Regex.IsMatch(csharpNs, @"\.v[^.]*"))
+            {
+                Console.WriteLine($"{api.PackageFromDirectory} has bad version number in C# namespace {csharpNs}");
+            }
+
+            // Split the protobuf package into segments and see whether any segment matches multiple words
+            // from the title.
+            foreach (var segment in api.PackageFromDirectory.Split('.'))
+            {
+                var sequence = FindTitleWordSequence(api, segment, titleWords);
+                if (sequence is null)
+                {
+                    continue;
+                }
+
+                // Use the C# inferred namespace as an indication of whether this has been manually configured.
+                // It's entirely possible for it to be *badly* configured, but that's slightly different and would
+                // be harder to detect.
+                var expectedUnconfiguredSegment = char.ToUpperInvariant(segment[0]) + segment[1..];
+                if (csharpNs.Split('.').Contains(expectedUnconfiguredSegment))
+                {
+                    Console.WriteLine($"{api.PackageFromDirectory} may need configuration: C# namespace is {csharpNs}");
+                }
+            }
+
+            // Known false negatives:
+            // - google/devtools/clouddebugger (Stackdriver Debugger API)
+            // - google/devtools/cloudtrace (Stackdriver Trace API)
+            // - google/cloud/security/privateca (Certificate Authority API)
+            // - google/cloud/recommendationengine (Recommendations AI)
+            // - google/cloud/managedidentities (Managed Service for Microsoft Active Directory API)
+        }
+
+        private static string[] FindTitleWordSequence(Service api, string packageSegment, string[] titleWords)
+        {
+            // Look for any sequence of multiple words which (when combined and lower-cased) matches the segment.
+            for (int start = 0; start < titleWords.Length - 1; start++)
+            {
+                for (int end = start + 2; end <= titleWords.Length; end++)
+                {
+                    var sequence = titleWords[start..end];
+                    string combined = string.Join("", sequence);
+                    if (packageSegment == combined.ToLowerInvariant())
+                    {
+                        return sequence;
+                    }
+                }
+            }
+            return null;
+        }
+
+        private static string[] GetTitleWords(Service api)
+        {
+            string title = api.Title;
+            if (title.EndsWith(" API"))
+            {
+                title = title[..^4];
+            }
+            // Replace all punctuation etc with spaces (e.g. Pub/Sub => Pub Sub)
+            title = Regex.Replace(title, "[^A-Za-z0-9]", " ");
+            // TODO: Work out how we want to treat words that include capitals. Examples:
+            // - OS
+            // - HomeGraph
+            // - IoT
+            // - BigQuery
+            // - IAM
+            // - reCAPTCHA
+            // - AI
+
+            // For the moment, split BigQuery and HomeGraph in a hard-coded way...
+            title = title
+                .Replace("BigQuery", "Big Query")
+                .Replace("HomeGraph", "Home Graph");
+            return title.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+        }
+    }
+}


### PR DESCRIPTION
This takes the API title, splits it into words, then looks for a sequence of those words in a single protobuf package segment. It's not foolproof, but it's a good start.

Note that this currently only checks against C#, but usually if C#
is misconfigured, PHP and Ruby are too.

cc @JustinBeckwith, @dazuma, @dwsupplee, @lukesneeringer, @hkdevandla.

Current output:

```text
google.api.servicecontrol.v1 may need configuration: C# namespace is Google.Api.Servicecontrol.V1
google.appengine.v1 may need configuration: C# namespace is Google.Appengine.V1
google.chromeos.moblab.v1beta1 may need configuration: C# namespace is Google.Chromeos.Moblab.V1Beta1
google.cloud.accessapproval.v1 may need configuration: C# namespace is Google.Cloud.Accessapproval.V1
google.cloud.aiplatform.v1beta1 may need configuration: C# namespace is Google.Cloud.Aiplatform.V1Beta1
google.cloud.asset.v1p2beta1 has bad version number in C# namespace <AMBIGUOUS: Google.Cloud.Asset.V1p2Beta1, Google.Cloud.Asset.v1p2beta1>
google.cloud.asset.v1p5beta1 has bad version number in C# namespace <AMBIGUOUS: Google.Cloud.Asset.V1P5Beta1, Google.Cloud.Asset.V1p5Beta1>
google.cloud.bigquery.reservation.v1beta1 may need configuration: C# namespace is Google.Cloud.Bigquery.Reservation.V1Beta1
google.cloud.bigquery.storage.v1alpha2 may need configuration: C# namespace is Google.Cloud.Bigquery.Storage.V1Alpha2
google.cloud.bigquery.storage.v1beta1 may need configuration: C# namespace is Google.Cloud.Bigquery.Storage.V1Beta1
google.cloud.bigquery.storage.v1beta2 may need configuration: C# namespace is Google.Cloud.Bigquery.Storage.V1Beta2
google.cloud.bigquery.v2 may need configuration: C# namespace is Google.Cloud.Bigquery.V2
google.cloud.binaryauthorization.v1beta1 may need configuration: C# namespace is Google.Cloud.Binaryauthorization.V1Beta1
google.cloud.datalabeling.v1beta1 may need configuration: C# namespace is Google.Cloud.Datalabeling.V1Beta1
google.cloud.dialogflow.v2beta1 has bad version number in C# namespace Google.Cloud.Dialogflow.V2beta1
google.cloud.documentai.v1beta3 has bad version number in C# namespace Google.Cloud.DocumentAI.v1beta3
google.cloud.mediatranslation.v1alpha1 may need configuration: C# namespace is Google.Cloud.Mediatranslation.V1Alpha1
google.cloud.osconfig.agentendpoint.v1 may need configuration: C# namespace is Google.Cloud.Osconfig.Agentendpoint.V1
google.cloud.osconfig.agentendpoint.v1beta may need configuration: C# namespace is Google.Cloud.Osconfig.Agentendpoint.V1Beta
google.cloud.osconfig.v1beta may need configuration: C# namespace is Google.Cloud.Osconfig.V1Beta
google.cloud.pubsublite.v1 may need configuration: C# namespace is Google.Cloud.Pubsublite.V1
google.cloud.texttospeech.v1beta1 has bad version number in C# namespace Google.Cloud.TextToSpeech.V1beta1
google.cloud.websecurityscanner.v1 may need configuration: C# namespace is Google.Cloud.Websecurityscanner.V1
google.cloud.websecurityscanner.v1alpha may need configuration: C# namespace is Google.Cloud.Websecurityscanner.V1Alpha
google.cloud.websecurityscanner.v1beta may need configuration: C# namespace is Google.Cloud.Websecurityscanner.V1Beta
google.devtools.cloudbuild.v1 may need configuration: C# namespace is Google.Devtools.Cloudbuild.V1
google.devtools.containeranalysis.v1beta1 may need configuration: C# namespace is Google.Devtools.Containeranalysis.V1Beta1
google.devtools.resultstore.v2 may need configuration: C# namespace is Google.Devtools.Resultstore.V2
google.partner.aistreams.v1alpha1 may need configuration: C# namespace is Google.Partner.Aistreams.V1Alpha1
```

I know this *doesn't* detect the following as "multi-word" APIs:

- google/devtools/clouddebugger (Stackdriver Debugger API)
- google/devtools/cloudtrace (Stackdriver Trace API)
- google/cloud/security/privateca (Certificate Authority API)
- google/cloud/recommendationengine (Recommendations AI)
- google/cloud/managedidentities (Managed Service for Microsoft Active Directory API)
