### PR TITLE
docs: Fix a link in the Firestore docs

### DIFF
--- a/apis/Google.Cloud.Firestore/docs/index.md
+++ b/apis/Google.Cloud.Firestore/docs/index.md
@@ -51,5 +51,5 @@ otherwise connect to the production environment.
 {{sample:Index.EmulatorDetection}}
 
 See the
-[EmulatorDetection](obj/api/Google.Cloud.Firestore.EmulatorDetection.yml)
-enum for details of the other possible values.
+[EmulatorDetection property](obj/api/Google.Cloud.Firestore.FirestoreDbBuilder.yml#Google_Cloud_Firestore_FirestoreDbBuilder_EmulatorDetection)
+for more details.


### PR DESCRIPTION
It's tricky to link to the GAX enum within Markdown (and it resolves
differently based on the docs final destination) so I figured I'd
just link to the property instead - users can click on the property
type from there if they want to, and it should be handled correctly
everywhere.