### PR TITLE
Release version 4.2.0 of all diagnostics packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Debugger.V2](https://googleapis.dev/dotnet/Google.Cloud.Debugger.V2/2.1.0) | 2.1.0 | [Google Cloud Debugger](https://cloud.google.com/debugger/) |
 | [Google.Cloud.DevTools.Common](https://googleapis.dev/dotnet/Google.Cloud.DevTools.Common/2.0.0) | 2.0.0 | Common Protocol Buffer messages for Google Cloud Developer Tools APIs |
 | [Google.Cloud.DevTools.ContainerAnalysis.V1](https://googleapis.dev/dotnet/Google.Cloud.DevTools.ContainerAnalysis.V1/2.1.0) | 2.1.0 | [Google Container Analysis](https://cloud.google.com/container-registry/docs/container-analysis/) |
-| [Google.Cloud.Diagnostics.AspNetCore](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.AspNetCore/4.2.0-beta02) | 4.2.0-beta02 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core |
-| [Google.Cloud.Diagnostics.AspNetCore3](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.AspNetCore3/4.0.0-beta01) | 4.0.0-beta01 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core 3 |
-| [Google.Cloud.Diagnostics.Common](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.Common/4.2.0-beta02) | 4.2.0-beta02 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries Common Components |
+| [Google.Cloud.Diagnostics.AspNetCore](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.AspNetCore/4.2.0) | 4.2.0 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core |
+| [Google.Cloud.Diagnostics.AspNetCore3](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.AspNetCore3/4.2.0) | 4.2.0 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core 3 |
+| [Google.Cloud.Diagnostics.Common](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.Common/4.2.0) | 4.2.0 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries Common Components |
 | [Google.Cloud.Dialogflow.V2](https://googleapis.dev/dotnet/Google.Cloud.Dialogflow.V2/3.1.0) | 3.1.0 | [Google Cloud Dialogflow](https://cloud.google.com/dialogflow-enterprise/) |
 | [Google.Cloud.Dlp.V2](https://googleapis.dev/dotnet/Google.Cloud.Dlp.V2/3.1.0) | 3.1.0 | [Google Cloud Data Loss Prevention](https://cloud.google.com/dlp/) |
 | [Google.Cloud.DocumentAI.V1Beta2](https://googleapis.dev/dotnet/Google.Cloud.DocumentAI.V1Beta2/1.0.0-beta02) | 1.0.0-beta02 | [Cloud Document AI](https://cloud.google.com/solutions/document-ai) |

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.2.0-beta02</Version>
+    <Version>4.2.0</Version>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core.</Description>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/docs/history.md
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 4.2.0, released 2020-12-07
+
+No API changes since 4.2.0-beta02; just a stable release of the changes since 4.1.0.
+
 # Version 4.2.0-beta02, released 2020-10-12
 
 - [Commit 1cd4ee6](https://github.com/googleapis/google-cloud-dotnet/commit/1cd4ee6): build: Removes ASP.NET Core unused dependencies from Diagnostics* packages. Towards [issue 4750](https://github.com/googleapis/google-cloud-dotnet/issues/4750).

--- a/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.0.0-beta01</Version>
+    <Version>4.2.0</Version>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core 3.</Description>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore3/docs/history.md
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore3/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+# Version 4.2.0, released 2020-12-07
+
+No API changes since 4.0.0-beta01, but this is the first stable release.
+
+The version number is 4.2.0 to align with
+Google.Cloud.Diagnostics.AspNetCore and
+Google.Cloud.Diagnostics.Common.
+
 # Version 4.0.0-beta01, released 2020-10-12
 
 - [Commit 1cd4ee6](https://github.com/googleapis/google-cloud-dotnet/commit/1cd4ee6): feat: Adds Google.Cloud.Diagnostics.AspNetCore3 library. Towards [issue 4750](https://github.com/googleapis/google-cloud-dotnet/issues/4750).

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Google.Cloud.Diagnostics.Common.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Google.Cloud.Diagnostics.Common.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.csproj" />
-    <PackageReference Include="Google.Cloud.ErrorReporting.V1Beta1" Version="[2.0.0-beta02, 3.0.0)" />
+    <PackageReference Include="Google.Cloud.ErrorReporting.V1Beta1" Version="[2.0.0-beta03, 3.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Moq" Version="4.12.0" />

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Google.Cloud.Diagnostics.Common.Tests.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Google.Cloud.Diagnostics.Common.Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.csproj" />
-    <PackageReference Include="Google.Cloud.ErrorReporting.V1Beta1" Version="[2.0.0-beta02, 3.0.0)" />
+    <PackageReference Include="Google.Cloud.ErrorReporting.V1Beta1" Version="[2.0.0-beta03, 3.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Moq" Version="4.12.0" />

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.2.0-beta02</Version>
+    <Version>4.2.0</Version>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries Common Components.</Description>
@@ -11,8 +11,8 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Logging.V2" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Trace.V1" Version="[2.0.0, 3.0.0)" />
+    <PackageReference Include="Google.Cloud.Logging.V2" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Trace.V1" Version="[2.1.0, 3.0.0)" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -510,7 +510,7 @@
     },
     {
       "id": "Google.Cloud.Diagnostics.AspNetCore",
-      "version": "4.2.0-beta02",
+      "version": "4.2.0",
       "type": "other",
       "targetFrameworks": "netstandard2.0",
       "testTargetFrameworks": "netcoreapp2.1;net461",
@@ -544,7 +544,7 @@
     },
     {
       "id": "Google.Cloud.Diagnostics.AspNetCore3",
-      "version": "4.0.0-beta01",
+      "version": "4.2.0",
       "type": "other",
       "targetFrameworks": "netcoreapp3.1",
       "testTargetFrameworks": "netcoreapp3.1",
@@ -570,7 +570,7 @@
     },
     {
       "id": "Google.Cloud.Diagnostics.Common",
-      "version": "4.2.0-beta02",
+      "version": "4.2.0",
       "type": "other",
       "targetFrameworks": "netstandard2.0",
       "testTargetFrameworks": "netcoreapp2.1;netcoreapp3.1;net461",
@@ -585,13 +585,13 @@
       ],
       "dependencies": {
         "Google.Api.Gax.Grpc.GrpcCore": "3.2.0",
-        "Google.Cloud.Logging.V2": "3.0.0",
-        "Google.Cloud.Trace.V1": "2.0.0",
+        "Google.Cloud.Logging.V2": "3.2.0",
+        "Google.Cloud.Trace.V1": "2.1.0",
         "Microsoft.Extensions.Http": "2.1.1",
         "System.Diagnostics.StackTrace": "4.3.0"
       },
       "testDependencies": {
-        "Google.Cloud.ErrorReporting.V1Beta1": "2.0.0-beta02"
+        "Google.Cloud.ErrorReporting.V1Beta1": "2.0.0-beta03"
       },
       "noVersionHistory": true
     },

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -46,9 +46,9 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Debugger.V2](Google.Cloud.Debugger.V2/index.html) | 2.1.0 | [Google Cloud Debugger](https://cloud.google.com/debugger/) |
 | [Google.Cloud.DevTools.Common](Google.Cloud.DevTools.Common/index.html) | 2.0.0 | Common Protocol Buffer messages for Google Cloud Developer Tools APIs |
 | [Google.Cloud.DevTools.ContainerAnalysis.V1](Google.Cloud.DevTools.ContainerAnalysis.V1/index.html) | 2.1.0 | [Google Container Analysis](https://cloud.google.com/container-registry/docs/container-analysis/) |
-| [Google.Cloud.Diagnostics.AspNetCore](Google.Cloud.Diagnostics.AspNetCore/index.html) | 4.2.0-beta02 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core |
-| [Google.Cloud.Diagnostics.AspNetCore3](Google.Cloud.Diagnostics.AspNetCore3/index.html) | 4.0.0-beta01 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core 3 |
-| [Google.Cloud.Diagnostics.Common](Google.Cloud.Diagnostics.Common/index.html) | 4.2.0-beta02 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries Common Components |
+| [Google.Cloud.Diagnostics.AspNetCore](Google.Cloud.Diagnostics.AspNetCore/index.html) | 4.2.0 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core |
+| [Google.Cloud.Diagnostics.AspNetCore3](Google.Cloud.Diagnostics.AspNetCore3/index.html) | 4.2.0 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core 3 |
+| [Google.Cloud.Diagnostics.Common](Google.Cloud.Diagnostics.Common/index.html) | 4.2.0 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries Common Components |
 | [Google.Cloud.Dialogflow.V2](Google.Cloud.Dialogflow.V2/index.html) | 3.1.0 | [Google Cloud Dialogflow](https://cloud.google.com/dialogflow-enterprise/) |
 | [Google.Cloud.Dlp.V2](Google.Cloud.Dlp.V2/index.html) | 3.1.0 | [Google Cloud Data Loss Prevention](https://cloud.google.com/dlp/) |
 | [Google.Cloud.DocumentAI.V1Beta2](Google.Cloud.DocumentAI.V1Beta2/index.html) | 1.0.0-beta02 | [Cloud Document AI](https://cloud.google.com/solutions/document-ai) |


### PR DESCRIPTION

Changes in Google.Cloud.Diagnostics.AspNetCore version 4.2.0:

No API changes since 4.2.0-beta02; just a stable release of the changes since 4.1.0.

Changes in Google.Cloud.Diagnostics.AspNetCore3 version 4.2.0:

No API changes since 4.0.0-beta01, but this is the first stable release.

The version number is 4.2.0 to align with Google.Cloud.Diagnostics.AspNetCore and Google.Cloud.Diagnostics.Common.

Packages in this release:
- Release Google.Cloud.Diagnostics.AspNetCore version 4.2.0
- Release Google.Cloud.Diagnostics.AspNetCore3 version 4.2.0
- Release Google.Cloud.Diagnostics.Common version 4.2.0
