### PR TITLE
Include history-less dependencies within parent version history

### DIFF
--- a/tools/Google.Cloud.Tools.Common/ApiCatalog.cs
+++ b/tools/Google.Cloud.Tools.Common/ApiCatalog.cs
@@ -53,7 +53,16 @@ namespace Google.Cloud.Tools.Common
         /// <param name="id"></param>
         /// <exception cref="UserErrorException"></exception>
         /// <returns>The API associated with the given ID</returns>
-        public ApiMetadata this[string id] => Apis.SingleOrDefault(api => api.Id == id) ?? throw new UserErrorException($"No API with ID '{id}'");
+        public ApiMetadata this[string id] => TryGetApi(id, out var api) ? api : throw new UserErrorException($"No API with ID '{id}'");
+
+        /// <summary>
+        /// Tries to retrieves an API by ID, without throwing an exception if it's not present.
+        /// </summary>
+        public bool TryGetApi(string id, out ApiMetadata api)
+        {
+            api = Apis.SingleOrDefault(api => api.Id == id);
+            return api is object;
+        }
 
         /// <summary>
         /// The path to the API catalog (apis.json).

--- a/tools/Google.Cloud.Tools.Common/ApiMetadata.cs
+++ b/tools/Google.Cloud.Tools.Common/ApiMetadata.cs
@@ -113,6 +113,7 @@ namespace Google.Cloud.Tools.Common
 
         /// <summary>
         /// When set to <c>true</c>, this API is skipped by the update-history command in ReleaseManager.
+        /// Instead, projects that depend on this API will include commits in their history.
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public bool NoVersionHistory { get; set; }

--- a/tools/Google.Cloud.Tools.ReleaseManager/ShowStaleCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/ShowStaleCommand.cs
@@ -40,12 +40,12 @@ namespace Google.Cloud.Tools.ReleaseManager
                 var allTags = repo.Tags.OrderByDescending(GitHelpers.GetDate).ToList();
                 foreach (var api in catalog.Apis)
                 {
-                    MaybeShowStale(repo, allTags, api);
+                    MaybeShowStale(repo, allTags, catalog, api);
                 }
             }
         }
 
-        private static void MaybeShowStale(Repository repo, List<Tag> allTags, ApiMetadata api)
+        private static void MaybeShowStale(Repository repo, List<Tag> allTags, ApiCatalog catalog, ApiMetadata api)
         {
             string expectedTagName = $"{api.Id}-{api.Version}";
             var latestRelease = allTags.FirstOrDefault(tag => tag.FriendlyName == expectedTagName);
@@ -58,7 +58,7 @@ namespace Google.Cloud.Tools.ReleaseManager
 
             var laterCommits = repo.Commits.TakeWhile(commit => commit.Sha != latestRelease.Target.Sha);
             var relevantCommits = laterCommits
-                .Where(GitHelpers.CreateCommitPredicate(repo, api.Id))
+                .Where(GitHelpers.CreateCommitPredicate(repo, catalog, api))
                 .Where(commit => !CommitOverrides.IsSkipped(commit))
                 .ToList();
 

--- a/tools/Google.Cloud.Tools.ReleaseManager/UpdateHistoryCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/UpdateHistoryCommand.cs
@@ -58,7 +58,7 @@ namespace Google.Cloud.Tools.ReleaseManager
             var root = DirectoryLayout.DetermineRootDirectory();
             using (var repo = new Repository(root))
             {
-                var releases = LoadReleases(repo, api).ToList();
+                var releases = LoadReleases(repo, catalog, api).ToList();
                 if (!File.Exists(historyFilePath))
                 {
                     File.WriteAllText(historyFilePath, "# Version history\r\n\r\n");
@@ -81,10 +81,10 @@ namespace Google.Cloud.Tools.ReleaseManager
             }
         }
 
-        private static IEnumerable<Release> LoadReleases(Repository repo, ApiMetadata api)
+        private static IEnumerable<Release> LoadReleases(Repository repo, ApiCatalog catalog, ApiMetadata api)
         {
             var id = api.Id;
-            var commitPredicate = GitHelpers.CreateCommitPredicate(repo, api.Id);
+            var commitPredicate = GitHelpers.CreateCommitPredicate(repo, catalog, api);
 
             List<Release> releases = new List<Release>();
             StructuredVersion currentVersion = StructuredVersion.FromString(api.Version);


### PR DESCRIPTION
This isn't as much of a change as it looks. The biggest "new code" is the private GitHelpers.GetHistoryApiIds method. The rest is mostly changes due to needing the ApiCatalog instead of just the API.