### PR TITLE
Update Log4Net dependency to fix issue on Linux

### DIFF
--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.csproj
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="log4net" Version="2.0.8" />
+    <PackageReference Include="log4net" Version="2.0.12" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -891,7 +891,7 @@
         "Google.Cloud.DevTools.Common": "2.0.0",
         "Google.Cloud.Logging.V2": "3.2.0",
         "Grpc.Core": "2.31.0",
-        "log4net": "2.0.8"
+        "log4net": "2.0.12"
       },
       "testDependencies": {
         "Google.Api.Gax.Testing": "3.2.0"


### PR DESCRIPTION
Log4net 2.0.11 (which
Microsoft.Extensions.Logging.Log4Net.AspNetCore version 3.1.5
depends on) fails on Linux due to depending on something not
implemented in .NET Core. 2.0.12 fixes that.

I've had 2.0.12 working successfully in production.