### PR TITLE
[Vision]: test: Checks for a different label in a Vision.DetectLabels test.

### DIFF
--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Snippets/ImageAnnotatorClientSnippets.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Snippets/ImageAnnotatorClientSnippets.cs
@@ -204,7 +204,7 @@ namespace Google.Cloud.Vision.V1.Snippets
             // Not exhaustive, but let's check certain basic labels.
             var descriptions = labels.Select(l => l.Description).ToList();
             Assert.Contains("flower", descriptions, StringComparer.OrdinalIgnoreCase);
-            Assert.Contains("plant", descriptions, StringComparer.OrdinalIgnoreCase);
+            Assert.Contains("petal", descriptions, StringComparer.OrdinalIgnoreCase);
             Assert.Contains("vase", descriptions, StringComparer.OrdinalIgnoreCase);
         }
 


### PR DESCRIPTION
The model has probably been updated and results are different now.