### PR TITLE
test(Storage): Changes resources accessed by unauthenticated access tests.

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/UnauthenticatedAccessTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/UnauthenticatedAccessTest.cs
@@ -25,7 +25,7 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
         // See https://cloud.google.com/storage/docs/public-datasets/landsat
         // We pick one particular prefix/directory and a small file to test.
         private const string LandsatBucket = "gcp-public-data-landsat";
-        private const string LandsatObject = "LC08/PRE/044/034/LC80440342016259LGN00/LC80440342016259LGN00_MTL.txt";
+        private const string LandsatObject = "LC08/01/001/002/LC08_L1GT_001002_20160817_20170322_01_T2/LC08_L1GT_001002_20160817_20170322_01_T2_ANG.txt";
 
         private readonly StorageFixture _fixture;
 
@@ -38,16 +38,16 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
             var client = StorageClient.CreateUnauthenticated();
             MemoryStream stream = new MemoryStream();
             client.DownloadObject(LandsatBucket, LandsatObject, stream);
-            Assert.Equal(7903, stream.Length);
+            Assert.Equal(117255, stream.Length);
         }
 
-        [SkippableFact(Skip = "https://github.com/googleapis/google-cloud-dotnet/issues/5548")]
+        [SkippableFact()]
         public void ListPublicData()
         {
             TestEnvironment.SkipIfVpcSc();
             var client = StorageClient.CreateUnauthenticated();
-            var objects = client.ListObjects(StorageFixture.CrossLanguageTestBucket).ToList();
-            Assert.Equal(3, objects.Count);
+            var objects = client.ListObjects(LandsatBucket);
+            Assert.NotEmpty(objects);
         }
 
         [Fact]


### PR DESCRIPTION
The landsat object we were accessing does not exist anymore. This fixes the latest CI failures.
The other test was a leftover from #5548. I've changed it to list the Landsat bucket instead of whatever internal bucket we had, so that we don't have to worry about our internal bucket being public or not.
