### PR TITLE
fix: parse WITH command as SELECT

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/ReadTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/ReadTests.cs
@@ -601,12 +601,12 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 // A statement that starts with a WITH clause should be treated as a query.
                 var cmd = connection.CreateCommand();
                 cmd.CommandText =
-                    $"WITH LastValue AS (" +
-                    $"  SELECT Key, StringValue" +
-                    $"  FROM {_fixture.TableName}" +
-                    $"  ORDER BY StringValue" +
-                    $"  LIMIT {int.MaxValue} OFFSET {_fixture.RowCount - 1}) " +
-                    $"SELECT * FROM LastValue";
+                    $@"WITH LastValue AS (
+                      SELECT Key, StringValue
+                      FROM {_fixture.TableName}
+                      ORDER BY StringValue
+                      LIMIT {int.MaxValue} OFFSET {_fixture.RowCount - 1})
+                    SELECT * FROM LastValue";
                 using (var reader = await cmd.ExecuteReaderAsync())
                 {
                     Assert.True(await reader.ReadAsync());

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerCommandTextBuilderTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerCommandTextBuilderTests.cs
@@ -64,5 +64,92 @@ namespace Google.Cloud.Spanner.Data.Tests
             var builder = SpannerCommandTextBuilder.FromCommandText(ddlString);
             Assert.False(builder.IsDropDatabaseCommand);
         }
+
+        // https://cloud.google.com/spanner/docs/query-syntax
+        [Theory]
+        [InlineData("SELECT * FROM Albums")]
+        [InlineData(" SELECT * FROM Albums")]
+        [InlineData("\t\nSELECT * FROM Albums")]
+        [InlineData("SELECT  * FROM Albums")]
+        [InlineData("SELECT\t\n* FROM Albums")]
+        [InlineData("WITH AlbumsView AS (SELECT * FROM Albums) select Title from AlbumsView")]
+        [InlineData(" WITH AlbumsView AS (SELECT * FROM Albums) select Title from AlbumsView")]
+        [InlineData("\t\nWITH AlbumsView AS (SELECT * FROM Albums) select Title from AlbumsView")]
+        [InlineData(" WITH   AlbumsView AS (SELECT * FROM Albums) select Title from AlbumsView")]
+        [InlineData("WITH\t\nAlbumsView AS (SELECT * FROM Albums) select Title from AlbumsView")]
+        public void SelectCommand(string commandText)
+        {
+            var builder = SpannerCommandTextBuilder.FromCommandText(commandText);
+            Assert.Equal(SpannerCommandType.Select, builder.SpannerCommandType);
+        }
+
+        // https://cloud.google.com/spanner/docs/dml-syntax#insert-statement
+        [Theory]
+        [InlineData("INSERT INTO Albums (AlbumId) VALUES (@id)")]
+        [InlineData(" INSERT INTO Albums (AlbumId) VALUES (@id)")]
+        [InlineData("\t\nINSERT\t\nINTO\t\nAlbums\t\n(AlbumId)t\nVALUESt\n(@id)")]
+        [InlineData("INSERT  INTO  Albums  (AlbumId) VALUES (@id)")]
+        [InlineData("INSERT\t\nINTO\t\nAlbums\t\n(AlbumId)t\nVALUESt\n(@id)")]
+        [InlineData("INSERT Albums (AlbumId) VALUES (@id)")]
+        [InlineData(" INSERT Albums (AlbumId) VALUES (@id)")]
+        [InlineData("\t\nINSERT\t\nAlbums\t\n(AlbumId)t\nVALUESt\n(@id)")]
+        [InlineData("INSERT  Albums  (AlbumId) VALUES (@id)")]
+        [InlineData("INSERT\t\nAlbums\t\n(AlbumId)t\nVALUESt\n(@id)")]
+        public void DmlInsertCommand(string commandText)
+        {
+            var builder = SpannerCommandTextBuilder.FromCommandText(commandText);
+            Assert.Equal(SpannerCommandType.Dml, builder.SpannerCommandType);
+        }
+
+        // https://cloud.google.com/spanner/docs/dml-syntax#update-statement
+        [Theory]
+        [InlineData("UPDATE Albums SET Title=@title WHERE TRUE")]
+        [InlineData(" UPDATE Albums SET Title=@title WHERE TRUE")]
+        [InlineData("\t\nUPDATE\t\nAlbumst\nSETt\nTitle=@titlet\nWHEREt\nTRUE")]
+        [InlineData("UPDATE  Albums  SET Title=@title WHERE TRUE")]
+        [InlineData("UPDATE\t\nAlbums\t\nSETt\nTitle=@titlet\nWHEREt\nTRUE")]
+        public void DmlUpdateCommand(string commandText)
+        {
+            var builder = SpannerCommandTextBuilder.FromCommandText(commandText);
+            Assert.Equal(SpannerCommandType.Dml, builder.SpannerCommandType);
+        }
+
+        // https://cloud.google.com/spanner/docs/dml-syntax#delete-statement
+        [Theory]
+        [InlineData("DELETE FROM Albums WHERE TRUE")]
+        [InlineData(" DELETE FROM Albums WHERE TRUE")]
+        [InlineData("\t\nDELETE FROM Albums WHERE TRUE")]
+        [InlineData("DELETE  FROM  Albums  WHERE  TRUE")]
+        [InlineData("DELETE\t\nFROM\t\nAlbumst\nWHEREt\nTRUE")]
+        [InlineData("DELETE Albums WHERE TRUE")]
+        [InlineData(" DELETE Albums WHERE TRUE")]
+        [InlineData("\t\nDELETE\t\nAlbumst\nWHEREt\nTRUE")]
+        [InlineData("DELETE  Albums  WHERE TRUE")]
+        [InlineData("DELETE\t\nAlbumst\nWHEREt\nTRUE")]
+        public void DmlDeleteCommand(string commandText)
+        {
+            var builder = SpannerCommandTextBuilder.FromCommandText(commandText);
+            Assert.Equal(SpannerCommandType.Dml, builder.SpannerCommandType);
+        }
+
+        // https://cloud.google.com/spanner/docs/data-definition-language
+        [Theory]
+        [InlineData("CREATE TABLE FOO")]
+        [InlineData(" CREATE TABLE FOO")]
+        [InlineData("CREATE\t\nTABLE\t\nFOO")]
+        [InlineData("\t\nCREATE\t\nTABLE\t\nFOO")]
+        [InlineData("DROP TABLE FOO")]
+        [InlineData(" DROP TABLE FOO")]
+        [InlineData("DROP\t\nTABLE\t\nFOO")]
+        [InlineData("\t\nDROP\t\nTABLE\t\nFOO")]
+        [InlineData("ALTER TABLE FOO")]
+        [InlineData(" ALTER TABLE FOO")]
+        [InlineData("ALTER\t\nTABLE\t\nFOO")]
+        [InlineData("\t\nALTER\t\nTABLE\t\nFOO")]
+        public void DdlCommand(string commandText)
+        {
+            var builder = SpannerCommandTextBuilder.FromCommandText(commandText);
+            Assert.Equal(SpannerCommandType.Ddl, builder.SpannerCommandType);
+        }
     }
 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommandTextBuilder.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommandTextBuilder.cs
@@ -220,7 +220,7 @@ namespace Google.Cloud.Spanner.Data
             GaxPreconditions.CheckNotNullOrEmpty(commandText, nameof(commandText));
             commandText = commandText.Trim();
             // Split(new char[0]) splits the string using all whitespace characters.
-            var commandSections = commandText.Split(new char[0], StringSplitOptions.RemoveEmptyEntries);
+            var commandSections = commandText.Split((char[]) null, StringSplitOptions.RemoveEmptyEntries);
             if (commandSections.Length < 2)
             {
                 throw new ArgumentException($"'{commandText}' is not a recognized Spanner command.", nameof(commandText));

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommandTextBuilder.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommandTextBuilder.cs
@@ -31,6 +31,7 @@ namespace Google.Cloud.Spanner.Data
         private const string UpdateCommand = "UPDATE";
         private const string DeleteCommand = "DELETE";
         private const string SelectCommand = "SELECT";
+        private const string WithCommand = "WITH"; // Queries may also start with a WITH clause.
         private const string AlterCommand = "ALTER";
         private const string CreateCommand = "CREATE";
         private const string DropCommand = "DROP";
@@ -45,6 +46,7 @@ namespace Google.Cloud.Spanner.Data
             { UpdateCommand, SpannerCommandType.Update },
             { DeleteCommand, SpannerCommandType.Delete },
             { SelectCommand, SpannerCommandType.Select },
+            { WithCommand, SpannerCommandType.Select },
             // These three form the ddl for spanner.
             // For reference: https://cloud.google.com/spanner/docs/data-definition-language
             { AlterCommand, SpannerCommandType.Ddl },
@@ -217,7 +219,8 @@ namespace Google.Cloud.Spanner.Data
         {
             GaxPreconditions.CheckNotNullOrEmpty(commandText, nameof(commandText));
             commandText = commandText.Trim();
-            var commandSections = commandText.Split(' ');
+            // Split(new char[0]) splits the string using all whitespace characters.
+            var commandSections = commandText.Split(new char[0], StringSplitOptions.RemoveEmptyEntries);
             if (commandSections.Length < 2)
             {
                 throw new ArgumentException($"'{commandText}' is not a recognized Spanner command.", nameof(commandText));


### PR DESCRIPTION
Parses `WITH` statements as queries and allows other whitespace characters than only ' '.

Fixes #5857