### PR TITLE
test: skip CommitStats test on emulator

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/TransactionTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/TransactionTests.cs
@@ -490,9 +490,10 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             }
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task ReturnCommitStats()
         {
+            Skip.If(_fixture.RunningOnEmulator, "Emulator does not yet support CommitStats");
             CommitStatsCapturerLogger logger = new CommitStatsCapturerLogger();
             string key = IdGenerator.FromGuid();
             await RetryHelpers.ExecuteWithRetryAsync(async () =>


### PR DESCRIPTION
Skips the CommitStats integration test when running on the emulator, as the emulator does not yet support this feature.

This change also adds automatic creation of a test instance on the emulator when needed. This makes it a lot easier to run integration tests on the emulator, as you don't have to manually create an instance on the emulator first before running the integration tests.

Fixes #5948