### PR TITLE
Release Google.Cloud.Firestore version 2.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.DocumentAI.V1Beta2](https://googleapis.dev/dotnet/Google.Cloud.DocumentAI.V1Beta2/1.0.0-beta02) | 1.0.0-beta02 | [Cloud Document AI](https://cloud.google.com/solutions/document-ai) |
 | [Google.Cloud.ErrorReporting.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.ErrorReporting.V1Beta1/2.0.0-beta03) | 2.0.0-beta03 | [Google Cloud Error Reporting](https://cloud.google.com/error-reporting/) |
 | [Google.Cloud.Firestore.Admin.V1](https://googleapis.dev/dotnet/Google.Cloud.Firestore.Admin.V1/2.1.0) | 2.1.0 | [Firestore Administration (e.g. index management)](https://firebase.google.com) |
-| [Google.Cloud.Firestore](https://googleapis.dev/dotnet/Google.Cloud.Firestore/2.3.0-beta01) | 2.3.0-beta01 | [Firestore high-level library](https://firebase.google.com/docs/firestore/) |
+| [Google.Cloud.Firestore](https://googleapis.dev/dotnet/Google.Cloud.Firestore/2.3.0) | 2.3.0 | [Firestore high-level library](https://firebase.google.com/docs/firestore/) |
 | [Google.Cloud.Firestore.V1](https://googleapis.dev/dotnet/Google.Cloud.Firestore.V1/2.2.0) | 2.2.0 | [Firestore low-level API access](https://firebase.google.com) |
 | [Google.Cloud.Functions.V1](https://googleapis.dev/dotnet/Google.Cloud.Functions.V1/1.0.0) | 1.0.0 | [Cloud Functions](https://cloud.google.com/functions) |
 | [Google.Cloud.Gaming.V1](https://googleapis.dev/dotnet/Google.Cloud.Gaming.V1/1.0.0) | 1.0.0 | [Game Services](https://cloud.google.com/solutions/gaming) |

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Google.Cloud.Firestore.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Google.Cloud.Firestore.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.3.0-beta01</Version>
+    <Version>2.3.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Firestore API.</Description>
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Cloud.Firestore.V1" Version="[2.1.0, 3.0.0)" />
+    <PackageReference Include="Google.Cloud.Firestore.V1" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />

--- a/apis/Google.Cloud.Firestore/docs/history.md
+++ b/apis/Google.Cloud.Firestore/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 2.3.0, released 2020-11-18
+
+No API surface change - just dependencies, and a GA release of the new serialization attribute from 2.3.0-beta01.
+
 # Version 2.3.0-beta01, released 2020-10-29
 
 - [Commit 126529d](https://github.com/googleapis/google-cloud-dotnet/commit/126529d): Mechanism for passing server-provided fields to custom type converters. Fixes [issue 5470](https://github.com/googleapis/google-cloud-dotnet/issues/5470).

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -696,7 +696,7 @@
       "productName": "Firestore",
       "productUrl": "https://firebase.google.com/docs/firestore/",
       "listingDescription": "Firestore high-level library",
-      "version": "2.3.0-beta01",
+      "version": "2.3.0",
       "type": "other",
       "targetFrameworks": "netstandard2.0;net461",
       "testTargetFrameworks": "netcoreapp2.1;net461",
@@ -706,7 +706,7 @@
         "firebase"
       ],
       "dependencies": {
-        "Google.Cloud.Firestore.V1": "2.1.0",
+        "Google.Cloud.Firestore.V1": "2.2.0",
         "Grpc.Core": "2.31.0",
         "System.Collections.Immutable": "1.4.0",
         "System.Linq.Async": "4.0.0"

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -54,7 +54,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.DocumentAI.V1Beta2](Google.Cloud.DocumentAI.V1Beta2/index.html) | 1.0.0-beta02 | [Cloud Document AI](https://cloud.google.com/solutions/document-ai) |
 | [Google.Cloud.ErrorReporting.V1Beta1](Google.Cloud.ErrorReporting.V1Beta1/index.html) | 2.0.0-beta03 | [Google Cloud Error Reporting](https://cloud.google.com/error-reporting/) |
 | [Google.Cloud.Firestore.Admin.V1](Google.Cloud.Firestore.Admin.V1/index.html) | 2.1.0 | [Firestore Administration (e.g. index management)](https://firebase.google.com) |
-| [Google.Cloud.Firestore](Google.Cloud.Firestore/index.html) | 2.3.0-beta01 | [Firestore high-level library](https://firebase.google.com/docs/firestore/) |
+| [Google.Cloud.Firestore](Google.Cloud.Firestore/index.html) | 2.3.0 | [Firestore high-level library](https://firebase.google.com/docs/firestore/) |
 | [Google.Cloud.Firestore.V1](Google.Cloud.Firestore.V1/index.html) | 2.2.0 | [Firestore low-level API access](https://firebase.google.com) |
 | [Google.Cloud.Functions.V1](Google.Cloud.Functions.V1/index.html) | 1.0.0 | [Cloud Functions](https://cloud.google.com/functions) |
 | [Google.Cloud.Gaming.V1](Google.Cloud.Gaming.V1/index.html) | 1.0.0 | [Game Services](https://cloud.google.com/solutions/gaming) |


### PR DESCRIPTION

Changes in this release:

No API surface change - just dependencies, and a GA release of the new serialization attribute from 2.3.0-beta01.
