### PR TITLE
Release Google.Cloud.Storage.V1 version 3.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Spanner.V1](https://googleapis.dev/dotnet/Google.Cloud.Spanner.V1/3.4.0) | 3.4.0 | [Google Cloud Spanner](https://cloud.google.com/spanner/) |
 | [Google.Cloud.Speech.V1](https://googleapis.dev/dotnet/Google.Cloud.Speech.V1/2.1.0) | 2.1.0 | [Google Cloud Speech (V1 API)](https://cloud.google.com/speech) |
 | [Google.Cloud.Speech.V1P1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Speech.V1P1Beta1/2.0.0-beta03) | 2.0.0-beta03 | [Google Cloud Speech (V1P1Beta1 API)](https://cloud.google.com/speech) |
-| [Google.Cloud.Storage.V1](https://googleapis.dev/dotnet/Google.Cloud.Storage.V1/3.4.0-beta01) | 3.4.0-beta01 | [Google Cloud Storage](https://cloud.google.com/storage/) |
+| [Google.Cloud.Storage.V1](https://googleapis.dev/dotnet/Google.Cloud.Storage.V1/3.4.0) | 3.4.0 | [Google Cloud Storage](https://cloud.google.com/storage/) |
 | [Google.Cloud.Talent.V4](https://googleapis.dev/dotnet/Google.Cloud.Talent.V4/1.0.0-beta02) | 1.0.0-beta02 | [Google Cloud Talent Solution (V4 API)](https://cloud.google.com/talent-solution/) |
 | [Google.Cloud.Talent.V4Beta1](https://googleapis.dev/dotnet/Google.Cloud.Talent.V4Beta1/2.0.0-beta04) | 2.0.0-beta04 | [Google Cloud Talent Solution (V4Beta1 API)](https://cloud.google.com/talent-solution/) |
 | [Google.Cloud.Tasks.V2](https://googleapis.dev/dotnet/Google.Cloud.Tasks.V2/2.1.0) | 2.1.0 | [Google Cloud Tasks (V2 API)](https://cloud.google.com/tasks/) |

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.4.0-beta01</Version>
+    <Version>3.4.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Storage API. It wraps the Google.Apis.Storage.v1 client library, making common operations simpler in client code. Google Cloud Storage stores and retrieves potentially large, immutable data objects.</Description>

--- a/apis/Google.Cloud.Storage.V1/docs/history.md
+++ b/apis/Google.Cloud.Storage.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+# Version 3.4.0, released 2021-01-18
+
+- [Commit 421ad3f](https://github.com/googleapis/google-cloud-dotnet/commit/421ad3f): Update Google.Apis.Storage.v1 dependency.
+
+(No API changes from 3.4.0-beta01.)
+
 # Version 3.4.0-beta01, released 2020-09-30
 
 - [Commit 572976f](https://github.com/googleapis/google-cloud-dotnet/commit/572976f): Update Google.Apis.Storage.v1 dependency.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1812,17 +1812,17 @@
       "id": "Google.Cloud.Storage.V1",
       "productName": "Google Cloud Storage",
       "productUrl": "https://cloud.google.com/storage/",
-      "version": "3.4.0-beta01",
+      "version": "3.4.0",
       "type": "rest",
       "description": "Recommended Google client library to access the Google Cloud Storage API. It wraps the Google.Apis.Storage.v1 client library, making common operations simpler in client code. Google Cloud Storage stores and retrieves potentially large, immutable data objects.",
       "dependencies": {
-        "Google.Apis.Storage.v1": "1.49.0.2151",
-        "Google.Api.Gax.Rest": "3.2.0"
+        "Google.Api.Gax.Rest": "3.2.0",
+        "Google.Apis.Storage.v1": "1.49.0.2151"
       },
       "testDependencies": {
-        "Google.Cloud.PubSub.V1": "project",
         "Google.Api.Gax.Testing": "3.2.0",
-        "Google.Apis.Iam.v1": "1.49.0.2151"
+        "Google.Apis.Iam.v1": "1.49.0.2151",
+        "Google.Cloud.PubSub.V1": "project"
       },
       "tags": [
         "Storage"

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -112,7 +112,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Spanner.V1](Google.Cloud.Spanner.V1/index.html) | 3.4.0 | [Google Cloud Spanner](https://cloud.google.com/spanner/) |
 | [Google.Cloud.Speech.V1](Google.Cloud.Speech.V1/index.html) | 2.1.0 | [Google Cloud Speech (V1 API)](https://cloud.google.com/speech) |
 | [Google.Cloud.Speech.V1P1Beta1](Google.Cloud.Speech.V1P1Beta1/index.html) | 2.0.0-beta03 | [Google Cloud Speech (V1P1Beta1 API)](https://cloud.google.com/speech) |
-| [Google.Cloud.Storage.V1](Google.Cloud.Storage.V1/index.html) | 3.4.0-beta01 | [Google Cloud Storage](https://cloud.google.com/storage/) |
+| [Google.Cloud.Storage.V1](Google.Cloud.Storage.V1/index.html) | 3.4.0 | [Google Cloud Storage](https://cloud.google.com/storage/) |
 | [Google.Cloud.Talent.V4](Google.Cloud.Talent.V4/index.html) | 1.0.0-beta02 | [Google Cloud Talent Solution (V4 API)](https://cloud.google.com/talent-solution/) |
 | [Google.Cloud.Talent.V4Beta1](Google.Cloud.Talent.V4Beta1/index.html) | 2.0.0-beta04 | [Google Cloud Talent Solution (V4Beta1 API)](https://cloud.google.com/talent-solution/) |
 | [Google.Cloud.Tasks.V2](Google.Cloud.Tasks.V2/index.html) | 2.1.0 | [Google Cloud Tasks (V2 API)](https://cloud.google.com/tasks/) |


### PR DESCRIPTION

Changes in this release:

- [Commit 421ad3f](https://github.com/googleapis/google-cloud-dotnet/commit/421ad3f): Update Google.Apis.Storage.v1 dependency.

(No API changes from 3.4.0-beta01.)
