### PR TITLE
Fix docfx xrefs

### DIFF
--- a/apis/Google.Cloud.Storage.V1/docs/index.md
+++ b/apis/Google.Cloud.Storage.V1/docs/index.md
@@ -85,7 +85,7 @@ Currently the default is V2, although in the future the library may
 be updated to use V4 by default.
 
 To specify the URL signing versioning, use the
-[UrlSigner.WithSigningVersion](obj/api/Google.Cloud.Storage.V1.UrlSigner.yml#Google_Cloud_Storage_V1_UrlSigner_WithSigningVersion_Google_Cloud_Storage_V1_SigningVersion_)
+[UrlSigner.Options.WithSigningVersion](obj/api/Google.Cloud.Storage.V1.UrlSigner.Options.yml#Google_Cloud_Storage_V1_UrlSigner_Options_WithSigningVersion_Google_Cloud_Storage_V1_SigningVersion_)
 method, specifying the signing version you wish to use. This does
 not change the UrlSigner it is called on; it returns a new UrlSigner
 that uses the specified version.

--- a/docs/generate-devsite-utilities.sh
+++ b/docs/generate-devsite-utilities.sh
@@ -159,7 +159,7 @@ python -m pip install -q gcp-docuploader
 XREF_TMP=""
 for xref in "${XREFS[@]}"
 do
-  FULL_XREF="https://cloud.devsite.corp.google.com/dotnet/docs/reference/$xref/latest/xrefmap.yml"
+  FULL_XREF="devsite://dotnet/$xref"
   XREF_TMP="$XREF_TMP --xrefs $FULL_XREF"
 done
 


### PR DESCRIPTION
Sample xrefs outputs:

Google.Cloud.Spanner.Data:

```text
"devsite://dotnet/Google.Api.CommonProtos",
"devsite://dotnet/Google.Api.Gax",
"devsite://dotnet/Google.Apis",
"devsite://dotnet/Google.Cloud.Iam.V1@2.1.0",
"devsite://dotnet/Google.Cloud.Spanner.Admin.Database.V1@3.5.0",
"devsite://dotnet/Google.Cloud.Spanner.Admin.Instance.V1@3.5.0",
"devsite://dotnet/Google.Cloud.Spanner.Common.V1@3.5.0",
"devsite://dotnet/Google.Cloud.Spanner.V1@3.5.0",
"devsite://dotnet/Google.LongRunning@2.1.0",
"devsite://dotnet/Grpc.Core"
```

Google.Cloud.Storage.V1:

```text
"devsite://dotnet/Google.Api.CommonProtos",
"devsite://dotnet/Google.Api.Gax",
"devsite://dotnet/Google.Apis",
"devsite://dotnet/Grpc.Core",
"https://googleapis.dev/dotnet/Google.Apis.Storage.v1/1.49.0.2151/xrefmap.yml"
```