### PR TITLE
ci: Deletes generated standalone snippets.

### DIFF
--- a/generateapis.sh
+++ b/generateapis.sh
@@ -140,7 +140,10 @@ generate_microgenerator() {
 
   # The microgenerator currently creates Google.Cloud directories due to being given
   # the common resources proto. Clean up for now; this is being fixed in the generator.
-  rm -rf $API_TMP_DIR/Google.Cloud{,.Snippets,.Tests}
+  rm -rf $API_TMP_DIR/Google.Cloud{,.Snippets,.Tests,.StandaloneSnippets}
+
+  # Remove the newly generated standalone snippets until they are ready for surfacing.
+  rm -rf $API_TMP_DIR/Google.*.StandaloneSnippets
 
   # We generate our own project files
   rm $(find tmp -name '*.csproj')


### PR DESCRIPTION
Until standalone snippets are ready to be surfaced.
In preparation for merging googleapis/gapic-generator-csharp#298.