### PR TITLE
Release Google.Cloud.Retail.V2 version 1.0.0-beta01

### DIFF
--- a/apis/Google.Cloud.Retail.V2/smoketests.json
+++ b/apis/Google.Cloud.Retail.V2/smoketests.json
@@ -3,7 +3,7 @@
     "method": "ListCatalogs",
     "client": "CatalogServiceClient",
     "arguments": {
-      "parent": "projects/${PROJECT_ID}/locations/us-east1"
+      "parent": "projects/${PROJECT_ID}/locations/global"
     }
   }
 ]


### PR DESCRIPTION
Changes in this release:

Initial release, for customers in the early access programme.