### PR TITLE
Release Google.Cloud.Channel.V1 version 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Billing.Budgets.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Billing.Budgets.V1Beta1/1.0.0-beta02) | 1.0.0-beta02 | [Cloud Billing Budget (V1Beta1 API)](https://cloud.google.com/billing/docs/how-to/budget-api-overview) |
 | [Google.Cloud.Billing.V1](https://googleapis.dev/dotnet/Google.Cloud.Billing.V1/2.1.0) | 2.1.0 | [Google Cloud Billing](https://cloud.google.com/billing/docs/) |
 | [Google.Cloud.BinaryAuthorization.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.BinaryAuthorization.V1Beta1/1.0.0-beta01) | 1.0.0-beta01 | [Binary Authorization](https://cloud.google.com/binary-authorization/docs/reference/rpc) |
-| [Google.Cloud.Channel.V1](https://googleapis.dev/dotnet/Google.Cloud.Channel.V1/1.0.0-beta01) | 1.0.0-beta01 | [Cloud Channel](https://cloud.google.com/channel/docs/) |
+| [Google.Cloud.Channel.V1](https://googleapis.dev/dotnet/Google.Cloud.Channel.V1/1.0.0) | 1.0.0 | [Cloud Channel](https://cloud.google.com/channel/docs/) |
 | [Google.Cloud.CloudBuild.V1](https://googleapis.dev/dotnet/Google.Cloud.CloudBuild.V1/1.0.0) | 1.0.0 | [Cloud Build](https://cloud.google.com/cloud-build) |
 | [Google.Cloud.Container.V1](https://googleapis.dev/dotnet/Google.Cloud.Container.V1/2.2.0) | 2.2.0 | [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/reference/rest/) |
 | [Google.Cloud.DataCatalog.V1](https://googleapis.dev/dotnet/Google.Cloud.DataCatalog.V1/1.1.0) | 1.1.0 | [Data Catalog](https://cloud.google.com/data-catalog/docs) |

--- a/apis/Google.Cloud.Channel.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.Channel.V1/.repo-metadata.json
@@ -1,5 +1,5 @@
 {
   "distribution_name": "Google.Cloud.Channel.V1",
-  "release_level": "beta",
+  "release_level": "ga",
   "client_documentation": "https://googleapis.dev/dotnet/Google.Cloud.Channel.V1/latest"
 }

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.csproj
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Channel API, which enables Google Cloud resellers and distributors to manage their customers, channel partners, entitlements and reports.</Description>

--- a/apis/Google.Cloud.Channel.V1/docs/history.md
+++ b/apis/Google.Cloud.Channel.V1/docs/history.md
@@ -1,5 +1,18 @@
 # Version history
 
+# Version 1.0.0, released 2021-03-03
+
+- [Commit 1620a3a](https://github.com/googleapis/google-cloud-dotnet/commit/1620a3a):
+  - feat: addition of billing_account field on Plan
+  - docs: clarification that valid address lines are required for all customers
+- [Commit f2fdc8f](https://github.com/googleapis/google-cloud-dotnet/commit/f2fdc8f):
+  - docs: Documentation update
+  - fix!: Removal of TransferableSkus fields `is_commitment` and `commitment_end_timestamp`
+- [Commit 59e5691](https://github.com/googleapis/google-cloud-dotnet/commit/59e5691): feat: Add Pub/Sub endpoints for Cloud Channel API.
+
+The breaking change to TransferableSkus was due to the fields having
+accidentally been included despite deprecation in previews.
+
 # Version 1.0.0-beta01, released 2021-01-13
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -411,7 +411,7 @@
     },
     {
       "id": "Google.Cloud.Channel.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Cloud Channel",
       "productUrl": "https://cloud.google.com/channel/docs/",
@@ -421,7 +421,9 @@
         "reseller"
       ],
       "dependencies": {
-        "Google.LongRunning": "2.1.0"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.2.0",
+        "Google.LongRunning": "2.1.0",
+        "Grpc.Core": "2.31.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/channel/v1"

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -40,7 +40,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Billing.Budgets.V1Beta1](Google.Cloud.Billing.Budgets.V1Beta1/index.html) | 1.0.0-beta02 | [Cloud Billing Budget (V1Beta1 API)](https://cloud.google.com/billing/docs/how-to/budget-api-overview) |
 | [Google.Cloud.Billing.V1](Google.Cloud.Billing.V1/index.html) | 2.1.0 | [Google Cloud Billing](https://cloud.google.com/billing/docs/) |
 | [Google.Cloud.BinaryAuthorization.V1Beta1](Google.Cloud.BinaryAuthorization.V1Beta1/index.html) | 1.0.0-beta01 | [Binary Authorization](https://cloud.google.com/binary-authorization/docs/reference/rpc) |
-| [Google.Cloud.Channel.V1](Google.Cloud.Channel.V1/index.html) | 1.0.0-beta01 | [Cloud Channel](https://cloud.google.com/channel/docs/) |
+| [Google.Cloud.Channel.V1](Google.Cloud.Channel.V1/index.html) | 1.0.0 | [Cloud Channel](https://cloud.google.com/channel/docs/) |
 | [Google.Cloud.CloudBuild.V1](Google.Cloud.CloudBuild.V1/index.html) | 1.0.0 | [Cloud Build](https://cloud.google.com/cloud-build) |
 | [Google.Cloud.Container.V1](Google.Cloud.Container.V1/index.html) | 2.2.0 | [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/reference/rest/) |
 | [Google.Cloud.DataCatalog.V1](Google.Cloud.DataCatalog.V1/index.html) | 1.1.0 | [Data Catalog](https://cloud.google.com/data-catalog/docs) |


### PR DESCRIPTION

Changes in this release:

- [Commit 1620a3a](https://github.com/googleapis/google-cloud-dotnet/commit/1620a3a): feat: addition of billing_account field on Plan. docs: clarification that valid address lines are required for all customers.
- [Commit f2fdc8f](https://github.com/googleapis/google-cloud-dotnet/commit/f2fdc8f):
  - docs: Documentation update
  - fix!: Removal of TransferableSkus fields `is_commitment` and `commitment_end_timestamp`
- [Commit 59e5691](https://github.com/googleapis/google-cloud-dotnet/commit/59e5691): feat: Add Pub/Sub endpoints for Cloud Channel API.

The breaking change to TransferableSkus was due to the fields having accidentally been included despite deprecation in previews.
