### PR TITLE
Release Google.Cloud.OsConfig.V1 version 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Monitoring.V3](https://googleapis.dev/dotnet/Google.Cloud.Monitoring.V3/2.2.0) | 2.2.0 | [Google Cloud Monitoring](https://cloud.google.com/monitoring/api/v3/) |
 | [Google.Cloud.Notebooks.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Notebooks.V1Beta1/1.0.0-beta01) | 1.0.0-beta01 | [AI Platform Notebooks](https://cloud.google.com/ai-platform-notebooks) |
 | [Google.Cloud.OrgPolicy.V1](https://googleapis.dev/dotnet/Google.Cloud.OrgPolicy.V1/2.0.0) | 2.0.0 | OrgPolicy API messages |
-| [Google.Cloud.OsConfig.V1](https://googleapis.dev/dotnet/Google.Cloud.OsConfig.V1/1.1.0) | 1.1.0 | [Google Cloud OS Config](https://cloud.google.com/compute/docs/osconfig/rest) |
+| [Google.Cloud.OsConfig.V1](https://googleapis.dev/dotnet/Google.Cloud.OsConfig.V1/1.2.0) | 1.2.0 | [Google Cloud OS Config](https://cloud.google.com/compute/docs/osconfig/rest) |
 | [Google.Cloud.OsLogin.Common](https://googleapis.dev/dotnet/Google.Cloud.OsLogin.Common/2.1.0) | 2.1.0 | Version-agnostic types for the Google OS Login API |
 | [Google.Cloud.OsLogin.V1](https://googleapis.dev/dotnet/Google.Cloud.OsLogin.V1/2.1.0) | 2.1.0 | [Google Cloud OS Login (V1 API)](https://cloud.google.com/compute/docs/instances/managing-instance-access) |
 | [Google.Cloud.OsLogin.V1Beta](https://googleapis.dev/dotnet/Google.Cloud.OsLogin.V1Beta/2.0.0-beta03) | 2.0.0-beta03 | [Google Cloud OS Login (V1Beta API)](https://cloud.google.com/compute/docs/instances/managing-instance-access) |

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.csproj
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library for the Cloud OS Config API. These are OS management tools that can be used for patch management, patch compliance, and configuration management on VM instances.</Description>

--- a/apis/Google.Cloud.OsConfig.V1/docs/history.md
+++ b/apis/Google.Cloud.OsConfig.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+# Version 1.2.0, released 2020-11-17
+
+- [Commit 696b75f](https://github.com/googleapis/google-cloud-dotnet/commit/696b75f):
+  - feat: Added PatchRollout feature to PatchDeployments
+  - feat: Added Inventory proto definitions for VM Manager Inventory.
+
 # Version 1.1.0, released 2020-10-23
 
 - [Commit 0790924](https://github.com/googleapis/google-cloud-dotnet/commit/0790924): fix: Add gRPC compatibility constructors

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1076,7 +1076,7 @@
       "protoPath": "google/cloud/osconfig/v1",
       "productName": "Google Cloud OS Config",
       "productUrl": "https://cloud.google.com/compute/docs/osconfig/rest",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "type": "grpc",
       "description": "Recommended Google client library for the Cloud OS Config API. These are OS management tools that can be used for patch management, patch compliance, and configuration management on VM instances.",
       "tags": [

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -73,7 +73,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Monitoring.V3](Google.Cloud.Monitoring.V3/index.html) | 2.2.0 | [Google Cloud Monitoring](https://cloud.google.com/monitoring/api/v3/) |
 | [Google.Cloud.Notebooks.V1Beta1](Google.Cloud.Notebooks.V1Beta1/index.html) | 1.0.0-beta01 | [AI Platform Notebooks](https://cloud.google.com/ai-platform-notebooks) |
 | [Google.Cloud.OrgPolicy.V1](Google.Cloud.OrgPolicy.V1/index.html) | 2.0.0 | OrgPolicy API messages |
-| [Google.Cloud.OsConfig.V1](Google.Cloud.OsConfig.V1/index.html) | 1.1.0 | [Google Cloud OS Config](https://cloud.google.com/compute/docs/osconfig/rest) |
+| [Google.Cloud.OsConfig.V1](Google.Cloud.OsConfig.V1/index.html) | 1.2.0 | [Google Cloud OS Config](https://cloud.google.com/compute/docs/osconfig/rest) |
 | [Google.Cloud.OsLogin.Common](Google.Cloud.OsLogin.Common/index.html) | 2.1.0 | Version-agnostic types for the Google OS Login API |
 | [Google.Cloud.OsLogin.V1](Google.Cloud.OsLogin.V1/index.html) | 2.1.0 | [Google Cloud OS Login (V1 API)](https://cloud.google.com/compute/docs/instances/managing-instance-access) |
 | [Google.Cloud.OsLogin.V1Beta](Google.Cloud.OsLogin.V1Beta/index.html) | 2.0.0-beta03 | [Google Cloud OS Login (V1Beta API)](https://cloud.google.com/compute/docs/instances/managing-instance-access) |


### PR DESCRIPTION

Changes in this release:

- [Commit 696b75f](https://github.com/googleapis/google-cloud-dotnet/commit/696b75f):
  - feat: Added PatchRollout feature to PatchDeployments
  - feat: Added Inventory proto definitions for VM Manager Inventory.
