### PR TITLE
Release Google.Analytics.Data.V1Alpha version 1.0.0-alpha03

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Each package name links to the documentation for that package.
 | Package | Latest version | Description |
 |---------|----------------|-------------|
 | [Google.Analytics.Admin.V1Alpha](https://googleapis.dev/dotnet/Google.Analytics.Admin.V1Alpha/1.0.0-alpha03) | 1.0.0-alpha03 | Analytics Admin |
-| [Google.Analytics.Data.V1Alpha](https://googleapis.dev/dotnet/Google.Analytics.Data.V1Alpha/1.0.0-alpha02) | 1.0.0-alpha02 | Google Analytics Data |
+| [Google.Analytics.Data.V1Alpha](https://googleapis.dev/dotnet/Google.Analytics.Data.V1Alpha/1.0.0-alpha03) | 1.0.0-alpha03 | Google Analytics Data |
 | [Google.Area120.Tables.V1Alpha1](https://googleapis.dev/dotnet/Google.Area120.Tables.V1Alpha1/1.0.0-alpha02) | 1.0.0-alpha02 | Google Area 120 Tables |
 | [Google.Cloud.ArtifactRegistry.V1Beta2](https://googleapis.dev/dotnet/Google.Cloud.ArtifactRegistry.V1Beta2/1.0.0-beta01) | 1.0.0-beta01 | [Artifact Registry](https://cloud.google.com/artifact-registry) |
 | [Google.Cloud.Asset.V1](https://googleapis.dev/dotnet/Google.Cloud.Asset.V1/2.6.0) | 2.6.0 | [Google Cloud Asset Inventory](https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview) |

--- a/apis/Google.Analytics.Data.V1Alpha/Google.Analytics.Data.V1Alpha/Google.Analytics.Data.V1Alpha.csproj
+++ b/apis/Google.Analytics.Data.V1Alpha/Google.Analytics.Data.V1Alpha/Google.Analytics.Data.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha02</Version>
+    <Version>1.0.0-alpha03</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Analytics Data API</Description>

--- a/apis/Google.Analytics.Data.V1Alpha/docs/history.md
+++ b/apis/Google.Analytics.Data.V1Alpha/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+# Version 1.0.0-alpha03, released 2020-11-19
+
+- [Commit 92d988e](https://github.com/googleapis/google-cloud-dotnet/commit/92d988e):
+  - fix!: GetUniversalMetadata method removed from the API, GetMetadata method should be used instead feat: reporting requests now support date ranges longer than one year docs: minor documentation updates ([issue 5556](https://github.com/googleapis/google-cloud-dotnet/issues/5556))
+  - fix!: GetUniversalMetadata method removed from the API, GetMetadata method should be used instead
+  - feat: reporting requests now support date ranges longer than one year
+  - docs: minor documentation updates ([issue 5556](https://github.com/googleapis/google-cloud-dotnet/issues/5556))
+
 # Version 1.0.0-alpha02, released 2020-11-05
 
 - [Commit b85cd73](https://github.com/googleapis/google-cloud-dotnet/commit/b85cd73):

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -15,7 +15,7 @@
     },
     {
       "id": "Google.Analytics.Data.V1Alpha",
-      "version": "1.0.0-alpha02",
+      "version": "1.0.0-alpha03",
       "type": "grpc",
       "productName": "Google Analytics Data",
       "description": "Recommended Google client library to access the Analytics Data API",

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -19,7 +19,7 @@ Each package name links to the documentation for that package.
 | Package | Latest version | Description |
 |---------|----------------|-------------|
 | [Google.Analytics.Admin.V1Alpha](Google.Analytics.Admin.V1Alpha/index.html) | 1.0.0-alpha03 | Analytics Admin |
-| [Google.Analytics.Data.V1Alpha](Google.Analytics.Data.V1Alpha/index.html) | 1.0.0-alpha02 | Google Analytics Data |
+| [Google.Analytics.Data.V1Alpha](Google.Analytics.Data.V1Alpha/index.html) | 1.0.0-alpha03 | Google Analytics Data |
 | [Google.Area120.Tables.V1Alpha1](Google.Area120.Tables.V1Alpha1/index.html) | 1.0.0-alpha02 | Google Area 120 Tables |
 | [Google.Cloud.ArtifactRegistry.V1Beta2](Google.Cloud.ArtifactRegistry.V1Beta2/index.html) | 1.0.0-beta01 | [Artifact Registry](https://cloud.google.com/artifact-registry) |
 | [Google.Cloud.Asset.V1](Google.Cloud.Asset.V1/index.html) | 2.6.0 | [Google Cloud Asset Inventory](https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview) |


### PR DESCRIPTION

Changes in this release:

- [Commit 92d988e](https://github.com/googleapis/google-cloud-dotnet/commit/92d988e):
  - fix!: GetUniversalMetadata method removed from the API, GetMetadata method should be used instead feat: reporting requests now support date ranges longer than one year docs: minor documentation updates ([issue 5556](https://github.com/googleapis/google-cloud-dotnet/issues/5556))
  - fix!: GetUniversalMetadata method removed from the API, GetMetadata method should be used instead
  - feat: reporting requests now support date ranges longer than one year
  - docs: minor documentation updates ([issue 5556](https://github.com/googleapis/google-cloud-dotnet/issues/5556))
