### PR TITLE
Require a client to be specified in all smoke tests

### DIFF
--- a/apis/Google.Cloud.Asset.V1/smoketests.json
+++ b/apis/Google.Cloud.Asset.V1/smoketests.json
@@ -1,5 +1,6 @@
 [
   {
+    "client": "AssetServiceClient",
     "method": "BatchGetAssetsHistory",
     "arguments": {
       "request": {

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/smoketests.json
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/smoketests.json
@@ -1,5 +1,6 @@
 [
   {
+    "client": "DataTransferServiceClient",
     "method":"ListDataSources",
     "arguments":{
       "parent":"projects/${PROJECT_ID}"

--- a/apis/Google.Cloud.Container.V1/smoketests.json
+++ b/apis/Google.Cloud.Container.V1/smoketests.json
@@ -1,5 +1,6 @@
 [
   {
+    "client": "ClusterManagerClient",
     "method": "ListClusters",
     "arguments": {
       "request": {

--- a/apis/Google.Cloud.Language.V1/smoketests.json
+++ b/apis/Google.Cloud.Language.V1/smoketests.json
@@ -1,10 +1,11 @@
 [
   {
-    "method":"AnalyzeSyntax",
-    "arguments":{
-      "document":{
-        "content":"This is a simple sentence",
-        "type":"PLAIN_TEXT"
+    "client": "LanguageServiceClient",
+    "method": "AnalyzeSyntax",
+    "arguments": {
+      "document": {
+        "content": "This is a simple sentence",
+        "type": "PLAIN_TEXT"
       }
     }
   }

--- a/apis/Google.Cloud.Redis.V1/smoketests.json
+++ b/apis/Google.Cloud.Redis.V1/smoketests.json
@@ -1,5 +1,6 @@
 [
   {
+    "client": "CloudRedisClient",
     "method": "ListInstances",
     "arguments": {
       "parent": "projects/${PROJECT_ID}/locations/-"

--- a/apis/Google.Cloud.Redis.V1Beta1/smoketests.json
+++ b/apis/Google.Cloud.Redis.V1Beta1/smoketests.json
@@ -1,5 +1,6 @@
 [
   {
+    "client": "CloudRedisClient",
     "method": "ListInstances",
     "arguments": {
       "parent": "projects/${PROJECT_ID}/locations/-"

--- a/apis/Google.Cloud.SecretManager.V1Beta1/smoketests.json
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/smoketests.json
@@ -1,5 +1,6 @@
 [
   {
+    "client": "SecretManagerServiceClient",
     "method": "ListSecrets",
     "arguments": {
       "parent": "projects/${PROJECT_ID}"

--- a/apis/Google.Cloud.Speech.V1/smoketests.json
+++ b/apis/Google.Cloud.Speech.V1/smoketests.json
@@ -1,5 +1,6 @@
 [
   {
+    "client": "SpeechClient",
     "method": "Recognize",
     "arguments": {
       "config": {

--- a/apis/Google.Cloud.Speech.V1P1Beta1/smoketests.json
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/smoketests.json
@@ -1,5 +1,6 @@
 [
   {
+    "client": "SpeechClient",
     "method": "Recognize",
     "arguments": {
       "config": {

--- a/apis/Google.Cloud.VideoIntelligence.V1/smoketests.json
+++ b/apis/Google.Cloud.VideoIntelligence.V1/smoketests.json
@@ -1,5 +1,6 @@
 [
   {
+    "client": "VideoIntelligenceServiceClient",
     "method": "AnnotateVideo",
     "arguments": {
       "inputUri": "gs://cloud-samples-data/video/cat.mp4",

--- a/tools/Google.Cloud.Tools.ReleaseManager/SmokeTest.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/SmokeTest.cs
@@ -35,7 +35,7 @@ namespace Google.Cloud.Tools.ReleaseManager
 
         /// <summary>
         /// The name of the client class, assumed to be in the same namespace as the package ID,
-        /// e.g. "PublisherClient". This is optional if the package only contains a single client.
+        /// e.g. "PublisherClient".
         /// </summary>
         public string Client { get; set; }
 
@@ -76,27 +76,15 @@ namespace Google.Cloud.Tools.ReleaseManager
 
         private Type FindClient(Assembly assembly)
         {
-            if (Client is object)
+            if (Client is null)
             {
-                // Assume the namespace is the same as the assembly name.
-                string ns = assembly.GetName().Name;
-                var typeName = $"{ns}.{Client}";
-                var type = assembly.GetType(typeName);
-                return type ?? throw new UserErrorException($"No such client type {typeName} in assembly");
+                throw new UserErrorException($"Smoke test configuration error: no client specified for method {Method}");
             }
-
-            // This is crude, but probably good enough.
-            var clients = assembly.GetTypes()
-                .Where(t => t.Name.EndsWith("Client"))
-                // Check that FooClient has FooSettings
-                .Where(t => assembly.GetType(t.FullName[..^6] + "Settings") is object)
-                .ToList();
-            return clients.Count switch
-            {
-                0 => throw new UserErrorException("Assembly contains no recognized API client classes"),
-                1 => clients[0],
-                _ => throw new UserErrorException($"Assembly contains multiple API clients: {string.Join(", ", clients.Select(c => c.Name))}")
-            };
+            // Assume the namespace is the same as the assembly name.
+            string ns = assembly.GetName().Name;
+            var typeName = $"{ns}.{Client}";
+            var type = assembly.GetType(typeName);
+            return type ?? throw new UserErrorException($"No such client type {typeName} in assembly");
         }
 
 


### PR DESCRIPTION
While not needing one is convenient when there's only a single
client, it makes the act of adding a new client a breaking change.