### PR TITLE
Google.Cloud.Logging.Nlog Adds possibility to use custom jsonLayout

### DIFF
--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.Snippets/Google.Cloud.Logging.NLog.Snippets.csproj
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.Snippets/Google.Cloud.Logging.NLog.Snippets.csproj
@@ -21,6 +21,7 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="nlog-jsonTemplate.xml" />
     <EmbeddedResource Include="nlog-template.xml" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.Snippets/nlog-jsonTemplate.xml
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.Snippets/nlog-jsonTemplate.xml
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+  <extensions>
+    <add assembly="Google.Cloud.Logging.NLog" />
+  </extensions>
+  
+  <targets async="true">
+    <target type="GoogleStackdriver" projectId="PROJECT_ID" logId="LOG_ID" name="stackdriver" resourceType="container" sendJsonPayload="true" enableJsonLayout="true" includeCallSite ="true" includeCallSiteStackTrace="true" IncludeEventProperties="false" IncludeMdlc="true">
+      <contextproperty name="contextProp" layout="propContextLayout" />
+      <layout xsi:type="JsonLayout" includeAllProperties="true">
+        <attribute name="someProp" layout="prop" />
+        <attribute name="nestedProp" encode="false">
+          <layout type='JsonLayout'>
+            <attribute name='insideNested1' layout='hello nested1!' />
+            <attribute name='insideNested2' layout='hello nested2!' />
+            <attribute name="nestedNestedProp" encode="false">
+              <layout type='JsonLayout'>
+                <attribute name='insideNestedNested1' layout='hello NestedNested1!' />
+                <attribute name='insideNestedNested2' layout='hello NestedNested2!' />
+              </layout>
+            </attribute>
+          </layout>
+        </attribute>
+      </layout>
+    </target>
+    <target name="console" xsi:type="Console" />
+  </targets>
+
+  <rules>
+    <logger name="*" minlevel="Info" writeTo="stackdriver" />
+    <logger name="*" minlevel="Info" writeTo="console" />
+  </rules>
+  
+</nlog>

--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/GoogleStackdriverTarget_Configuration.cs
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/GoogleStackdriverTarget_Configuration.cs
@@ -117,10 +117,17 @@ namespace Google.Cloud.Logging.NLog
 
         /// <summary>
         /// Fills <see cref="LogEntry.JsonPayload"/> instead of <see cref="LogEntry.TextPayload"/>.
-        /// JSON serialization can be customed using <see cref="JsonConverterTypeName"/> and <see cref="JsonConverterMethodName"/>,
+        /// JSON values serialization can be customized using <see cref="JsonConverterTypeName"/> and <see cref="JsonConverterMethodName"/>,
         /// or <see cref="JsonConverter"/>.
         /// </summary>
         public bool SendJsonPayload { get; set; }
+
+        /// <summary>
+        /// Fills <see cref="LogEntry.JsonPayload"/> in specified by user way with <see cref="T:NLog.Layouts.JsonLayout"/> layout type.
+        /// JSON values serialization can be customized using <see cref="JsonConverterTypeName"/> and <see cref="JsonConverterMethodName"/>,
+        /// or <see cref="JsonConverter"/>.
+        /// </summary>
+        public bool EnableJsonLayout { get; set; }
 
         /// <summary>
         /// When <see cref="SendJsonPayload"/> is <c>true</c>, a custom JSON serialization method may be specified by


### PR DESCRIPTION
As we discussed here: https://github.com/googleapis/google-cloud-dotnet/issues/5634

Now there is a possibility to use a custom JSON payload structure as the user desire.
Eg.
![image](https://user-images.githubusercontent.com/17548765/100347592-e622f900-2fe5-11eb-9e39-7565495dd133.png)

It's breaking nothing for that library users don't have to change config files and so on.

@jskeet I called flag to enable this feature **UseNLogCustomJsonLayout**. It informs users about what they should do if the current JSON layout doesn't meet their needs. I mean JsonLayout type from NLog's library.