### PR TITLE
Release Google.Cloud.Memcache.V1 version 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Logging.V2](https://googleapis.dev/dotnet/Google.Cloud.Logging.V2/3.2.0) | 3.2.0 | [Google Cloud Logging](https://cloud.google.com/logging/) |
 | [Google.Cloud.ManagedIdentities.V1](https://googleapis.dev/dotnet/Google.Cloud.ManagedIdentities.V1/2.1.0) | 2.1.0 | [Managed Service for Microsoft Active Directory](https://cloud.google.com/managed-microsoft-ad/) |
 | [Google.Cloud.MediaTranslation.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.MediaTranslation.V1Beta1/1.0.0-beta01) | 1.0.0-beta01 | [Media Translation](https://cloud.google.com/media-translation) |
-| [Google.Cloud.Memcache.V1](https://googleapis.dev/dotnet/Google.Cloud.Memcache.V1/1.0.0-beta01) | 1.0.0-beta01 | [Cloud Memorystore for Memcached](https://cloud.google.com/memorystore/) |
+| [Google.Cloud.Memcache.V1](https://googleapis.dev/dotnet/Google.Cloud.Memcache.V1/1.0.0) | 1.0.0 | [Cloud Memorystore for Memcached](https://cloud.google.com/memorystore/) |
 | [Google.Cloud.Memcache.V1Beta2](https://googleapis.dev/dotnet/Google.Cloud.Memcache.V1Beta2/1.0.0-beta03) | 1.0.0-beta03 | [Google Cloud Memorystore for Memcache](https://cloud.google.com/memorystore/) |
 | [Google.Cloud.Metastore.V1Alpha](https://googleapis.dev/dotnet/Google.Cloud.Metastore.V1Alpha/1.0.0-alpha01) | 1.0.0-alpha01 | [Dataproc Metastore](https://cloud.google.com/dataproc-metastore/docs) |
 | [Google.Cloud.Monitoring.V3](https://googleapis.dev/dotnet/Google.Cloud.Monitoring.V3/2.2.0) | 2.2.0 | [Google Cloud Monitoring](https://cloud.google.com/monitoring/api/v3/) |

--- a/apis/Google.Cloud.Memcache.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.Memcache.V1/.repo-metadata.json
@@ -1,5 +1,5 @@
 {
   "distribution_name": "Google.Cloud.Memcache.V1",
-  "release_level": "beta",
+  "release_level": "ga",
   "client_documentation": "https://googleapis.dev/dotnet/Google.Cloud.Memcache.V1/latest"
 }

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.csproj
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library at access the Google Cloud Memorystore for Memcached API (v1), which is used for creating and managing Memcached instances in GCP.</Description>

--- a/apis/Google.Cloud.Memcache.V1/docs/history.md
+++ b/apis/Google.Cloud.Memcache.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.0.0, released 2021-03-02
+
+No API surface changes since 1.0.0-beta01
+
 # Version 1.0.0-beta01, released 2021-02-03
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1224,7 +1224,7 @@
     },
     {
       "id": "Google.Cloud.Memcache.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Cloud Memorystore for Memcached",
       "productUrl": "https://cloud.google.com/memorystore/",
@@ -1234,7 +1234,9 @@
         "Memorystore"
       ],
       "dependencies": {
-        "Google.LongRunning": "2.1.0"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.2.0",
+        "Google.LongRunning": "2.1.0",
+        "Grpc.Core": "2.31.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/memcache/v1"

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -79,7 +79,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Logging.V2](Google.Cloud.Logging.V2/index.html) | 3.2.0 | [Google Cloud Logging](https://cloud.google.com/logging/) |
 | [Google.Cloud.ManagedIdentities.V1](Google.Cloud.ManagedIdentities.V1/index.html) | 2.1.0 | [Managed Service for Microsoft Active Directory](https://cloud.google.com/managed-microsoft-ad/) |
 | [Google.Cloud.MediaTranslation.V1Beta1](Google.Cloud.MediaTranslation.V1Beta1/index.html) | 1.0.0-beta01 | [Media Translation](https://cloud.google.com/media-translation) |
-| [Google.Cloud.Memcache.V1](Google.Cloud.Memcache.V1/index.html) | 1.0.0-beta01 | [Cloud Memorystore for Memcached](https://cloud.google.com/memorystore/) |
+| [Google.Cloud.Memcache.V1](Google.Cloud.Memcache.V1/index.html) | 1.0.0 | [Cloud Memorystore for Memcached](https://cloud.google.com/memorystore/) |
 | [Google.Cloud.Memcache.V1Beta2](Google.Cloud.Memcache.V1Beta2/index.html) | 1.0.0-beta03 | [Google Cloud Memorystore for Memcache](https://cloud.google.com/memorystore/) |
 | [Google.Cloud.Metastore.V1Alpha](Google.Cloud.Metastore.V1Alpha/index.html) | 1.0.0-alpha01 | [Dataproc Metastore](https://cloud.google.com/dataproc-metastore/docs) |
 | [Google.Cloud.Monitoring.V3](Google.Cloud.Monitoring.V3/index.html) | 2.2.0 | [Google Cloud Monitoring](https://cloud.google.com/monitoring/api/v3/) |


### PR DESCRIPTION

Changes in this release:

No API surface changes since 1.0.0-beta01
