### PR TITLE
Improve TOC handling for DevSite

### DIFF
--- a/Google.Cloud.Tools.DocfxMetadata/Google.Cloud.Tools.DocfxMetadata.csproj
+++ b/Google.Cloud.Tools.DocfxMetadata/Google.Cloud.Tools.DocfxMetadata.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <IsPackable>False</IsPackable>
+    <Description>Library to help consume docfx metadata</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="YamlDotNet" Version="9.1.4" />
+  </ItemGroup>
+
+</Project>

--- a/Google.Cloud.Tools.DocfxMetadata/ItemType.cs
+++ b/Google.Cloud.Tools.DocfxMetadata/ItemType.cs
@@ -1,0 +1,35 @@
+﻿// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Google.Cloud.Tools.DocfxMetadata
+{
+    /// <summary>
+    /// Type of a metadata item
+    /// </summary>
+    public enum ItemType
+    {
+        Class,
+        Property,
+        Namespace,
+        Enum,
+        Interface,
+        Struct,
+        Delegate,
+        Constructor,
+        Method,
+        Field,
+        Event,
+        Operator
+    }
+}

--- a/Google.Cloud.Tools.DocfxMetadata/MetadataFile.cs
+++ b/Google.Cloud.Tools.DocfxMetadata/MetadataFile.cs
@@ -1,0 +1,33 @@
+﻿// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace Google.Cloud.Tools.DocfxMetadata
+{
+    /// <summary>
+    /// Top level YAML file as emitted by docfx.
+    /// </summary>
+    public class MetadataFile
+    {
+        public List<MetadataItem> Items { get; set; }
+
+        public static MetadataFile LoadYaml(string file)
+        {
+            var json = YamlHelpers.LoadYamlAsJson(file);
+            return JsonConvert.DeserializeObject<MetadataFile>(json);
+        }
+    }
+}

--- a/Google.Cloud.Tools.DocfxMetadata/MetadataItem.cs
+++ b/Google.Cloud.Tools.DocfxMetadata/MetadataItem.cs
@@ -1,0 +1,41 @@
+﻿// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Google.Cloud.Tools.DocfxMetadata
+{
+    /// <summary>
+    /// Simplified representation of a metadata item. (This can be added to
+    /// as required; we could use the Microsoft.DocAsCode.DataContracts.ManagedReference
+    /// package if we really needed the full representation.)
+    /// </summary>
+    public class MetadataItem
+    {
+        private static readonly ItemType[] s_typeItems =
+        {
+            ItemType.Class, ItemType.Struct, ItemType.Interface, ItemType.Delegate
+        };
+
+        public string Uid { get; set; }
+        public string Name { get; set; }
+        public ItemType Type { get; set; }
+        public List<string> Assemblies { get; set; }
+        public string Parent { get; set; }
+        public List<string> Children { get; set; }
+
+        public bool IsType => s_typeItems.Contains(Type);
+    }
+}

--- a/Google.Cloud.Tools.DocfxMetadata/TocEntry.cs
+++ b/Google.Cloud.Tools.DocfxMetadata/TocEntry.cs
@@ -1,0 +1,40 @@
+﻿// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Google.Cloud.Tools.DocfxMetadata
+{
+    public class TocEntry
+    {
+        public string Uid { get; set; }
+        public string Name { get; set; }
+        public List<TocEntry> Items { get; set; }
+
+        public static string CreateToc(IEnumerable<TocEntry> entries)
+        {
+            var serializer = new SerializerBuilder()
+                .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull)
+                .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                .Build();
+            var writer = new StringWriter();
+            serializer.Serialize(writer, entries);
+            return "### YamlMime:TableOfContent" + Environment.NewLine + writer.ToString();
+        }
+    }
+}

--- a/Google.Cloud.Tools.DocfxMetadata/YamlHelpers.cs
+++ b/Google.Cloud.Tools.DocfxMetadata/YamlHelpers.cs
@@ -1,0 +1,36 @@
+﻿// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.IO;
+using YamlDotNet.Serialization;
+
+namespace Google.Cloud.Tools.DocfxMetadata
+{
+    internal class YamlHelpers
+    {
+        internal static string LoadYamlAsJson(string file)
+        {
+            using var reader = File.OpenText(file);
+            var deserializer = new Deserializer();
+            var yamlObject = deserializer.Deserialize(reader);
+
+            // now convert the object to JSON. Simple!
+            var serializer = new SerializerBuilder().JsonCompatible().Build();
+
+            var writer = new StringWriter();
+            serializer.Serialize(writer, yamlObject);
+            return writer.ToString();
+        }
+    }
+}

--- a/docs/Google.Cloud.DocTools.sln
+++ b/docs/Google.Cloud.DocTools.sln
@@ -25,7 +25,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Tools.Common",
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Tools.GenerateSnippetMarkdown", "..\tools\Google.Cloud.Tools.GenerateSnippetMarkdown\Google.Cloud.Tools.GenerateSnippetMarkdown.csproj", "{2D842EDF-EFAE-41FE-9DAF-1338D3705077}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Tools.PostProcessDevSite", "..\tools\Google.Cloud.Tools.PostProcessDevSite\Google.Cloud.Tools.PostProcessDevSite.csproj", "{F6D3A1D9-4D6D-4DAF-85B6-AB8CDDE10780}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Tools.PostProcessDevSite", "..\tools\Google.Cloud.Tools.PostProcessDevSite\Google.Cloud.Tools.PostProcessDevSite.csproj", "{F6D3A1D9-4D6D-4DAF-85B6-AB8CDDE10780}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Tools.RegenerateToc", "..\tools\Google.Cloud.Tools.RegenerateToc\Google.Cloud.Tools.RegenerateToc.csproj", "{D1C3EFCD-0ED3-4555-8437-007BAB1D3D63}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Tools.DocfxMetadata", "..\Google.Cloud.Tools.DocfxMetadata\Google.Cloud.Tools.DocfxMetadata.csproj", "{150FE2B7-0DEA-4EEE-A47B-30A2DE7D397E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -181,6 +185,30 @@ Global
 		{F6D3A1D9-4D6D-4DAF-85B6-AB8CDDE10780}.Release|x64.Build.0 = Release|Any CPU
 		{F6D3A1D9-4D6D-4DAF-85B6-AB8CDDE10780}.Release|x86.ActiveCfg = Release|Any CPU
 		{F6D3A1D9-4D6D-4DAF-85B6-AB8CDDE10780}.Release|x86.Build.0 = Release|Any CPU
+		{D1C3EFCD-0ED3-4555-8437-007BAB1D3D63}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D1C3EFCD-0ED3-4555-8437-007BAB1D3D63}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D1C3EFCD-0ED3-4555-8437-007BAB1D3D63}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D1C3EFCD-0ED3-4555-8437-007BAB1D3D63}.Debug|x64.Build.0 = Debug|Any CPU
+		{D1C3EFCD-0ED3-4555-8437-007BAB1D3D63}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D1C3EFCD-0ED3-4555-8437-007BAB1D3D63}.Debug|x86.Build.0 = Debug|Any CPU
+		{D1C3EFCD-0ED3-4555-8437-007BAB1D3D63}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D1C3EFCD-0ED3-4555-8437-007BAB1D3D63}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D1C3EFCD-0ED3-4555-8437-007BAB1D3D63}.Release|x64.ActiveCfg = Release|Any CPU
+		{D1C3EFCD-0ED3-4555-8437-007BAB1D3D63}.Release|x64.Build.0 = Release|Any CPU
+		{D1C3EFCD-0ED3-4555-8437-007BAB1D3D63}.Release|x86.ActiveCfg = Release|Any CPU
+		{D1C3EFCD-0ED3-4555-8437-007BAB1D3D63}.Release|x86.Build.0 = Release|Any CPU
+		{150FE2B7-0DEA-4EEE-A47B-30A2DE7D397E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{150FE2B7-0DEA-4EEE-A47B-30A2DE7D397E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{150FE2B7-0DEA-4EEE-A47B-30A2DE7D397E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{150FE2B7-0DEA-4EEE-A47B-30A2DE7D397E}.Debug|x64.Build.0 = Debug|Any CPU
+		{150FE2B7-0DEA-4EEE-A47B-30A2DE7D397E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{150FE2B7-0DEA-4EEE-A47B-30A2DE7D397E}.Debug|x86.Build.0 = Debug|Any CPU
+		{150FE2B7-0DEA-4EEE-A47B-30A2DE7D397E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{150FE2B7-0DEA-4EEE-A47B-30A2DE7D397E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{150FE2B7-0DEA-4EEE-A47B-30A2DE7D397E}.Release|x64.ActiveCfg = Release|Any CPU
+		{150FE2B7-0DEA-4EEE-A47B-30A2DE7D397E}.Release|x64.Build.0 = Release|Any CPU
+		{150FE2B7-0DEA-4EEE-A47B-30A2DE7D397E}.Release|x86.ActiveCfg = Release|Any CPU
+		{150FE2B7-0DEA-4EEE-A47B-30A2DE7D397E}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/docs/generate-devsite-utilities.sh
+++ b/docs/generate-devsite-utilities.sh
@@ -148,6 +148,9 @@ do
   sleep 1
 done
 
+echo 'Regenerating TOC'
+dotnet run -p ../../tools/Google.Cloud.Tools.RegenerateToc -- devsite/api
+
 cd devsite
 
 echo 'Creating metadata file'

--- a/tools/Google.Cloud.Tools.PostProcessDevSite/Google.Cloud.Tools.PostProcessDevSite.csproj
+++ b/tools/Google.Cloud.Tools.PostProcessDevSite/Google.Cloud.Tools.PostProcessDevSite.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Google.Cloud.Tools.Common\Google.Cloud.Tools.Common.csproj" />
+    <ProjectReference Include="..\Google.Cloud.Tools.RegenerateToc\Google.Cloud.Tools.RegenerateToc.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tools/Google.Cloud.Tools.RegenerateToc/Google.Cloud.Tools.RegenerateToc.csproj
+++ b/tools/Google.Cloud.Tools.RegenerateToc/Google.Cloud.Tools.RegenerateToc.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Google.Cloud.Tools.DocfxMetadata\Google.Cloud.Tools.DocfxMetadata.csproj" />
+  </ItemGroup>
+
+
+</Project>

--- a/tools/Google.Cloud.Tools.RegenerateToc/Program.cs
+++ b/tools/Google.Cloud.Tools.RegenerateToc/Program.cs
@@ -1,0 +1,147 @@
+﻿// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Tools.DocfxMetadata;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Google.Cloud.Tools.RegenerateToc
+{
+    /// <summary>
+    /// Tool to regenerate the TOC of a docfx API, using the assembly name as the top-level
+    /// entry, rather than namespace. Namespaces within the assembly are handled intelligently:
+    /// <list type="bullet">
+    /// <item><description>
+    /// If the name of the assembly is the same as the name of the namespace, the namespace
+    /// contents are included directly.
+    /// </description></item>
+    /// <item><description>
+    /// "Nested" namespaces are included using the differentiator, e.g. Google.Protobuf.Collections
+    /// is included as a subnode of Google.Protobuf, with a name "Collections"
+    /// </description></item>
+    /// <item><description>
+    /// Initially, doubly-nested namespaces have no special support; so if Google.Protobuf.Collections.Immutable
+    /// existed, it would be shown as "Collections.Immutable". This will not affect many docs, and can be
+    /// revisited later.
+    /// </description></item>
+    /// <item><description>
+    /// Non-nested namespaces are included with a full name, e.g. the namespace of Google.Apis
+    /// within the assembly Google.Apis.Core is listed as "Google.Apis".
+    /// </description></item>
+    /// </list>
+    /// </summary>
+    public class Program
+    {
+        public static int Main(string[] args)
+        {
+            if (args.Length != 1)
+            {
+                Console.WriteLine("Expected argument: directory containing API YML files");
+                return 1;
+            }
+            try
+            {
+                Regenerate(args[0]);
+                return 0;
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+                return 1;
+            }
+        }
+
+        public static void Regenerate(string directory)
+        {
+            var allMetadata = Directory
+                .GetFiles(directory, "*.yml")
+                .Where(file => Path.GetFileName(file) != "toc.yml")
+                .SelectMany(file => MetadataFile.LoadYaml(file).Items)
+                .ToDictionary(item => item.Uid);
+            var assemblies = allMetadata.Values
+                .SelectMany(item => item.Assemblies)
+                .Distinct()
+                .OrderBy(assembly => assembly, StringComparer.Ordinal)
+                .ToList();
+
+            var tocEntries = assemblies.Select(assembly => CreateTocEntryForAssembly(assembly, allMetadata)).ToList();
+            var tocText = TocEntry.CreateToc(tocEntries);
+            File.WriteAllText(Path.Combine(directory, "toc.yml"), tocText);
+        }
+
+        private static TocEntry CreateTocEntryForAssembly(string assembly, Dictionary<string, MetadataItem> allMetadata)
+        {
+            // Note: we can't trust the namespace metadata entries for assemblies,
+            // because when types from different assemblies are in the same namespace, the assembly
+            // list only contains one of them. (For example, Google.Apis contains Google.Apis.ETagAction
+            // from Google.Apis.dll, and Google.Apis.ISerializer from Google.Apis.Core.dll.)
+            // The namespace metadata contains all of the types across the assemblies though, so we can use
+            // those to find namespaces which actually contribute to this assembly.
+            var allNamespaces = allMetadata.Values.Where(item => item.Type == ItemType.Namespace).ToList();
+            var assemblyNamespaces = allNamespaces
+                .Where(ns => ns.Children.Any(child => allMetadata[child].Assemblies.Contains(assembly)))
+                .ToList();
+
+            var tocEntry = new TocEntry
+            {
+                Uid = assembly,
+                Name = assembly,
+                Items = new List<TocEntry>()
+            };
+
+            var prefix = assembly + ".";
+            // Entries in the TOC for an assembly:
+            // - Namespace nodes for namespaces with different names to the assembly
+            // - Directly-included nodes for the namespace with the same name as the assembly
+            foreach (var ns in assemblyNamespaces.Where(candidate => candidate.Uid != assembly))
+            {
+                string contractedName = ns.Name.StartsWith(prefix) ? ns.Name.Substring(prefix.Length) : ns.Name;
+                var nsNode = new TocEntry
+                {
+                    Name = $"{contractedName} (namespace)",
+                    Uid = ns.Uid,
+                    Items = new List<TocEntry>()
+                };
+                nsNode.Items.AddRange(GetTocEntriesForNamespace(ns));
+                tocEntry.Items.Add(nsNode);
+            }
+            // We can't easily sort until we've worked out the names, due to the prefixing.
+            tocEntry.Items = tocEntry.Items.OrderBy(item => item.Name, StringComparer.Ordinal).ToList();
+
+            // We'll almost always have a namespace with the same name as the assembly, but we shouldn't
+            // fail if we don't... (and there's no Google.Apis.Core namespace).
+            if (allMetadata.GetValueOrDefault(assembly) is MetadataItem exactAssemblyNs)
+            {
+                tocEntry.Items.AddRange(GetTocEntriesForNamespace(exactAssemblyNs));
+            }
+            return tocEntry;
+
+            IEnumerable<TocEntry> GetTocEntriesForNamespace(MetadataItem nsMetadata)
+            {
+                yield return new TocEntry { Name = "All types", Uid = nsMetadata.Uid };
+                // TODO: Consider adding a level of nesting for classes with multiple nested types.
+                // Where there's just one nested type, it's not too bad, but beyond that it ends up
+                // causing a rather large list. We could also potentially omit nested types with no children,
+                // which is common for protobufs (e.g. RecognitionConfig.Types).
+                foreach (var child in nsMetadata.Children)
+                {
+                    var childMetadata = allMetadata[child];
+                    yield return new TocEntry { Name = childMetadata.Name, Uid = childMetadata.Uid };
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
We now group by assembly rather than by namespace; if an assembly
contains multiple namespaces, those are listed within the assembly
node.