### PR TITLE
Prepare for the next stage of Cloud Rad

### DIFF
--- a/docs/Google.Cloud.DocTools.sln
+++ b/docs/Google.Cloud.DocTools.sln
@@ -25,6 +25,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Tools.Common",
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Tools.GenerateSnippetMarkdown", "..\tools\Google.Cloud.Tools.GenerateSnippetMarkdown\Google.Cloud.Tools.GenerateSnippetMarkdown.csproj", "{2D842EDF-EFAE-41FE-9DAF-1338D3705077}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Tools.PostProcessDevSite", "..\tools\Google.Cloud.Tools.PostProcessDevSite\Google.Cloud.Tools.PostProcessDevSite.csproj", "{F6D3A1D9-4D6D-4DAF-85B6-AB8CDDE10780}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -167,6 +169,18 @@ Global
 		{2D842EDF-EFAE-41FE-9DAF-1338D3705077}.Release|x64.Build.0 = Release|Any CPU
 		{2D842EDF-EFAE-41FE-9DAF-1338D3705077}.Release|x86.ActiveCfg = Release|Any CPU
 		{2D842EDF-EFAE-41FE-9DAF-1338D3705077}.Release|x86.Build.0 = Release|Any CPU
+		{F6D3A1D9-4D6D-4DAF-85B6-AB8CDDE10780}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F6D3A1D9-4D6D-4DAF-85B6-AB8CDDE10780}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F6D3A1D9-4D6D-4DAF-85B6-AB8CDDE10780}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F6D3A1D9-4D6D-4DAF-85B6-AB8CDDE10780}.Debug|x64.Build.0 = Debug|Any CPU
+		{F6D3A1D9-4D6D-4DAF-85B6-AB8CDDE10780}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F6D3A1D9-4D6D-4DAF-85B6-AB8CDDE10780}.Debug|x86.Build.0 = Debug|Any CPU
+		{F6D3A1D9-4D6D-4DAF-85B6-AB8CDDE10780}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F6D3A1D9-4D6D-4DAF-85B6-AB8CDDE10780}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F6D3A1D9-4D6D-4DAF-85B6-AB8CDDE10780}.Release|x64.ActiveCfg = Release|Any CPU
+		{F6D3A1D9-4D6D-4DAF-85B6-AB8CDDE10780}.Release|x64.Build.0 = Release|Any CPU
+		{F6D3A1D9-4D6D-4DAF-85B6-AB8CDDE10780}.Release|x86.ActiveCfg = Release|Any CPU
+		{F6D3A1D9-4D6D-4DAF-85B6-AB8CDDE10780}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/docs/builddocs.sh
+++ b/docs/builddocs.sh
@@ -64,6 +64,8 @@ build_api_docs() {
     cp -r -t output/assembled output/$api/site/*
   else
     cp -r output/$api/site output/assembled/$api
+    # We need to make some changes to meet DevSite build expectations.
+    dotnet run --no-build --no-restore -p ../tools/Google.Cloud.Tools.PostProcessDevSite -- $api
   fi
   echo Finished building docs for $api
 }
@@ -79,8 +81,7 @@ mkdir output
 mkdir output/assembled
 
 # Build the tools once, then we can run them without restoring/building each time
-dotnet build ../tools/Google.Cloud.Tools.GenerateDocfxSources -v quiet -nologo -clp:NoSummary
-dotnet build ../tools/Google.Cloud.Tools.GenerateSnippetMarkdown -v quiet -nologo -clp:NoSummary
+dotnet build Google.Cloud.DocTools.sln -v quiet -nologo -clp:NoSummary
 
 apis=$@
 if [ -z "$apis" ]

--- a/tools/Google.Cloud.Tools.PostProcessDevSite/Google.Cloud.Tools.PostProcessDevSite.csproj
+++ b/tools/Google.Cloud.Tools.PostProcessDevSite/Google.Cloud.Tools.PostProcessDevSite.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Google.Cloud.Tools.Common\Google.Cloud.Tools.Common.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tools/Google.Cloud.Tools.PostProcessDevSite/Program.cs
+++ b/tools/Google.Cloud.Tools.PostProcessDevSite/Program.cs
@@ -1,0 +1,262 @@
+﻿// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Tools.Common;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Google.Cloud.Tools.PostProcessDevSite
+{
+    /// <summary>
+    /// Performs post-processing on the result of a docfx metadata build,
+    /// so that it's ready for uploading to be presented on DevSite.
+    /// 
+    /// Command line argument: package ID
+    /// 
+    /// Expected inputs:
+    /// - docs/output/{package}/obj/bareapi
+    /// - docs/output/{package}/obj/snippets
+    /// - docs/output/{package}/*.md (created by GenerateDocfxSources)
+    /// 
+    /// Output:
+    /// - docs/output/{package}/devsite/api (including guides and tweaked TOC)
+    /// - docs/output/{package}/devsite/examples
+    /// - docs/output/{package}/devsite/docs-metadata.json (includes xrefs and xrefservices)
+    /// </summary>
+    class Program
+    {
+        /// <summary>
+        /// The package/API ID
+        /// </summary>
+        private readonly string _apiId;
+
+        /// <summary>
+        /// Root docs output directory for the package: docs/output/{package}
+        /// </summary>
+        private readonly string _outputRoot;
+
+        /// <summary>
+        /// Output directory for everything for DevSite: docs/output/{package}/devsite
+        /// </summary>
+        private readonly string _devSiteRoot;
+
+        private readonly ApiCatalog _apiCatalog;
+        private readonly HashSet<string> _apiIds;
+
+        private static int Main(string[] args)
+        {
+            if (args.Length != 1)
+            {
+                Console.WriteLine("Expected argument: package ID");
+                return 1;
+            }
+            new Program(args[0]).Execute();
+            return 0;
+        }
+
+        private Program(string apiId)
+        {
+            DirectoryLayout layout = DirectoryLayout.ForApi(apiId);
+            _apiId = apiId;
+            _outputRoot = layout.DocsOutputDirectory;
+            _devSiteRoot = Path.Combine(_outputRoot, "devsite");
+            _apiCatalog = ApiCatalog.Load();
+            _apiIds = _apiCatalog.CreateIdHashSet();
+        }
+
+        private void Execute()
+        {
+            if (Directory.Exists(_devSiteRoot))
+            {
+                Directory.Delete(_devSiteRoot, recursive: true);
+            }
+            Directory.CreateDirectory(_devSiteRoot);
+
+            CopyApiDirectory();
+            CopyGuides();
+            AddGuidesToToc();
+            CopySnippetsToExamples();
+            CreateDocUploaderMetadata();
+        }
+
+        private void CopyApiDirectory()
+        {
+            var src = Path.Combine(_outputRoot, "obj", "bareapi");
+            var dest = Path.Combine(_devSiteRoot, "api");
+            Directory.CreateDirectory(dest);
+            foreach (var file in Directory.GetFiles(src))
+            {
+                File.Copy(file, Path.Combine(dest, Path.GetFileName(file)));
+            }
+        }
+
+        private void CopyGuides()
+        {
+            var dest = Path.Combine(_devSiteRoot, "api");
+            foreach (var file in Directory.GetFiles(_outputRoot, "*.md"))
+            {
+                var destFile = Path.Combine(dest, Path.GetFileName(file));
+                // Fix up links within the guides
+                var text = File.ReadAllText(file)
+                    .Replace("obj/api/", "")
+                    .Replace("obj/snippets/", "../examples/");
+                File.WriteAllText(destFile, text);
+            }
+        }
+
+        private void AddGuidesToToc()
+        {
+            var apiDirectory = Path.Combine(_devSiteRoot, "api");
+            var tocFile = Path.Combine(apiDirectory, "toc.yml");
+            // Read the current TOC
+            var deserializer = new DeserializerBuilder().WithNamingConvention(CamelCaseNamingConvention.Instance).Build();
+            var apiToc = deserializer.Deserialize<List<dynamic>>(File.ReadAllText(tocFile));
+
+            // Construct a TOC for guides from files
+            var guidesToc = new List<dynamic>();
+            foreach (var file in Directory.GetFiles(_outputRoot, "*.md"))
+            {
+                string title = Path.GetFileName(file) == "index.md"
+                    ? "Getting started"
+                    : File.ReadLines(file).First().TrimStart(' ', '#');
+                guidesToc.Add(new { Name = title, Href = Path.GetFileName(file) });
+            }
+
+            // All guides go under a "Guides" node
+            var guidesNode = new Dictionary<string, object>
+            {
+                ["name"] = "User Guides",
+                ["items"] = guidesToc
+            };
+
+            // After the Guides node, there's an "All types" page
+            var allTypesNode = new Dictionary<string, object>
+            {
+                ["name"] = "All types",
+                ["uid"] = apiToc[0]["uid"]
+            };
+
+            // All other items come after Guides and All types
+            var items = new dynamic[] { guidesNode, allTypesNode }.Concat((IEnumerable<dynamic>)apiToc[0]["items"]).ToList();
+
+            var newToc = new[]
+            {
+                new Dictionary<string, object>
+                {
+                    ["name"] = apiToc[0]["name"],
+                    ["items"] = items
+                }
+            };
+
+            var serializer = new SerializerBuilder()
+                .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull)
+                .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                .Build();
+            string newText = serializer.Serialize(newToc);
+            File.WriteAllText(tocFile, newText);
+
+        }
+
+        private void CopySnippetsToExamples()
+        {
+            var src = Path.Combine(_outputRoot, "obj", "snippets");
+            var dest = Path.Combine(_devSiteRoot, "examples");
+            Directory.CreateDirectory(dest);
+            foreach (var file in Directory.GetFiles(src, "*.md"))
+            {
+                var lines = File.ReadAllLines(file)
+                    .Select(MaybeReplaceSnippetWithExample);
+                var destFile = Path.Combine(dest, Path.GetFileName(file));
+                File.WriteAllLines(destFile, lines);
+            }
+            foreach (var file in Directory.GetFiles(src, "*.txt"))
+            {
+                var destFile = Path.Combine(dest, Path.GetFileName(file));
+                File.Copy(file, destFile);
+            }
+
+            // The template expects "example" to be a list, so we wrap it in a single element list.
+            string MaybeReplaceSnippetWithExample(string line) =>
+                line == "snippet: *content" ? "example: [*content]" : line;
+        }
+
+        private void CreateDocUploaderMetadata()
+        {
+            var apiMetadata = ApiCatalog.Load()[_apiId];
+            var docUploaderMetadata = new JObject
+            {
+                ["version"] = apiMetadata.Version,
+                ["language"] = "dotnet",
+                ["name"] = apiMetadata.Id,
+                ["xrefs"] = new JArray(GetXrefUrls(apiMetadata)),
+                ["xrefservices"] = new JArray("https://xref.docs.microsoft.com/query?uid={uid}")
+                // TODO: xrefs
+            };
+            string json = docUploaderMetadata.ToString(Formatting.Indented);
+            File.WriteAllText(Path.Combine(_devSiteRoot, "docs-metadata.json"), json);
+        }
+
+        private const string GoogleApisXrefPrefix = "https://googleapis.dev/dotnet";
+        private const string GoogleApisXrefSuffix = "latest/xrefmap.yml";
+        private const string DevSiteXrefPrefix = "https://cloud.devsite.corp.google.com/dotnet/docs/reference";
+        private const string DevSiteXrefSuffix = "latest/xrefmap.yml";
+
+        private static readonly string[] s_utilityXrefUrls =
+        {
+            $"{DevSiteXrefPrefix}/Google.Apis/{DevSiteXrefSuffix}",
+            $"{DevSiteXrefPrefix}/Google.Api.Gax/{DevSiteXrefSuffix}",
+            $"{DevSiteXrefPrefix}/Google.Protobuf/{DevSiteXrefSuffix}",
+            $"{DevSiteXrefPrefix}/Grpc.Core/{DevSiteXrefSuffix}",
+        };
+
+        private List<string> GetXrefUrls(ApiMetadata api) =>
+            s_utilityXrefUrls // It's harmless to include all of these, even if we don't use them.
+                .Concat(GetTransitiveDependencies(api).Select(GetXrefUrl))
+                .Where(xref => xref is object)
+                .OrderBy(xref => xref)
+                .ToList();
+
+        private HashSet<string> GetTransitiveDependencies(ApiMetadata api)
+        {
+            // Note: this assumes there are no dependency cycles, but that's pretty reasonable.
+            HashSet<string> ret = new HashSet<string>(api.Dependencies.Keys);
+            foreach (var immediateDependency in ret.ToList())
+            {
+                if (_apiIds.Contains(immediateDependency))
+                {
+                    var dependencyMetadata = _apiCatalog[immediateDependency];
+                    foreach (var transitive in GetTransitiveDependencies(dependencyMetadata))
+                    {
+                        ret.Add(transitive);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        private string GetXrefUrl(string dependency) =>
+            dependency switch
+            {
+                string pkg when pkg.StartsWith("Google.Apis") => $"{GoogleApisXrefPrefix}/{pkg}/{GoogleApisXrefSuffix}",
+                string pkg when _apiCatalog.CreateIdHashSet().Contains(pkg) => $"{DevSiteXrefPrefix}/{pkg}/{DevSiteXrefSuffix}",
+                _ => null
+            };
+    }
+}


### PR DESCRIPTION
This involves a bit more work *after* metadata generation, but *before* uploading to DevSite.
With this in place, we need to wait for:

- docuploader to handle JSON files
- doc-pipeline to handle tar files with separate api/ and examples/ directories

At that point, we'll just need to update uploaddocs.sh to tweak the stage where it currently uses bareapi.