### PR TITLE
Release all OsLogin packages

### DIFF
--- a/apis/Google.Cloud.OsLogin.Common/docs/history.md
+++ b/apis/Google.Cloud.OsLogin.Common/docs/history.md
@@ -1,3 +1,3 @@
 # Version history
 
-There is no version history for this package, as it is primarily a dependency.
+(There is no version history for this package, as it is primarily a dependency.)

--- a/apis/Google.Cloud.OsLogin.V1/docs/history.md
+++ b/apis/Google.Cloud.OsLogin.V1/docs/history.md
@@ -7,7 +7,7 @@
 - [Commit 6bde7a3](https://github.com/googleapis/google-cloud-dotnet/commit/6bde7a3): docs: Regenerate all APIs with service comments in client documentation
 - [Commit 947a573](https://github.com/googleapis/google-cloud-dotnet/commit/947a573): docs: Regenerate all clients with more explicit documentation
 
-(Note - this took multiple attempts to release, leading to separate commits with this history in the description.)
+(This took multiple attempts to release, leading to separate commits with this history in the description.)
 
 # Version 2.0.0, released 2020-03-18
 

--- a/apis/Google.Cloud.OsLogin.V1Beta/docs/history.md
+++ b/apis/Google.Cloud.OsLogin.V1Beta/docs/history.md
@@ -6,6 +6,8 @@
 - [Commit 6bde7a3](https://github.com/googleapis/google-cloud-dotnet/commit/6bde7a3): docs: Regenerate all APIs with service comments in client documentation
 - [Commit 947a573](https://github.com/googleapis/google-cloud-dotnet/commit/947a573): docs: Regenerate all clients with more explicit documentation
 
+(This release took multiple attempts, so there are multiple commits with this message.)
+
 # Version 2.0.0-beta02, released 2020-03-18
 
 No API surface changes compared with 2.0.0-beta01, just dependency


### PR DESCRIPTION
Changes in Google.Cloud.OsLogin.V1 version 2.1.0:

- [Commit 0790924](0790924): fix: Add gRPC compatibility constructors
- [Commit 0ca05f5](0ca05f5): chore: Regenerate all APIs using protoc 3.13 and Grpc.Tools 2.31
- [Commit 6bde7a3](6bde7a3): docs: Regenerate all APIs with service comments in client documentation
- [Commit 947a573](947a573): docs: Regenerate all clients with more explicit documentation

Changes in Google.Cloud.OsLogin.V1Beta version 2.0.0-beta03:

- [Commit 0ca05f5](0ca05f5): chore: Regenerate all APIs using protoc 3.13 and Grpc.Tools 2.31
- [Commit 6bde7a3](6bde7a3): docs: Regenerate all APIs with service comments in client documentation
- [Commit 947a573](947a573): docs: Regenerate all clients with more explicit documentation

Packages in this release:
- Release Google.Cloud.OsLogin.Common version 2.1.0
- Release Google.Cloud.OsLogin.V1 version 2.1.0
- Release Google.Cloud.OsLogin.V1Beta version 2.0.0-beta03