### PR TITLE
Use the right xref URL for Google.Protobuf

### DIFF
--- a/tools/Google.Cloud.Tools.PostProcessDevSite/Program.cs
+++ b/tools/Google.Cloud.Tools.PostProcessDevSite/Program.cs
@@ -281,6 +281,7 @@ namespace Google.Cloud.Tools.PostProcessDevSite
                     "Google.Apis.Core" => $"{DevSiteXrefPrefix}/Google.Apis",
                     "Google.Apis.Auth" => $"{DevSiteXrefPrefix}/Google.Apis",
                     "Google.Api.CommonProtos" => $"{DevSiteXrefPrefix}/Google.Api.CommonProtos",
+                    "Google.Protobuf" => $"{DevSiteXrefPrefix}/Google.Protobuf",
                     var grpc when grpc.StartsWith("Grpc.") => $"{DevSiteXrefPrefix}/Grpc.Core",
                     var gax when gax.StartsWith("Google.Api.Gax") => $"{DevSiteXrefPrefix}/Google.Api.Gax",
                     var api when _apiIds.Contains(api) => $"{DevSiteXrefPrefix}/{api}",


### PR DESCRIPTION
(Previously we were just throwing it away.)