### PR TITLE
Release Google.Cloud.Logging.NLog version 3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Kms.V1](https://googleapis.dev/dotnet/Google.Cloud.Kms.V1/2.1.0) | 2.1.0 | [Google Cloud Key Management Service](https://cloud.google.com/kms/) |
 | [Google.Cloud.Language.V1](https://googleapis.dev/dotnet/Google.Cloud.Language.V1/2.1.0) | 2.1.0 | [Google Cloud Natural Language](https://cloud.google.com/natural-language) |
 | [Google.Cloud.Logging.Log4Net](https://googleapis.dev/dotnet/Google.Cloud.Logging.Log4Net/3.1.0) | 3.1.0 | Log4Net client library for the Google Cloud Logging API |
-| [Google.Cloud.Logging.NLog](https://googleapis.dev/dotnet/Google.Cloud.Logging.NLog/3.0.1) | 3.0.1 | NLog target for the Google Cloud Logging API |
+| [Google.Cloud.Logging.NLog](https://googleapis.dev/dotnet/Google.Cloud.Logging.NLog/3.1.0) | 3.1.0 | NLog target for the Google Cloud Logging API |
 | [Google.Cloud.Logging.Type](https://googleapis.dev/dotnet/Google.Cloud.Logging.Type/3.2.0) | 3.2.0 | Version-agnostic types for the Google Cloud Logging API |
 | [Google.Cloud.Logging.V2](https://googleapis.dev/dotnet/Google.Cloud.Logging.V2/3.2.0) | 3.2.0 | [Google Cloud Logging](https://cloud.google.com/logging/) |
 | [Google.Cloud.ManagedIdentities.V1](https://googleapis.dev/dotnet/Google.Cloud.ManagedIdentities.V1/2.1.0) | 2.1.0 | [Managed Service for Microsoft Active Directory](https://cloud.google.com/managed-microsoft-ad/) |

--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.csproj
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.1</Version>
+    <Version>3.1.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>NLog target for the Google Cloud Logging API.</Description>
@@ -13,7 +13,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.DevTools.Common" Version="[2.0.0, 3.0.0)" />
-    <PackageReference Include="Google.Cloud.Logging.V2" Version="[3.0.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Logging.V2" Version="[3.2.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />

--- a/apis/Google.Cloud.Logging.NLog/docs/history.md
+++ b/apis/Google.Cloud.Logging.NLog/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+# Version 3.1.0, released 2020-11-19
+
+- [Commit cbaa00a](https://github.com/googleapis/google-cloud-dotnet/commit/cbaa00a): Renormalize line endings
+- [Commit 02e2ddc](https://github.com/googleapis/google-cloud-dotnet/commit/02e2ddc): NLog GoogleStackDriverTarget skip reflection on Stream-objects ([issue 5230](https://github.com/googleapis/google-cloud-dotnet/issues/5230))
+- [Commit 0e6d135](https://github.com/googleapis/google-cloud-dotnet/commit/0e6d135): NLog GoogleStackdriverTarget improve handling of System.Reflection (MemberInfo is better than MethodInfo)
+
 # Version 3.0.1, released 2020-04-20
 
 - [Commit ced67e4](https://github.com/googleapis/google-cloud-dotnet/commit/ced67e4): Fix: Improve handling of System.Reflection objects that will dump all types in the application-assembly.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -916,7 +916,7 @@
     },
     {
       "id": "Google.Cloud.Logging.NLog",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "type": "other",
       "targetFrameworks": "netstandard2.0;net461",
       "testTargetFrameworks": "netcoreapp2.1;net461",
@@ -927,11 +927,11 @@
         "Stackdriver"
       ],
       "dependencies": {
-        "NLog": "4.5.11",
         "Google.Api.Gax.Grpc.GrpcCore": "3.2.0",
-        "Google.Cloud.Logging.V2": "3.0.0",
         "Google.Cloud.DevTools.Common": "2.0.0",
-        "Grpc.Core": "2.31.0"
+        "Google.Cloud.Logging.V2": "3.2.0",
+        "Grpc.Core": "2.31.0",
+        "NLog": "4.5.11"
       },
       "testDependencies": {
         "Google.Api.Gax.Testing": "3.2.0"

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -64,7 +64,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Kms.V1](Google.Cloud.Kms.V1/index.html) | 2.1.0 | [Google Cloud Key Management Service](https://cloud.google.com/kms/) |
 | [Google.Cloud.Language.V1](Google.Cloud.Language.V1/index.html) | 2.1.0 | [Google Cloud Natural Language](https://cloud.google.com/natural-language) |
 | [Google.Cloud.Logging.Log4Net](Google.Cloud.Logging.Log4Net/index.html) | 3.1.0 | Log4Net client library for the Google Cloud Logging API |
-| [Google.Cloud.Logging.NLog](Google.Cloud.Logging.NLog/index.html) | 3.0.1 | NLog target for the Google Cloud Logging API |
+| [Google.Cloud.Logging.NLog](Google.Cloud.Logging.NLog/index.html) | 3.1.0 | NLog target for the Google Cloud Logging API |
 | [Google.Cloud.Logging.Type](Google.Cloud.Logging.Type/index.html) | 3.2.0 | Version-agnostic types for the Google Cloud Logging API |
 | [Google.Cloud.Logging.V2](Google.Cloud.Logging.V2/index.html) | 3.2.0 | [Google Cloud Logging](https://cloud.google.com/logging/) |
 | [Google.Cloud.ManagedIdentities.V1](Google.Cloud.ManagedIdentities.V1/index.html) | 2.1.0 | [Managed Service for Microsoft Active Directory](https://cloud.google.com/managed-microsoft-ad/) |


### PR DESCRIPTION

Changes in this release:

- [Commit cbaa00a](https://github.com/googleapis/google-cloud-dotnet/commit/cbaa00a): Renormalize line endings
- [Commit 02e2ddc](https://github.com/googleapis/google-cloud-dotnet/commit/02e2ddc): NLog GoogleStackDriverTarget skip reflection on Stream-objects ([issue 5230](https://github.com/googleapis/google-cloud-dotnet/issues/5230))
- [Commit 0e6d135](https://github.com/googleapis/google-cloud-dotnet/commit/0e6d135): NLog GoogleStackdriverTarget improve handling of System.Reflection (MemberInfo is better than MethodInfo)
