### PR TITLE
Release Google.Analytics.Admin.V1Alpha version 1.0.0-alpha04

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Each package name links to the documentation for that package.
 
 | Package | Latest version | Description |
 |---------|----------------|-------------|
-| [Google.Analytics.Admin.V1Alpha](https://googleapis.dev/dotnet/Google.Analytics.Admin.V1Alpha/1.0.0-alpha03) | 1.0.0-alpha03 | Analytics Admin |
+| [Google.Analytics.Admin.V1Alpha](https://googleapis.dev/dotnet/Google.Analytics.Admin.V1Alpha/1.0.0-alpha04) | 1.0.0-alpha04 | Analytics Admin |
 | [Google.Analytics.Data.V1Alpha](https://googleapis.dev/dotnet/Google.Analytics.Data.V1Alpha/1.0.0-alpha03) | 1.0.0-alpha03 | Google Analytics Data |
 | [Google.Area120.Tables.V1Alpha1](https://googleapis.dev/dotnet/Google.Area120.Tables.V1Alpha1/1.0.0-alpha02) | 1.0.0-alpha02 | Google Area 120 Tables |
 | [Google.Cloud.AccessApproval.V1](https://googleapis.dev/dotnet/Google.Cloud.AccessApproval.V1/1.0.0) | 1.0.0 | [Access Approval](https://cloud.google.com/access-approval/docs/) |

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha03</Version>
+    <Version>1.0.0-alpha04</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Analytics Admin API</Description>

--- a/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
+++ b/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+# Version 1.0.0-alpha04, released 2021-02-05
+
+- [Commit 3a758af](https://github.com/googleapis/google-cloud-dotnet/commit/3a758af):
+  - fix!: remove unused fields from `EnhancedMeasurementSettings`
+  - fix!: `update_mask` field is required for all Update operations
+  - feat: add pagination support for `ListFirebaseLinks` operation
+  - fix!: rename `country_code` field to `region_code` in `Account`
+  - fix!: rename `url_query_parameter` field to `uri_query_parameter` in `EnhancedMeasurementSettings`
+  - fix!: remove `parent` field from `GoogleAdsLink` ([issue 5841](https://github.com/googleapis/google-cloud-dotnet/issues/5841))
+- [Commit 99b6d03](https://github.com/googleapis/google-cloud-dotnet/commit/99b6d03): docs: put markdown table in a codeblock
+- [Commit 4f5c935](https://github.com/googleapis/google-cloud-dotnet/commit/4f5c935): feat: Add global site tag name
+
 # Version 1.0.0-alpha03, released 2020-11-19
 
 - [Commit 766a6d0](https://github.com/googleapis/google-cloud-dotnet/commit/766a6d0):

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2,7 +2,7 @@
   "apis": [
     {
       "id": "Google.Analytics.Admin.V1Alpha",
-      "version": "1.0.0-alpha03",
+      "version": "1.0.0-alpha04",
       "type": "grpc",
       "productName": "Analytics Admin",
       "description": "Recommended Google client library to access the Analytics Admin API",

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -18,7 +18,7 @@ Each package name links to the documentation for that package.
 
 | Package | Latest version | Description |
 |---------|----------------|-------------|
-| [Google.Analytics.Admin.V1Alpha](Google.Analytics.Admin.V1Alpha/index.html) | 1.0.0-alpha03 | Analytics Admin |
+| [Google.Analytics.Admin.V1Alpha](Google.Analytics.Admin.V1Alpha/index.html) | 1.0.0-alpha04 | Analytics Admin |
 | [Google.Analytics.Data.V1Alpha](Google.Analytics.Data.V1Alpha/index.html) | 1.0.0-alpha03 | Google Analytics Data |
 | [Google.Area120.Tables.V1Alpha1](Google.Area120.Tables.V1Alpha1/index.html) | 1.0.0-alpha02 | Google Area 120 Tables |
 | [Google.Cloud.AccessApproval.V1](Google.Cloud.AccessApproval.V1/index.html) | 1.0.0 | [Access Approval](https://cloud.google.com/access-approval/docs/) |


### PR DESCRIPTION

Changes in this release:

- [Commit 3a758af](https://github.com/googleapis/google-cloud-dotnet/commit/3a758af):
  - fix!: remove unused fields from `EnhancedMeasurementSettings`
  - fix!: `update_mask` field is required for all Update operations
  - feat: add pagination support for `ListFirebaseLinks` operation
  - fix!: rename `country_code` field to `region_code` in `Account`
  - fix!: rename `url_query_parameter` field to `uri_query_parameter` in `EnhancedMeasurementSettings`
  - fix!: remove `parent` field from `GoogleAdsLink` ([issue 5841](https://github.com/googleapis/google-cloud-dotnet/issues/5841))
- [Commit 99b6d03](https://github.com/googleapis/google-cloud-dotnet/commit/99b6d03): docs: put markdown table in a codeblock
- [Commit 4f5c935](https://github.com/googleapis/google-cloud-dotnet/commit/4f5c935): feat: Add global site tag name
