### PR TITLE
Release Google.Cloud.DocumentAI.V1Beta2 version 1.0.0-beta02

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Diagnostics.Common](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.Common/4.2.0-beta02) | 4.2.0-beta02 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries Common Components |
 | [Google.Cloud.Dialogflow.V2](https://googleapis.dev/dotnet/Google.Cloud.Dialogflow.V2/3.1.0) | 3.1.0 | [Google Cloud Dialogflow](https://cloud.google.com/dialogflow-enterprise/) |
 | [Google.Cloud.Dlp.V2](https://googleapis.dev/dotnet/Google.Cloud.Dlp.V2/3.1.0) | 3.1.0 | [Google Cloud Data Loss Prevention](https://cloud.google.com/dlp/) |
-| [Google.Cloud.DocumentAI.V1Beta2](https://googleapis.dev/dotnet/Google.Cloud.DocumentAI.V1Beta2/1.0.0-beta01) | 1.0.0-beta01 | [Cloud Document AI](https://cloud.google.com/solutions/document-ai) |
+| [Google.Cloud.DocumentAI.V1Beta2](https://googleapis.dev/dotnet/Google.Cloud.DocumentAI.V1Beta2/1.0.0-beta02) | 1.0.0-beta02 | [Cloud Document AI](https://cloud.google.com/solutions/document-ai) |
 | [Google.Cloud.ErrorReporting.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.ErrorReporting.V1Beta1/2.0.0-beta03) | 2.0.0-beta03 | [Google Cloud Error Reporting](https://cloud.google.com/error-reporting/) |
 | [Google.Cloud.Firestore.Admin.V1](https://googleapis.dev/dotnet/Google.Cloud.Firestore.Admin.V1/2.1.0) | 2.1.0 | [Firestore Administration (e.g. index management)](https://firebase.google.com) |
 | [Google.Cloud.Firestore](https://googleapis.dev/dotnet/Google.Cloud.Firestore/2.3.0-beta01) | 2.3.0-beta01 | [Firestore high-level library](https://firebase.google.com/docs/firestore/) |

--- a/apis/Google.Cloud.DocumentAI.V1Beta2/Google.Cloud.DocumentAI.V1Beta2/Google.Cloud.DocumentAI.V1Beta2.csproj
+++ b/apis/Google.Cloud.DocumentAI.V1Beta2/Google.Cloud.DocumentAI.V1Beta2/Google.Cloud.DocumentAI.V1Beta2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Document AI API, which is a service to parse structured information from unstructured or semi-structured documents using state-of-the-art Google AI such as natural language, computer vision, translation, and AutoML.</Description>
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.0.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />

--- a/apis/Google.Cloud.DocumentAI.V1Beta2/docs/history.md
+++ b/apis/Google.Cloud.DocumentAI.V1Beta2/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+# Version 1.0.0-beta02, released 2020-11-18
+
+- [Commit a7ea8e7](https://github.com/googleapis/google-cloud-dotnet/commit/a7ea8e7): chore: Fix namespaces for Ruby, PHP, and C# clients
+- [Commit 0ca05f5](https://github.com/googleapis/google-cloud-dotnet/commit/0ca05f5): chore: Regenerate all APIs using protoc 3.13 and Grpc.Tools 2.31
+- [Commit 6bde7a3](https://github.com/googleapis/google-cloud-dotnet/commit/6bde7a3): docs: Regenerate all APIs with service comments in client documentation
+- [Commit b71ac78](https://github.com/googleapis/google-cloud-dotnet/commit/b71ac78): fix: updated timeouts
+- [Commit 149e872](https://github.com/googleapis/google-cloud-dotnet/commit/149e872): fix!: Provide C#, Ruby and PHP namespace/package options.
+
 # Version 1.0.0-beta01, released 2020-06-03
 
 First beta release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -634,7 +634,7 @@
     },
     {
       "id": "Google.Cloud.DocumentAI.V1Beta2",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "generator": "micro",
       "productName": "Cloud Document AI",
       "productUrl": "https://cloud.google.com/solutions/document-ai",
@@ -650,7 +650,7 @@
         "automl"
       ],
       "dependencies": {
-        "Google.LongRunning": "2.0.0"
+        "Google.LongRunning": "2.1.0"
       }
     },
     {

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -51,7 +51,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Diagnostics.Common](Google.Cloud.Diagnostics.Common/index.html) | 4.2.0-beta02 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries Common Components |
 | [Google.Cloud.Dialogflow.V2](Google.Cloud.Dialogflow.V2/index.html) | 3.1.0 | [Google Cloud Dialogflow](https://cloud.google.com/dialogflow-enterprise/) |
 | [Google.Cloud.Dlp.V2](Google.Cloud.Dlp.V2/index.html) | 3.1.0 | [Google Cloud Data Loss Prevention](https://cloud.google.com/dlp/) |
-| [Google.Cloud.DocumentAI.V1Beta2](Google.Cloud.DocumentAI.V1Beta2/index.html) | 1.0.0-beta01 | [Cloud Document AI](https://cloud.google.com/solutions/document-ai) |
+| [Google.Cloud.DocumentAI.V1Beta2](Google.Cloud.DocumentAI.V1Beta2/index.html) | 1.0.0-beta02 | [Cloud Document AI](https://cloud.google.com/solutions/document-ai) |
 | [Google.Cloud.ErrorReporting.V1Beta1](Google.Cloud.ErrorReporting.V1Beta1/index.html) | 2.0.0-beta03 | [Google Cloud Error Reporting](https://cloud.google.com/error-reporting/) |
 | [Google.Cloud.Firestore.Admin.V1](Google.Cloud.Firestore.Admin.V1/index.html) | 2.1.0 | [Firestore Administration (e.g. index management)](https://firebase.google.com) |
 | [Google.Cloud.Firestore](Google.Cloud.Firestore/index.html) | 2.3.0-beta01 | [Firestore high-level library](https://firebase.google.com/docs/firestore/) |


### PR DESCRIPTION

Changes in this release:

- [Commit a7ea8e7](https://github.com/googleapis/google-cloud-dotnet/commit/a7ea8e7): chore: Fix namespaces for Ruby, PHP, and C# clients
- [Commit 0ca05f5](https://github.com/googleapis/google-cloud-dotnet/commit/0ca05f5): chore: Regenerate all APIs using protoc 3.13 and Grpc.Tools 2.31
- [Commit 6bde7a3](https://github.com/googleapis/google-cloud-dotnet/commit/6bde7a3): docs: Regenerate all APIs with service comments in client documentation
- [Commit b71ac78](https://github.com/googleapis/google-cloud-dotnet/commit/b71ac78): fix: updated timeouts
- [Commit 149e872](https://github.com/googleapis/google-cloud-dotnet/commit/149e872): fix!: Provide C#, Ruby and PHP namespace/package options.
