### PR TITLE
Skip the copyright year update commit in history

### DIFF
--- a/tools/Google.Cloud.Tools.ReleaseManager/History/overrides.json
+++ b/tools/Google.Cloud.Tools.ReleaseManager/History/overrides.json
@@ -7,7 +7,8 @@
   "6bde7a3": "docs: Regenerate all APIs with service comments in client documentation",
   "f83bdf1": "fix: Apply timeouts to RPCs without retry",
   "947a573": "docs: Regenerate all clients with more explicit documentation",
-  "0b0773d": "skip", // enum generation change
+  "0b0773d": "skip", // Enum generation change
+  "5c05159": "skip", // Update copyright year
   // Various commits for Ruby/PHP namespace changes, or a C# namespace
   // change in the proto that was previously patched in (so no real change)
   "f6976a5": "skip",


### PR DESCRIPTION
(This also affects show-stale.)