### PR TITLE
ci: Cleans up GitHub actions configs.

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,38 +1,22 @@
 name: Build and test PR (changed APIs only)
 
-on: [pull_request]	
+on: [pull_request]
 
-jobs:	
+jobs:
 
-  build:	
-    runs-on: ubuntu-18.04	
-    env:	
-      DOTNET_NOLOGO: true	
-    strategy:	
-      matrix:	
-        regex: ["'Google\\.Cloud\\.[A-L].*'", "'Google\\.Cloud\\.[M-Z].*'", "'!Google\\.Cloud'"]	
-    steps:	
-    - uses: actions/checkout@v2	
-      with:	
-        submodules: true	
-        fetch-depth: 100	
-
-    # We use the .NET Core 2.1 runtime for testing most packages
-    - name: Setup .NET Core 2.1	
-      uses: actions/setup-dotnet@v1	
-      with:	
-        dotnet-version: 2.1.x	
-
-    # We build with .NET Core 3.1 SDK	
-    - name: Setup .NET Core 3.1	
-      uses: actions/setup-dotnet@v1	
-      with:	
-        dotnet-version: 3.1.x
-
-    - name: Setup Python	
-      uses: actions/setup-python@v2	
-      with:	
-        python-version: 3.x	
+  build:
+    runs-on: ubuntu-latest
+    env:
+      DOTNET_NOLOGO: true
+    strategy:
+      matrix:
+        regex: ["'Google\\.Cloud\\.[A-L].*'", "'Google\\.Cloud\\.[M-Z].*'", "'!Google\\.Cloud'"]
+    
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+        fetch-depth: 100
 
     # The GitHub checkout action leaves the repo in a slightly awkward
     # state. This tidies it up.
@@ -42,8 +26,8 @@ jobs:
         git checkout -b master ${{ github.event.pull_request.base.sha }}
         git checkout pr-head
 
-    - name: Build and test	
+    - name: Build and test
       run: |
-        touch build_timing_log.txt	
-        ./build.sh --diff --regex ${{ matrix.regex }}	
-        ./processbuildtiminglog.sh	
+        touch build_timing_log.txt
+        ./build.sh --diff --regex ${{ matrix.regex }}
+        ./processbuildtiminglog.sh

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -5,39 +5,21 @@ on:
     branches:
       - master
 
-jobs:	
+jobs:
 
-  build:	
-    runs-on: ubuntu-18.04	
-    env:	
-      DOTNET_NOLOGO: true	
+  build:
+    runs-on: ubuntu-latest
+    env:
+      DOTNET_NOLOGO: true
 
-    steps:	
-    - uses: actions/checkout@v2	
-      with:	
-        submodules: true	
-        fetch-depth: 100	
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
 
-    # We use the .NET Core 2.1 runtime for testing most packages
-    - name: Setup .NET Core 2.1	
-      uses: actions/setup-dotnet@v1	
-      with:	
-        dotnet-version: 2.1.x	
-
-    # We build with .NET Core 3.1 SDK	
-    - name: Setup .NET Core 3.1	
-      uses: actions/setup-dotnet@v1	
-      with:	
-        dotnet-version: 3.1.x	
-
-    - name: Setup Python	
-      uses: actions/setup-python@v2	
-      with:	
-        python-version: 3.x	
-
-    - name: Build and test	
-      run: |	
+    - name: Build and test
+      run: |
         dotnet --info
-        touch build_timing_log.txt	
+        touch build_timing_log.txt
         ./build.sh
-        ./processbuildtiminglog.sh	
+        ./processbuildtiminglog.sh

--- a/.github/workflows/diff-pr.yml
+++ b/.github/workflows/diff-pr.yml
@@ -5,28 +5,16 @@ on: [pull_request]
 jobs:
 
   diff:
-    runs-on: ubuntu-18.04
-    env:	
-      DOTNET_NOLOGO: true	
+    runs-on: ubuntu-latest
+    env:
+      DOTNET_NOLOGO: true
 
     steps:
     - uses: actions/checkout@v2
       with:
         submodules: true
-        # TODO: Try depth 100. We diff against master, and we don't know
-        # how far back that is... there may be a better approach
-        fetch-depth: 0
-        
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 3.1.x
-        
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.x
-        
+        fetch-depth: 100
+
     # The GitHub checkout action leaves the repo in a slightly awkward
     # state. This tidies it up.
     - name: Set up git branches


### PR DESCRIPTION
@jskeet  this is a proposal, not sure if you want to be explicit about Ubuntu, .NET and Python versions, but looking at the [GitHub-hosted runners spec](https://docs.github.com/en/actions/reference/specifications-for-github-hosted-runners) it seems that we should be OK.

Also, making some changes here based on some of your comments in #5952.