### PR TITLE
Release Google.Cloud.Logging.Type version 3.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Language.V1](https://googleapis.dev/dotnet/Google.Cloud.Language.V1/2.1.0) | 2.1.0 | [Google Cloud Natural Language](https://cloud.google.com/natural-language) |
 | [Google.Cloud.Logging.Log4Net](https://googleapis.dev/dotnet/Google.Cloud.Logging.Log4Net/3.1.0) | 3.1.0 | Log4Net client library for the Google Cloud Logging API |
 | [Google.Cloud.Logging.NLog](https://googleapis.dev/dotnet/Google.Cloud.Logging.NLog/3.0.1) | 3.0.1 | NLog target for the Google Cloud Logging API |
-| [Google.Cloud.Logging.Type](https://googleapis.dev/dotnet/Google.Cloud.Logging.Type/3.1.0) | 3.1.0 | Version-agnostic types for the Google Cloud Logging API |
+| [Google.Cloud.Logging.Type](https://googleapis.dev/dotnet/Google.Cloud.Logging.Type/3.2.0) | 3.2.0 | Version-agnostic types for the Google Cloud Logging API |
 | [Google.Cloud.Logging.V2](https://googleapis.dev/dotnet/Google.Cloud.Logging.V2/3.1.0) | 3.1.0 | [Google Cloud Logging](https://cloud.google.com/logging/) |
 | [Google.Cloud.ManagedIdentities.V1](https://googleapis.dev/dotnet/Google.Cloud.ManagedIdentities.V1/2.1.0) | 2.1.0 | [Managed Service for Microsoft Active Directory](https://cloud.google.com/managed-microsoft-ad/) |
 | [Google.Cloud.MediaTranslation.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.MediaTranslation.V1Beta1/1.0.0-beta01) | 1.0.0-beta01 | [Media Translation](https://cloud.google.com/media-translation) |

--- a/apis/Google.Cloud.Logging.Type/Google.Cloud.Logging.Type/Google.Cloud.Logging.Type.csproj
+++ b/apis/Google.Cloud.Logging.Type/Google.Cloud.Logging.Type/Google.Cloud.Logging.Type.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.1.0</Version>
+    <Version>3.2.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Version-agnostic types for the Google Cloud Logging API.</Description>

--- a/apis/Google.Cloud.Logging.Type/docs/history.md
+++ b/apis/Google.Cloud.Logging.Type/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 3.2.0, released 2020-11-18
+
+- [Commit 762ed1f](https://github.com/googleapis/google-cloud-dotnet/commit/762ed1f): docs: Updates to IP address comments
+
 # Version 3.1.0, released 2020-10-20
 
 - [Commit 0ca05f5](https://github.com/googleapis/google-cloud-dotnet/commit/0ca05f5): chore: Regenerate all APIs using protoc 3.13 and Grpc.Tools 2.31

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -936,7 +936,7 @@
       "id": "Google.Cloud.Logging.Type",
       "generator": "proto",
       "protoPath": "google/logging/type",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "type": "other",
       "targetFrameworks": "netstandard2.0;net461",
       "description": "Version-agnostic types for the Google Cloud Logging API.",

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -65,7 +65,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Language.V1](Google.Cloud.Language.V1/index.html) | 2.1.0 | [Google Cloud Natural Language](https://cloud.google.com/natural-language) |
 | [Google.Cloud.Logging.Log4Net](Google.Cloud.Logging.Log4Net/index.html) | 3.1.0 | Log4Net client library for the Google Cloud Logging API |
 | [Google.Cloud.Logging.NLog](Google.Cloud.Logging.NLog/index.html) | 3.0.1 | NLog target for the Google Cloud Logging API |
-| [Google.Cloud.Logging.Type](Google.Cloud.Logging.Type/index.html) | 3.1.0 | Version-agnostic types for the Google Cloud Logging API |
+| [Google.Cloud.Logging.Type](Google.Cloud.Logging.Type/index.html) | 3.2.0 | Version-agnostic types for the Google Cloud Logging API |
 | [Google.Cloud.Logging.V2](Google.Cloud.Logging.V2/index.html) | 3.1.0 | [Google Cloud Logging](https://cloud.google.com/logging/) |
 | [Google.Cloud.ManagedIdentities.V1](Google.Cloud.ManagedIdentities.V1/index.html) | 2.1.0 | [Managed Service for Microsoft Active Directory](https://cloud.google.com/managed-microsoft-ad/) |
 | [Google.Cloud.MediaTranslation.V1Beta1](Google.Cloud.MediaTranslation.V1Beta1/index.html) | 1.0.0-beta01 | [Media Translation](https://cloud.google.com/media-translation) |


### PR DESCRIPTION

Changes in this release:

- [Commit 762ed1f](https://github.com/googleapis/google-cloud-dotnet/commit/762ed1f): docs: Updates to IP address comments
