### PR TITLE
[Log4Net]: Adds snippet showing how to set Log4Net properties as Google Cloud log entry labels.

### DIFF
--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Snippets/AssemblyInfo.cs
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Snippets/AssemblyInfo.cs
@@ -1,0 +1,17 @@
+﻿// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Snippets/Google.Cloud.Logging.Log4Net.Snippets.csproj
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Snippets/Google.Cloud.Logging.Log4Net.Snippets.csproj
@@ -21,6 +21,7 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="log4net-custom-labels-template.xml" />
     <EmbeddedResource Include="log4net-template.xml" />
     <EmbeddedResource Include="log4net-aspnet-template.xml" />
   </ItemGroup>

--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Snippets/log4net-custom-labels-template.xml
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Snippets/log4net-custom-labels-template.xml
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<log4net>
+  <appender name="CloudLogger" type="Google.Cloud.Logging.Log4Net.GoogleStackdriverAppender,Google.Cloud.Logging.Log4Net">
+    <layout type="log4net.Layout.PatternLayout">
+      <conversionPattern value="%-4timestamp [%thread] %-5level %logger %ndc - %message" />
+    </layout>
+    <projectId value="PROJECT_ID" />
+    <logId value="LOG_ID" />
+    <usePatternWithinCustomLabels value="true"/>
+    <customLabel>
+      <key value="label_from_property" />
+      <value value="%property{property_for_label}" />
+    </customLabel>
+  </appender>
+  <root>
+    <level value="ALL" />
+    <appender-ref ref="CloudLogger" />
+  </root>
+</log4net>

--- a/apis/Google.Cloud.Logging.Log4Net/docs/configuration.md
+++ b/apis/Google.Cloud.Logging.Log4Net/docs/configuration.md
@@ -78,6 +78,16 @@ By default no extra metadata is logged. `withMetaData` specifies which extra met
 ```
 Allows custom labels to be added to the metadata of log entries.
 
+### UsePatternWithinCustomLabels
+
+```xml
+<usePatternWithinCustomLabels value="true"/>
+```
+
+Defaults to `false`. Setting this to `true` enables `PatternLayout` use in custom labels.
+All the standard patterns documented for Log4Net `PatternLayout` are available.
+Custom pattern conversions are not possible.
+
 ### resourceType
 
 ```xml
@@ -131,6 +141,27 @@ So, for example, a complete configuration might look like this:
   </appender>
 </log4net>
 ```
+### Configuration example: Translating Log4Net properties to Google Cloud Logging labels
+
+If you wanted to transalate Log4Net properties to Google Cloud Logging labels, you can do as follows:
+
+Create a `log4net` configuration file (`log4net.xml`):
+
+[!code-xml[](obj/snippets/Google.Cloud.Logging.Log4Net.GoogleStackdriverAppender.txt#log4net_custom_labels_template)]
+
+Edit the file replacing `PROJECT_ID` with your Google Cloud Project
+ID, and `LOG_ID` with an identifier for your application.
+
+Use this file to configure `log4net` and then set Log4Net properties per scopes and log as normal.
+If a property referenced in a custom label doesn't have a value for a given entry, the value will be
+`(null)`.
+
+{{sample:GoogleStackdriverAppender.Custom_Labels}}
+
+If executing on [Google App Engine (GAE)](https://cloud.google.com/appengine/),
+[Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine/),
+or [Google Compute Engine (GCE)](https://cloud.google.com/compute/),
+then the `<projectId value="PROJECT_ID" />` configuration setting can be omitted; it will be auto-detected from the platform at run-time.
 
 ## Local queuing configuration
 

--- a/apis/Google.Cloud.Logging.Log4Net/docs/index.md
+++ b/apis/Google.Cloud.Logging.Log4Net/docs/index.md
@@ -1,6 +1,6 @@
 {{title}}
 
-`Google.Cloud.Logging.Log4Net` is a .NET client library to integrate  [Google Stackdriver
+`Google.Cloud.Logging.Log4Net` is a .NET client library to integrate  [Google Cloud
 Logging](https://cloud.google.com/logging/) with
 [log4net](https://logging.apache.org/log4net/).
 


### PR DESCRIPTION
Towards #5325