### PR TITLE
ci: Pass "APIs to check" into the NuGet compatibility check

### DIFF
--- a/detect-pr-changes.sh
+++ b/detect-pr-changes.sh
@@ -2,7 +2,18 @@
 
 set -e
 
+# Writes the argument to the console in bold magenta, to make it stand out.
+log_header() {
+  echo -e "\e[1;35m$1\e[0m"
+}
+
 apis=$(git diff master --name-only | grep -e 'apis/.*/' | cut -d/ -f 2 | uniq)
+
+if [[ "$apis" == "" ]]
+then
+  log_header "No APIs have changed in this PR. Exiting diff."
+  exit 0
+fi
 
 git clone . tmpgit --no-local -q -b master --depth 1 --recursive
 
@@ -12,11 +23,6 @@ mkdir tmpgit/new
 # First build everything, so we can get straight to the good stuff at the end of the log.
 dotnet build -nologo -clp:NoSummary -v quiet tools/Google.Cloud.Tools.CompareVersions
 dotnet build -nologo -clp:NoSummary -v quiet tools/Google.Cloud.Tools.ReleaseManager
-
-# Writes the argument to the console in bold magenta, to make it stand out.
-log_header() {
-  echo -e "\e[1;35m$1\e[0m"
-}
 
 for api in $apis
 do  
@@ -58,4 +64,4 @@ log_header "Checking compatibility with previous releases"
 
 # Make sure all the tags are available for checking compatibility
 git fetch --tags -q
-dotnet run --no-build -p tools/Google.Cloud.Tools.ReleaseManager -- check-version-compatibility
+dotnet run --no-build -p tools/Google.Cloud.Tools.ReleaseManager -- check-version-compatibility $apis


### PR DESCRIPTION
This will prevent PRs from being held up by other releases that haven't completed yet.