### PR TITLE
Release Google.Cloud.Metastore.V1Alpha version 1.0.0-alpha02

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.MediaTranslation.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.MediaTranslation.V1Beta1/1.0.0-beta01) | 1.0.0-beta01 | [Media Translation](https://cloud.google.com/media-translation) |
 | [Google.Cloud.Memcache.V1](https://googleapis.dev/dotnet/Google.Cloud.Memcache.V1/1.0.0) | 1.0.0 | [Cloud Memorystore for Memcached](https://cloud.google.com/memorystore/) |
 | [Google.Cloud.Memcache.V1Beta2](https://googleapis.dev/dotnet/Google.Cloud.Memcache.V1Beta2/1.0.0-beta03) | 1.0.0-beta03 | [Google Cloud Memorystore for Memcache](https://cloud.google.com/memorystore/) |
-| [Google.Cloud.Metastore.V1Alpha](https://googleapis.dev/dotnet/Google.Cloud.Metastore.V1Alpha/1.0.0-alpha01) | 1.0.0-alpha01 | [Dataproc Metastore (V1Alpha API)](https://cloud.google.com/dataproc-metastore/docs) |
+| [Google.Cloud.Metastore.V1Alpha](https://googleapis.dev/dotnet/Google.Cloud.Metastore.V1Alpha/1.0.0-alpha02) | 1.0.0-alpha02 | [Dataproc Metastore (V1Alpha API)](https://cloud.google.com/dataproc-metastore/docs) |
 | [Google.Cloud.Metastore.V1Beta](https://googleapis.dev/dotnet/Google.Cloud.Metastore.V1Beta/1.0.0-beta01) | 1.0.0-beta01 | [Dataproc Metastore (V1Beta API)](https://cloud.google.com/dataproc-metastore/docs) |
 | [Google.Cloud.Monitoring.V3](https://googleapis.dev/dotnet/Google.Cloud.Monitoring.V3/2.2.0) | 2.2.0 | [Google Cloud Monitoring](https://cloud.google.com/monitoring/api/v3/) |
 | [Google.Cloud.NetworkConnectivity.V1Alpha1](https://googleapis.dev/dotnet/Google.Cloud.NetworkConnectivity.V1Alpha1/1.0.0-alpha01) | 1.0.0-alpha01 | [Network Connectivity](https://cloud.google.com/network-connectivity/docs/apis) |

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.csproj
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha01</Version>
+    <Version>1.0.0-alpha02</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Dataproc Metastore API (v1alpha) which is used to manage the lifecycle and configuration of metastore services.</Description>

--- a/apis/Google.Cloud.Metastore.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.Metastore.V1Alpha/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+# Version 1.0.0-alpha02, released 2021-03-10
+
+- [Commit 7ee3de9](https://github.com/googleapis/google-cloud-dotnet/commit/7ee3de9): feat: added support for release channels when creating service
+- [Commit 4019cd7](https://github.com/googleapis/google-cloud-dotnet/commit/4019cd7): feat: Backup and export support
+
 # Version 1.0.0-alpha01, released 2021-02-26
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1281,7 +1281,7 @@
     },
     {
       "id": "Google.Cloud.Metastore.V1Alpha",
-      "version": "1.0.0-alpha01",
+      "version": "1.0.0-alpha02",
       "type": "grpc",
       "productName": "Dataproc Metastore",
       "productUrl": "https://cloud.google.com/dataproc-metastore/docs",

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -82,7 +82,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.MediaTranslation.V1Beta1](Google.Cloud.MediaTranslation.V1Beta1/index.html) | 1.0.0-beta01 | [Media Translation](https://cloud.google.com/media-translation) |
 | [Google.Cloud.Memcache.V1](Google.Cloud.Memcache.V1/index.html) | 1.0.0 | [Cloud Memorystore for Memcached](https://cloud.google.com/memorystore/) |
 | [Google.Cloud.Memcache.V1Beta2](Google.Cloud.Memcache.V1Beta2/index.html) | 1.0.0-beta03 | [Google Cloud Memorystore for Memcache](https://cloud.google.com/memorystore/) |
-| [Google.Cloud.Metastore.V1Alpha](Google.Cloud.Metastore.V1Alpha/index.html) | 1.0.0-alpha01 | [Dataproc Metastore (V1Alpha API)](https://cloud.google.com/dataproc-metastore/docs) |
+| [Google.Cloud.Metastore.V1Alpha](Google.Cloud.Metastore.V1Alpha/index.html) | 1.0.0-alpha02 | [Dataproc Metastore (V1Alpha API)](https://cloud.google.com/dataproc-metastore/docs) |
 | [Google.Cloud.Metastore.V1Beta](Google.Cloud.Metastore.V1Beta/index.html) | 1.0.0-beta01 | [Dataproc Metastore (V1Beta API)](https://cloud.google.com/dataproc-metastore/docs) |
 | [Google.Cloud.Monitoring.V3](Google.Cloud.Monitoring.V3/index.html) | 2.2.0 | [Google Cloud Monitoring](https://cloud.google.com/monitoring/api/v3/) |
 | [Google.Cloud.NetworkConnectivity.V1Alpha1](Google.Cloud.NetworkConnectivity.V1Alpha1/index.html) | 1.0.0-alpha01 | [Network Connectivity](https://cloud.google.com/network-connectivity/docs/apis) |


### PR DESCRIPTION

Changes in this release:

- [Commit 7ee3de9](https://github.com/googleapis/google-cloud-dotnet/commit/7ee3de9): feat: added support for release channels when creating service
- [Commit 4019cd7](https://github.com/googleapis/google-cloud-dotnet/commit/4019cd7): feat: Backup and export support
