### PR TITLE
fix: NUMERIC was missing from default mappings

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerParameterTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerParameterTests.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Cloud.Spanner.V1;
 using System;
 using System.Collections.Generic;
 using System.Data;
@@ -29,13 +30,14 @@ namespace Google.Cloud.Spanner.Data.Tests
             yield return new object[] { SpannerDbType.Timestamp, DbType.DateTime };
             yield return new object[] { SpannerDbType.Float64, DbType.Double };
             yield return new object[] { SpannerDbType.Int64, DbType.Int64 };
+            yield return new object[] { SpannerDbType.Numeric, DbType.VarNumeric };
             yield return new object[] { SpannerDbType.Unspecified, DbType.Object };
             yield return new object[] { SpannerDbType.String, DbType.String };
         }
 
         [Theory]
         [MemberData(nameof(GetDbTypeConversions))]
-        public void DbTypeMappgings(SpannerDbType spannerType, DbType adoType)
+        public void DbTypeMappings(SpannerDbType spannerType, DbType adoType)
         {
             var parameter = new SpannerParameter { SpannerDbType = spannerType };
             Assert.Equal(adoType, parameter.DbType);
@@ -44,6 +46,29 @@ namespace Google.Cloud.Spanner.Data.Tests
 
             parameter.DbType = adoType;
             Assert.Equal(spannerType, parameter.SpannerDbType);
+        }
+
+        // TODO: There is no value that will default to Spanner type DATE.
+        public static IEnumerable<object[]> GetValueConversions()
+        {
+            yield return new object[] { new byte[] { 1 }, SpannerDbType.Bytes, DbType.Binary };
+            yield return new object[] { true, SpannerDbType.Bool, DbType.Boolean };
+            yield return new object[] { new DateTime(2021, 1, 13, 12, 3, 10), SpannerDbType.Timestamp, DbType.DateTime };
+            yield return new object[] { 3.14D, SpannerDbType.Float64, DbType.Double };
+            yield return new object[] { 1L, SpannerDbType.Int64, DbType.Int64 };
+            yield return new object[] { (SpannerNumeric)3.14m, SpannerDbType.Numeric, DbType.VarNumeric };
+            yield return new object[] { "test", SpannerDbType.String, DbType.String };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetValueConversions))]
+        public void ValueMappings(object value, SpannerDbType spannerType, DbType adoType)
+        {
+            var parameter = new SpannerParameter { Value = value };
+
+            Assert.Equal(value.GetType(), spannerType.DefaultClrType);
+            Assert.Equal(spannerType, parameter.SpannerDbType);
+            Assert.Equal(adoType, parameter.DbType);
         }
 
         public static IEnumerable<object[]> GetDbTypeSizes()

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerParameterTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerParameterTests.cs
@@ -51,22 +51,33 @@ namespace Google.Cloud.Spanner.Data.Tests
         // TODO: There is no value that will default to Spanner type DATE.
         public static IEnumerable<object[]> GetValueConversions()
         {
-            yield return new object[] { new byte[] { 1 }, SpannerDbType.Bytes, DbType.Binary };
-            yield return new object[] { true, SpannerDbType.Bool, DbType.Boolean };
-            yield return new object[] { new DateTime(2021, 1, 13, 12, 3, 10), SpannerDbType.Timestamp, DbType.DateTime };
-            yield return new object[] { 3.14D, SpannerDbType.Float64, DbType.Double };
-            yield return new object[] { 1L, SpannerDbType.Int64, DbType.Int64 };
-            yield return new object[] { (SpannerNumeric)3.14m, SpannerDbType.Numeric, DbType.VarNumeric };
-            yield return new object[] { "test", SpannerDbType.String, DbType.String };
+            yield return new object[] { new byte[] { 1 }, SpannerDbType.Bytes, DbType.Binary, typeof(byte[]) };
+            yield return new object[] { new List<byte> { 1 }, SpannerDbType.Bytes, DbType.Binary, typeof(byte[]) };
+            yield return new object[] { true, SpannerDbType.Bool, DbType.Boolean, typeof(bool) };
+            yield return new object[] { new DateTime(2021, 1, 13, 12, 3, 10), SpannerDbType.Timestamp, DbType.DateTime, typeof(DateTime) };
+
+            yield return new object[] { 3.14f, SpannerDbType.Float64, DbType.Double, typeof(double) };
+            yield return new object[] { 3.14d, SpannerDbType.Float64, DbType.Double, typeof(double) };
+            yield return new object[] { 3.14m, SpannerDbType.Float64, DbType.Double, typeof(double) };
+
+            yield return new object[] { (short)1, SpannerDbType.Int64, DbType.Int64, typeof(long) };
+            yield return new object[] { (ushort)1, SpannerDbType.Int64, DbType.Int64, typeof(long) };
+            yield return new object[] { 1, SpannerDbType.Int64, DbType.Int64, typeof(long) };
+            yield return new object[] { 1u, SpannerDbType.Int64, DbType.Int64, typeof(long) };
+            yield return new object[] { 1L, SpannerDbType.Int64, DbType.Int64, typeof(long) };
+            yield return new object[] { 1uL, SpannerDbType.Int64, DbType.Int64, typeof(long) };
+
+            yield return new object[] { (SpannerNumeric)3.14m, SpannerDbType.Numeric, DbType.VarNumeric, typeof(SpannerNumeric) };
+            yield return new object[] { "test", SpannerDbType.String, DbType.String, typeof(string) };
         }
 
         [Theory]
         [MemberData(nameof(GetValueConversions))]
-        public void ValueMappings(object value, SpannerDbType spannerType, DbType adoType)
+        public void ValueMappings(object value, SpannerDbType spannerType, DbType adoType, System.Type defaultClrType)
         {
             var parameter = new SpannerParameter { Value = value };
 
-            Assert.Equal(value.GetType(), spannerType.DefaultClrType);
+            Assert.Equal(defaultClrType, spannerType.DefaultClrType);
             Assert.Equal(spannerType, parameter.SpannerDbType);
             Assert.Equal(adoType, parameter.DbType);
         }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDbType.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDbType.cs
@@ -194,22 +194,19 @@ namespace Google.Cloud.Spanner.Data
         /// <summary>
         /// Converts a <see cref="DbType"/> to the corresponding <see cref="SpannerDbType"/>
         /// </summary>
-        internal static SpannerDbType FromDbType(DbType dbType)
+        internal static SpannerDbType FromDbType(DbType dbType) => dbType switch
         {
-            return dbType switch
-            {
-                DbType.Binary => Bytes,
-                DbType.Boolean => Bool,
-                DbType.Date => Date,
-                DbType.DateTime => Timestamp,
-                DbType.Double => Float64,
-                DbType.Int64 => Int64,
-                DbType.VarNumeric => Numeric,
-                DbType.Object => Unspecified,
-                DbType.String => String,
-                _ => throw new ArgumentOutOfRangeException(nameof(DbType), dbType, null),
-            };
-        }
+            DbType.Binary => Bytes,
+            DbType.Boolean => Bool,
+            DbType.Date => Date,
+            DbType.DateTime => Timestamp,
+            DbType.Double => Float64,
+            DbType.Int64 => Int64,
+            DbType.VarNumeric => Numeric,
+            DbType.Object => Unspecified,
+            DbType.String => String,
+            _ => throw new ArgumentOutOfRangeException(nameof(DbType), dbType, null),
+        };
 
         internal static SpannerDbType FromProtobufType(V1.Type type)
         {

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDbType.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDbType.cs
@@ -191,6 +191,26 @@ namespace Google.Cloud.Spanner.Data
             }
         }
 
+        /// <summary>
+        /// Converts a <see cref="DbType"/> to the corresponding <see cref="SpannerDbType"/>
+        /// </summary>
+        internal static SpannerDbType FromDbType(DbType dbType)
+        {
+            return dbType switch
+            {
+                DbType.Binary => Bytes,
+                DbType.Boolean => Bool,
+                DbType.Date => Date,
+                DbType.DateTime => Timestamp,
+                DbType.Double => Float64,
+                DbType.Int64 => Int64,
+                DbType.VarNumeric => Numeric,
+                DbType.Object => Unspecified,
+                DbType.String => String,
+                _ => throw new ArgumentOutOfRangeException(nameof(DbType), dbType, null),
+            };
+        }
+
         internal static SpannerDbType FromProtobufType(V1.Type type)
         {
             switch (type.Code)
@@ -250,13 +270,6 @@ namespace Google.Cloud.Spanner.Data
         /// </summary>
         internal static SpannerDbType ForStruct(SpannerStruct spannerStruct) =>
             new SpannerDbType(TypeCode.Struct, spannerStruct.Select(f => new StructField(f.Name, f.Type)).ToList());
-
-        /// <summary>
-        /// Factory method for creating a SpannerDbType from SpannerNumeric. Public access would be via the instance
-        /// method; making this internal allows us to avoid exposing constructors even internally.
-        /// </summary>
-        internal static SpannerDbType ForNumeric(SpannerNumeric spannerNumeric) =>
-            new SpannerDbType(TypeCode.Numeric);
 
         /// <summary>
         /// Returns a SpannerDbType given a ClrType.

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDbType.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDbType.cs
@@ -140,6 +140,8 @@ namespace Google.Cloud.Spanner.Data
                         return DbType.Int64;
                     case TypeCode.Float64:
                         return DbType.Double;
+                    case TypeCode.Numeric:
+                        return DbType.VarNumeric;
                     case TypeCode.Timestamp:
                         return DbType.DateTime;
                     case TypeCode.Date:
@@ -284,6 +286,10 @@ namespace Google.Cloud.Spanner.Data
                 || type == typeof(ulong) || type == typeof(ushort) || type == typeof(uint))
             {
                 return Int64;
+            }
+            if (type == typeof(SpannerNumeric))
+            {
+                return Numeric;
             }
             if (type == typeof(string))
             {

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerParameter.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerParameter.cs
@@ -37,41 +37,7 @@ namespace Google.Cloud.Spanner.Data
         public override DbType DbType
         {
             get => (SpannerDbType?.DbType).GetValueOrDefault(DbType.Object);
-            set
-            {
-                switch (value)
-                {
-                    case DbType.Binary:
-                        SpannerDbType = SpannerDbType.Bytes;
-                        break;
-                    case DbType.Boolean:
-                        SpannerDbType = SpannerDbType.Bool;
-                        break;
-                    case DbType.Date:
-                        SpannerDbType = SpannerDbType.Date;
-                        break;
-                    case DbType.DateTime:
-                        SpannerDbType = SpannerDbType.Timestamp;
-                        break;
-                    case DbType.Double:
-                        SpannerDbType = SpannerDbType.Float64;
-                        break;
-                    case DbType.Int64:
-                        SpannerDbType = SpannerDbType.Int64;
-                        break;
-                    case DbType.VarNumeric:
-                        SpannerDbType = SpannerDbType.Numeric;
-                        break;
-                    case DbType.Object:
-                        SpannerDbType = SpannerDbType.Unspecified;
-                        break;
-                    case DbType.String:
-                        SpannerDbType = SpannerDbType.String;
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(DbType), value, null);
-                }
-            }
+            set => SpannerDbType = SpannerDbType.FromDbType(value);
         }
 
         /// <inheritdoc />

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerParameter.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerParameter.cs
@@ -59,6 +59,9 @@ namespace Google.Cloud.Spanner.Data
                     case DbType.Int64:
                         SpannerDbType = SpannerDbType.Int64;
                         break;
+                    case DbType.VarNumeric:
+                        SpannerDbType = SpannerDbType.Numeric;
+                        break;
                     case DbType.Object:
                         SpannerDbType = SpannerDbType.Unspecified;
                         break;


### PR DESCRIPTION
Adds `NUMERIC` to the default mappings of `DbType => SpannerDbType`, `SpannerDbType => DbType` and `ClrType => SpannerDbType`.

Two considerations:
1. The Spanner `NUMERIC` data type is mapped to `DbType.VarNumeric` and not `DbType.Decimal`, as the latter has a lower range and precision than the Spanner `NUMERIC` type.
2. The .NET `decimal` ClrType [is currently mapped](https://github.com/olavloite/google-cloud-dotnet/blob/243c9fb4f32cd9e1cd48af07a48962c38f8e831e/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDbType.cs#L281) to the Spanner `FLOAT64` data type. That is correct in the sense that both are floating point types. It does however not correspond with the default mapping for other database systems:
2.1. [SQL Server](https://docs.microsoft.com/en-us/dotnet/framework/data/adonet/sql/linq/sql-clr-type-mapping#numeric-mapping) maps it to `DECIMAL(29,4)`
2.2. [PostgreSQL](https://www.npgsql.org/doc/types/basic.html) maps it to `numeric` (which is a fixed point exact type)
2.3. [MySQL ](https://www.devart.com/dotconnect/mysql/docs/datatypemapping.html)maps it to `decimal` (which is a fixed point exact type).

Point 2 might cause some surprises for users moving from other DBMS'es to Spanner, and I would prefer to change that mapping to `NUMERIC` as well. WDYT?