### PR TITLE
Release Google.Cloud.Container.V1 version 2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Billing.Budgets.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Billing.Budgets.V1Beta1/1.0.0-beta02) | 1.0.0-beta02 | [Cloud Billing Budget (V1Beta1 API)](https://cloud.google.com/billing/docs/how-to/budget-api-overview) |
 | [Google.Cloud.Billing.V1](https://googleapis.dev/dotnet/Google.Cloud.Billing.V1/2.1.0) | 2.1.0 | [Google Cloud Billing](https://cloud.google.com/billing/docs/) |
 | [Google.Cloud.BinaryAuthorization.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.BinaryAuthorization.V1Beta1/1.0.0-beta01) | 1.0.0-beta01 | [Binary Authorization](https://cloud.google.com/binary-authorization/docs/reference/rpc) |
-| [Google.Cloud.Container.V1](https://googleapis.dev/dotnet/Google.Cloud.Container.V1/2.1.0) | 2.1.0 | [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/reference/rest/) |
+| [Google.Cloud.Container.V1](https://googleapis.dev/dotnet/Google.Cloud.Container.V1/2.2.0) | 2.2.0 | [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/reference/rest/) |
 | [Google.Cloud.DataCatalog.V1](https://googleapis.dev/dotnet/Google.Cloud.DataCatalog.V1/1.1.0) | 1.1.0 | [Data Catalog](https://cloud.google.com/data-catalog/docs) |
 | [Google.Cloud.DataLabeling.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.DataLabeling.V1Beta1/1.0.0-beta01) | 1.0.0-beta01 | [Data Labeling](https://cloud.google.com/ai-platform/data-labeling/docs) |
 | [Google.Cloud.Dataproc.V1](https://googleapis.dev/dotnet/Google.Cloud.Dataproc.V1/3.0.0) | 3.0.0 | [Google Cloud Dataproc](https://cloud.google.com/dataproc/docs/concepts/overview) |

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.</Description>

--- a/apis/Google.Cloud.Container.V1/docs/history.md
+++ b/apis/Google.Cloud.Container.V1/docs/history.md
@@ -1,5 +1,32 @@
 # Version history
 
+# Version 2.2.0, released 2020-11-19
+
+- [Commit 3a8598f](https://github.com/googleapis/google-cloud-dotnet/commit/3a8598f):
+  - fix: deprecate SetLocations; use UpdateCluster
+  - refactor: provide name alias for GetOperation (as method signature annotation)
+  - feat: support for GetJSONWebKeys
+  - feat: support for Workload Identity
+  - feat: support for Gvisor in nodes
+  - feat: support for node reservation affinity
+  - feat: support for Customer Managed Encryption in nodes
+  - fix: deprecate basic auth fields (removed in 1.19 clusters)
+  - feat: support for NodeLocalDNS
+  - feat: support for ConfigConnector
+  - feat: support for private cluster VPC peering
+  - feat: support for CloudRun load balancers
+  - feat: support using routes for pod IPs
+  - feat: support for Shielded Nodes
+  - feat: support for release channels
+  - fix: deprecated Cluster/NodePool.status_message; use conditions
+  - feat: support for disabling default sNAT
+  - feat: operations now store more granular progress
+  - feat: support for node Surge Upgrades
+  - feat: support for updating node pool locations.
+  - feat: support for Node Auto Provisioning
+  - feat: support for specifying node disk size and type
+  - docs: many minor documentation clarifications
+
 # Version 2.1.0, released 2020-10-14
 
 - [Commit 0790924](https://github.com/googleapis/google-cloud-dotnet/commit/0790924): fix: Add gRPC compatibility constructors

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -346,7 +346,7 @@
       "protoPath": "google/container/v1",
       "productName": "Google Kubernetes Engine",
       "productUrl": "https://cloud.google.com/kubernetes-engine/docs/reference/rest/",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.",
       "dependencies": {

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -37,7 +37,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Billing.Budgets.V1Beta1](Google.Cloud.Billing.Budgets.V1Beta1/index.html) | 1.0.0-beta02 | [Cloud Billing Budget (V1Beta1 API)](https://cloud.google.com/billing/docs/how-to/budget-api-overview) |
 | [Google.Cloud.Billing.V1](Google.Cloud.Billing.V1/index.html) | 2.1.0 | [Google Cloud Billing](https://cloud.google.com/billing/docs/) |
 | [Google.Cloud.BinaryAuthorization.V1Beta1](Google.Cloud.BinaryAuthorization.V1Beta1/index.html) | 1.0.0-beta01 | [Binary Authorization](https://cloud.google.com/binary-authorization/docs/reference/rpc) |
-| [Google.Cloud.Container.V1](Google.Cloud.Container.V1/index.html) | 2.1.0 | [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/reference/rest/) |
+| [Google.Cloud.Container.V1](Google.Cloud.Container.V1/index.html) | 2.2.0 | [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/reference/rest/) |
 | [Google.Cloud.DataCatalog.V1](Google.Cloud.DataCatalog.V1/index.html) | 1.1.0 | [Data Catalog](https://cloud.google.com/data-catalog/docs) |
 | [Google.Cloud.DataLabeling.V1Beta1](Google.Cloud.DataLabeling.V1Beta1/index.html) | 1.0.0-beta01 | [Data Labeling](https://cloud.google.com/ai-platform/data-labeling/docs) |
 | [Google.Cloud.Dataproc.V1](Google.Cloud.Dataproc.V1/index.html) | 3.0.0 | [Google Cloud Dataproc](https://cloud.google.com/dataproc/docs/concepts/overview) |


### PR DESCRIPTION

Changes in this release:

- [Commit 3a8598f](https://github.com/googleapis/google-cloud-dotnet/commit/3a8598f):
  - fix: deprecate SetLocations; use UpdateCluster
  - refactor: provide name alias for GetOperation (as method signature annotation)
  - feat: support for GetJSONWebKeys
  - feat: support for Workload Identity
  - feat: support for Gvisor in nodes
  - feat: support for node reservation affinity
  - feat: support for Customer Managed Encryption in nodes
  - fix: deprecate basic auth fields (removed in 1.19 clusters)
  - feat: support for NodeLocalDNS
  - feat: support for ConfigConnector
  - feat: support for private cluster VPC peering
  - feat: support for CloudRun load balancers
  - feat: support using routes for pod IPs
  - feat: support for Shielded Nodes
  - feat: support for release channels
  - fix: deprecated Cluster/NodePool.status_message; use conditions
  - feat: support for disabling default sNAT
  - feat: operations now store more granular progress
  - feat: support for node Surge Upgrades
  - feat: support for updating node pool locations.
  - feat: support for Node Auto Provisioning
  - feat: support for specifying node disk size and type
  - docs: many minor documentation clarifications
