### PR TITLE
Release Google.Analytics.Data.V1Alpha version 1.0.0-alpha02

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Each package name links to the documentation for that package.
 | Package | Latest version | Description |
 |---------|----------------|-------------|
 | [Google.Analytics.Admin.V1Alpha](https://googleapis.dev/dotnet/Google.Analytics.Admin.V1Alpha/1.0.0-alpha02) | 1.0.0-alpha02 | Analytics Admin API |
-| [Google.Analytics.Data.V1Alpha](https://googleapis.dev/dotnet/Google.Analytics.Data.V1Alpha/1.0.0-alpha01) | 1.0.0-alpha01 | Google Analytics Data API |
+| [Google.Analytics.Data.V1Alpha](https://googleapis.dev/dotnet/Google.Analytics.Data.V1Alpha/1.0.0-alpha02) | 1.0.0-alpha02 | Google Analytics Data API |
 | [Google.Area120.Tables.V1Alpha1](https://googleapis.dev/dotnet/Google.Area120.Tables.V1Alpha1/1.0.0-alpha01) | 1.0.0-alpha01 | Google Area 120 Tables API |
 | [Google.Cloud.Asset.V1](https://googleapis.dev/dotnet/Google.Cloud.Asset.V1/2.5.0) | 2.5.0 | [Google Cloud Asset Inventory](https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview) |
 | [Google.Cloud.AssuredWorkloads.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.AssuredWorkloads.V1Beta1/1.0.0-beta01) | 1.0.0-beta01 | [Assured Workloads API](https://cloud.google.com/assured-workloads/docs) |

--- a/apis/Google.Analytics.Data.V1Alpha/Google.Analytics.Data.V1Alpha/Google.Analytics.Data.V1Alpha.csproj
+++ b/apis/Google.Analytics.Data.V1Alpha/Google.Analytics.Data.V1Alpha/Google.Analytics.Data.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha01</Version>
+    <Version>1.0.0-alpha02</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Analytics Data API</Description>

--- a/apis/Google.Analytics.Data.V1Alpha/docs/history.md
+++ b/apis/Google.Analytics.Data.V1Alpha/docs/history.md
@@ -1,6 +1,22 @@
 # Version history
 
+# Version 1.0.0-alpha02, released 2020-11-05
+
+- [Commit b85cd73](https://github.com/googleapis/google-cloud-dotnet/commit/b85cd73):
+  - feat: added RunRealtimeReport method that returns a customized report of realtime event data for a GA4 property
+  - docs: minor documentation updates
+- [Commit ff07808](https://github.com/googleapis/google-cloud-dotnet/commit/ff07808): docs: App+Web properties renamed to GA4
+- [Commit 36b2ef2](https://github.com/googleapis/google-cloud-dotnet/commit/36b2ef2): feat: added GetMetadata method for metadata including custom dimensions and metrics.
+- [Commit ee32999](https://github.com/googleapis/google-cloud-dotnet/commit/ee32999):
+  - feat!: GetMetadata method renamed to GetUniversalMetdata
+  - docs: documentation updates
+- [Commit 0ca05f5](https://github.com/googleapis/google-cloud-dotnet/commit/0ca05f5): chore: Regenerate all APIs using protoc 3.13 and Grpc.Tools 2.31
+- [Commit 1b0afcc](https://github.com/googleapis/google-cloud-dotnet/commit/1b0afcc):
+  - feat: added GetMetadata method
+  - feat: DimensionHeader type renamed to PivotDimensionHeader
+  - feat: added TYPE_SECONDS,TYPE_CURRENCY to MetricType enum
+  - docs: documentation updates
+
 # Version 1.0.0-alpha01, released 2020-08-18
 
 First alpha release.
-

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -15,7 +15,7 @@
     },
     {
       "id": "Google.Analytics.Data.V1Alpha",
-      "version": "1.0.0-alpha01",
+      "version": "1.0.0-alpha02",
       "type": "grpc",
       "productName": "Google Analytics Data API",
       "description": "Recommended Google client library to access the Analytics Data API",

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -19,7 +19,7 @@ Each package name links to the documentation for that package.
 | Package | Latest version | Description |
 |---------|----------------|-------------|
 | [Google.Analytics.Admin.V1Alpha](Google.Analytics.Admin.V1Alpha/index.html) | 1.0.0-alpha02 | Analytics Admin API |
-| [Google.Analytics.Data.V1Alpha](Google.Analytics.Data.V1Alpha/index.html) | 1.0.0-alpha01 | Google Analytics Data API |
+| [Google.Analytics.Data.V1Alpha](Google.Analytics.Data.V1Alpha/index.html) | 1.0.0-alpha02 | Google Analytics Data API |
 | [Google.Area120.Tables.V1Alpha1](Google.Area120.Tables.V1Alpha1/index.html) | 1.0.0-alpha01 | Google Area 120 Tables API |
 | [Google.Cloud.Asset.V1](Google.Cloud.Asset.V1/index.html) | 2.5.0 | [Google Cloud Asset Inventory](https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview) |
 | [Google.Cloud.AssuredWorkloads.V1Beta1](Google.Cloud.AssuredWorkloads.V1Beta1/index.html) | 1.0.0-beta01 | [Assured Workloads API](https://cloud.google.com/assured-workloads/docs) |


### PR DESCRIPTION

Changes in this release:

- [Commit b85cd73](https://github.com/googleapis/google-cloud-dotnet/commit/b85cd73):
  - feat: added RunRealtimeReport method that returns a customized report of realtime event data for a GA4 property
  - docs: minor documentation updates
- [Commit ff07808](https://github.com/googleapis/google-cloud-dotnet/commit/ff07808): docs: App+Web properties renamed to GA4
- [Commit 36b2ef2](https://github.com/googleapis/google-cloud-dotnet/commit/36b2ef2): feat: added GetMetadata method for metadata including custom dimensions and metrics.
- [Commit ee32999](https://github.com/googleapis/google-cloud-dotnet/commit/ee32999):
  - feat!: GetMetadata method renamed to GetUniversalMetdata
  - docs: documentation updates
- [Commit 0ca05f5](https://github.com/googleapis/google-cloud-dotnet/commit/0ca05f5): chore: Regenerate all APIs using protoc 3.13 and Grpc.Tools 2.31
- [Commit 1b0afcc](https://github.com/googleapis/google-cloud-dotnet/commit/1b0afcc):
  - feat: added GetMetadata method
  - feat: DimensionHeader type renamed to PivotDimensionHeader
  - feat: added TYPE_SECONDS,TYPE_CURRENCY to MetricType enum
  - docs: documentation updates
