### PR TITLE
Release Google.Cloud.OrgPolicy.V2 version 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.NetworkConnectivity.V1Alpha1](https://googleapis.dev/dotnet/Google.Cloud.NetworkConnectivity.V1Alpha1/1.0.0-alpha01) | 1.0.0-alpha01 | [Network Connectivity](https://cloud.google.com/network-connectivity/docs/apis) |
 | [Google.Cloud.Notebooks.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Notebooks.V1Beta1/1.0.0-beta02) | 1.0.0-beta02 | [AI Platform Notebooks](https://cloud.google.com/ai-platform-notebooks) |
 | [Google.Cloud.OrgPolicy.V1](https://googleapis.dev/dotnet/Google.Cloud.OrgPolicy.V1/2.1.0) | 2.1.0 | OrgPolicy API messages |
-| [Google.Cloud.OrgPolicy.V2](https://googleapis.dev/dotnet/Google.Cloud.OrgPolicy.V2/1.0.0-beta01) | 1.0.0-beta01 | [Organization Policy](https://cloud.google.com/resource-manager/docs/organization-policy/overview) |
+| [Google.Cloud.OrgPolicy.V2](https://googleapis.dev/dotnet/Google.Cloud.OrgPolicy.V2/1.0.0) | 1.0.0 | [Organization Policy](https://cloud.google.com/resource-manager/docs/organization-policy/overview) |
 | [Google.Cloud.OsConfig.V1](https://googleapis.dev/dotnet/Google.Cloud.OsConfig.V1/1.2.0) | 1.2.0 | [Google Cloud OS Config](https://cloud.google.com/compute/docs/osconfig/rest) |
 | [Google.Cloud.OsLogin.Common](https://googleapis.dev/dotnet/Google.Cloud.OsLogin.Common/2.1.0) | 2.1.0 | Version-agnostic types for the Google OS Login API |
 | [Google.Cloud.OsLogin.V1](https://googleapis.dev/dotnet/Google.Cloud.OsLogin.V1/2.1.0) | 2.1.0 | [Google Cloud OS Login (V1 API)](https://cloud.google.com/compute/docs/instances/managing-instance-access) |

--- a/apis/Google.Cloud.OrgPolicy.V2/.repo-metadata.json
+++ b/apis/Google.Cloud.OrgPolicy.V2/.repo-metadata.json
@@ -1,5 +1,5 @@
 {
   "distribution_name": "Google.Cloud.OrgPolicy.V2",
-  "release_level": "beta",
+  "release_level": "ga",
   "client_documentation": "https://googleapis.dev/dotnet/Google.Cloud.OrgPolicy.V2/latest"
 }

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.csproj
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Organization Policy API (v2), which allows users to configure governance rules on their GCP resources across the Cloud Resource Hierarchy.</Description>

--- a/apis/Google.Cloud.OrgPolicy.V2/docs/history.md
+++ b/apis/Google.Cloud.OrgPolicy.V2/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.0.0, released 2021-03-10
+
+No API surface change since 1.0.0-beta01.
+
 # Version 1.0.0-beta01, released 2021-02-09
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1381,7 +1381,7 @@
     },
     {
       "id": "Google.Cloud.OrgPolicy.V2",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Organization Policy",
       "productUrl": "https://cloud.google.com/resource-manager/docs/organization-policy/overview",
@@ -1391,7 +1391,10 @@
         "policy",
         "governance"
       ],
-      "dependencies": {},
+      "dependencies": {
+        "Google.Api.Gax.Grpc.GrpcCore": "3.2.0",
+        "Grpc.Core": "2.31.0"
+      },
       "generator": "micro",
       "protoPath": "google/cloud/orgpolicy/v2"
     },

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -88,7 +88,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.NetworkConnectivity.V1Alpha1](Google.Cloud.NetworkConnectivity.V1Alpha1/index.html) | 1.0.0-alpha01 | [Network Connectivity](https://cloud.google.com/network-connectivity/docs/apis) |
 | [Google.Cloud.Notebooks.V1Beta1](Google.Cloud.Notebooks.V1Beta1/index.html) | 1.0.0-beta02 | [AI Platform Notebooks](https://cloud.google.com/ai-platform-notebooks) |
 | [Google.Cloud.OrgPolicy.V1](Google.Cloud.OrgPolicy.V1/index.html) | 2.1.0 | OrgPolicy API messages |
-| [Google.Cloud.OrgPolicy.V2](Google.Cloud.OrgPolicy.V2/index.html) | 1.0.0-beta01 | [Organization Policy](https://cloud.google.com/resource-manager/docs/organization-policy/overview) |
+| [Google.Cloud.OrgPolicy.V2](Google.Cloud.OrgPolicy.V2/index.html) | 1.0.0 | [Organization Policy](https://cloud.google.com/resource-manager/docs/organization-policy/overview) |
 | [Google.Cloud.OsConfig.V1](Google.Cloud.OsConfig.V1/index.html) | 1.2.0 | [Google Cloud OS Config](https://cloud.google.com/compute/docs/osconfig/rest) |
 | [Google.Cloud.OsLogin.Common](Google.Cloud.OsLogin.Common/index.html) | 2.1.0 | Version-agnostic types for the Google OS Login API |
 | [Google.Cloud.OsLogin.V1](Google.Cloud.OsLogin.V1/index.html) | 2.1.0 | [Google Cloud OS Login (V1 API)](https://cloud.google.com/compute/docs/instances/managing-instance-access) |


### PR DESCRIPTION

Changes in this release:

No API surface change since 1.0.0-beta01.
