### PR TITLE
Fixes broken link

### DIFF
--- a/apis/Google.Cloud.Spanner.V1/docs/index.md
+++ b/apis/Google.Cloud.Spanner.V1/docs/index.md
@@ -2,7 +2,7 @@
 
 The `Google.Cloud.Spanner.V1` package provides low-level access to the Google Cloud Spanner API.
 This is not recommended for most scenarios. Where possible, use the
-[Spanner ADO.NET provider](../Google.Cloud.Spanner.Data/) instead. (That in turn depends on this package,
+[Spanner ADO.NET provider](../../Google.Cloud.Spanner.Data/) instead. (That in turn depends on this package,
 but provides a much more user-friendly API, and takes care of a lot of resource management automatically.)
 
 {{installation}}


### PR DESCRIPTION
The path to Google.Cloud.Spanner.Data was wrong. Fixing this.