### PR TITLE
Release Google.Analytics.Admin.V1Alpha version 1.0.0-alpha02

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Each package name links to the documentation for that package.
 
 | Package | Latest version | Description |
 |---------|----------------|-------------|
-| [Google.Analytics.Admin.V1Alpha](https://googleapis.dev/dotnet/Google.Analytics.Admin.V1Alpha/1.0.0-alpha01) | 1.0.0-alpha01 | Analytics Admin API |
+| [Google.Analytics.Admin.V1Alpha](https://googleapis.dev/dotnet/Google.Analytics.Admin.V1Alpha/1.0.0-alpha02) | 1.0.0-alpha02 | Analytics Admin API |
 | [Google.Analytics.Data.V1Alpha](https://googleapis.dev/dotnet/Google.Analytics.Data.V1Alpha/1.0.0-alpha01) | 1.0.0-alpha01 | Google Analytics Data API |
 | [Google.Area120.Tables.V1Alpha1](https://googleapis.dev/dotnet/Google.Area120.Tables.V1Alpha1/1.0.0-alpha01) | 1.0.0-alpha01 | Google Area 120 Tables API |
 | [Google.Cloud.Asset.V1](https://googleapis.dev/dotnet/Google.Cloud.Asset.V1/2.5.0) | 2.5.0 | [Google Cloud Asset Inventory](https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview) |

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha01</Version>
+    <Version>1.0.0-alpha02</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Analytics Admin API</Description>

--- a/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
+++ b/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+# Version 1.0.0-alpha02, released 2020-11-05
+
+- [Commit 667e40f](https://github.com/googleapis/google-cloud-dotnet/commit/667e40f): docs: renamed App + Web to Google Analytics 4 (GA4) in public documentation
+- [Commit 7824ab2](https://github.com/googleapis/google-cloud-dotnet/commit/7824ab2): feat: added ListAccountSummaries method ([issue 5441](https://github.com/googleapis/google-cloud-dotnet/issues/5441))
+- [Commit 0ca05f5](https://github.com/googleapis/google-cloud-dotnet/commit/0ca05f5): chore: Regenerate all APIs using protoc 3.13 and Grpc.Tools 2.31
+
 # Version 1.0.0-alpha01, released 2020-07-14
 
 Initial alpha release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2,7 +2,7 @@
   "apis": [
     {
       "id": "Google.Analytics.Admin.V1Alpha",
-      "version": "1.0.0-alpha01",
+      "version": "1.0.0-alpha02",
       "type": "grpc",
       "productName": "Analytics Admin API",
       "description": "Recommended Google client library to access the Analytics Admin API",

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -18,7 +18,7 @@ Each package name links to the documentation for that package.
 
 | Package | Latest version | Description |
 |---------|----------------|-------------|
-| [Google.Analytics.Admin.V1Alpha](Google.Analytics.Admin.V1Alpha/index.html) | 1.0.0-alpha01 | Analytics Admin API |
+| [Google.Analytics.Admin.V1Alpha](Google.Analytics.Admin.V1Alpha/index.html) | 1.0.0-alpha02 | Analytics Admin API |
 | [Google.Analytics.Data.V1Alpha](Google.Analytics.Data.V1Alpha/index.html) | 1.0.0-alpha01 | Google Analytics Data API |
 | [Google.Area120.Tables.V1Alpha1](Google.Area120.Tables.V1Alpha1/index.html) | 1.0.0-alpha01 | Google Area 120 Tables API |
 | [Google.Cloud.Asset.V1](Google.Cloud.Asset.V1/index.html) | 2.5.0 | [Google Cloud Asset Inventory](https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview) |


### PR DESCRIPTION

Changes in this release:

- [Commit 667e40f](https://github.com/googleapis/google-cloud-dotnet/commit/667e40f): docs: renamed App + Web to Google Analytics 4 (GA4) in public documentation
- [Commit 7824ab2](https://github.com/googleapis/google-cloud-dotnet/commit/7824ab2): feat: added ListAccountSummaries method ([issue 5441](https://github.com/googleapis/google-cloud-dotnet/issues/5441))
- [Commit 0ca05f5](https://github.com/googleapis/google-cloud-dotnet/commit/0ca05f5): chore: Regenerate all APIs using protoc 3.13 and Grpc.Tools 2.31
