### PR TITLE
chore: Remove generation tweaking scripts for Google.Cloud.Container.V1

### DIFF
--- a/apis/Google.Cloud.Container.V1/postgeneration.sh
+++ b/apis/Google.Cloud.Container.V1/postgeneration.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -e
-
-# Undo the changes made in pregeneration.sh
-git -C $GOOGLEAPIS checkout google/container/v1

--- a/apis/Google.Cloud.Container.V1/pregeneration.sh
+++ b/apis/Google.Cloud.Container.V1/pregeneration.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-# Fix links such as [zones](/compute/docs/zones) to include the full URL
-# Note: using | instead of / to avoid worrying about escaping.
-
-sed -i 's|](/|](https://cloud.google.com/|g' $GOOGLEAPIS/google/container/v1/*.proto


### PR DESCRIPTION
I've regenerated locally without these scripts present, and there are no differences.