### PR TITLE
Release Google.Cloud.Speech.V1P1Beta1 version 2.0.0-beta03

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Spanner.Common.V1](https://googleapis.dev/dotnet/Google.Cloud.Spanner.Common.V1/3.3.0) | 3.3.0 | Common resource names used by all Spanner V1 APIs |
 | [Google.Cloud.Spanner.V1](https://googleapis.dev/dotnet/Google.Cloud.Spanner.V1/3.3.0) | 3.3.0 | [Google Cloud Spanner](https://cloud.google.com/spanner/) |
 | [Google.Cloud.Speech.V1](https://googleapis.dev/dotnet/Google.Cloud.Speech.V1/2.1.0) | 2.1.0 | [Google Cloud Speech (V1 API)](https://cloud.google.com/speech) |
-| [Google.Cloud.Speech.V1P1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Speech.V1P1Beta1/2.0.0-beta02) | 2.0.0-beta02 | [Google Cloud Speech (V1P1Beta1 API)](https://cloud.google.com/speech) |
+| [Google.Cloud.Speech.V1P1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Speech.V1P1Beta1/2.0.0-beta03) | 2.0.0-beta03 | [Google Cloud Speech (V1P1Beta1 API)](https://cloud.google.com/speech) |
 | [Google.Cloud.Storage.V1](https://googleapis.dev/dotnet/Google.Cloud.Storage.V1/3.4.0-beta01) | 3.4.0-beta01 | [Google Cloud Storage](https://cloud.google.com/storage/) |
 | [Google.Cloud.Talent.V4](https://googleapis.dev/dotnet/Google.Cloud.Talent.V4/1.0.0-beta02) | 1.0.0-beta02 | [Google Cloud Talent Solution (V4 API)](https://cloud.google.com/talent-solution/) |
 | [Google.Cloud.Talent.V4Beta1](https://googleapis.dev/dotnet/Google.Cloud.Talent.V4Beta1/2.0.0-beta03) | 2.0.0-beta03 | [Google Cloud Talent Solution (V4Beta1 API)](https://cloud.google.com/talent-solution/) |

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.csproj
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta02</Version>
+    <Version>2.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google client library to access the Google Cloud Speech API version v1p1beta1 with upcoming features.</Description>
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.0.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />

--- a/apis/Google.Cloud.Speech.V1P1Beta1/docs/history.md
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+# Version 2.0.0-beta03, released 2020-11-18
+
+- [Commit 0ca05f5](https://github.com/googleapis/google-cloud-dotnet/commit/0ca05f5): chore: Regenerate all APIs using protoc 3.13 and Grpc.Tools 2.31
+- [Commit 6bde7a3](https://github.com/googleapis/google-cloud-dotnet/commit/6bde7a3): docs: Regenerate all APIs with service comments in client documentation
+- [Commit f83bdf1](https://github.com/googleapis/google-cloud-dotnet/commit/f83bdf1): fix: Apply timeouts to RPCs without retry
+- [Commit 947a573](https://github.com/googleapis/google-cloud-dotnet/commit/947a573): docs: Regenerate all clients with more explicit documentation
+- [Commit 7cf6cd8](https://github.com/googleapis/google-cloud-dotnet/commit/7cf6cd8): feat: Add speech adaptation, phrase sets and custom classes.
+
 # Version 2.0.0-beta02, released 2020-03-19
 
 No API surface changes compared with 2.0.0-beta01, just dependency

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1639,7 +1639,7 @@
       "protoPath": "google/cloud/speech/v1p1beta1",
       "productName": "Google Cloud Speech",
       "productUrl": "https://cloud.google.com/speech",
-      "version": "2.0.0-beta02",
+      "version": "2.0.0-beta03",
       "releaseLevelOverride": "beta",
       "type": "grpc",
       "description": "Google client library to access the Google Cloud Speech API version v1p1beta1 with upcoming features.",
@@ -1647,7 +1647,7 @@
         "Speech"
       ],
       "dependencies": {
-        "Google.LongRunning": "2.0.0"
+        "Google.LongRunning": "2.1.0"
       }
     },
     {

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -103,7 +103,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Spanner.Common.V1](Google.Cloud.Spanner.Common.V1/index.html) | 3.3.0 | Common resource names used by all Spanner V1 APIs |
 | [Google.Cloud.Spanner.V1](Google.Cloud.Spanner.V1/index.html) | 3.3.0 | [Google Cloud Spanner](https://cloud.google.com/spanner/) |
 | [Google.Cloud.Speech.V1](Google.Cloud.Speech.V1/index.html) | 2.1.0 | [Google Cloud Speech (V1 API)](https://cloud.google.com/speech) |
-| [Google.Cloud.Speech.V1P1Beta1](Google.Cloud.Speech.V1P1Beta1/index.html) | 2.0.0-beta02 | [Google Cloud Speech (V1P1Beta1 API)](https://cloud.google.com/speech) |
+| [Google.Cloud.Speech.V1P1Beta1](Google.Cloud.Speech.V1P1Beta1/index.html) | 2.0.0-beta03 | [Google Cloud Speech (V1P1Beta1 API)](https://cloud.google.com/speech) |
 | [Google.Cloud.Storage.V1](Google.Cloud.Storage.V1/index.html) | 3.4.0-beta01 | [Google Cloud Storage](https://cloud.google.com/storage/) |
 | [Google.Cloud.Talent.V4](Google.Cloud.Talent.V4/index.html) | 1.0.0-beta02 | [Google Cloud Talent Solution (V4 API)](https://cloud.google.com/talent-solution/) |
 | [Google.Cloud.Talent.V4Beta1](Google.Cloud.Talent.V4Beta1/index.html) | 2.0.0-beta03 | [Google Cloud Talent Solution (V4Beta1 API)](https://cloud.google.com/talent-solution/) |


### PR DESCRIPTION

Changes in this release:

- [Commit 0ca05f5](https://github.com/googleapis/google-cloud-dotnet/commit/0ca05f5): chore: Regenerate all APIs using protoc 3.13 and Grpc.Tools 2.31
- [Commit 6bde7a3](https://github.com/googleapis/google-cloud-dotnet/commit/6bde7a3): docs: Regenerate all APIs with service comments in client documentation
- [Commit f83bdf1](https://github.com/googleapis/google-cloud-dotnet/commit/f83bdf1): fix: Apply timeouts to RPCs without retry
- [Commit 947a573](https://github.com/googleapis/google-cloud-dotnet/commit/947a573): docs: Regenerate all clients with more explicit documentation
- [Commit 7cf6cd8](https://github.com/googleapis/google-cloud-dotnet/commit/7cf6cd8): feat: Add speech adaptation, phrase sets and custom classes.
