### PR TITLE
Add OsConfig.V1 dependency to Asset.V1

### DIFF
--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.csproj
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.Cloud.OrgPolicy.V1" Version="[2.0.0, 3.0.0)" />
+    <PackageReference Include="Google.Cloud.OsConfig.V1" Version="[1.2.0, 2.0.0)" />
     <PackageReference Include="Google.Identity.AccessContextManager.Type" Version="[1.0.0, 2.0.0)" />
     <PackageReference Include="Google.Identity.AccessContextManager.V1" Version="[1.0.0, 2.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.0.0, 3.0.0)" />

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -74,6 +74,7 @@
         "Google.LongRunning": "2.0.0",
         "Google.Cloud.Iam.V1": "2.0.0",
         "Google.Cloud.OrgPolicy.V1": "2.0.0",
+        "Google.Cloud.OsConfig.V1": "1.2.0",
         "Grpc.Core": "2.31.0"
       },
       "tags": [


### PR DESCRIPTION
Fixes #5585.

Note that this won't build until the OsConfig.V1 version 1.2.0
release has actually happened.