### PR TITLE
Release Google.Cloud.Logging.NLog version 3.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Kms.V1](https://googleapis.dev/dotnet/Google.Cloud.Kms.V1/2.1.0) | 2.1.0 | [Google Cloud Key Management Service](https://cloud.google.com/kms/) |
 | [Google.Cloud.Language.V1](https://googleapis.dev/dotnet/Google.Cloud.Language.V1/2.1.0) | 2.1.0 | [Google Cloud Natural Language](https://cloud.google.com/natural-language) |
 | [Google.Cloud.Logging.Log4Net](https://googleapis.dev/dotnet/Google.Cloud.Logging.Log4Net/3.2.0) | 3.2.0 | Log4Net client library for the Google Cloud Logging API |
-| [Google.Cloud.Logging.NLog](https://googleapis.dev/dotnet/Google.Cloud.Logging.NLog/3.2.0) | 3.2.0 | NLog target for the Google Cloud Logging API |
+| [Google.Cloud.Logging.NLog](https://googleapis.dev/dotnet/Google.Cloud.Logging.NLog/3.3.0) | 3.3.0 | NLog target for the Google Cloud Logging API |
 | [Google.Cloud.Logging.Type](https://googleapis.dev/dotnet/Google.Cloud.Logging.Type/3.2.0) | 3.2.0 | Version-agnostic types for the Google Cloud Logging API |
 | [Google.Cloud.Logging.V2](https://googleapis.dev/dotnet/Google.Cloud.Logging.V2/3.2.0) | 3.2.0 | [Google Cloud Logging](https://cloud.google.com/logging/) |
 | [Google.Cloud.ManagedIdentities.V1](https://googleapis.dev/dotnet/Google.Cloud.ManagedIdentities.V1/2.1.0) | 2.1.0 | [Managed Service for Microsoft Active Directory](https://cloud.google.com/managed-microsoft-ad/) |

--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.csproj
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.2.0</Version>
+    <Version>3.3.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>NLog target for the Google Cloud Logging API.</Description>

--- a/apis/Google.Cloud.Logging.NLog/docs/history.md
+++ b/apis/Google.Cloud.Logging.NLog/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+# Version 3.3.0, released 2021-03-22
+
+- [Commit 9ed450c](https://github.com/googleapis/google-cloud-dotnet/commit/9ed450c): refactor: Extract RenderJsonPayload from BuildLogEntry in GoogleStackdriverTarget
+- [Commit f553511](https://github.com/googleapis/google-cloud-dotnet/commit/f553511): docs: Add documentation for trace related config options in GoogleStackdriverTarget
+- [Commit d94c27b](https://github.com/googleapis/google-cloud-dotnet/commit/d94c27b): docs: Clarify XML doc for GoogleStackdriverTarget trace related options
+- [Commit 0da1f45](https://github.com/googleapis/google-cloud-dotnet/commit/0da1f45): test: Add more unit tests around log and trace correlation
+- Commits [a106579](https://github.com/googleapis/google-cloud-dotnet/commit/a106579) and [858f161](https://github.com/googleapis/google-cloud-dotnet/commit/858f161): feat: Add support for trace information to be included with log entries
+
 # Version 3.2.0, released 2020-12-07
 
 - [Commit a0f7730](https://github.com/googleapis/google-cloud-dotnet/commit/a0f7730): docs: Move NLog configuration into docs directory and expand it

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1172,7 +1172,7 @@
     },
     {
       "id": "Google.Cloud.Logging.NLog",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "type": "other",
       "targetFrameworks": "netstandard2.0;net461",
       "testTargetFrameworks": "netcoreapp2.1;net461",

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -76,7 +76,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Kms.V1](Google.Cloud.Kms.V1/index.html) | 2.1.0 | [Google Cloud Key Management Service](https://cloud.google.com/kms/) |
 | [Google.Cloud.Language.V1](Google.Cloud.Language.V1/index.html) | 2.1.0 | [Google Cloud Natural Language](https://cloud.google.com/natural-language) |
 | [Google.Cloud.Logging.Log4Net](Google.Cloud.Logging.Log4Net/index.html) | 3.2.0 | Log4Net client library for the Google Cloud Logging API |
-| [Google.Cloud.Logging.NLog](Google.Cloud.Logging.NLog/index.html) | 3.2.0 | NLog target for the Google Cloud Logging API |
+| [Google.Cloud.Logging.NLog](Google.Cloud.Logging.NLog/index.html) | 3.3.0 | NLog target for the Google Cloud Logging API |
 | [Google.Cloud.Logging.Type](Google.Cloud.Logging.Type/index.html) | 3.2.0 | Version-agnostic types for the Google Cloud Logging API |
 | [Google.Cloud.Logging.V2](Google.Cloud.Logging.V2/index.html) | 3.2.0 | [Google Cloud Logging](https://cloud.google.com/logging/) |
 | [Google.Cloud.ManagedIdentities.V1](Google.Cloud.ManagedIdentities.V1/index.html) | 2.1.0 | [Managed Service for Microsoft Active Directory](https://cloud.google.com/managed-microsoft-ad/) |


### PR DESCRIPTION

Changes in this release:

- [Commit 9ed450c](https://github.com/googleapis/google-cloud-dotnet/commit/9ed450c): refactor: Extract RenderJsonPayload from BuildLogEntry in GoogleStackdriverTarget
- [Commit f553511](https://github.com/googleapis/google-cloud-dotnet/commit/f553511): docs: Add documentation for trace related config options in GoogleStackdriverTarget
- [Commit d94c27b](https://github.com/googleapis/google-cloud-dotnet/commit/d94c27b): docs: Clarify XML doc for GoogleStackdriverTarget trace related options
- [Commit 0da1f45](https://github.com/googleapis/google-cloud-dotnet/commit/0da1f45): test: Add more unit tests around log and trace correlation
- Commits [a106579](https://github.com/googleapis/google-cloud-dotnet/commit/a106579) and [858f161](https://github.com/googleapis/google-cloud-dotnet/commit/858f161): feat: Add support for trace information to be included with log entries
