### PR TITLE
build: Downgrades gRPC default version back to 2.31.0.

### DIFF
--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.35.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Analytics.Data.V1Alpha/Google.Analytics.Data.V1Alpha/Google.Analytics.Data.V1Alpha.csproj
+++ b/apis/Google.Analytics.Data.V1Alpha/Google.Analytics.Data.V1Alpha/Google.Analytics.Data.V1Alpha.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.35.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.csproj
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.35.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.csproj
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.35.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.csproj
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.1.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.35.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.csproj
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.35.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1.csproj
+++ b/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.35.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.csproj
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.35.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.csproj
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.35.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.csproj
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.35.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.DataLabeling.V1Beta1/Google.Cloud.DataLabeling.V1Beta1/Google.Cloud.DataLabeling.V1Beta1.csproj
+++ b/apis/Google.Cloud.DataLabeling.V1Beta1/Google.Cloud.DataLabeling.V1Beta1/Google.Cloud.DataLabeling.V1Beta1.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.35.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.DocumentAI.V1Beta2/Google.Cloud.DocumentAI.V1Beta2/Google.Cloud.DocumentAI.V1Beta2.csproj
+++ b/apis/Google.Cloud.DocumentAI.V1Beta2/Google.Cloud.DocumentAI.V1Beta2/Google.Cloud.DocumentAI.V1Beta2.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.35.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.csproj
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.35.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.csproj
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.35.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta.csproj
+++ b/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.35.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.csproj
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.35.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.MediaTranslation.V1Beta1/Google.Cloud.MediaTranslation.V1Beta1/Google.Cloud.MediaTranslation.V1Beta1.csproj
+++ b/apis/Google.Cloud.MediaTranslation.V1Beta1/Google.Cloud.MediaTranslation.V1Beta1/Google.Cloud.MediaTranslation.V1Beta1.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.35.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.csproj
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.35.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.csproj
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.35.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.csproj
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.35.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1.csproj
+++ b/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.35.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.csproj
+++ b/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.35.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.csproj
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.35.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.csproj
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.35.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.csproj
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.35.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.csproj
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.35.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Security.PrivateCA.V1Beta1/Google.Cloud.Security.PrivateCA.V1Beta1/Google.Cloud.Security.PrivateCA.V1Beta1.csproj
+++ b/apis/Google.Cloud.Security.PrivateCA.V1Beta1/Google.Cloud.Security.PrivateCA.V1Beta1/Google.Cloud.Security.PrivateCA.V1Beta1.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.0.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.35.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.csproj
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.35.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.csproj
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.35.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.csproj
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.35.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.csproj
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.35.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Video.Transcoder.V1Beta1/Google.Cloud.Video.Transcoder.V1Beta1/Google.Cloud.Video.Transcoder.V1Beta1.csproj
+++ b/apis/Google.Cloud.Video.Transcoder.V1Beta1/Google.Cloud.Video.Transcoder.V1Beta1/Google.Cloud.Video.Transcoder.V1Beta1.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.35.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1.csproj
+++ b/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.35.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.csproj
+++ b/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.Workflows.Common.V1\Google.Cloud.Workflows.Common.V1\Google.Cloud.Workflows.Common.V1.csproj" />
-    <PackageReference Include="Grpc.Core" Version="[2.35.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.csproj
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.Workflows.Common.V1Beta\Google.Cloud.Workflows.Common.V1Beta\Google.Cloud.Workflows.Common.V1Beta.csproj" />
-    <PackageReference Include="Grpc.Core" Version="[2.35.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.csproj
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.Workflows.Common.V1\Google.Cloud.Workflows.Common.V1\Google.Cloud.Workflows.Common.V1.csproj" />
     <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.35.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.csproj
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.Workflows.Common.V1Beta\Google.Cloud.Workflows.Common.V1Beta\Google.Cloud.Workflows.Common.V1Beta.csproj" />
     <PackageReference Include="Google.LongRunning" Version="[2.0.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.35.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/tools/Google.Cloud.Tools.ReleaseManager/GenerateProjectsCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/GenerateProjectsCommand.cs
@@ -62,7 +62,7 @@ namespace Google.Cloud.Tools.ReleaseManager
         private const string DefaultVersionValue = "default";
         private const string GrpcPackage = "Grpc.Core";
         private const string DefaultGaxVersion = "3.2.0";
-        private const string GrpcVersion = "2.35.0";
+        private const string GrpcVersion = "2.31.0";
         private static readonly Dictionary<string, string> DefaultPackageVersions = new Dictionary<string, string>
         {
             { "Google.Api.Gax", DefaultGaxVersion },


### PR DESCRIPTION
This effectively rolls #5916 back.
Need to look at some isues seen on CI.