### PR TITLE
GoogleStackdriverTarget - Added support for TraceId and SpanId for LogEntry

### DIFF
--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.Tests/GoogleStackdriverTargetTest.cs
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.Tests/GoogleStackdriverTargetTest.cs
@@ -289,6 +289,7 @@ namespace Google.Cloud.Logging.NLog.Tests
                 {
                     googleTarget.SpanId = "${event-properties:SpanId:Format=x16}";
                     googleTarget.TraceId = "${activityid}";
+                    googleTarget.TraceSampled = "TRUE";
                     System.Diagnostics.Trace.CorrelationManager.ActivityId = guidTraceId;
                     LogManager.GetLogger("testlogger").Info("Hello {SpanId}", 74);
                     return Task.FromResult(0);
@@ -296,6 +297,7 @@ namespace Google.Cloud.Logging.NLog.Tests
             Assert.Single(uploadedEntries);
             Assert.Equal("000000000000004a", uploadedEntries[0].SpanId);
             Assert.Equal($"projects/projectId/traces/{guidTraceId}", uploadedEntries[0].Trace);
+            Assert.True(uploadedEntries[0].TraceSampled);
         }
 
         [Fact]

--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/GoogleStackdriverTarget_Configuration.cs
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/GoogleStackdriverTarget_Configuration.cs
@@ -99,6 +99,22 @@ namespace Google.Cloud.Logging.NLog
         public Layout LogId { get; set; } = "Default";
 
         /// <summary>
+        /// Request TraceId for correlation of LogEvents from same request
+        /// </summary>
+        /// <remarks>
+        /// Resource name of the trace associated with the log entry. Ex: '06796866738c859f2f19b7cfb3214824'
+        /// </remarks>
+        public Layout TraceId { get; set; }
+
+        /// <summary>
+        /// Activity SpanId for correlation of LogEvents from same activity.
+        /// </summary>
+        /// <remarks>
+        /// Trace API v2 uses: a 16-character hexadecimal encoding of an 8-byte array. Ex: `000000000000004a` = String.format("{0:x16}", 74)
+        /// </remarks>
+        public Layout SpanId { get; set; }
+
+        /// <summary>
         /// Specify labels for the resource type;
         /// only used if platform detection is disabled or detects an unknown platform.
         /// </summary>

--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/GoogleStackdriverTarget_Configuration.cs
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/GoogleStackdriverTarget_Configuration.cs
@@ -115,6 +115,13 @@ namespace Google.Cloud.Logging.NLog
         public Layout SpanId { get; set; }
 
         /// <summary>
+        /// True means that the trace resource name in the trace field was sampled for storage in a trace backend.
+        /// False means that the trace was not sampled for storage when this log entry was written, or the sampling decision was unknown at the time.
+        /// A non-sampled trace value is still useful as a request correlation identifier. The default is False.
+        /// </summary>
+        public Layout TraceSampled { get; set; }
+
+        /// <summary>
         /// Specify labels for the resource type;
         /// only used if platform detection is disabled or detects an unknown platform.
         /// </summary>


### PR DESCRIPTION
Resolves #5677 by supporting [Log correlation with traces](https://cloud.google.com/trace/docs/trace-log-integration)

One could use [System.DiagnosticSource.Activity](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.activity) with help from [NLog.DiagnosticSource](https://www.nuget.org/packages/NLog.DiagnosticSource):

```xml
  <extensions>
    <add assembly="Google.Cloud.Logging.NLog" />
    <add assembly="NLog.DiagnosticSource" />
  </extensions>

  <targets>
    <target name="stackdriver" xsi:type="GoogleStackdriver" projectId="PROJECT_ID" logId="LOG_ID" traceId="${activity:TraceId}" spanId="${activity:SpanId}">
    </target>
  </targets>
```

Alternative one could capture TraceId using [System.Diagnostics.Trace.CorrelationManager.ActivityId](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.correlationmanager.activityid) and Nlog [${activityid}](https://github.com/NLog/NLog/wiki/Trace-Activity-Id-Layout-Renderer).