### PR TITLE
Updated NLog config snippets to be simpler and cater for sendJsonPayload

### DIFF
--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.Snippets/GoogleStackdriverTargetSnippets.cs
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.Snippets/GoogleStackdriverTargetSnippets.cs
@@ -34,6 +34,7 @@ namespace Google.Cloud.Logging.NLog.Snippets
 
         public GoogleStackdriverTargetSnippets(NLogSnippetFixture fixture) => _fixture = fixture;
 
+        // Resource: nlog-jsonPayload.xml nlog_jsonPayload
         // Resource: nlog-jsonTemplate.xml nlog_jsonTemplate
 
         [Fact]

--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.Snippets/nlog-jsonPayload.xml
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.Snippets/nlog-jsonPayload.xml
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+  <extensions>
+    <add assembly="Google.Cloud.Logging.NLog" />
+  </extensions>
+  
+  <targets async="true">
+    <target name="stackdriver" xsi:type="GoogleStackdriver" projectId="PROJECT_ID" logId="LOG_ID" includeEventProperties="true" sendJsonPayload="true">
+      <contextproperty name="exception" layout="${exception:format=tostring}" />  <!-- Optional and repeatable -->
+    </target>
+    <target name="console" xsi:type="Console" />
+  </targets>
+
+  <rules>
+    <logger name="*" minlevel="Info" writeTo="stackdriver" />
+    <logger name="*" minlevel="Info" writeTo="console" />
+  </rules>
+  
+</nlog>

--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.Snippets/nlog-jsonTemplate.xml
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.Snippets/nlog-jsonTemplate.xml
@@ -8,10 +8,7 @@
   
   <targets async="true">
     <target type="GoogleStackdriver" name="stackdriver"
-            projectId="PROJECT_ID" logId="LOG_ID" resourceType="container"
-            includeCallSite ="true" includeCallSiteStackTrace="true" includeEventProperties="false" includeMdlc="true"
-            sendJsonPayload="true" enableJsonLayout="true">
-      <contextproperty name="contextProp" layout="propContextLayout" />
+            projectId="PROJECT_ID" logId="LOG_ID" resourceType="container" sendJsonPayload="true" enableJsonLayout="true">
       <layout xsi:type="JsonLayout" includeAllProperties="true">
         <attribute name="someProp" layout="prop" />
         <attribute name="nestedProp" encode="false">

--- a/apis/Google.Cloud.Logging.NLog/docs/index.md
+++ b/apis/Google.Cloud.Logging.NLog/docs/index.md
@@ -49,6 +49,14 @@ then the `projectId="PROJECT_ID"` configuration setting can be omitted; it will 
 - `EnableJsonLayout` - Uses NLog's native JSON layout to format JSON payloads, completely replacing the default layout.
 - `JsonConverter` or `JsonConverterTypeName`/`JsonConverterMethodName` - Configures a custom conversion for individual values within a JSON payload.
 
-Many of the options above are used to configure the JSON payload within the emitted log entries. The configuration file below uses a JSON layout via NLog configuration to completely replace the payload.
+## Sending JsonPayload
+
+Enabling `SendJsonPayload` will capture structured logging properties in JSON format (instead of saving them as resource labels).
+
+[!code-xml[](obj/snippets/Google.Cloud.Logging.NLog.GoogleStackdriverTarget.txt#nlog_jsonPayload)]
+
+## Custom JsonPayload
+
+Enabling `EnableJsonLayout` will override the standard JSON format, and instead depend on the output from NLog JsonLayout. This will completely replace the JSON payload, but has a performance penalty because of additional parsing.
 
 [!code-xml[](obj/snippets/Google.Cloud.Logging.NLog.GoogleStackdriverTarget.txt#nlog_jsonTemplate)]


### PR DESCRIPTION
When using `enableJsonLayout="true"` then it doesn't make sense to specify `<contextproperty>`.

NLog callsite capture has a performance-hit, so think it is a bad idea to activate them in example snippets (`includeCallSite ="true" includeCallSiteStackTrace="true"`)