### PR TITLE
Release Google.Cloud.WebSecurityScanner.V1 version 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Vision.V1](https://googleapis.dev/dotnet/Google.Cloud.Vision.V1/2.2.0) | 2.2.0 | [Google Cloud Vision](https://cloud.google.com/vision) |
 | [Google.Cloud.WebRisk.V1](https://googleapis.dev/dotnet/Google.Cloud.WebRisk.V1/1.1.0) | 1.1.0 | [Google Cloud Web Risk (V1 API)](https://cloud.google.com/web-risk/) |
 | [Google.Cloud.WebRisk.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.WebRisk.V1Beta1/2.0.0-beta03) | 2.0.0-beta03 | [Google Cloud Web Risk (V1Beta1 API)](https://cloud.google.com/web-risk/) |
-| [Google.Cloud.WebSecurityScanner.V1](https://googleapis.dev/dotnet/Google.Cloud.WebSecurityScanner.V1/1.0.0-beta01) | 1.0.0-beta01 | [Web Security Scanner](https://cloud.google.com/security-command-center/docs/concepts-web-security-scanner-overview) |
+| [Google.Cloud.WebSecurityScanner.V1](https://googleapis.dev/dotnet/Google.Cloud.WebSecurityScanner.V1/1.0.0) | 1.0.0 | [Web Security Scanner](https://cloud.google.com/security-command-center/docs/concepts-web-security-scanner-overview) |
 | [Google.Cloud.Workflows.Common.V1Beta](https://googleapis.dev/dotnet/Google.Cloud.Workflows.Common.V1Beta/1.0.0-beta01) | 1.0.0-beta01 | Common resource names used by all Workflows V1Beta APIs |
 | [Google.Cloud.Workflows.Executions.V1Beta](https://googleapis.dev/dotnet/Google.Cloud.Workflows.Executions.V1Beta/1.0.0-beta01) | 1.0.0-beta01 | [Workflow Executions (V1Beta API)](https://cloud.google.com/workflows/docs/apis) |
 | [Google.Cloud.Workflows.V1Beta](https://googleapis.dev/dotnet/Google.Cloud.Workflows.V1Beta/1.0.0-beta01) | 1.0.0-beta01 | [Workflows (V1Beta API)](https://cloud.google.com/workflows/docs/apis) |

--- a/apis/Google.Cloud.WebSecurityScanner.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/.repo-metadata.json
@@ -1,5 +1,5 @@
 {
   "distribution_name": "Google.Cloud.WebSecurityScanner.V1",
-  "release_level": "beta",
+  "release_level": "ga",
   "client_documentation": "https://googleapis.dev/dotnet/Google.Cloud.WebSecurityScanner.V1/latest"
 }

--- a/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.csproj
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Web Security Scanner API, which scans your Compute and App Engine apps for common web vulnerabilities.</Description>

--- a/apis/Google.Cloud.WebSecurityScanner.V1/docs/history.md
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.0.0, released 2021-01-20
+
+No API changes since 1.0.0-beta01.
+
 # Version 1.0.0-beta01, released 2020-11-05
 
 Initial beta release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2080,7 +2080,7 @@
     },
     {
       "id": "Google.Cloud.WebSecurityScanner.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Web Security Scanner",
       "productUrl": "https://cloud.google.com/security-command-center/docs/concepts-web-security-scanner-overview",
@@ -2089,7 +2089,10 @@
         "security",
         "scanner"
       ],
-      "dependencies": {},
+      "dependencies": {
+        "Google.Api.Gax.Grpc.GrpcCore": "3.2.0",
+        "Grpc.Core": "2.31.0"
+      },
       "generator": "micro",
       "protoPath": "google/cloud/websecurityscanner/v1"
     },

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -126,7 +126,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Vision.V1](Google.Cloud.Vision.V1/index.html) | 2.2.0 | [Google Cloud Vision](https://cloud.google.com/vision) |
 | [Google.Cloud.WebRisk.V1](Google.Cloud.WebRisk.V1/index.html) | 1.1.0 | [Google Cloud Web Risk (V1 API)](https://cloud.google.com/web-risk/) |
 | [Google.Cloud.WebRisk.V1Beta1](Google.Cloud.WebRisk.V1Beta1/index.html) | 2.0.0-beta03 | [Google Cloud Web Risk (V1Beta1 API)](https://cloud.google.com/web-risk/) |
-| [Google.Cloud.WebSecurityScanner.V1](Google.Cloud.WebSecurityScanner.V1/index.html) | 1.0.0-beta01 | [Web Security Scanner](https://cloud.google.com/security-command-center/docs/concepts-web-security-scanner-overview) |
+| [Google.Cloud.WebSecurityScanner.V1](Google.Cloud.WebSecurityScanner.V1/index.html) | 1.0.0 | [Web Security Scanner](https://cloud.google.com/security-command-center/docs/concepts-web-security-scanner-overview) |
 | [Google.Cloud.Workflows.Common.V1Beta](Google.Cloud.Workflows.Common.V1Beta/index.html) | 1.0.0-beta01 | Common resource names used by all Workflows V1Beta APIs |
 | [Google.Cloud.Workflows.Executions.V1Beta](Google.Cloud.Workflows.Executions.V1Beta/index.html) | 1.0.0-beta01 | [Workflow Executions (V1Beta API)](https://cloud.google.com/workflows/docs/apis) |
 | [Google.Cloud.Workflows.V1Beta](Google.Cloud.Workflows.V1Beta/index.html) | 1.0.0-beta01 | [Workflows (V1Beta API)](https://cloud.google.com/workflows/docs/apis) |


### PR DESCRIPTION

Changes in this release:

No API changes since 1.0.0-beta01.
