### PR TITLE
Release Google.Cloud.Redis.V1 version 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.RecaptchaEnterprise.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.RecaptchaEnterprise.V1Beta1/1.0.0-beta02) | 1.0.0-beta02 | [Google Cloud reCAPTCHA Enterprise (V1Beta1 API)](https://cloud.google.com/recaptcha-enterprise/) |
 | [Google.Cloud.RecommendationEngine.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.RecommendationEngine.V1Beta1/1.0.0-beta01) | 1.0.0-beta01 | [Recommendations AI](https://cloud.google.com/recommendations) |
 | [Google.Cloud.Recommender.V1](https://googleapis.dev/dotnet/Google.Cloud.Recommender.V1/2.3.0) | 2.3.0 | [Google Cloud Recommender](https://cloud.google.com/recommender/) |
-| [Google.Cloud.Redis.V1](https://googleapis.dev/dotnet/Google.Cloud.Redis.V1/2.0.0) | 2.0.0 | [Google Cloud Memorystore for Redis (V1 API)](https://cloud.google.com/memorystore/) |
+| [Google.Cloud.Redis.V1](https://googleapis.dev/dotnet/Google.Cloud.Redis.V1/2.1.0) | 2.1.0 | [Google Cloud Memorystore for Redis (V1 API)](https://cloud.google.com/memorystore/) |
 | [Google.Cloud.Redis.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Redis.V1Beta1/2.0.0-beta02) | 2.0.0-beta02 | [Google Cloud Memorystore for Redis (V1Beta1 API)](https://cloud.google.com/memorystore/) |
 | [Google.Cloud.Scheduler.V1](https://googleapis.dev/dotnet/Google.Cloud.Scheduler.V1/2.0.0) | 2.0.0 | [Google Cloud Scheduler](https://cloud.google.com/scheduler/) |
 | [Google.Cloud.SecretManager.V1](https://googleapis.dev/dotnet/Google.Cloud.SecretManager.V1/1.1.0) | 1.1.0 | [Secret Manager (V1 API)](https://cloud.google.com/secret-manager) |

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.csproj
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to administer Cloud Memorystore for Redis.</Description>
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.0.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />

--- a/apis/Google.Cloud.Redis.V1/docs/history.md
+++ b/apis/Google.Cloud.Redis.V1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+# Version 2.1.0, released 2020-11-09
+
+- [Commit 0790924](https://github.com/googleapis/google-cloud-dotnet/commit/0790924): fix: Add gRPC compatibility constructors
+- [Commit 0ca05f5](https://github.com/googleapis/google-cloud-dotnet/commit/0ca05f5): chore: Regenerate all APIs using protoc 3.13 and Grpc.Tools 2.31
+- [Commit 6bde7a3](https://github.com/googleapis/google-cloud-dotnet/commit/6bde7a3): docs: Regenerate all APIs with service comments in client documentation
+- [Commit 0014243](https://github.com/googleapis/google-cloud-dotnet/commit/0014243): redis: v1 add UpgradeInstance request
+- [Commit f83bdf1](https://github.com/googleapis/google-cloud-dotnet/commit/f83bdf1): fix: Apply timeouts to RPCs without retry
+- [Commit a9ff54c](https://github.com/googleapis/google-cloud-dotnet/commit/a9ff54c): docs: change relative URLs to absolute URLs to fix broken links.
+- [Commit 947a573](https://github.com/googleapis/google-cloud-dotnet/commit/947a573): docs: Regenerate all clients with more explicit documentation
+- [Commit c9149b9](https://github.com/googleapis/google-cloud-dotnet/commit/c9149b9): docs: Comment-only changes
+
 # Version 2.0.0, released 2020-03-18
 
 No API surface changes compared with 2.0.0-beta01, just dependency

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1237,12 +1237,12 @@
       "protoPath": "google/cloud/redis/v1",
       "productName": "Google Cloud Memorystore for Redis",
       "productUrl": "https://cloud.google.com/memorystore/",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "type": "grpc",
       "description": "Recommended Google client library to administer Cloud Memorystore for Redis.",
       "dependencies": {
         "Google.Api.Gax.Grpc.GrpcCore": "3.2.0",
-        "Google.LongRunning": "2.0.0",
+        "Google.LongRunning": "2.1.0",
         "Grpc.Core": "2.31.0"
       },
       "tags": [

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -82,7 +82,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.RecaptchaEnterprise.V1Beta1](Google.Cloud.RecaptchaEnterprise.V1Beta1/index.html) | 1.0.0-beta02 | [Google Cloud reCAPTCHA Enterprise (V1Beta1 API)](https://cloud.google.com/recaptcha-enterprise/) |
 | [Google.Cloud.RecommendationEngine.V1Beta1](Google.Cloud.RecommendationEngine.V1Beta1/index.html) | 1.0.0-beta01 | [Recommendations AI](https://cloud.google.com/recommendations) |
 | [Google.Cloud.Recommender.V1](Google.Cloud.Recommender.V1/index.html) | 2.3.0 | [Google Cloud Recommender](https://cloud.google.com/recommender/) |
-| [Google.Cloud.Redis.V1](Google.Cloud.Redis.V1/index.html) | 2.0.0 | [Google Cloud Memorystore for Redis (V1 API)](https://cloud.google.com/memorystore/) |
+| [Google.Cloud.Redis.V1](Google.Cloud.Redis.V1/index.html) | 2.1.0 | [Google Cloud Memorystore for Redis (V1 API)](https://cloud.google.com/memorystore/) |
 | [Google.Cloud.Redis.V1Beta1](Google.Cloud.Redis.V1Beta1/index.html) | 2.0.0-beta02 | [Google Cloud Memorystore for Redis (V1Beta1 API)](https://cloud.google.com/memorystore/) |
 | [Google.Cloud.Scheduler.V1](Google.Cloud.Scheduler.V1/index.html) | 2.0.0 | [Google Cloud Scheduler](https://cloud.google.com/scheduler/) |
 | [Google.Cloud.SecretManager.V1](Google.Cloud.SecretManager.V1/index.html) | 1.1.0 | [Secret Manager (V1 API)](https://cloud.google.com/secret-manager) |


### PR DESCRIPTION

Changes in this release:

- [Commit 0790924](https://github.com/googleapis/google-cloud-dotnet/commit/0790924): fix: Add gRPC compatibility constructors
- [Commit 0ca05f5](https://github.com/googleapis/google-cloud-dotnet/commit/0ca05f5): chore: Regenerate all APIs using protoc 3.13 and Grpc.Tools 2.31
- [Commit 6bde7a3](https://github.com/googleapis/google-cloud-dotnet/commit/6bde7a3): docs: Regenerate all APIs with service comments in client documentation
- [Commit 0014243](https://github.com/googleapis/google-cloud-dotnet/commit/0014243): redis: v1 add UpgradeInstance request
- [Commit f83bdf1](https://github.com/googleapis/google-cloud-dotnet/commit/f83bdf1): fix: Apply timeouts to RPCs without retry
- [Commit a9ff54c](https://github.com/googleapis/google-cloud-dotnet/commit/a9ff54c): docs: change relative URLs to absolute URLs to fix broken links.
- [Commit 947a573](https://github.com/googleapis/google-cloud-dotnet/commit/947a573): docs: Regenerate all clients with more explicit documentation
- [Commit c9149b9](https://github.com/googleapis/google-cloud-dotnet/commit/c9149b9): docs: Comment-only changes
