### PR TITLE
Support the Pub/Sub emulator in a more standard way

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.IntegrationTests/PubSubClientTest.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.IntegrationTests/PubSubClientTest.cs
@@ -377,7 +377,7 @@ namespace Google.Cloud.PubSub.V1.IntegrationTests
         }
 
         [Theory]
-        [InlineData(10_000, 1_000, 2)]
+        [InlineData(10_000, 1_000, 4)]
         [InlineData(2_000, 100, 6)]
         [InlineData(10, 0.1, 4)]
         public async Task StopStartSubscriber(int totalMessageCount, double publisherFrequencyHz, double subscriberLifetimeSeconds)
@@ -451,7 +451,7 @@ namespace Google.Cloud.PubSub.V1.IntegrationTests
                         noRecvCount = 0;
                     }
                     // It can take a while for the last few messages to be received.
-                    Assert.True(noRecvCount < 50, "No message has been recvied for too long; failing test.");
+                    Assert.True(noRecvCount < 50, $"No message has been received for too long; failing test. Received {recvCount} messages out of {totalMessageCount}");
                 }
             });
             Console.WriteLine("Waiting for pub+sub to complete.");

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.IntegrationTests/PubsubFixture.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.IntegrationTests/PubsubFixture.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Api.Gax;
 using Google.Api.Gax.ResourceNames;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudResourceManager.v1;
@@ -56,7 +57,7 @@ namespace Google.Cloud.PubSub.V1.IntegrationTests
 
         public override void Dispose()
         {
-            var subscriber = SubscriberServiceApiClient.Create();
+            var subscriber = new SubscriberServiceApiClientBuilder { EmulatorDetection = EmulatorDetection.EmulatorOrProduction }.Build();
             var subscriptions = subscriber.ListSubscriptions(new ProjectName(ProjectId))
                 .Where(sub => sub.SubscriptionName.SubscriptionId.StartsWith(SubscriptionPrefix))
                 .ToList();
@@ -65,7 +66,7 @@ namespace Google.Cloud.PubSub.V1.IntegrationTests
                 subscriber.DeleteSubscription(sub.SubscriptionName);
             }
 
-            var publisher = PublisherServiceApiClient.Create();
+            var publisher = new PublisherServiceApiClientBuilder { EmulatorDetection = EmulatorDetection.EmulatorOrProduction }.Build();
             var topics = publisher.ListTopics(new ProjectName(ProjectId))
                 .Where(topic => topic.TopicName.TopicId.StartsWith(TopicPrefix))
                 .ToList();

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/PublisherClient.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/PublisherClient.cs
@@ -225,24 +225,6 @@ namespace Google.Cloud.PubSub.V1
         }
 
         /// <summary>
-        /// Create a <see cref="PublisherClient"/> instance associated with the specified <see cref="TopicName"/>.
-        /// The gRPC <see cref="Channel"/>s underlying the provided <see cref="PublisherServiceApiClient"/>s must have their
-        /// maximum send and maximum receive sizes set to unlimited, otherwise performance will be severly affected,
-        /// possibly causing a deadlock.
-        /// The default <paramref name="settings"/> are suitable for machines with high network bandwidth
-        /// (e.g. Google Compute Engine instances). If running with more limited network bandwidth, some
-        /// settings may need changing.
-        /// </summary>
-        /// <param name="topicName">The <see cref="TopicName"/> to publish messages to.</param>
-        /// <param name="clients">The <see cref="PublisherServiceApiClient"/>s to use in a <see cref="PublisherClient"/>.
-        /// For high performance, these should all use distinct <see cref="Channel"/>s.</param>
-        /// <param name="settings">Optional. <see cref="Settings"/> for creating a <see cref="PublisherClient"/>.</param>
-        /// <returns>A <see cref="PublisherClient"/> instance associated with the specified <see cref="TopicName"/>.</returns>
-        internal static PublisherClient Create(TopicName topicName, IEnumerable<PublisherServiceApiClient> clients, Settings settings = null) =>
-            // No need to clone clients, it's synchronously used to initialise a Queue<T> in the constructor
-            new PublisherClientImpl(topicName, clients, settings?.Clone() ?? new Settings(), null);
-
-        /// <summary>
         /// The associated <see cref="TopicName"/>. 
         /// </summary>
         public virtual TopicName TopicName => throw new NotImplementedException();

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/PublisherServiceApiClientBuilder.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/PublisherServiceApiClientBuilder.cs
@@ -1,0 +1,60 @@
+﻿// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Cloud.PubSub.V1
+{
+    // Partial class to enable emulator support for the low-level client.
+
+    public partial class PublisherServiceApiClientBuilder
+    {
+        /// <summary>
+        /// Specifies how the builder responds to the presence of emulator environment variables.
+        /// </summary>
+        /// <remarks>
+        /// This property defaults to <see cref="EmulatorDetection.None"/>, meaning that
+        /// environment variables are ignored.
+        /// </remarks>
+        public new EmulatorDetection EmulatorDetection
+        {
+            get => base.EmulatorDetection;
+            set => base.EmulatorDetection = value;
+        }
+
+        private const string s_emulatorHostEnvironmentVariable = "PUBSUB_EMULATOR_HOST";
+        private static readonly string[] s_emulatorEnvironmentVariables = { s_emulatorHostEnvironmentVariable };
+
+        partial void InterceptBuild(ref PublisherServiceApiClient client) => client = MaybeCreateEmulatorClientBuilder()?.Build();
+
+        partial void InterceptBuildAsync(CancellationToken cancellationToken, ref Task<PublisherServiceApiClient> task) =>
+            task = MaybeCreateEmulatorClientBuilder()?.BuildAsync(cancellationToken);
+
+        private PublisherServiceApiClientBuilder MaybeCreateEmulatorClientBuilder()
+        {
+            var emulatorEnvironment = GetEmulatorEnvironment(s_emulatorEnvironmentVariables, s_emulatorEnvironmentVariables);
+            return emulatorEnvironment is null ? null :
+                // We don't set the EmulatorDetection property here to avoid recursively calling
+                // MaybeCreateEmulatorClientBuilder().
+                new PublisherServiceApiClientBuilder
+                {
+                    Settings = Settings,
+                    Endpoint = emulatorEnvironment[s_emulatorHostEnvironmentVariable],
+                    ChannelCredentials = Grpc.Core.ChannelCredentials.Insecure
+                };
+        }
+    }
+}

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberClient.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberClient.cs
@@ -291,23 +291,6 @@ namespace Google.Cloud.PubSub.V1
         }
 
         /// <summary>
-        /// Create a <see cref="SubscriberClient"/> instance associated with the specified <see cref="SubscriptionName"/>.
-        /// The gRPC <see cref="Channel"/>s underlying the provided <see cref="SubscriberServiceApiClient"/>s must have their
-        /// maximum send and maximum receive sizes set to unlimited, otherwise performance will be severly affected,
-        /// possibly causing a deadlock.
-        /// The default <paramref name="settings"/> are suitable for machines with high network bandwidth (e.g. Google
-        /// Compute Engine instances). If running with more limited network bandwidth, some settings may need changing;
-        /// especially <see cref="Settings.AckDeadline"/>.
-        /// </summary>
-        /// <param name="subscriptionName">The <see cref="SubscriptionName"/> to receive messages from.</param>
-        /// <param name="clients">The <see cref="SubscriberServiceApiClient"/>s to use in a <see cref="SubscriberClient"/>.
-        /// For high performance, these should all use distinct <see cref="Channel"/>s.</param>
-        /// <param name="settings">Optional. <see cref="Settings"/> for creating a <see cref="SubscriberClient"/>.</param>
-        /// <returns>A <see cref="SubscriberClient"/> instance associated with the specified <see cref="SubscriptionName"/>.</returns>
-        internal static SubscriberClient Create(SubscriptionName subscriptionName, IEnumerable<SubscriberServiceApiClient> clients, Settings settings = null) =>
-            new SubscriberClientImpl(subscriptionName, clients, settings?.Clone() ?? new Settings(), null);
-
-        /// <summary>
         /// The associated <see cref="SubscriptionName"/>.
         /// </summary>
         public virtual SubscriptionName SubscriptionName => throw new NotImplementedException();

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberServiceApiClientBuilder.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberServiceApiClientBuilder.cs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 using Google.Api.Gax;
+using Google.Api.Gax.Grpc;
+using Grpc.Core;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -22,6 +24,14 @@ namespace Google.Cloud.PubSub.V1
 
     public partial class SubscriberServiceApiClientBuilder
     {
+        /// <summary>
+        /// Additional channel options to use, if any.
+        /// </summary>
+        internal GrpcChannelOptions ChannelOptions { get; set; }
+
+        /// <inheritdoc />
+        protected override GrpcChannelOptions GetChannelOptions() => base.GetChannelOptions().MergedWith(ChannelOptions ?? GrpcChannelOptions.Empty);
+
         /// <summary>
         /// Specifies how the builder responds to the presence of emulator environment variables.
         /// </summary>
@@ -53,8 +63,23 @@ namespace Google.Cloud.PubSub.V1
                 {
                     Settings = Settings,
                     Endpoint = emulatorEnvironment[s_emulatorHostEnvironmentVariable],
-                    ChannelCredentials = Grpc.Core.ChannelCredentials.Insecure
+                    ChannelCredentials = ChannelCredentials.Insecure,
+                    ChannelOptions = ChannelOptions
                 };
+        }
+
+        /// <summary>
+        /// Creates a channel for this builder, observing any emulator configuration that has been set.
+        /// This method is used by SubscriberClient, which needs the channel for shutdown purposes.
+        /// </summary>
+        internal async Task<ChannelBase> CreateChannelAsync(CancellationToken cancellationToken)
+        {
+            // Note: no need to try to detect the channel pool here, as we know we don't want to use it.
+            var effectiveBuilder = MaybeCreateEmulatorClientBuilder() ?? this;
+            var endpoint = effectiveBuilder.Endpoint ?? GetDefaultEndpoint();
+            var credentials = await effectiveBuilder.GetChannelCredentialsAsync(cancellationToken).ConfigureAwait(false);
+            var grpcAdapter = GrpcAdapter ?? DefaultGrpcAdapter;
+            return grpcAdapter.CreateChannel(endpoint, credentials, effectiveBuilder.GetChannelOptions());
         }
     }
 }

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberServiceApiClientBuilder.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberServiceApiClientBuilder.cs
@@ -1,0 +1,60 @@
+﻿// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Cloud.PubSub.V1
+{
+    // Partial class to enable emulator support for the low-level client.
+
+    public partial class SubscriberServiceApiClientBuilder
+    {
+        /// <summary>
+        /// Specifies how the builder responds to the presence of emulator environment variables.
+        /// </summary>
+        /// <remarks>
+        /// This property defaults to <see cref="EmulatorDetection.None"/>, meaning that
+        /// environment variables are ignored.
+        /// </remarks>
+        public new EmulatorDetection EmulatorDetection
+        {
+            get => base.EmulatorDetection;
+            set => base.EmulatorDetection = value;
+        }
+
+        private const string s_emulatorHostEnvironmentVariable = "PUBSUB_EMULATOR_HOST";
+        private static readonly string[] s_emulatorEnvironmentVariables = { s_emulatorHostEnvironmentVariable };
+
+        partial void InterceptBuild(ref SubscriberServiceApiClient client) => client = MaybeCreateEmulatorClientBuilder()?.Build();
+
+        partial void InterceptBuildAsync(CancellationToken cancellationToken, ref Task<SubscriberServiceApiClient> task) =>
+            task = MaybeCreateEmulatorClientBuilder()?.BuildAsync(cancellationToken);
+
+        private SubscriberServiceApiClientBuilder MaybeCreateEmulatorClientBuilder()
+        {
+            var emulatorEnvironment = GetEmulatorEnvironment(s_emulatorEnvironmentVariables, s_emulatorEnvironmentVariables);
+            return emulatorEnvironment is null ? null :
+                // We don't set the EmulatorDetection property here to avoid recursively calling
+                // MaybeCreateEmulatorClientBuilder().
+                new SubscriberServiceApiClientBuilder
+                {
+                    Settings = Settings,
+                    Endpoint = emulatorEnvironment[s_emulatorHostEnvironmentVariable],
+                    ChannelCredentials = Grpc.Core.ChannelCredentials.Insecure
+                };
+        }
+    }
+}

--- a/apis/Google.Cloud.PubSub.V1/docs/index.md
+++ b/apis/Google.Cloud.PubSub.V1/docs/index.md
@@ -46,3 +46,19 @@ Using [PublisherServiceApiClient](obj/api/Google.Cloud.PubSub.V1.PublisherServic
 [SubscriberServiceApiClient](obj/api/Google.Cloud.PubSub.V1.SubscriberServiceApiClient.yml) only:
 
 {{sample:SubscriberServiceApiClient.Overview}}
+
+# Using the emulator
+
+To connect to a [Pub/Sub
+Emulator](https://cloud.google.com/pubsub/docs/emulator), set the
+`EmulatorDetection` property in the appropriate class depending on
+which client type you are constructing:
+
+- `PublisherClient.ClientCreationSettings` (for `PublisherClient`)
+- `SubscriberClient.ClientCreationSettings` (for `SubscriberClient`)
+- `PublisherServiceApiClientBuilder` (for `PublisherServiceApiClient`)
+- `SubscriberServiceApiClientBuilder` (for `SubscriberServiceApiClient`)
+
+See the [FAQ
+entry](https://googleapis.github.io/google-cloud-dotnet/docs/faq.html#how-can-i-use-emulators)
+for more details.


### PR DESCRIPTION
I haven't yet run the integration tests with this turned on - I will do so shortly. (There's no urgency on this review.)

It's a little convoluted due to the way PublisherClient and SubscriberClient work, but I've managed to keep the emulator awareness within the builders.

Fixes #5261.