### PR TITLE
fix: retry consecutive retryable errors in sql stream without timeout

### DIFF
--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SqlResultStream.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SqlResultStream.cs
@@ -111,7 +111,9 @@ namespace Google.Cloud.Spanner.V1
         private async Task<PartialResultSet> ComputeNextAsync(CancellationToken cancellationToken)
         {
             // The retry state is local to the method as we're not trying to handle callers retrying.
-            RetryState retryState = new RetryState(_client.Settings.Scheduler ?? SystemScheduler.Instance, _retrySettings);
+            // Max 115 consecutive errors is roughly equal to the default timeout of ExecuteStreamingSql (1 hour)
+            // based on the default backoff settings (InitialBackoff: 1 second, MaxBackoff: 32 seconds).
+            RetryState retryState = new RetryState(_client.Settings.Scheduler ?? SystemScheduler.Instance, _retrySettings, maxConsecutiveErrors: 115);
 
             while (true)
             {


### PR DESCRIPTION
Retry consecutive retryable errors for the same resume token in a stream of `PartialResultSet`s. This will prevent `SpannerDataReader` from throwing `Unavailable` exceptions while reading data. The `ExecuteSqlStreaming` RPC will be retried at most 115 times for the same resume token. This value is chosen as it will cause retries to be attempted for roughly the same amount of time as the default timeout of ExecuteStreamingSql (1 hour), and prevents an eternal loop in the unlikely case that the backend continues to return `Unavailable`.

Fixes #5977