### PR TITLE
chore: Regenerates all libraries with changes in generator.

### DIFF
--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.Snippets/AnalyticsAdminServiceClientSnippets.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.Snippets/AnalyticsAdminServiceClientSnippets.g.cs
@@ -157,7 +157,7 @@ namespace Google.Analytics.Admin.V1Alpha.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAccounts</summary>
+        /// <summary>Snippet for ListAccountsAsync</summary>
         public async Task ListAccountsRequestObjectAsync()
         {
             // Snippet: ListAccountsAsync(ListAccountsRequest, CallSettings)
@@ -433,7 +433,7 @@ namespace Google.Analytics.Admin.V1Alpha.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAccountSummaries</summary>
+        /// <summary>Snippet for ListAccountSummariesAsync</summary>
         public async Task ListAccountSummariesRequestObjectAsync()
         {
             // Snippet: ListAccountSummariesAsync(ListAccountSummariesRequest, CallSettings)
@@ -614,7 +614,7 @@ namespace Google.Analytics.Admin.V1Alpha.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListProperties</summary>
+        /// <summary>Snippet for ListPropertiesAsync</summary>
         public async Task ListPropertiesRequestObjectAsync()
         {
             // Snippet: ListPropertiesAsync(ListPropertiesRequest, CallSettings)
@@ -1050,7 +1050,7 @@ namespace Google.Analytics.Admin.V1Alpha.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListUserLinks</summary>
+        /// <summary>Snippet for ListUserLinksAsync</summary>
         public async Task ListUserLinksRequestObjectAsync()
         {
             // Snippet: ListUserLinksAsync(ListUserLinksRequest, CallSettings)
@@ -1143,7 +1143,7 @@ namespace Google.Analytics.Admin.V1Alpha.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListUserLinks</summary>
+        /// <summary>Snippet for ListUserLinksAsync</summary>
         public async Task ListUserLinksAsync()
         {
             // Snippet: ListUserLinksAsync(string, string, int?, CallSettings)
@@ -1233,7 +1233,7 @@ namespace Google.Analytics.Admin.V1Alpha.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListUserLinks</summary>
+        /// <summary>Snippet for ListUserLinksAsync</summary>
         public async Task ListUserLinksResourceNames1Async()
         {
             // Snippet: ListUserLinksAsync(AccountName, string, int?, CallSettings)
@@ -1323,7 +1323,7 @@ namespace Google.Analytics.Admin.V1Alpha.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListUserLinks</summary>
+        /// <summary>Snippet for ListUserLinksAsync</summary>
         public async Task ListUserLinksResourceNames2Async()
         {
             // Snippet: ListUserLinksAsync(PropertyName, string, int?, CallSettings)
@@ -1416,7 +1416,7 @@ namespace Google.Analytics.Admin.V1Alpha.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for AuditUserLinks</summary>
+        /// <summary>Snippet for AuditUserLinksAsync</summary>
         public async Task AuditUserLinksRequestObjectAsync()
         {
             // Snippet: AuditUserLinksAsync(AuditUserLinksRequest, CallSettings)
@@ -2239,7 +2239,7 @@ namespace Google.Analytics.Admin.V1Alpha.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListWebDataStreams</summary>
+        /// <summary>Snippet for ListWebDataStreamsAsync</summary>
         public async Task ListWebDataStreamsRequestObjectAsync()
         {
             // Snippet: ListWebDataStreamsAsync(ListWebDataStreamsRequest, CallSettings)
@@ -2332,7 +2332,7 @@ namespace Google.Analytics.Admin.V1Alpha.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListWebDataStreams</summary>
+        /// <summary>Snippet for ListWebDataStreamsAsync</summary>
         public async Task ListWebDataStreamsAsync()
         {
             // Snippet: ListWebDataStreamsAsync(string, string, int?, CallSettings)
@@ -2422,7 +2422,7 @@ namespace Google.Analytics.Admin.V1Alpha.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListWebDataStreams</summary>
+        /// <summary>Snippet for ListWebDataStreamsAsync</summary>
         public async Task ListWebDataStreamsResourceNamesAsync()
         {
             // Snippet: ListWebDataStreamsAsync(PropertyName, string, int?, CallSettings)
@@ -2846,7 +2846,7 @@ namespace Google.Analytics.Admin.V1Alpha.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListIosAppDataStreams</summary>
+        /// <summary>Snippet for ListIosAppDataStreamsAsync</summary>
         public async Task ListIosAppDataStreamsRequestObjectAsync()
         {
             // Snippet: ListIosAppDataStreamsAsync(ListIosAppDataStreamsRequest, CallSettings)
@@ -2939,7 +2939,7 @@ namespace Google.Analytics.Admin.V1Alpha.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListIosAppDataStreams</summary>
+        /// <summary>Snippet for ListIosAppDataStreamsAsync</summary>
         public async Task ListIosAppDataStreamsAsync()
         {
             // Snippet: ListIosAppDataStreamsAsync(string, string, int?, CallSettings)
@@ -3029,7 +3029,7 @@ namespace Google.Analytics.Admin.V1Alpha.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListIosAppDataStreams</summary>
+        /// <summary>Snippet for ListIosAppDataStreamsAsync</summary>
         public async Task ListIosAppDataStreamsResourceNamesAsync()
         {
             // Snippet: ListIosAppDataStreamsAsync(PropertyName, string, int?, CallSettings)
@@ -3453,7 +3453,7 @@ namespace Google.Analytics.Admin.V1Alpha.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAndroidAppDataStreams</summary>
+        /// <summary>Snippet for ListAndroidAppDataStreamsAsync</summary>
         public async Task ListAndroidAppDataStreamsRequestObjectAsync()
         {
             // Snippet: ListAndroidAppDataStreamsAsync(ListAndroidAppDataStreamsRequest, CallSettings)
@@ -3546,7 +3546,7 @@ namespace Google.Analytics.Admin.V1Alpha.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAndroidAppDataStreams</summary>
+        /// <summary>Snippet for ListAndroidAppDataStreamsAsync</summary>
         public async Task ListAndroidAppDataStreamsAsync()
         {
             // Snippet: ListAndroidAppDataStreamsAsync(string, string, int?, CallSettings)
@@ -3636,7 +3636,7 @@ namespace Google.Analytics.Admin.V1Alpha.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAndroidAppDataStreams</summary>
+        /// <summary>Snippet for ListAndroidAppDataStreamsAsync</summary>
         public async Task ListAndroidAppDataStreamsResourceNamesAsync()
         {
             // Snippet: ListAndroidAppDataStreamsAsync(PropertyName, string, int?, CallSettings)
@@ -4124,7 +4124,7 @@ namespace Google.Analytics.Admin.V1Alpha.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListFirebaseLinks</summary>
+        /// <summary>Snippet for ListFirebaseLinksAsync</summary>
         public async Task ListFirebaseLinksRequestObjectAsync()
         {
             // Snippet: ListFirebaseLinksAsync(ListFirebaseLinksRequest, CallSettings)
@@ -4217,7 +4217,7 @@ namespace Google.Analytics.Admin.V1Alpha.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListFirebaseLinks</summary>
+        /// <summary>Snippet for ListFirebaseLinksAsync</summary>
         public async Task ListFirebaseLinksAsync()
         {
             // Snippet: ListFirebaseLinksAsync(string, string, int?, CallSettings)
@@ -4307,7 +4307,7 @@ namespace Google.Analytics.Admin.V1Alpha.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListFirebaseLinks</summary>
+        /// <summary>Snippet for ListFirebaseLinksAsync</summary>
         public async Task ListFirebaseLinksResourceNamesAsync()
         {
             // Snippet: ListFirebaseLinksAsync(PropertyName, string, int?, CallSettings)
@@ -4731,7 +4731,7 @@ namespace Google.Analytics.Admin.V1Alpha.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListGoogleAdsLinks</summary>
+        /// <summary>Snippet for ListGoogleAdsLinksAsync</summary>
         public async Task ListGoogleAdsLinksRequestObjectAsync()
         {
             // Snippet: ListGoogleAdsLinksAsync(ListGoogleAdsLinksRequest, CallSettings)
@@ -4824,7 +4824,7 @@ namespace Google.Analytics.Admin.V1Alpha.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListGoogleAdsLinks</summary>
+        /// <summary>Snippet for ListGoogleAdsLinksAsync</summary>
         public async Task ListGoogleAdsLinksAsync()
         {
             // Snippet: ListGoogleAdsLinksAsync(string, string, int?, CallSettings)
@@ -4914,7 +4914,7 @@ namespace Google.Analytics.Admin.V1Alpha.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListGoogleAdsLinks</summary>
+        /// <summary>Snippet for ListGoogleAdsLinksAsync</summary>
         public async Task ListGoogleAdsLinksResourceNamesAsync()
         {
             // Snippet: ListGoogleAdsLinksAsync(PropertyName, string, int?, CallSettings)

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.Snippets/TablesServiceClientSnippets.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.Snippets/TablesServiceClientSnippets.g.cs
@@ -157,7 +157,7 @@ namespace Google.Area120.Tables.V1Alpha1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTables</summary>
+        /// <summary>Snippet for ListTablesAsync</summary>
         public async Task ListTablesRequestObjectAsync()
         {
             // Snippet: ListTablesAsync(ListTablesRequest, CallSettings)
@@ -334,7 +334,7 @@ namespace Google.Area120.Tables.V1Alpha1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListWorkspaces</summary>
+        /// <summary>Snippet for ListWorkspacesAsync</summary>
         public async Task ListWorkspacesRequestObjectAsync()
         {
             // Snippet: ListWorkspacesAsync(ListWorkspacesRequest, CallSettings)
@@ -518,7 +518,7 @@ namespace Google.Area120.Tables.V1Alpha1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListRows</summary>
+        /// <summary>Snippet for ListRowsAsync</summary>
         public async Task ListRowsRequestObjectAsync()
         {
             // Snippet: ListRowsAsync(ListRowsRequest, CallSettings)
@@ -613,7 +613,7 @@ namespace Google.Area120.Tables.V1Alpha1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListRows</summary>
+        /// <summary>Snippet for ListRowsAsync</summary>
         public async Task ListRowsAsync()
         {
             // Snippet: ListRowsAsync(string, string, int?, CallSettings)

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.Snippets/AccessApprovalServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.Snippets/AccessApprovalServiceClientSnippets.g.cs
@@ -74,7 +74,7 @@ namespace Google.Cloud.AccessApproval.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListApprovalRequests</summary>
+        /// <summary>Snippet for ListApprovalRequestsAsync</summary>
         public async Task ListApprovalRequestsRequestObjectAsync()
         {
             // Snippet: ListApprovalRequestsAsync(ListApprovalRequestsMessage, CallSettings)
@@ -168,7 +168,7 @@ namespace Google.Cloud.AccessApproval.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListApprovalRequests</summary>
+        /// <summary>Snippet for ListApprovalRequestsAsync</summary>
         public async Task ListApprovalRequestsAsync()
         {
             // Snippet: ListApprovalRequestsAsync(string, string, int?, CallSettings)

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.Snippets/ApiGatewayServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.Snippets/ApiGatewayServiceClientSnippets.g.cs
@@ -78,7 +78,7 @@ namespace Google.Cloud.ApiGateway.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListGateways</summary>
+        /// <summary>Snippet for ListGatewaysAsync</summary>
         public async Task ListGatewaysRequestObjectAsync()
         {
             // Snippet: ListGatewaysAsync(ListGatewaysRequest, CallSettings)
@@ -173,7 +173,7 @@ namespace Google.Cloud.ApiGateway.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListGateways</summary>
+        /// <summary>Snippet for ListGatewaysAsync</summary>
         public async Task ListGatewaysAsync()
         {
             // Snippet: ListGatewaysAsync(string, string, int?, CallSettings)
@@ -263,7 +263,7 @@ namespace Google.Cloud.ApiGateway.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListGateways</summary>
+        /// <summary>Snippet for ListGatewaysAsync</summary>
         public async Task ListGatewaysResourceNamesAsync()
         {
             // Snippet: ListGatewaysAsync(LocationName, string, int?, CallSettings)
@@ -951,7 +951,7 @@ namespace Google.Cloud.ApiGateway.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListApis</summary>
+        /// <summary>Snippet for ListApisAsync</summary>
         public async Task ListApisRequestObjectAsync()
         {
             // Snippet: ListApisAsync(ListApisRequest, CallSettings)
@@ -1046,7 +1046,7 @@ namespace Google.Cloud.ApiGateway.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListApis</summary>
+        /// <summary>Snippet for ListApisAsync</summary>
         public async Task ListApisAsync()
         {
             // Snippet: ListApisAsync(string, string, int?, CallSettings)
@@ -1136,7 +1136,7 @@ namespace Google.Cloud.ApiGateway.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListApis</summary>
+        /// <summary>Snippet for ListApisAsync</summary>
         public async Task ListApisResourceNamesAsync()
         {
             // Snippet: ListApisAsync(LocationName, string, int?, CallSettings)
@@ -1824,7 +1824,7 @@ namespace Google.Cloud.ApiGateway.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListApiConfigs</summary>
+        /// <summary>Snippet for ListApiConfigsAsync</summary>
         public async Task ListApiConfigsRequestObjectAsync()
         {
             // Snippet: ListApiConfigsAsync(ListApiConfigsRequest, CallSettings)
@@ -1919,7 +1919,7 @@ namespace Google.Cloud.ApiGateway.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListApiConfigs</summary>
+        /// <summary>Snippet for ListApiConfigsAsync</summary>
         public async Task ListApiConfigsAsync()
         {
             // Snippet: ListApiConfigsAsync(string, string, int?, CallSettings)
@@ -2009,7 +2009,7 @@ namespace Google.Cloud.ApiGateway.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListApiConfigs</summary>
+        /// <summary>Snippet for ListApiConfigsAsync</summary>
         public async Task ListApiConfigsResourceNamesAsync()
         {
             // Snippet: ListApiConfigsAsync(ApiName, string, int?, CallSettings)

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.Snippets/AuthorizedCertificatesClientSnippets.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.Snippets/AuthorizedCertificatesClientSnippets.g.cs
@@ -74,7 +74,7 @@ namespace Google.Cloud.AppEngine.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAuthorizedCertificates</summary>
+        /// <summary>Snippet for ListAuthorizedCertificatesAsync</summary>
         public async Task ListAuthorizedCertificatesRequestObjectAsync()
         {
             // Snippet: ListAuthorizedCertificatesAsync(ListAuthorizedCertificatesRequest, CallSettings)

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.Snippets/AuthorizedDomainsClientSnippets.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.Snippets/AuthorizedDomainsClientSnippets.g.cs
@@ -69,7 +69,7 @@ namespace Google.Cloud.AppEngine.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAuthorizedDomains</summary>
+        /// <summary>Snippet for ListAuthorizedDomainsAsync</summary>
         public async Task ListAuthorizedDomainsRequestObjectAsync()
         {
             // Snippet: ListAuthorizedDomainsAsync(ListAuthorizedDomainsRequest, CallSettings)

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.Snippets/DomainMappingsClientSnippets.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.Snippets/DomainMappingsClientSnippets.g.cs
@@ -71,7 +71,7 @@ namespace Google.Cloud.AppEngine.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDomainMappings</summary>
+        /// <summary>Snippet for ListDomainMappingsAsync</summary>
         public async Task ListDomainMappingsRequestObjectAsync()
         {
             // Snippet: ListDomainMappingsAsync(ListDomainMappingsRequest, CallSettings)

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.Snippets/FirewallClientSnippets.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.Snippets/FirewallClientSnippets.g.cs
@@ -74,7 +74,7 @@ namespace Google.Cloud.AppEngine.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListIngressRules</summary>
+        /// <summary>Snippet for ListIngressRulesAsync</summary>
         public async Task ListIngressRulesRequestObjectAsync()
         {
             // Snippet: ListIngressRulesAsync(ListIngressRulesRequest, CallSettings)

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.Snippets/InstancesClientSnippets.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.Snippets/InstancesClientSnippets.g.cs
@@ -71,7 +71,7 @@ namespace Google.Cloud.AppEngine.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListInstances</summary>
+        /// <summary>Snippet for ListInstancesAsync</summary>
         public async Task ListInstancesRequestObjectAsync()
         {
             // Snippet: ListInstancesAsync(ListInstancesRequest, CallSettings)

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.Snippets/ServicesClientSnippets.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.Snippets/ServicesClientSnippets.g.cs
@@ -71,7 +71,7 @@ namespace Google.Cloud.AppEngine.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListServices</summary>
+        /// <summary>Snippet for ListServicesAsync</summary>
         public async Task ListServicesRequestObjectAsync()
         {
             // Snippet: ListServicesAsync(ListServicesRequest, CallSettings)

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.Snippets/VersionsClientSnippets.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.Snippets/VersionsClientSnippets.g.cs
@@ -76,7 +76,7 @@ namespace Google.Cloud.AppEngine.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListVersions</summary>
+        /// <summary>Snippet for ListVersionsAsync</summary>
         public async Task ListVersionsRequestObjectAsync()
         {
             // Snippet: ListVersionsAsync(ListVersionsRequest, CallSettings)

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.Snippets/ArtifactRegistryClientSnippets.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.Snippets/ArtifactRegistryClientSnippets.g.cs
@@ -73,7 +73,7 @@ namespace Google.Cloud.ArtifactRegistry.V1Beta2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListRepositories</summary>
+        /// <summary>Snippet for ListRepositoriesAsync</summary>
         public async Task ListRepositoriesRequestObjectAsync()
         {
             // Snippet: ListRepositoriesAsync(ListRepositoriesRequest, CallSettings)
@@ -163,7 +163,7 @@ namespace Google.Cloud.ArtifactRegistry.V1Beta2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListRepositories</summary>
+        /// <summary>Snippet for ListRepositoriesAsync</summary>
         public async Task ListRepositoriesAsync()
         {
             // Snippet: ListRepositoriesAsync(string, string, int?, CallSettings)
@@ -621,7 +621,7 @@ namespace Google.Cloud.ArtifactRegistry.V1Beta2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListPackages</summary>
+        /// <summary>Snippet for ListPackagesAsync</summary>
         public async Task ListPackagesRequestObjectAsync()
         {
             // Snippet: ListPackagesAsync(ListPackagesRequest, CallSettings)
@@ -711,7 +711,7 @@ namespace Google.Cloud.ArtifactRegistry.V1Beta2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListPackages</summary>
+        /// <summary>Snippet for ListPackagesAsync</summary>
         public async Task ListPackagesAsync()
         {
             // Snippet: ListPackagesAsync(string, string, int?, CallSettings)
@@ -977,7 +977,7 @@ namespace Google.Cloud.ArtifactRegistry.V1Beta2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListVersions</summary>
+        /// <summary>Snippet for ListVersionsAsync</summary>
         public async Task ListVersionsRequestObjectAsync()
         {
             // Snippet: ListVersionsAsync(ListVersionsRequest, CallSettings)
@@ -1071,7 +1071,7 @@ namespace Google.Cloud.ArtifactRegistry.V1Beta2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListVersions</summary>
+        /// <summary>Snippet for ListVersionsAsync</summary>
         public async Task ListVersionsAsync()
         {
             // Snippet: ListVersionsAsync(string, string, int?, CallSettings)
@@ -1353,7 +1353,7 @@ namespace Google.Cloud.ArtifactRegistry.V1Beta2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListFiles</summary>
+        /// <summary>Snippet for ListFilesAsync</summary>
         public async Task ListFilesRequestObjectAsync()
         {
             // Snippet: ListFilesAsync(ListFilesRequest, CallSettings)
@@ -1447,7 +1447,7 @@ namespace Google.Cloud.ArtifactRegistry.V1Beta2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListFiles</summary>
+        /// <summary>Snippet for ListFilesAsync</summary>
         public async Task ListFilesAsync()
         {
             // Snippet: ListFilesAsync(string, string, int?, CallSettings)
@@ -1595,7 +1595,7 @@ namespace Google.Cloud.ArtifactRegistry.V1Beta2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTags</summary>
+        /// <summary>Snippet for ListTagsAsync</summary>
         public async Task ListTagsRequestObjectAsync()
         {
             // Snippet: ListTagsAsync(ListTagsRequest, CallSettings)
@@ -1689,7 +1689,7 @@ namespace Google.Cloud.ArtifactRegistry.V1Beta2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTags</summary>
+        /// <summary>Snippet for ListTagsAsync</summary>
         public async Task ListTagsAsync()
         {
             // Snippet: ListTagsAsync(string, string, int?, CallSettings)

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.Snippets/AssetServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.Snippets/AssetServiceClientSnippets.g.cs
@@ -544,7 +544,7 @@ namespace Google.Cloud.Asset.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for SearchAllResources</summary>
+        /// <summary>Snippet for SearchAllResourcesAsync</summary>
         public async Task SearchAllResourcesRequestObjectAsync()
         {
             // Snippet: SearchAllResourcesAsync(SearchAllResourcesRequest, CallSettings)
@@ -642,7 +642,7 @@ namespace Google.Cloud.Asset.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for SearchAllResources</summary>
+        /// <summary>Snippet for SearchAllResourcesAsync</summary>
         public async Task SearchAllResourcesAsync()
         {
             // Snippet: SearchAllResourcesAsync(string, string, IEnumerable<string>, string, int?, CallSettings)
@@ -734,7 +734,7 @@ namespace Google.Cloud.Asset.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for SearchAllIamPolicies</summary>
+        /// <summary>Snippet for SearchAllIamPoliciesAsync</summary>
         public async Task SearchAllIamPoliciesRequestObjectAsync()
         {
             // Snippet: SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest, CallSettings)
@@ -825,7 +825,7 @@ namespace Google.Cloud.Asset.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for SearchAllIamPolicies</summary>
+        /// <summary>Snippet for SearchAllIamPoliciesAsync</summary>
         public async Task SearchAllIamPoliciesAsync()
         {
             // Snippet: SearchAllIamPoliciesAsync(string, string, string, int?, CallSettings)

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.Snippets/AssuredWorkloadsServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.Snippets/AssuredWorkloadsServiceClientSnippets.g.cs
@@ -506,7 +506,7 @@ namespace Google.Cloud.AssuredWorkloads.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListWorkloads</summary>
+        /// <summary>Snippet for ListWorkloadsAsync</summary>
         public async Task ListWorkloadsRequestObjectAsync()
         {
             // Snippet: ListWorkloadsAsync(ListWorkloadsRequest, CallSettings)
@@ -600,7 +600,7 @@ namespace Google.Cloud.AssuredWorkloads.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListWorkloads</summary>
+        /// <summary>Snippet for ListWorkloadsAsync</summary>
         public async Task ListWorkloadsAsync()
         {
             // Snippet: ListWorkloadsAsync(string, string, int?, CallSettings)
@@ -690,7 +690,7 @@ namespace Google.Cloud.AssuredWorkloads.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListWorkloads</summary>
+        /// <summary>Snippet for ListWorkloadsAsync</summary>
         public async Task ListWorkloadsResourceNamesAsync()
         {
             // Snippet: ListWorkloadsAsync(LocationName, string, int?, CallSettings)

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.Snippets/AutoMlClientSnippets.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.Snippets/AutoMlClientSnippets.g.cs
@@ -352,7 +352,7 @@ namespace Google.Cloud.AutoML.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDatasets</summary>
+        /// <summary>Snippet for ListDatasetsAsync</summary>
         public async Task ListDatasetsRequestObjectAsync()
         {
             // Snippet: ListDatasetsAsync(ListDatasetsRequest, CallSettings)
@@ -446,7 +446,7 @@ namespace Google.Cloud.AutoML.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDatasets</summary>
+        /// <summary>Snippet for ListDatasetsAsync</summary>
         public async Task ListDatasetsAsync()
         {
             // Snippet: ListDatasetsAsync(string, string, int?, CallSettings)
@@ -536,7 +536,7 @@ namespace Google.Cloud.AutoML.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDatasets</summary>
+        /// <summary>Snippet for ListDatasetsAsync</summary>
         public async Task ListDatasetsResourceNamesAsync()
         {
             // Snippet: ListDatasetsAsync(LocationName, string, int?, CallSettings)
@@ -1618,7 +1618,7 @@ namespace Google.Cloud.AutoML.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListModels</summary>
+        /// <summary>Snippet for ListModelsAsync</summary>
         public async Task ListModelsRequestObjectAsync()
         {
             // Snippet: ListModelsAsync(ListModelsRequest, CallSettings)
@@ -1712,7 +1712,7 @@ namespace Google.Cloud.AutoML.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListModels</summary>
+        /// <summary>Snippet for ListModelsAsync</summary>
         public async Task ListModelsAsync()
         {
             // Snippet: ListModelsAsync(string, string, int?, CallSettings)
@@ -1802,7 +1802,7 @@ namespace Google.Cloud.AutoML.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListModels</summary>
+        /// <summary>Snippet for ListModelsAsync</summary>
         public async Task ListModelsResourceNamesAsync()
         {
             // Snippet: ListModelsAsync(LocationName, string, int?, CallSettings)
@@ -2787,7 +2787,7 @@ namespace Google.Cloud.AutoML.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListModelEvaluations</summary>
+        /// <summary>Snippet for ListModelEvaluationsAsync</summary>
         public async Task ListModelEvaluationsRequestObjectAsync()
         {
             // Snippet: ListModelEvaluationsAsync(ListModelEvaluationsRequest, CallSettings)
@@ -2882,7 +2882,7 @@ namespace Google.Cloud.AutoML.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListModelEvaluations</summary>
+        /// <summary>Snippet for ListModelEvaluationsAsync</summary>
         public async Task ListModelEvaluationsAsync()
         {
             // Snippet: ListModelEvaluationsAsync(string, string, string, int?, CallSettings)
@@ -2974,7 +2974,7 @@ namespace Google.Cloud.AutoML.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListModelEvaluations</summary>
+        /// <summary>Snippet for ListModelEvaluationsAsync</summary>
         public async Task ListModelEvaluationsResourceNamesAsync()
         {
             // Snippet: ListModelEvaluationsAsync(ModelName, string, string, int?, CallSettings)

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.Snippets/ConnectionServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.Snippets/ConnectionServiceClientSnippets.g.cs
@@ -262,7 +262,7 @@ namespace Google.Cloud.BigQuery.Connection.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListConnections</summary>
+        /// <summary>Snippet for ListConnectionsAsync</summary>
         public async Task ListConnectionsRequestObjectAsync()
         {
             // Snippet: ListConnectionsAsync(ListConnectionsRequest, CallSettings)
@@ -355,7 +355,7 @@ namespace Google.Cloud.BigQuery.Connection.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListConnections</summary>
+        /// <summary>Snippet for ListConnectionsAsync</summary>
         public async Task ListConnectionsAsync()
         {
             // Snippet: ListConnectionsAsync(string, string, int?, CallSettings)
@@ -445,7 +445,7 @@ namespace Google.Cloud.BigQuery.Connection.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListConnections</summary>
+        /// <summary>Snippet for ListConnectionsAsync</summary>
         public async Task ListConnectionsResourceNamesAsync()
         {
             // Snippet: ListConnectionsAsync(LocationName, string, int?, CallSettings)

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.Snippets/DataTransferServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.Snippets/DataTransferServiceClientSnippets.g.cs
@@ -161,7 +161,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDataSources</summary>
+        /// <summary>Snippet for ListDataSourcesAsync</summary>
         public async Task ListDataSourcesRequestObjectAsync()
         {
             // Snippet: ListDataSourcesAsync(ListDataSourcesRequest, CallSettings)
@@ -254,7 +254,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDataSources</summary>
+        /// <summary>Snippet for ListDataSourcesAsync</summary>
         public async Task ListDataSourcesAsync()
         {
             // Snippet: ListDataSourcesAsync(string, string, int?, CallSettings)
@@ -344,7 +344,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDataSources</summary>
+        /// <summary>Snippet for ListDataSourcesAsync</summary>
         public async Task ListDataSourcesResourceNames1Async()
         {
             // Snippet: ListDataSourcesAsync(ProjectName, string, int?, CallSettings)
@@ -434,7 +434,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDataSources</summary>
+        /// <summary>Snippet for ListDataSourcesAsync</summary>
         public async Task ListDataSourcesResourceNames2Async()
         {
             // Snippet: ListDataSourcesAsync(LocationName, string, int?, CallSettings)
@@ -900,7 +900,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTransferConfigs</summary>
+        /// <summary>Snippet for ListTransferConfigsAsync</summary>
         public async Task ListTransferConfigsRequestObjectAsync()
         {
             // Snippet: ListTransferConfigsAsync(ListTransferConfigsRequest, CallSettings)
@@ -994,7 +994,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTransferConfigs</summary>
+        /// <summary>Snippet for ListTransferConfigsAsync</summary>
         public async Task ListTransferConfigsAsync()
         {
             // Snippet: ListTransferConfigsAsync(string, string, int?, CallSettings)
@@ -1084,7 +1084,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTransferConfigs</summary>
+        /// <summary>Snippet for ListTransferConfigsAsync</summary>
         public async Task ListTransferConfigsResourceNames1Async()
         {
             // Snippet: ListTransferConfigsAsync(ProjectName, string, int?, CallSettings)
@@ -1174,7 +1174,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTransferConfigs</summary>
+        /// <summary>Snippet for ListTransferConfigsAsync</summary>
         public async Task ListTransferConfigsResourceNames2Async()
         {
             // Snippet: ListTransferConfigsAsync(LocationName, string, int?, CallSettings)
@@ -1580,7 +1580,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTransferRuns</summary>
+        /// <summary>Snippet for ListTransferRunsAsync</summary>
         public async Task ListTransferRunsRequestObjectAsync()
         {
             // Snippet: ListTransferRunsAsync(ListTransferRunsRequest, CallSettings)
@@ -1678,7 +1678,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTransferRuns</summary>
+        /// <summary>Snippet for ListTransferRunsAsync</summary>
         public async Task ListTransferRunsAsync()
         {
             // Snippet: ListTransferRunsAsync(string, string, int?, CallSettings)
@@ -1768,7 +1768,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTransferRuns</summary>
+        /// <summary>Snippet for ListTransferRunsAsync</summary>
         public async Task ListTransferRunsResourceNamesAsync()
         {
             // Snippet: ListTransferRunsAsync(TransferConfigName, string, int?, CallSettings)
@@ -1865,7 +1865,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTransferLogs</summary>
+        /// <summary>Snippet for ListTransferLogsAsync</summary>
         public async Task ListTransferLogsRequestObjectAsync()
         {
             // Snippet: ListTransferLogsAsync(ListTransferLogsRequest, CallSettings)
@@ -1962,7 +1962,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTransferLogs</summary>
+        /// <summary>Snippet for ListTransferLogsAsync</summary>
         public async Task ListTransferLogsAsync()
         {
             // Snippet: ListTransferLogsAsync(string, string, int?, CallSettings)
@@ -2052,7 +2052,7 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTransferLogs</summary>
+        /// <summary>Snippet for ListTransferLogsAsync</summary>
         public async Task ListTransferLogsResourceNamesAsync()
         {
             // Snippet: ListTransferLogsAsync(RunName, string, int?, CallSettings)

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.Snippets/ReservationServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.Snippets/ReservationServiceClientSnippets.g.cs
@@ -174,7 +174,7 @@ namespace Google.Cloud.BigQuery.Reservation.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListReservations</summary>
+        /// <summary>Snippet for ListReservationsAsync</summary>
         public async Task ListReservationsRequestObjectAsync()
         {
             // Snippet: ListReservationsAsync(ListReservationsRequest, CallSettings)
@@ -267,7 +267,7 @@ namespace Google.Cloud.BigQuery.Reservation.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListReservations</summary>
+        /// <summary>Snippet for ListReservationsAsync</summary>
         public async Task ListReservationsAsync()
         {
             // Snippet: ListReservationsAsync(string, string, int?, CallSettings)
@@ -357,7 +357,7 @@ namespace Google.Cloud.BigQuery.Reservation.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListReservations</summary>
+        /// <summary>Snippet for ListReservationsAsync</summary>
         public async Task ListReservationsResourceNamesAsync()
         {
             // Snippet: ListReservationsAsync(LocationName, string, int?, CallSettings)
@@ -783,7 +783,7 @@ namespace Google.Cloud.BigQuery.Reservation.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListCapacityCommitments</summary>
+        /// <summary>Snippet for ListCapacityCommitmentsAsync</summary>
         public async Task ListCapacityCommitmentsRequestObjectAsync()
         {
             // Snippet: ListCapacityCommitmentsAsync(ListCapacityCommitmentsRequest, CallSettings)
@@ -876,7 +876,7 @@ namespace Google.Cloud.BigQuery.Reservation.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListCapacityCommitments</summary>
+        /// <summary>Snippet for ListCapacityCommitmentsAsync</summary>
         public async Task ListCapacityCommitmentsAsync()
         {
             // Snippet: ListCapacityCommitmentsAsync(string, string, int?, CallSettings)
@@ -966,7 +966,7 @@ namespace Google.Cloud.BigQuery.Reservation.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListCapacityCommitments</summary>
+        /// <summary>Snippet for ListCapacityCommitmentsAsync</summary>
         public async Task ListCapacityCommitmentsResourceNamesAsync()
         {
             // Snippet: ListCapacityCommitmentsAsync(LocationName, string, int?, CallSettings)
@@ -1576,7 +1576,7 @@ namespace Google.Cloud.BigQuery.Reservation.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAssignments</summary>
+        /// <summary>Snippet for ListAssignmentsAsync</summary>
         public async Task ListAssignmentsRequestObjectAsync()
         {
             // Snippet: ListAssignmentsAsync(ListAssignmentsRequest, CallSettings)
@@ -1669,7 +1669,7 @@ namespace Google.Cloud.BigQuery.Reservation.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAssignments</summary>
+        /// <summary>Snippet for ListAssignmentsAsync</summary>
         public async Task ListAssignmentsAsync()
         {
             // Snippet: ListAssignmentsAsync(string, string, int?, CallSettings)
@@ -1759,7 +1759,7 @@ namespace Google.Cloud.BigQuery.Reservation.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAssignments</summary>
+        /// <summary>Snippet for ListAssignmentsAsync</summary>
         public async Task ListAssignmentsResourceNamesAsync()
         {
             // Snippet: ListAssignmentsAsync(ReservationName, string, int?, CallSettings)
@@ -1940,7 +1940,7 @@ namespace Google.Cloud.BigQuery.Reservation.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for SearchAssignments</summary>
+        /// <summary>Snippet for SearchAssignmentsAsync</summary>
         public async Task SearchAssignmentsRequestObjectAsync()
         {
             // Snippet: SearchAssignmentsAsync(SearchAssignmentsRequest, CallSettings)
@@ -2035,7 +2035,7 @@ namespace Google.Cloud.BigQuery.Reservation.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for SearchAssignments</summary>
+        /// <summary>Snippet for SearchAssignmentsAsync</summary>
         public async Task SearchAssignmentsAsync()
         {
             // Snippet: SearchAssignmentsAsync(string, string, string, int?, CallSettings)
@@ -2127,7 +2127,7 @@ namespace Google.Cloud.BigQuery.Reservation.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for SearchAssignments</summary>
+        /// <summary>Snippet for SearchAssignmentsAsync</summary>
         public async Task SearchAssignmentsResourceNamesAsync()
         {
             // Snippet: SearchAssignmentsAsync(LocationName, string, string, int?, CallSettings)

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.Snippets/BigtableInstanceAdminClientSnippets.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.Snippets/BigtableInstanceAdminClientSnippets.g.cs
@@ -1431,7 +1431,7 @@ namespace Google.Cloud.Bigtable.Admin.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAppProfiles</summary>
+        /// <summary>Snippet for ListAppProfilesAsync</summary>
         public async Task ListAppProfilesRequestObjectAsync()
         {
             // Snippet: ListAppProfilesAsync(ListAppProfilesRequest, CallSettings)
@@ -1524,7 +1524,7 @@ namespace Google.Cloud.Bigtable.Admin.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAppProfiles</summary>
+        /// <summary>Snippet for ListAppProfilesAsync</summary>
         public async Task ListAppProfilesAsync()
         {
             // Snippet: ListAppProfilesAsync(string, string, int?, CallSettings)
@@ -1614,7 +1614,7 @@ namespace Google.Cloud.Bigtable.Admin.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAppProfiles</summary>
+        /// <summary>Snippet for ListAppProfilesAsync</summary>
         public async Task ListAppProfilesResourceNamesAsync()
         {
             // Snippet: ListAppProfilesAsync(InstanceName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.Snippets/BigtableTableAdminClientSnippets.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.Snippets/BigtableTableAdminClientSnippets.g.cs
@@ -381,7 +381,7 @@ namespace Google.Cloud.Bigtable.Admin.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTables</summary>
+        /// <summary>Snippet for ListTablesAsync</summary>
         public async Task ListTablesRequestObjectAsync()
         {
             // Snippet: ListTablesAsync(ListTablesRequest, CallSettings)
@@ -475,7 +475,7 @@ namespace Google.Cloud.Bigtable.Admin.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTables</summary>
+        /// <summary>Snippet for ListTablesAsync</summary>
         public async Task ListTablesAsync()
         {
             // Snippet: ListTablesAsync(string, string, int?, CallSettings)
@@ -565,7 +565,7 @@ namespace Google.Cloud.Bigtable.Admin.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTables</summary>
+        /// <summary>Snippet for ListTablesAsync</summary>
         public async Task ListTablesResourceNamesAsync()
         {
             // Snippet: ListTablesAsync(InstanceName, string, int?, CallSettings)
@@ -1450,7 +1450,7 @@ namespace Google.Cloud.Bigtable.Admin.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSnapshots</summary>
+        /// <summary>Snippet for ListSnapshotsAsync</summary>
         public async Task ListSnapshotsRequestObjectAsync()
         {
             // Snippet: ListSnapshotsAsync(ListSnapshotsRequest, CallSettings)
@@ -1543,7 +1543,7 @@ namespace Google.Cloud.Bigtable.Admin.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSnapshots</summary>
+        /// <summary>Snippet for ListSnapshotsAsync</summary>
         public async Task ListSnapshotsAsync()
         {
             // Snippet: ListSnapshotsAsync(string, string, int?, CallSettings)
@@ -1633,7 +1633,7 @@ namespace Google.Cloud.Bigtable.Admin.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSnapshots</summary>
+        /// <summary>Snippet for ListSnapshotsAsync</summary>
         public async Task ListSnapshotsResourceNamesAsync()
         {
             // Snippet: ListSnapshotsAsync(ClusterName, string, int?, CallSettings)
@@ -2248,7 +2248,7 @@ namespace Google.Cloud.Bigtable.Admin.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListBackups</summary>
+        /// <summary>Snippet for ListBackupsAsync</summary>
         public async Task ListBackupsRequestObjectAsync()
         {
             // Snippet: ListBackupsAsync(ListBackupsRequest, CallSettings)
@@ -2343,7 +2343,7 @@ namespace Google.Cloud.Bigtable.Admin.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListBackups</summary>
+        /// <summary>Snippet for ListBackupsAsync</summary>
         public async Task ListBackupsAsync()
         {
             // Snippet: ListBackupsAsync(string, string, int?, CallSettings)
@@ -2433,7 +2433,7 @@ namespace Google.Cloud.Bigtable.Admin.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListBackups</summary>
+        /// <summary>Snippet for ListBackupsAsync</summary>
         public async Task ListBackupsResourceNamesAsync()
         {
             // Snippet: ListBackupsAsync(ClusterName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.Snippets/BudgetServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.Snippets/BudgetServiceClientSnippets.g.cs
@@ -318,7 +318,7 @@ namespace Google.Cloud.Billing.Budgets.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListBudgets</summary>
+        /// <summary>Snippet for ListBudgetsAsync</summary>
         public async Task ListBudgetsRequestObjectAsync()
         {
             // Snippet: ListBudgetsAsync(ListBudgetsRequest, CallSettings)
@@ -411,7 +411,7 @@ namespace Google.Cloud.Billing.Budgets.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListBudgets</summary>
+        /// <summary>Snippet for ListBudgetsAsync</summary>
         public async Task ListBudgetsAsync()
         {
             // Snippet: ListBudgetsAsync(string, string, int?, CallSettings)
@@ -501,7 +501,7 @@ namespace Google.Cloud.Billing.Budgets.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListBudgets</summary>
+        /// <summary>Snippet for ListBudgetsAsync</summary>
         public async Task ListBudgetsResourceNamesAsync()
         {
             // Snippet: ListBudgetsAsync(BillingAccountName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1.Snippets/BudgetServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1.Snippets/BudgetServiceClientSnippets.g.cs
@@ -177,7 +177,7 @@ namespace Google.Cloud.Billing.Budgets.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListBudgets</summary>
+        /// <summary>Snippet for ListBudgetsAsync</summary>
         public async Task ListBudgetsRequestObjectAsync()
         {
             // Snippet: ListBudgetsAsync(ListBudgetsRequest, CallSettings)

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.Snippets/CloudBillingClientSnippets.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.Snippets/CloudBillingClientSnippets.g.cs
@@ -160,7 +160,7 @@ namespace Google.Cloud.Billing.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListBillingAccounts</summary>
+        /// <summary>Snippet for ListBillingAccountsAsync</summary>
         public async Task ListBillingAccountsRequestObjectAsync()
         {
             // Snippet: ListBillingAccountsAsync(ListBillingAccountsRequest, CallSettings)
@@ -248,7 +248,7 @@ namespace Google.Cloud.Billing.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListBillingAccounts</summary>
+        /// <summary>Snippet for ListBillingAccountsAsync</summary>
         public async Task ListBillingAccountsAsync()
         {
             // Snippet: ListBillingAccountsAsync(string, int?, CallSettings)
@@ -494,7 +494,7 @@ namespace Google.Cloud.Billing.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListProjectBillingInfo</summary>
+        /// <summary>Snippet for ListProjectBillingInfoAsync</summary>
         public async Task ListProjectBillingInfoRequestObjectAsync()
         {
             // Snippet: ListProjectBillingInfoAsync(ListProjectBillingInfoRequest, CallSettings)
@@ -587,7 +587,7 @@ namespace Google.Cloud.Billing.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListProjectBillingInfo</summary>
+        /// <summary>Snippet for ListProjectBillingInfoAsync</summary>
         public async Task ListProjectBillingInfoAsync()
         {
             // Snippet: ListProjectBillingInfoAsync(string, string, int?, CallSettings)
@@ -677,7 +677,7 @@ namespace Google.Cloud.Billing.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListProjectBillingInfo</summary>
+        /// <summary>Snippet for ListProjectBillingInfoAsync</summary>
         public async Task ListProjectBillingInfoResourceNamesAsync()
         {
             // Snippet: ListProjectBillingInfoAsync(BillingAccountName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.Snippets/CloudCatalogClientSnippets.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.Snippets/CloudCatalogClientSnippets.g.cs
@@ -70,7 +70,7 @@ namespace Google.Cloud.Billing.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListServices</summary>
+        /// <summary>Snippet for ListServicesAsync</summary>
         public async Task ListServicesRequestObjectAsync()
         {
             // Snippet: ListServicesAsync(ListServicesRequest, CallSettings)
@@ -158,7 +158,7 @@ namespace Google.Cloud.Billing.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListServices</summary>
+        /// <summary>Snippet for ListServicesAsync</summary>
         public async Task ListServicesAsync()
         {
             // Snippet: ListServicesAsync(string, int?, CallSettings)
@@ -252,7 +252,7 @@ namespace Google.Cloud.Billing.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSkus</summary>
+        /// <summary>Snippet for ListSkusAsync</summary>
         public async Task ListSkusRequestObjectAsync()
         {
             // Snippet: ListSkusAsync(ListSkusRequest, CallSettings)
@@ -348,7 +348,7 @@ namespace Google.Cloud.Billing.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSkus</summary>
+        /// <summary>Snippet for ListSkusAsync</summary>
         public async Task ListSkusAsync()
         {
             // Snippet: ListSkusAsync(string, string, int?, CallSettings)
@@ -438,7 +438,7 @@ namespace Google.Cloud.Billing.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSkus</summary>
+        /// <summary>Snippet for ListSkusAsync</summary>
         public async Task ListSkusResourceNamesAsync()
         {
             // Snippet: ListSkusAsync(ServiceName, string, int?, CallSettings)

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.Snippets/BinauthzManagementServiceV1Beta1ClientSnippets.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.Snippets/BinauthzManagementServiceV1Beta1ClientSnippets.g.cs
@@ -466,7 +466,7 @@ namespace Google.Cloud.BinaryAuthorization.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAttestors</summary>
+        /// <summary>Snippet for ListAttestorsAsync</summary>
         public async Task ListAttestorsRequestObjectAsync()
         {
             // Snippet: ListAttestorsAsync(ListAttestorsRequest, CallSettings)
@@ -559,7 +559,7 @@ namespace Google.Cloud.BinaryAuthorization.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAttestors</summary>
+        /// <summary>Snippet for ListAttestorsAsync</summary>
         public async Task ListAttestorsAsync()
         {
             // Snippet: ListAttestorsAsync(string, string, int?, CallSettings)
@@ -649,7 +649,7 @@ namespace Google.Cloud.BinaryAuthorization.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAttestors</summary>
+        /// <summary>Snippet for ListAttestorsAsync</summary>
         public async Task ListAttestorsResourceNamesAsync()
         {
             // Snippet: ListAttestorsAsync(ProjectName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.Snippets/CloudChannelServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.Snippets/CloudChannelServiceClientSnippets.g.cs
@@ -71,7 +71,7 @@ namespace Google.Cloud.Channel.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListCustomers</summary>
+        /// <summary>Snippet for ListCustomersAsync</summary>
         public async Task ListCustomersRequestObjectAsync()
         {
             // Snippet: ListCustomersAsync(ListCustomersRequest, CallSettings)
@@ -514,7 +514,7 @@ namespace Google.Cloud.Channel.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListEntitlements</summary>
+        /// <summary>Snippet for ListEntitlementsAsync</summary>
         public async Task ListEntitlementsRequestObjectAsync()
         {
             // Snippet: ListEntitlementsAsync(ListEntitlementsRequest, CallSettings)
@@ -613,7 +613,7 @@ namespace Google.Cloud.Channel.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTransferableSkus</summary>
+        /// <summary>Snippet for ListTransferableSkusAsync</summary>
         public async Task ListTransferableSkusRequestObjectAsync()
         {
             // Snippet: ListTransferableSkusAsync(ListTransferableSkusRequest, CallSettings)
@@ -715,7 +715,7 @@ namespace Google.Cloud.Channel.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTransferableOffers</summary>
+        /// <summary>Snippet for ListTransferableOffersAsync</summary>
         public async Task ListTransferableOffersRequestObjectAsync()
         {
             // Snippet: ListTransferableOffersAsync(ListTransferableOffersRequest, CallSettings)
@@ -1538,7 +1538,7 @@ namespace Google.Cloud.Channel.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListChannelPartnerLinks</summary>
+        /// <summary>Snippet for ListChannelPartnerLinksAsync</summary>
         public async Task ListChannelPartnerLinksRequestObjectAsync()
         {
             // Snippet: ListChannelPartnerLinksAsync(ListChannelPartnerLinksRequest, CallSettings)
@@ -1743,7 +1743,7 @@ namespace Google.Cloud.Channel.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListProducts</summary>
+        /// <summary>Snippet for ListProductsAsync</summary>
         public async Task ListProductsRequestObjectAsync()
         {
             // Snippet: ListProductsAsync(ListProductsRequest, CallSettings)
@@ -1842,7 +1842,7 @@ namespace Google.Cloud.Channel.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSkus</summary>
+        /// <summary>Snippet for ListSkusAsync</summary>
         public async Task ListSkusRequestObjectAsync()
         {
             // Snippet: ListSkusAsync(ListSkusRequest, CallSettings)
@@ -1942,7 +1942,7 @@ namespace Google.Cloud.Channel.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListOffers</summary>
+        /// <summary>Snippet for ListOffersAsync</summary>
         public async Task ListOffersRequestObjectAsync()
         {
             // Snippet: ListOffersAsync(ListOffersRequest, CallSettings)
@@ -2042,7 +2042,7 @@ namespace Google.Cloud.Channel.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListPurchasableSkus</summary>
+        /// <summary>Snippet for ListPurchasableSkusAsync</summary>
         public async Task ListPurchasableSkusRequestObjectAsync()
         {
             // Snippet: ListPurchasableSkusAsync(ListPurchasableSkusRequest, CallSettings)
@@ -2142,7 +2142,7 @@ namespace Google.Cloud.Channel.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListPurchasableOffers</summary>
+        /// <summary>Snippet for ListPurchasableOffersAsync</summary>
         public async Task ListPurchasableOffersRequestObjectAsync()
         {
             // Snippet: ListPurchasableOffersAsync(ListPurchasableOffersRequest, CallSettings)
@@ -2307,7 +2307,7 @@ namespace Google.Cloud.Channel.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSubscribers</summary>
+        /// <summary>Snippet for ListSubscribersAsync</summary>
         public async Task ListSubscribersRequestObjectAsync()
         {
             // Snippet: ListSubscribersAsync(ListSubscribersRequest, CallSettings)

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.Snippets/CloudBuildClientSnippets.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.Snippets/CloudBuildClientSnippets.g.cs
@@ -273,7 +273,7 @@ namespace Google.Cloud.CloudBuild.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListBuilds</summary>
+        /// <summary>Snippet for ListBuildsAsync</summary>
         public async Task ListBuildsRequestObjectAsync()
         {
             // Snippet: ListBuildsAsync(ListBuildsRequest, CallSettings)
@@ -369,7 +369,7 @@ namespace Google.Cloud.CloudBuild.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListBuilds</summary>
+        /// <summary>Snippet for ListBuildsAsync</summary>
         public async Task ListBuildsAsync()
         {
             // Snippet: ListBuildsAsync(string, string, string, int?, CallSettings)
@@ -784,7 +784,7 @@ namespace Google.Cloud.CloudBuild.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListBuildTriggers</summary>
+        /// <summary>Snippet for ListBuildTriggersAsync</summary>
         public async Task ListBuildTriggersRequestObjectAsync()
         {
             // Snippet: ListBuildTriggersAsync(ListBuildTriggersRequest, CallSettings)
@@ -874,7 +874,7 @@ namespace Google.Cloud.CloudBuild.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListBuildTriggers</summary>
+        /// <summary>Snippet for ListBuildTriggersAsync</summary>
         public async Task ListBuildTriggersAsync()
         {
             // Snippet: ListBuildTriggersAsync(string, string, int?, CallSettings)

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.Snippets/ClusterManagerClientSnippets.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.Snippets/ClusterManagerClientSnippets.g.cs
@@ -2480,7 +2480,7 @@ namespace Google.Cloud.Container.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListUsableSubnetworks</summary>
+        /// <summary>Snippet for ListUsableSubnetworksAsync</summary>
         public async Task ListUsableSubnetworksRequestObjectAsync()
         {
             // Snippet: ListUsableSubnetworksAsync(ListUsableSubnetworksRequest, CallSettings)

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.Snippets/DataCatalogClientSnippets.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.Snippets/DataCatalogClientSnippets.g.cs
@@ -77,7 +77,7 @@ namespace Google.Cloud.DataCatalog.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for SearchCatalog</summary>
+        /// <summary>Snippet for SearchCatalogAsync</summary>
         public async Task SearchCatalogRequestObjectAsync()
         {
             // Snippet: SearchCatalogAsync(SearchCatalogRequest, CallSettings)
@@ -173,7 +173,7 @@ namespace Google.Cloud.DataCatalog.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for SearchCatalog</summary>
+        /// <summary>Snippet for SearchCatalogAsync</summary>
         public async Task SearchCatalogAsync()
         {
             // Snippet: SearchCatalogAsync(SearchCatalogRequest.Types.Scope, string, string, int?, CallSettings)
@@ -693,7 +693,7 @@ namespace Google.Cloud.DataCatalog.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListEntryGroups</summary>
+        /// <summary>Snippet for ListEntryGroupsAsync</summary>
         public async Task ListEntryGroupsRequestObjectAsync()
         {
             // Snippet: ListEntryGroupsAsync(ListEntryGroupsRequest, CallSettings)
@@ -786,7 +786,7 @@ namespace Google.Cloud.DataCatalog.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListEntryGroups</summary>
+        /// <summary>Snippet for ListEntryGroupsAsync</summary>
         public async Task ListEntryGroupsAsync()
         {
             // Snippet: ListEntryGroupsAsync(string, string, int?, CallSettings)
@@ -876,7 +876,7 @@ namespace Google.Cloud.DataCatalog.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListEntryGroups</summary>
+        /// <summary>Snippet for ListEntryGroupsAsync</summary>
         public async Task ListEntryGroupsResourceNamesAsync()
         {
             // Snippet: ListEntryGroupsAsync(EntryGroupName, string, int?, CallSettings)
@@ -1361,7 +1361,7 @@ namespace Google.Cloud.DataCatalog.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListEntries</summary>
+        /// <summary>Snippet for ListEntriesAsync</summary>
         public async Task ListEntriesRequestObjectAsync()
         {
             // Snippet: ListEntriesAsync(ListEntriesRequest, CallSettings)
@@ -1455,7 +1455,7 @@ namespace Google.Cloud.DataCatalog.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListEntries</summary>
+        /// <summary>Snippet for ListEntriesAsync</summary>
         public async Task ListEntriesAsync()
         {
             // Snippet: ListEntriesAsync(string, string, int?, CallSettings)
@@ -1545,7 +1545,7 @@ namespace Google.Cloud.DataCatalog.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListEntries</summary>
+        /// <summary>Snippet for ListEntriesAsync</summary>
         public async Task ListEntriesResourceNamesAsync()
         {
             // Snippet: ListEntriesAsync(EntryGroupName, string, int?, CallSettings)
@@ -2721,7 +2721,7 @@ namespace Google.Cloud.DataCatalog.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTags</summary>
+        /// <summary>Snippet for ListTagsAsync</summary>
         public async Task ListTagsRequestObjectAsync()
         {
             // Snippet: ListTagsAsync(ListTagsRequest, CallSettings)
@@ -2814,7 +2814,7 @@ namespace Google.Cloud.DataCatalog.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTags</summary>
+        /// <summary>Snippet for ListTagsAsync</summary>
         public async Task ListTagsAsync()
         {
             // Snippet: ListTagsAsync(string, string, int?, CallSettings)
@@ -2904,7 +2904,7 @@ namespace Google.Cloud.DataCatalog.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTags</summary>
+        /// <summary>Snippet for ListTagsAsync</summary>
         public async Task ListTagsResourceNamesAsync()
         {
             // Snippet: ListTagsAsync(EntryName, string, int?, CallSettings)

--- a/apis/Google.Cloud.DataLabeling.V1Beta1/Google.Cloud.DataLabeling.V1Beta1.Snippets/DataLabelingServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DataLabeling.V1Beta1/Google.Cloud.DataLabeling.V1Beta1.Snippets/DataLabelingServiceClientSnippets.g.cs
@@ -256,7 +256,7 @@ namespace Google.Cloud.DataLabeling.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDatasets</summary>
+        /// <summary>Snippet for ListDatasetsAsync</summary>
         public async Task ListDatasetsRequestObjectAsync()
         {
             // Snippet: ListDatasetsAsync(ListDatasetsRequest, CallSettings)
@@ -351,7 +351,7 @@ namespace Google.Cloud.DataLabeling.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDatasets</summary>
+        /// <summary>Snippet for ListDatasetsAsync</summary>
         public async Task ListDatasetsAsync()
         {
             // Snippet: ListDatasetsAsync(string, string, string, int?, CallSettings)
@@ -443,7 +443,7 @@ namespace Google.Cloud.DataLabeling.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDatasets</summary>
+        /// <summary>Snippet for ListDatasetsAsync</summary>
         public async Task ListDatasetsResourceNamesAsync()
         {
             // Snippet: ListDatasetsAsync(ProjectName, string, string, int?, CallSettings)
@@ -1106,7 +1106,7 @@ namespace Google.Cloud.DataLabeling.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDataItems</summary>
+        /// <summary>Snippet for ListDataItemsAsync</summary>
         public async Task ListDataItemsRequestObjectAsync()
         {
             // Snippet: ListDataItemsAsync(ListDataItemsRequest, CallSettings)
@@ -1201,7 +1201,7 @@ namespace Google.Cloud.DataLabeling.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDataItems</summary>
+        /// <summary>Snippet for ListDataItemsAsync</summary>
         public async Task ListDataItemsAsync()
         {
             // Snippet: ListDataItemsAsync(string, string, string, int?, CallSettings)
@@ -1293,7 +1293,7 @@ namespace Google.Cloud.DataLabeling.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDataItems</summary>
+        /// <summary>Snippet for ListDataItemsAsync</summary>
         public async Task ListDataItemsResourceNamesAsync()
         {
             // Snippet: ListDataItemsAsync(DatasetName, string, string, int?, CallSettings)
@@ -1475,7 +1475,7 @@ namespace Google.Cloud.DataLabeling.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAnnotatedDatasets</summary>
+        /// <summary>Snippet for ListAnnotatedDatasetsAsync</summary>
         public async Task ListAnnotatedDatasetsRequestObjectAsync()
         {
             // Snippet: ListAnnotatedDatasetsAsync(ListAnnotatedDatasetsRequest, CallSettings)
@@ -1570,7 +1570,7 @@ namespace Google.Cloud.DataLabeling.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAnnotatedDatasets</summary>
+        /// <summary>Snippet for ListAnnotatedDatasetsAsync</summary>
         public async Task ListAnnotatedDatasetsAsync()
         {
             // Snippet: ListAnnotatedDatasetsAsync(string, string, string, int?, CallSettings)
@@ -1662,7 +1662,7 @@ namespace Google.Cloud.DataLabeling.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAnnotatedDatasets</summary>
+        /// <summary>Snippet for ListAnnotatedDatasetsAsync</summary>
         public async Task ListAnnotatedDatasetsResourceNamesAsync()
         {
             // Snippet: ListAnnotatedDatasetsAsync(DatasetName, string, string, int?, CallSettings)
@@ -2474,7 +2474,7 @@ namespace Google.Cloud.DataLabeling.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListExamples</summary>
+        /// <summary>Snippet for ListExamplesAsync</summary>
         public async Task ListExamplesRequestObjectAsync()
         {
             // Snippet: ListExamplesAsync(ListExamplesRequest, CallSettings)
@@ -2569,7 +2569,7 @@ namespace Google.Cloud.DataLabeling.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListExamples</summary>
+        /// <summary>Snippet for ListExamplesAsync</summary>
         public async Task ListExamplesAsync()
         {
             // Snippet: ListExamplesAsync(string, string, string, int?, CallSettings)
@@ -2661,7 +2661,7 @@ namespace Google.Cloud.DataLabeling.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListExamples</summary>
+        /// <summary>Snippet for ListExamplesAsync</summary>
         public async Task ListExamplesResourceNamesAsync()
         {
             // Snippet: ListExamplesAsync(AnnotatedDatasetName, string, string, int?, CallSettings)
@@ -2936,7 +2936,7 @@ namespace Google.Cloud.DataLabeling.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAnnotationSpecSets</summary>
+        /// <summary>Snippet for ListAnnotationSpecSetsAsync</summary>
         public async Task ListAnnotationSpecSetsRequestObjectAsync()
         {
             // Snippet: ListAnnotationSpecSetsAsync(ListAnnotationSpecSetsRequest, CallSettings)
@@ -3031,7 +3031,7 @@ namespace Google.Cloud.DataLabeling.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAnnotationSpecSets</summary>
+        /// <summary>Snippet for ListAnnotationSpecSetsAsync</summary>
         public async Task ListAnnotationSpecSetsAsync()
         {
             // Snippet: ListAnnotationSpecSetsAsync(string, string, string, int?, CallSettings)
@@ -3123,7 +3123,7 @@ namespace Google.Cloud.DataLabeling.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAnnotationSpecSets</summary>
+        /// <summary>Snippet for ListAnnotationSpecSetsAsync</summary>
         public async Task ListAnnotationSpecSetsResourceNamesAsync()
         {
             // Snippet: ListAnnotationSpecSetsAsync(ProjectName, string, string, int?, CallSettings)
@@ -3581,7 +3581,7 @@ namespace Google.Cloud.DataLabeling.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListInstructions</summary>
+        /// <summary>Snippet for ListInstructionsAsync</summary>
         public async Task ListInstructionsRequestObjectAsync()
         {
             // Snippet: ListInstructionsAsync(ListInstructionsRequest, CallSettings)
@@ -3676,7 +3676,7 @@ namespace Google.Cloud.DataLabeling.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListInstructions</summary>
+        /// <summary>Snippet for ListInstructionsAsync</summary>
         public async Task ListInstructionsAsync()
         {
             // Snippet: ListInstructionsAsync(string, string, string, int?, CallSettings)
@@ -3768,7 +3768,7 @@ namespace Google.Cloud.DataLabeling.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListInstructions</summary>
+        /// <summary>Snippet for ListInstructionsAsync</summary>
         public async Task ListInstructionsResourceNamesAsync()
         {
             // Snippet: ListInstructionsAsync(ProjectName, string, string, int?, CallSettings)
@@ -4037,7 +4037,7 @@ namespace Google.Cloud.DataLabeling.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for SearchEvaluations</summary>
+        /// <summary>Snippet for SearchEvaluationsAsync</summary>
         public async Task SearchEvaluationsRequestObjectAsync()
         {
             // Snippet: SearchEvaluationsAsync(SearchEvaluationsRequest, CallSettings)
@@ -4132,7 +4132,7 @@ namespace Google.Cloud.DataLabeling.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for SearchEvaluations</summary>
+        /// <summary>Snippet for SearchEvaluationsAsync</summary>
         public async Task SearchEvaluationsAsync()
         {
             // Snippet: SearchEvaluationsAsync(string, string, string, int?, CallSettings)
@@ -4224,7 +4224,7 @@ namespace Google.Cloud.DataLabeling.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for SearchEvaluations</summary>
+        /// <summary>Snippet for SearchEvaluationsAsync</summary>
         public async Task SearchEvaluationsResourceNamesAsync()
         {
             // Snippet: SearchEvaluationsAsync(EvaluationName, string, string, int?, CallSettings)
@@ -4318,7 +4318,7 @@ namespace Google.Cloud.DataLabeling.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for SearchExampleComparisons</summary>
+        /// <summary>Snippet for SearchExampleComparisonsAsync</summary>
         public async Task SearchExampleComparisonsRequestObjectAsync()
         {
             // Snippet: SearchExampleComparisonsAsync(SearchExampleComparisonsRequest, CallSettings)
@@ -4411,7 +4411,7 @@ namespace Google.Cloud.DataLabeling.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for SearchExampleComparisons</summary>
+        /// <summary>Snippet for SearchExampleComparisonsAsync</summary>
         public async Task SearchExampleComparisonsAsync()
         {
             // Snippet: SearchExampleComparisonsAsync(string, string, int?, CallSettings)
@@ -4501,7 +4501,7 @@ namespace Google.Cloud.DataLabeling.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for SearchExampleComparisons</summary>
+        /// <summary>Snippet for SearchExampleComparisonsAsync</summary>
         public async Task SearchExampleComparisonsResourceNamesAsync()
         {
             // Snippet: SearchExampleComparisonsAsync(EvaluationName, string, int?, CallSettings)
@@ -5100,7 +5100,7 @@ namespace Google.Cloud.DataLabeling.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListEvaluationJobs</summary>
+        /// <summary>Snippet for ListEvaluationJobsAsync</summary>
         public async Task ListEvaluationJobsRequestObjectAsync()
         {
             // Snippet: ListEvaluationJobsAsync(ListEvaluationJobsRequest, CallSettings)
@@ -5195,7 +5195,7 @@ namespace Google.Cloud.DataLabeling.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListEvaluationJobs</summary>
+        /// <summary>Snippet for ListEvaluationJobsAsync</summary>
         public async Task ListEvaluationJobsAsync()
         {
             // Snippet: ListEvaluationJobsAsync(string, string, string, int?, CallSettings)
@@ -5287,7 +5287,7 @@ namespace Google.Cloud.DataLabeling.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListEvaluationJobs</summary>
+        /// <summary>Snippet for ListEvaluationJobsAsync</summary>
         public async Task ListEvaluationJobsResourceNamesAsync()
         {
             // Snippet: ListEvaluationJobsAsync(ProjectName, string, string, int?, CallSettings)

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.Snippets/AutoscalingPolicyServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.Snippets/AutoscalingPolicyServiceClientSnippets.g.cs
@@ -342,7 +342,7 @@ namespace Google.Cloud.Dataproc.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAutoscalingPolicies</summary>
+        /// <summary>Snippet for ListAutoscalingPoliciesAsync</summary>
         public async Task ListAutoscalingPoliciesRequestObjectAsync()
         {
             // Snippet: ListAutoscalingPoliciesAsync(ListAutoscalingPoliciesRequest, CallSettings)
@@ -435,7 +435,7 @@ namespace Google.Cloud.Dataproc.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAutoscalingPolicies</summary>
+        /// <summary>Snippet for ListAutoscalingPoliciesAsync</summary>
         public async Task ListAutoscalingPoliciesAsync()
         {
             // Snippet: ListAutoscalingPoliciesAsync(string, string, int?, CallSettings)
@@ -525,7 +525,7 @@ namespace Google.Cloud.Dataproc.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAutoscalingPolicies</summary>
+        /// <summary>Snippet for ListAutoscalingPoliciesAsync</summary>
         public async Task ListAutoscalingPoliciesResourceNames1Async()
         {
             // Snippet: ListAutoscalingPoliciesAsync(LocationName, string, int?, CallSettings)
@@ -615,7 +615,7 @@ namespace Google.Cloud.Dataproc.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAutoscalingPolicies</summary>
+        /// <summary>Snippet for ListAutoscalingPoliciesAsync</summary>
         public async Task ListAutoscalingPoliciesResourceNames2Async()
         {
             // Snippet: ListAutoscalingPoliciesAsync(RegionName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.Snippets/ClusterControllerClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.Snippets/ClusterControllerClientSnippets.g.cs
@@ -558,7 +558,7 @@ namespace Google.Cloud.Dataproc.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListClusters</summary>
+        /// <summary>Snippet for ListClustersAsync</summary>
         public async Task ListClustersRequestObjectAsync()
         {
             // Snippet: ListClustersAsync(ListClustersRequest, CallSettings)
@@ -654,7 +654,7 @@ namespace Google.Cloud.Dataproc.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListClusters</summary>
+        /// <summary>Snippet for ListClustersAsync</summary>
         public async Task ListClusters1Async()
         {
             // Snippet: ListClustersAsync(string, string, string, int?, CallSettings)
@@ -747,7 +747,7 @@ namespace Google.Cloud.Dataproc.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListClusters</summary>
+        /// <summary>Snippet for ListClustersAsync</summary>
         public async Task ListClusters2Async()
         {
             // Snippet: ListClustersAsync(string, string, string, string, int?, CallSettings)

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.Snippets/JobControllerClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.Snippets/JobControllerClientSnippets.g.cs
@@ -350,7 +350,7 @@ namespace Google.Cloud.Dataproc.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListJobs</summary>
+        /// <summary>Snippet for ListJobsAsync</summary>
         public async Task ListJobsRequestObjectAsync()
         {
             // Snippet: ListJobsAsync(ListJobsRequest, CallSettings)
@@ -448,7 +448,7 @@ namespace Google.Cloud.Dataproc.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListJobs</summary>
+        /// <summary>Snippet for ListJobsAsync</summary>
         public async Task ListJobs1Async()
         {
             // Snippet: ListJobsAsync(string, string, string, int?, CallSettings)
@@ -541,7 +541,7 @@ namespace Google.Cloud.Dataproc.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListJobs</summary>
+        /// <summary>Snippet for ListJobsAsync</summary>
         public async Task ListJobs2Async()
         {
             // Snippet: ListJobsAsync(string, string, string, string, int?, CallSettings)

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.Snippets/WorkflowTemplateServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.Snippets/WorkflowTemplateServiceClientSnippets.g.cs
@@ -910,7 +910,7 @@ namespace Google.Cloud.Dataproc.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListWorkflowTemplates</summary>
+        /// <summary>Snippet for ListWorkflowTemplatesAsync</summary>
         public async Task ListWorkflowTemplatesRequestObjectAsync()
         {
             // Snippet: ListWorkflowTemplatesAsync(ListWorkflowTemplatesRequest, CallSettings)
@@ -1003,7 +1003,7 @@ namespace Google.Cloud.Dataproc.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListWorkflowTemplates</summary>
+        /// <summary>Snippet for ListWorkflowTemplatesAsync</summary>
         public async Task ListWorkflowTemplatesAsync()
         {
             // Snippet: ListWorkflowTemplatesAsync(string, string, int?, CallSettings)
@@ -1093,7 +1093,7 @@ namespace Google.Cloud.Dataproc.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListWorkflowTemplates</summary>
+        /// <summary>Snippet for ListWorkflowTemplatesAsync</summary>
         public async Task ListWorkflowTemplatesResourceNames1Async()
         {
             // Snippet: ListWorkflowTemplatesAsync(RegionName, string, int?, CallSettings)
@@ -1183,7 +1183,7 @@ namespace Google.Cloud.Dataproc.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListWorkflowTemplates</summary>
+        /// <summary>Snippet for ListWorkflowTemplatesAsync</summary>
         public async Task ListWorkflowTemplatesResourceNames2Async()
         {
             // Snippet: ListWorkflowTemplatesAsync(LocationName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.Snippets/DatastoreAdminClientSnippets.g.cs
+++ b/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.Snippets/DatastoreAdminClientSnippets.g.cs
@@ -518,7 +518,7 @@ namespace Google.Cloud.Datastore.Admin.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListIndexes</summary>
+        /// <summary>Snippet for ListIndexesAsync</summary>
         public async Task ListIndexesRequestObjectAsync()
         {
             // Snippet: ListIndexesAsync(ListIndexesRequest, CallSettings)

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/AgentsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/AgentsClientSnippets.g.cs
@@ -75,7 +75,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAgents</summary>
+        /// <summary>Snippet for ListAgentsAsync</summary>
         public async Task ListAgentsRequestObjectAsync()
         {
             // Snippet: ListAgentsAsync(ListAgentsRequest, CallSettings)
@@ -168,7 +168,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAgents</summary>
+        /// <summary>Snippet for ListAgentsAsync</summary>
         public async Task ListAgentsAsync()
         {
             // Snippet: ListAgentsAsync(string, string, int?, CallSettings)
@@ -258,7 +258,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAgents</summary>
+        /// <summary>Snippet for ListAgentsAsync</summary>
         public async Task ListAgentsResourceNamesAsync()
         {
             // Snippet: ListAgentsAsync(LocationName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/EntityTypesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/EntityTypesClientSnippets.g.cs
@@ -74,7 +74,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListEntityTypes</summary>
+        /// <summary>Snippet for ListEntityTypesAsync</summary>
         public async Task ListEntityTypesRequestObjectAsync()
         {
             // Snippet: ListEntityTypesAsync(ListEntityTypesRequest, CallSettings)
@@ -168,7 +168,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListEntityTypes</summary>
+        /// <summary>Snippet for ListEntityTypesAsync</summary>
         public async Task ListEntityTypesAsync()
         {
             // Snippet: ListEntityTypesAsync(string, string, int?, CallSettings)
@@ -258,7 +258,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListEntityTypes</summary>
+        /// <summary>Snippet for ListEntityTypesAsync</summary>
         public async Task ListEntityTypesResourceNamesAsync()
         {
             // Snippet: ListEntityTypesAsync(AgentName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/EnvironmentsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/EnvironmentsClientSnippets.g.cs
@@ -75,7 +75,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListEnvironments</summary>
+        /// <summary>Snippet for ListEnvironmentsAsync</summary>
         public async Task ListEnvironmentsRequestObjectAsync()
         {
             // Snippet: ListEnvironmentsAsync(ListEnvironmentsRequest, CallSettings)
@@ -168,7 +168,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListEnvironments</summary>
+        /// <summary>Snippet for ListEnvironmentsAsync</summary>
         public async Task ListEnvironmentsAsync()
         {
             // Snippet: ListEnvironmentsAsync(string, string, int?, CallSettings)
@@ -258,7 +258,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListEnvironments</summary>
+        /// <summary>Snippet for ListEnvironmentsAsync</summary>
         public async Task ListEnvironmentsResourceNamesAsync()
         {
             // Snippet: ListEnvironmentsAsync(AgentName, string, int?, CallSettings)
@@ -842,7 +842,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for LookupEnvironmentHistory</summary>
+        /// <summary>Snippet for LookupEnvironmentHistoryAsync</summary>
         public async Task LookupEnvironmentHistoryRequestObjectAsync()
         {
             // Snippet: LookupEnvironmentHistoryAsync(LookupEnvironmentHistoryRequest, CallSettings)
@@ -935,7 +935,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for LookupEnvironmentHistory</summary>
+        /// <summary>Snippet for LookupEnvironmentHistoryAsync</summary>
         public async Task LookupEnvironmentHistoryAsync()
         {
             // Snippet: LookupEnvironmentHistoryAsync(string, string, int?, CallSettings)
@@ -1025,7 +1025,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for LookupEnvironmentHistory</summary>
+        /// <summary>Snippet for LookupEnvironmentHistoryAsync</summary>
         public async Task LookupEnvironmentHistoryResourceNamesAsync()
         {
             // Snippet: LookupEnvironmentHistoryAsync(EnvironmentName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/ExperimentsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/ExperimentsClientSnippets.g.cs
@@ -73,7 +73,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListExperiments</summary>
+        /// <summary>Snippet for ListExperimentsAsync</summary>
         public async Task ListExperimentsRequestObjectAsync()
         {
             // Snippet: ListExperimentsAsync(ListExperimentsRequest, CallSettings)
@@ -166,7 +166,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListExperiments</summary>
+        /// <summary>Snippet for ListExperimentsAsync</summary>
         public async Task ListExperimentsAsync()
         {
             // Snippet: ListExperimentsAsync(string, string, int?, CallSettings)
@@ -256,7 +256,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListExperiments</summary>
+        /// <summary>Snippet for ListExperimentsAsync</summary>
         public async Task ListExperimentsResourceNamesAsync()
         {
             // Snippet: ListExperimentsAsync(EnvironmentName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/FlowsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/FlowsClientSnippets.g.cs
@@ -259,7 +259,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListFlows</summary>
+        /// <summary>Snippet for ListFlowsAsync</summary>
         public async Task ListFlowsRequestObjectAsync()
         {
             // Snippet: ListFlowsAsync(ListFlowsRequest, CallSettings)
@@ -353,7 +353,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListFlows</summary>
+        /// <summary>Snippet for ListFlowsAsync</summary>
         public async Task ListFlowsAsync()
         {
             // Snippet: ListFlowsAsync(string, string, int?, CallSettings)
@@ -443,7 +443,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListFlows</summary>
+        /// <summary>Snippet for ListFlowsAsync</summary>
         public async Task ListFlowsResourceNamesAsync()
         {
             // Snippet: ListFlowsAsync(AgentName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/IntentsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/IntentsClientSnippets.g.cs
@@ -75,7 +75,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListIntents</summary>
+        /// <summary>Snippet for ListIntentsAsync</summary>
         public async Task ListIntentsRequestObjectAsync()
         {
             // Snippet: ListIntentsAsync(ListIntentsRequest, CallSettings)
@@ -170,7 +170,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListIntents</summary>
+        /// <summary>Snippet for ListIntentsAsync</summary>
         public async Task ListIntentsAsync()
         {
             // Snippet: ListIntentsAsync(string, string, int?, CallSettings)
@@ -260,7 +260,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListIntents</summary>
+        /// <summary>Snippet for ListIntentsAsync</summary>
         public async Task ListIntentsResourceNamesAsync()
         {
             // Snippet: ListIntentsAsync(AgentName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/PagesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/PagesClientSnippets.g.cs
@@ -74,7 +74,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListPages</summary>
+        /// <summary>Snippet for ListPagesAsync</summary>
         public async Task ListPagesRequestObjectAsync()
         {
             // Snippet: ListPagesAsync(ListPagesRequest, CallSettings)
@@ -168,7 +168,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListPages</summary>
+        /// <summary>Snippet for ListPagesAsync</summary>
         public async Task ListPagesAsync()
         {
             // Snippet: ListPagesAsync(string, string, int?, CallSettings)
@@ -258,7 +258,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListPages</summary>
+        /// <summary>Snippet for ListPagesAsync</summary>
         public async Task ListPagesResourceNamesAsync()
         {
             // Snippet: ListPagesAsync(FlowName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/SecuritySettingsServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/SecuritySettingsServiceClientSnippets.g.cs
@@ -318,7 +318,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSecuritySettings</summary>
+        /// <summary>Snippet for ListSecuritySettingsAsync</summary>
         public async Task ListSecuritySettingsRequestObjectAsync()
         {
             // Snippet: ListSecuritySettingsAsync(ListSecuritySettingsRequest, CallSettings)
@@ -411,7 +411,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSecuritySettings</summary>
+        /// <summary>Snippet for ListSecuritySettingsAsync</summary>
         public async Task ListSecuritySettingsAsync()
         {
             // Snippet: ListSecuritySettingsAsync(string, string, int?, CallSettings)
@@ -501,7 +501,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSecuritySettings</summary>
+        /// <summary>Snippet for ListSecuritySettingsAsync</summary>
         public async Task ListSecuritySettingsResourceNamesAsync()
         {
             // Snippet: ListSecuritySettingsAsync(LocationName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/SessionEntityTypesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/SessionEntityTypesClientSnippets.g.cs
@@ -73,7 +73,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSessionEntityTypes</summary>
+        /// <summary>Snippet for ListSessionEntityTypesAsync</summary>
         public async Task ListSessionEntityTypesRequestObjectAsync()
         {
             // Snippet: ListSessionEntityTypesAsync(ListSessionEntityTypesRequest, CallSettings)
@@ -166,7 +166,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSessionEntityTypes</summary>
+        /// <summary>Snippet for ListSessionEntityTypesAsync</summary>
         public async Task ListSessionEntityTypesAsync()
         {
             // Snippet: ListSessionEntityTypesAsync(string, string, int?, CallSettings)
@@ -256,7 +256,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSessionEntityTypes</summary>
+        /// <summary>Snippet for ListSessionEntityTypesAsync</summary>
         public async Task ListSessionEntityTypesResourceNamesAsync()
         {
             // Snippet: ListSessionEntityTypesAsync(SessionName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/TestCasesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/TestCasesClientSnippets.g.cs
@@ -75,7 +75,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTestCases</summary>
+        /// <summary>Snippet for ListTestCasesAsync</summary>
         public async Task ListTestCasesRequestObjectAsync()
         {
             // Snippet: ListTestCasesAsync(ListTestCasesRequest, CallSettings)
@@ -169,7 +169,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTestCases</summary>
+        /// <summary>Snippet for ListTestCasesAsync</summary>
         public async Task ListTestCasesAsync()
         {
             // Snippet: ListTestCasesAsync(string, string, int?, CallSettings)
@@ -259,7 +259,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTestCases</summary>
+        /// <summary>Snippet for ListTestCasesAsync</summary>
         public async Task ListTestCasesResourceNamesAsync()
         {
             // Snippet: ListTestCasesAsync(AgentName, string, int?, CallSettings)
@@ -1007,7 +1007,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTestCaseResults</summary>
+        /// <summary>Snippet for ListTestCaseResultsAsync</summary>
         public async Task ListTestCaseResultsRequestObjectAsync()
         {
             // Snippet: ListTestCaseResultsAsync(ListTestCaseResultsRequest, CallSettings)
@@ -1101,7 +1101,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTestCaseResults</summary>
+        /// <summary>Snippet for ListTestCaseResultsAsync</summary>
         public async Task ListTestCaseResultsAsync()
         {
             // Snippet: ListTestCaseResultsAsync(string, string, int?, CallSettings)
@@ -1191,7 +1191,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTestCaseResults</summary>
+        /// <summary>Snippet for ListTestCaseResultsAsync</summary>
         public async Task ListTestCaseResultsResourceNamesAsync()
         {
             // Snippet: ListTestCaseResultsAsync(TestCaseName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/TransitionRouteGroupsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/TransitionRouteGroupsClientSnippets.g.cs
@@ -74,7 +74,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTransitionRouteGroups</summary>
+        /// <summary>Snippet for ListTransitionRouteGroupsAsync</summary>
         public async Task ListTransitionRouteGroupsRequestObjectAsync()
         {
             // Snippet: ListTransitionRouteGroupsAsync(ListTransitionRouteGroupsRequest, CallSettings)
@@ -168,7 +168,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTransitionRouteGroups</summary>
+        /// <summary>Snippet for ListTransitionRouteGroupsAsync</summary>
         public async Task ListTransitionRouteGroupsAsync()
         {
             // Snippet: ListTransitionRouteGroupsAsync(string, string, int?, CallSettings)
@@ -258,7 +258,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTransitionRouteGroups</summary>
+        /// <summary>Snippet for ListTransitionRouteGroupsAsync</summary>
         public async Task ListTransitionRouteGroupsResourceNamesAsync()
         {
             // Snippet: ListTransitionRouteGroupsAsync(FlowName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/VersionsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/VersionsClientSnippets.g.cs
@@ -75,7 +75,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListVersions</summary>
+        /// <summary>Snippet for ListVersionsAsync</summary>
         public async Task ListVersionsRequestObjectAsync()
         {
             // Snippet: ListVersionsAsync(ListVersionsRequest, CallSettings)
@@ -168,7 +168,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListVersions</summary>
+        /// <summary>Snippet for ListVersionsAsync</summary>
         public async Task ListVersionsAsync()
         {
             // Snippet: ListVersionsAsync(string, string, int?, CallSettings)
@@ -258,7 +258,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListVersions</summary>
+        /// <summary>Snippet for ListVersionsAsync</summary>
         public async Task ListVersionsResourceNamesAsync()
         {
             // Snippet: ListVersionsAsync(FlowName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/WebhooksClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/WebhooksClientSnippets.g.cs
@@ -73,7 +73,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListWebhooks</summary>
+        /// <summary>Snippet for ListWebhooksAsync</summary>
         public async Task ListWebhooksRequestObjectAsync()
         {
             // Snippet: ListWebhooksAsync(ListWebhooksRequest, CallSettings)
@@ -166,7 +166,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListWebhooks</summary>
+        /// <summary>Snippet for ListWebhooksAsync</summary>
         public async Task ListWebhooksAsync()
         {
             // Snippet: ListWebhooksAsync(string, string, int?, CallSettings)
@@ -256,7 +256,7 @@ namespace Google.Cloud.Dialogflow.Cx.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListWebhooks</summary>
+        /// <summary>Snippet for ListWebhooksAsync</summary>
         public async Task ListWebhooksResourceNamesAsync()
         {
             // Snippet: ListWebhooksAsync(AgentName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/AgentsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/AgentsClientSnippets.g.cs
@@ -311,7 +311,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for SearchAgents</summary>
+        /// <summary>Snippet for SearchAgentsAsync</summary>
         public async Task SearchAgentsRequestObjectAsync()
         {
             // Snippet: SearchAgentsAsync(SearchAgentsRequest, CallSettings)
@@ -404,7 +404,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for SearchAgents</summary>
+        /// <summary>Snippet for SearchAgentsAsync</summary>
         public async Task SearchAgentsAsync()
         {
             // Snippet: SearchAgentsAsync(string, string, int?, CallSettings)
@@ -494,7 +494,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for SearchAgents</summary>
+        /// <summary>Snippet for SearchAgentsAsync</summary>
         public async Task SearchAgentsResourceNamesAsync()
         {
             // Snippet: SearchAgentsAsync(ProjectName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/AnswerRecordsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/AnswerRecordsClientSnippets.g.cs
@@ -75,7 +75,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAnswerRecords</summary>
+        /// <summary>Snippet for ListAnswerRecordsAsync</summary>
         public async Task ListAnswerRecordsRequestObjectAsync()
         {
             // Snippet: ListAnswerRecordsAsync(ListAnswerRecordsRequest, CallSettings)
@@ -169,7 +169,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAnswerRecords</summary>
+        /// <summary>Snippet for ListAnswerRecordsAsync</summary>
         public async Task ListAnswerRecordsAsync()
         {
             // Snippet: ListAnswerRecordsAsync(string, string, int?, CallSettings)
@@ -259,7 +259,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAnswerRecords</summary>
+        /// <summary>Snippet for ListAnswerRecordsAsync</summary>
         public async Task ListAnswerRecordsResourceNames1Async()
         {
             // Snippet: ListAnswerRecordsAsync(ProjectName, string, int?, CallSettings)
@@ -349,7 +349,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAnswerRecords</summary>
+        /// <summary>Snippet for ListAnswerRecordsAsync</summary>
         public async Task ListAnswerRecordsResourceNames2Async()
         {
             // Snippet: ListAnswerRecordsAsync(LocationName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/ContextsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/ContextsClientSnippets.g.cs
@@ -73,7 +73,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListContexts</summary>
+        /// <summary>Snippet for ListContextsAsync</summary>
         public async Task ListContextsRequestObjectAsync()
         {
             // Snippet: ListContextsAsync(ListContextsRequest, CallSettings)
@@ -166,7 +166,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListContexts</summary>
+        /// <summary>Snippet for ListContextsAsync</summary>
         public async Task ListContextsAsync()
         {
             // Snippet: ListContextsAsync(string, string, int?, CallSettings)
@@ -256,7 +256,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListContexts</summary>
+        /// <summary>Snippet for ListContextsAsync</summary>
         public async Task ListContextsResourceNamesAsync()
         {
             // Snippet: ListContextsAsync(SessionName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/ConversationProfilesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/ConversationProfilesClientSnippets.g.cs
@@ -74,7 +74,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListConversationProfiles</summary>
+        /// <summary>Snippet for ListConversationProfilesAsync</summary>
         public async Task ListConversationProfilesRequestObjectAsync()
         {
             // Snippet: ListConversationProfilesAsync(ListConversationProfilesRequest, CallSettings)
@@ -167,7 +167,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListConversationProfiles</summary>
+        /// <summary>Snippet for ListConversationProfilesAsync</summary>
         public async Task ListConversationProfilesAsync()
         {
             // Snippet: ListConversationProfilesAsync(string, string, int?, CallSettings)
@@ -257,7 +257,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListConversationProfiles</summary>
+        /// <summary>Snippet for ListConversationProfilesAsync</summary>
         public async Task ListConversationProfilesResourceNames1Async()
         {
             // Snippet: ListConversationProfilesAsync(ProjectName, string, int?, CallSettings)
@@ -347,7 +347,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListConversationProfiles</summary>
+        /// <summary>Snippet for ListConversationProfilesAsync</summary>
         public async Task ListConversationProfilesResourceNames2Async()
         {
             // Snippet: ListConversationProfilesAsync(LocationName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/ConversationsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/ConversationsClientSnippets.g.cs
@@ -198,7 +198,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListConversations</summary>
+        /// <summary>Snippet for ListConversationsAsync</summary>
         public async Task ListConversationsRequestObjectAsync()
         {
             // Snippet: ListConversationsAsync(ListConversationsRequest, CallSettings)
@@ -292,7 +292,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListConversations</summary>
+        /// <summary>Snippet for ListConversationsAsync</summary>
         public async Task ListConversationsAsync()
         {
             // Snippet: ListConversationsAsync(string, string, int?, CallSettings)
@@ -382,7 +382,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListConversations</summary>
+        /// <summary>Snippet for ListConversationsAsync</summary>
         public async Task ListConversationsResourceNames1Async()
         {
             // Snippet: ListConversationsAsync(ProjectName, string, int?, CallSettings)
@@ -472,7 +472,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListConversations</summary>
+        /// <summary>Snippet for ListConversationsAsync</summary>
         public async Task ListConversationsResourceNames2Async()
         {
             // Snippet: ListConversationsAsync(LocationName, string, int?, CallSettings)
@@ -740,7 +740,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListMessages</summary>
+        /// <summary>Snippet for ListMessagesAsync</summary>
         public async Task ListMessagesRequestObjectAsync()
         {
             // Snippet: ListMessagesAsync(ListMessagesRequest, CallSettings)
@@ -834,7 +834,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListMessages</summary>
+        /// <summary>Snippet for ListMessagesAsync</summary>
         public async Task ListMessagesAsync()
         {
             // Snippet: ListMessagesAsync(string, string, int?, CallSettings)
@@ -924,7 +924,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListMessages</summary>
+        /// <summary>Snippet for ListMessagesAsync</summary>
         public async Task ListMessagesResourceNamesAsync()
         {
             // Snippet: ListMessagesAsync(ConversationName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/DocumentsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/DocumentsClientSnippets.g.cs
@@ -74,7 +74,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDocuments</summary>
+        /// <summary>Snippet for ListDocumentsAsync</summary>
         public async Task ListDocumentsRequestObjectAsync()
         {
             // Snippet: ListDocumentsAsync(ListDocumentsRequest, CallSettings)
@@ -167,7 +167,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDocuments</summary>
+        /// <summary>Snippet for ListDocumentsAsync</summary>
         public async Task ListDocumentsAsync()
         {
             // Snippet: ListDocumentsAsync(string, string, int?, CallSettings)
@@ -257,7 +257,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDocuments</summary>
+        /// <summary>Snippet for ListDocumentsAsync</summary>
         public async Task ListDocumentsResourceNamesAsync()
         {
             // Snippet: ListDocumentsAsync(KnowledgeBaseName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/EntityTypesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/EntityTypesClientSnippets.g.cs
@@ -76,7 +76,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListEntityTypes</summary>
+        /// <summary>Snippet for ListEntityTypesAsync</summary>
         public async Task ListEntityTypesRequestObjectAsync()
         {
             // Snippet: ListEntityTypesAsync(ListEntityTypesRequest, CallSettings)
@@ -170,7 +170,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListEntityTypes</summary>
+        /// <summary>Snippet for ListEntityTypesAsync</summary>
         public async Task ListEntityTypes1Async()
         {
             // Snippet: ListEntityTypesAsync(string, string, int?, CallSettings)
@@ -260,7 +260,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListEntityTypes</summary>
+        /// <summary>Snippet for ListEntityTypesAsync</summary>
         public async Task ListEntityTypes1ResourceNamesAsync()
         {
             // Snippet: ListEntityTypesAsync(AgentName, string, int?, CallSettings)
@@ -351,7 +351,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListEntityTypes</summary>
+        /// <summary>Snippet for ListEntityTypesAsync</summary>
         public async Task ListEntityTypes2Async()
         {
             // Snippet: ListEntityTypesAsync(string, string, string, int?, CallSettings)
@@ -443,7 +443,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListEntityTypes</summary>
+        /// <summary>Snippet for ListEntityTypesAsync</summary>
         public async Task ListEntityTypes2ResourceNamesAsync()
         {
             // Snippet: ListEntityTypesAsync(AgentName, string, string, int?, CallSettings)

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/EnvironmentsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/EnvironmentsClientSnippets.g.cs
@@ -73,7 +73,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListEnvironments</summary>
+        /// <summary>Snippet for ListEnvironmentsAsync</summary>
         public async Task ListEnvironmentsRequestObjectAsync()
         {
             // Snippet: ListEnvironmentsAsync(ListEnvironmentsRequest, CallSettings)

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/IntentsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/IntentsClientSnippets.g.cs
@@ -77,7 +77,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListIntents</summary>
+        /// <summary>Snippet for ListIntentsAsync</summary>
         public async Task ListIntentsRequestObjectAsync()
         {
             // Snippet: ListIntentsAsync(ListIntentsRequest, CallSettings)
@@ -172,7 +172,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListIntents</summary>
+        /// <summary>Snippet for ListIntentsAsync</summary>
         public async Task ListIntents1Async()
         {
             // Snippet: ListIntentsAsync(string, string, int?, CallSettings)
@@ -262,7 +262,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListIntents</summary>
+        /// <summary>Snippet for ListIntentsAsync</summary>
         public async Task ListIntents1ResourceNamesAsync()
         {
             // Snippet: ListIntentsAsync(AgentName, string, int?, CallSettings)
@@ -353,7 +353,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListIntents</summary>
+        /// <summary>Snippet for ListIntentsAsync</summary>
         public async Task ListIntents2Async()
         {
             // Snippet: ListIntentsAsync(string, string, string, int?, CallSettings)
@@ -445,7 +445,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListIntents</summary>
+        /// <summary>Snippet for ListIntentsAsync</summary>
         public async Task ListIntents2ResourceNamesAsync()
         {
             // Snippet: ListIntentsAsync(AgentName, string, string, int?, CallSettings)

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/KnowledgeBasesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/KnowledgeBasesClientSnippets.g.cs
@@ -74,7 +74,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListKnowledgeBases</summary>
+        /// <summary>Snippet for ListKnowledgeBasesAsync</summary>
         public async Task ListKnowledgeBasesRequestObjectAsync()
         {
             // Snippet: ListKnowledgeBasesAsync(ListKnowledgeBasesRequest, CallSettings)
@@ -167,7 +167,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListKnowledgeBases</summary>
+        /// <summary>Snippet for ListKnowledgeBasesAsync</summary>
         public async Task ListKnowledgeBasesAsync()
         {
             // Snippet: ListKnowledgeBasesAsync(string, string, int?, CallSettings)
@@ -257,7 +257,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListKnowledgeBases</summary>
+        /// <summary>Snippet for ListKnowledgeBasesAsync</summary>
         public async Task ListKnowledgeBasesResourceNames1Async()
         {
             // Snippet: ListKnowledgeBasesAsync(ProjectName, string, int?, CallSettings)
@@ -347,7 +347,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListKnowledgeBases</summary>
+        /// <summary>Snippet for ListKnowledgeBasesAsync</summary>
         public async Task ListKnowledgeBasesResourceNames2Async()
         {
             // Snippet: ListKnowledgeBasesAsync(LocationName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/ParticipantsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/ParticipantsClientSnippets.g.cs
@@ -253,7 +253,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListParticipants</summary>
+        /// <summary>Snippet for ListParticipantsAsync</summary>
         public async Task ListParticipantsRequestObjectAsync()
         {
             // Snippet: ListParticipantsAsync(ListParticipantsRequest, CallSettings)
@@ -346,7 +346,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListParticipants</summary>
+        /// <summary>Snippet for ListParticipantsAsync</summary>
         public async Task ListParticipantsAsync()
         {
             // Snippet: ListParticipantsAsync(string, string, int?, CallSettings)
@@ -436,7 +436,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListParticipants</summary>
+        /// <summary>Snippet for ListParticipantsAsync</summary>
         public async Task ListParticipantsResourceNamesAsync()
         {
             // Snippet: ListParticipantsAsync(ConversationName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/SessionEntityTypesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/SessionEntityTypesClientSnippets.g.cs
@@ -73,7 +73,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSessionEntityTypes</summary>
+        /// <summary>Snippet for ListSessionEntityTypesAsync</summary>
         public async Task ListSessionEntityTypesRequestObjectAsync()
         {
             // Snippet: ListSessionEntityTypesAsync(ListSessionEntityTypesRequest, CallSettings)
@@ -166,7 +166,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSessionEntityTypes</summary>
+        /// <summary>Snippet for ListSessionEntityTypesAsync</summary>
         public async Task ListSessionEntityTypesAsync()
         {
             // Snippet: ListSessionEntityTypesAsync(string, string, int?, CallSettings)
@@ -256,7 +256,7 @@ namespace Google.Cloud.Dialogflow.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSessionEntityTypes</summary>
+        /// <summary>Snippet for ListSessionEntityTypesAsync</summary>
         public async Task ListSessionEntityTypesResourceNamesAsync()
         {
             // Snippet: ListSessionEntityTypesAsync(SessionName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.Snippets/DlpServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.Snippets/DlpServiceClientSnippets.g.cs
@@ -692,7 +692,7 @@ namespace Google.Cloud.Dlp.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListInspectTemplates</summary>
+        /// <summary>Snippet for ListInspectTemplatesAsync</summary>
         public async Task ListInspectTemplatesRequestObjectAsync()
         {
             // Snippet: ListInspectTemplatesAsync(ListInspectTemplatesRequest, CallSettings)
@@ -787,7 +787,7 @@ namespace Google.Cloud.Dlp.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListInspectTemplates</summary>
+        /// <summary>Snippet for ListInspectTemplatesAsync</summary>
         public async Task ListInspectTemplatesAsync()
         {
             // Snippet: ListInspectTemplatesAsync(string, string, int?, CallSettings)
@@ -877,7 +877,7 @@ namespace Google.Cloud.Dlp.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListInspectTemplates</summary>
+        /// <summary>Snippet for ListInspectTemplatesAsync</summary>
         public async Task ListInspectTemplatesResourceNames1Async()
         {
             // Snippet: ListInspectTemplatesAsync(OrganizationName, string, int?, CallSettings)
@@ -967,7 +967,7 @@ namespace Google.Cloud.Dlp.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListInspectTemplates</summary>
+        /// <summary>Snippet for ListInspectTemplatesAsync</summary>
         public async Task ListInspectTemplatesResourceNames2Async()
         {
             // Snippet: ListInspectTemplatesAsync(ProjectName, string, int?, CallSettings)
@@ -1057,7 +1057,7 @@ namespace Google.Cloud.Dlp.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListInspectTemplates</summary>
+        /// <summary>Snippet for ListInspectTemplatesAsync</summary>
         public async Task ListInspectTemplatesResourceNames3Async()
         {
             // Snippet: ListInspectTemplatesAsync(OrganizationLocationName, string, int?, CallSettings)
@@ -1147,7 +1147,7 @@ namespace Google.Cloud.Dlp.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListInspectTemplates</summary>
+        /// <summary>Snippet for ListInspectTemplatesAsync</summary>
         public async Task ListInspectTemplatesResourceNames4Async()
         {
             // Snippet: ListInspectTemplatesAsync(LocationName, string, int?, CallSettings)
@@ -1699,7 +1699,7 @@ namespace Google.Cloud.Dlp.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDeidentifyTemplates</summary>
+        /// <summary>Snippet for ListDeidentifyTemplatesAsync</summary>
         public async Task ListDeidentifyTemplatesRequestObjectAsync()
         {
             // Snippet: ListDeidentifyTemplatesAsync(ListDeidentifyTemplatesRequest, CallSettings)
@@ -1794,7 +1794,7 @@ namespace Google.Cloud.Dlp.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDeidentifyTemplates</summary>
+        /// <summary>Snippet for ListDeidentifyTemplatesAsync</summary>
         public async Task ListDeidentifyTemplatesAsync()
         {
             // Snippet: ListDeidentifyTemplatesAsync(string, string, int?, CallSettings)
@@ -1884,7 +1884,7 @@ namespace Google.Cloud.Dlp.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDeidentifyTemplates</summary>
+        /// <summary>Snippet for ListDeidentifyTemplatesAsync</summary>
         public async Task ListDeidentifyTemplatesResourceNames1Async()
         {
             // Snippet: ListDeidentifyTemplatesAsync(OrganizationName, string, int?, CallSettings)
@@ -1974,7 +1974,7 @@ namespace Google.Cloud.Dlp.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDeidentifyTemplates</summary>
+        /// <summary>Snippet for ListDeidentifyTemplatesAsync</summary>
         public async Task ListDeidentifyTemplatesResourceNames2Async()
         {
             // Snippet: ListDeidentifyTemplatesAsync(ProjectName, string, int?, CallSettings)
@@ -2064,7 +2064,7 @@ namespace Google.Cloud.Dlp.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDeidentifyTemplates</summary>
+        /// <summary>Snippet for ListDeidentifyTemplatesAsync</summary>
         public async Task ListDeidentifyTemplatesResourceNames3Async()
         {
             // Snippet: ListDeidentifyTemplatesAsync(OrganizationLocationName, string, int?, CallSettings)
@@ -2154,7 +2154,7 @@ namespace Google.Cloud.Dlp.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDeidentifyTemplates</summary>
+        /// <summary>Snippet for ListDeidentifyTemplatesAsync</summary>
         public async Task ListDeidentifyTemplatesResourceNames4Async()
         {
             // Snippet: ListDeidentifyTemplatesAsync(LocationName, string, int?, CallSettings)
@@ -2738,7 +2738,7 @@ namespace Google.Cloud.Dlp.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListJobTriggers</summary>
+        /// <summary>Snippet for ListJobTriggersAsync</summary>
         public async Task ListJobTriggersRequestObjectAsync()
         {
             // Snippet: ListJobTriggersAsync(ListJobTriggersRequest, CallSettings)
@@ -2834,7 +2834,7 @@ namespace Google.Cloud.Dlp.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListJobTriggers</summary>
+        /// <summary>Snippet for ListJobTriggersAsync</summary>
         public async Task ListJobTriggersAsync()
         {
             // Snippet: ListJobTriggersAsync(string, string, int?, CallSettings)
@@ -2924,7 +2924,7 @@ namespace Google.Cloud.Dlp.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListJobTriggers</summary>
+        /// <summary>Snippet for ListJobTriggersAsync</summary>
         public async Task ListJobTriggersResourceNames1Async()
         {
             // Snippet: ListJobTriggersAsync(ProjectName, string, int?, CallSettings)
@@ -3014,7 +3014,7 @@ namespace Google.Cloud.Dlp.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListJobTriggers</summary>
+        /// <summary>Snippet for ListJobTriggersAsync</summary>
         public async Task ListJobTriggersResourceNames2Async()
         {
             // Snippet: ListJobTriggersAsync(LocationName, string, int?, CallSettings)
@@ -3444,7 +3444,7 @@ namespace Google.Cloud.Dlp.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDlpJobs</summary>
+        /// <summary>Snippet for ListDlpJobsAsync</summary>
         public async Task ListDlpJobsRequestObjectAsync()
         {
             // Snippet: ListDlpJobsAsync(ListDlpJobsRequest, CallSettings)
@@ -3541,7 +3541,7 @@ namespace Google.Cloud.Dlp.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDlpJobs</summary>
+        /// <summary>Snippet for ListDlpJobsAsync</summary>
         public async Task ListDlpJobsAsync()
         {
             // Snippet: ListDlpJobsAsync(string, string, int?, CallSettings)
@@ -3631,7 +3631,7 @@ namespace Google.Cloud.Dlp.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDlpJobs</summary>
+        /// <summary>Snippet for ListDlpJobsAsync</summary>
         public async Task ListDlpJobsResourceNames1Async()
         {
             // Snippet: ListDlpJobsAsync(ProjectName, string, int?, CallSettings)
@@ -3721,7 +3721,7 @@ namespace Google.Cloud.Dlp.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDlpJobs</summary>
+        /// <summary>Snippet for ListDlpJobsAsync</summary>
         public async Task ListDlpJobsResourceNames2Async()
         {
             // Snippet: ListDlpJobsAsync(LocationName, string, int?, CallSettings)
@@ -4393,7 +4393,7 @@ namespace Google.Cloud.Dlp.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListStoredInfoTypes</summary>
+        /// <summary>Snippet for ListStoredInfoTypesAsync</summary>
         public async Task ListStoredInfoTypesRequestObjectAsync()
         {
             // Snippet: ListStoredInfoTypesAsync(ListStoredInfoTypesRequest, CallSettings)
@@ -4488,7 +4488,7 @@ namespace Google.Cloud.Dlp.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListStoredInfoTypes</summary>
+        /// <summary>Snippet for ListStoredInfoTypesAsync</summary>
         public async Task ListStoredInfoTypesAsync()
         {
             // Snippet: ListStoredInfoTypesAsync(string, string, int?, CallSettings)
@@ -4578,7 +4578,7 @@ namespace Google.Cloud.Dlp.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListStoredInfoTypes</summary>
+        /// <summary>Snippet for ListStoredInfoTypesAsync</summary>
         public async Task ListStoredInfoTypesResourceNames1Async()
         {
             // Snippet: ListStoredInfoTypesAsync(OrganizationName, string, int?, CallSettings)
@@ -4668,7 +4668,7 @@ namespace Google.Cloud.Dlp.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListStoredInfoTypes</summary>
+        /// <summary>Snippet for ListStoredInfoTypesAsync</summary>
         public async Task ListStoredInfoTypesResourceNames2Async()
         {
             // Snippet: ListStoredInfoTypesAsync(ProjectName, string, int?, CallSettings)
@@ -4758,7 +4758,7 @@ namespace Google.Cloud.Dlp.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListStoredInfoTypes</summary>
+        /// <summary>Snippet for ListStoredInfoTypesAsync</summary>
         public async Task ListStoredInfoTypesResourceNames3Async()
         {
             // Snippet: ListStoredInfoTypesAsync(OrganizationLocationName, string, int?, CallSettings)
@@ -4848,7 +4848,7 @@ namespace Google.Cloud.Dlp.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListStoredInfoTypes</summary>
+        /// <summary>Snippet for ListStoredInfoTypesAsync</summary>
         public async Task ListStoredInfoTypesResourceNames4Async()
         {
             // Snippet: ListStoredInfoTypesAsync(LocationName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.Snippets/DomainsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.Snippets/DomainsClientSnippets.g.cs
@@ -476,7 +476,7 @@ namespace Google.Cloud.Domains.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListRegistrations</summary>
+        /// <summary>Snippet for ListRegistrationsAsync</summary>
         public async Task ListRegistrationsRequestObjectAsync()
         {
             // Snippet: ListRegistrationsAsync(ListRegistrationsRequest, CallSettings)
@@ -570,7 +570,7 @@ namespace Google.Cloud.Domains.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListRegistrations</summary>
+        /// <summary>Snippet for ListRegistrationsAsync</summary>
         public async Task ListRegistrationsAsync()
         {
             // Snippet: ListRegistrationsAsync(string, string, int?, CallSettings)
@@ -660,7 +660,7 @@ namespace Google.Cloud.Domains.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListRegistrations</summary>
+        /// <summary>Snippet for ListRegistrationsAsync</summary>
         public async Task ListRegistrationsResourceNamesAsync()
         {
             // Snippet: ListRegistrationsAsync(LocationName, string, int?, CallSettings)

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.Snippets/ErrorStatsServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.Snippets/ErrorStatsServiceClientSnippets.g.cs
@@ -81,7 +81,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListGroupStats</summary>
+        /// <summary>Snippet for ListGroupStatsAsync</summary>
         public async Task ListGroupStatsRequestObjectAsync()
         {
             // Snippet: ListGroupStatsAsync(ListGroupStatsRequest, CallSettings)
@@ -182,7 +182,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListGroupStats</summary>
+        /// <summary>Snippet for ListGroupStatsAsync</summary>
         public async Task ListGroupStatsAsync()
         {
             // Snippet: ListGroupStatsAsync(string, QueryTimeRange, string, int?, CallSettings)
@@ -274,7 +274,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListGroupStats</summary>
+        /// <summary>Snippet for ListGroupStatsAsync</summary>
         public async Task ListGroupStatsResourceNamesAsync()
         {
             // Snippet: ListGroupStatsAsync(ProjectName, QueryTimeRange, string, int?, CallSettings)
@@ -371,7 +371,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListEvents</summary>
+        /// <summary>Snippet for ListEventsAsync</summary>
         public async Task ListEventsRequestObjectAsync()
         {
             // Snippet: ListEventsAsync(ListEventsRequest, CallSettings)
@@ -468,7 +468,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListEvents</summary>
+        /// <summary>Snippet for ListEventsAsync</summary>
         public async Task ListEventsAsync()
         {
             // Snippet: ListEventsAsync(string, string, string, int?, CallSettings)
@@ -560,7 +560,7 @@ namespace Google.Cloud.ErrorReporting.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListEvents</summary>
+        /// <summary>Snippet for ListEventsAsync</summary>
         public async Task ListEventsResourceNamesAsync()
         {
             // Snippet: ListEventsAsync(ProjectName, string, string, int?, CallSettings)

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.Snippets/FirestoreAdminClientSnippets.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.Snippets/FirestoreAdminClientSnippets.g.cs
@@ -265,7 +265,7 @@ namespace Google.Cloud.Firestore.Admin.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListIndexes</summary>
+        /// <summary>Snippet for ListIndexesAsync</summary>
         public async Task ListIndexesRequestObjectAsync()
         {
             // Snippet: ListIndexesAsync(ListIndexesRequest, CallSettings)
@@ -359,7 +359,7 @@ namespace Google.Cloud.Firestore.Admin.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListIndexes</summary>
+        /// <summary>Snippet for ListIndexesAsync</summary>
         public async Task ListIndexesAsync()
         {
             // Snippet: ListIndexesAsync(string, string, int?, CallSettings)
@@ -449,7 +449,7 @@ namespace Google.Cloud.Firestore.Admin.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListIndexes</summary>
+        /// <summary>Snippet for ListIndexesAsync</summary>
         public async Task ListIndexesResourceNamesAsync()
         {
             // Snippet: ListIndexesAsync(CollectionGroupName, string, int?, CallSettings)
@@ -930,7 +930,7 @@ namespace Google.Cloud.Firestore.Admin.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListFields</summary>
+        /// <summary>Snippet for ListFieldsAsync</summary>
         public async Task ListFieldsRequestObjectAsync()
         {
             // Snippet: ListFieldsAsync(ListFieldsRequest, CallSettings)
@@ -1024,7 +1024,7 @@ namespace Google.Cloud.Firestore.Admin.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListFields</summary>
+        /// <summary>Snippet for ListFieldsAsync</summary>
         public async Task ListFieldsAsync()
         {
             // Snippet: ListFieldsAsync(string, string, int?, CallSettings)
@@ -1114,7 +1114,7 @@ namespace Google.Cloud.Firestore.Admin.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListFields</summary>
+        /// <summary>Snippet for ListFieldsAsync</summary>
         public async Task ListFieldsResourceNamesAsync()
         {
             // Snippet: ListFieldsAsync(CollectionGroupName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.Snippets/FirestoreClientSnippets.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.Snippets/FirestoreClientSnippets.g.cs
@@ -117,7 +117,7 @@ namespace Google.Cloud.Firestore.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDocuments</summary>
+        /// <summary>Snippet for ListDocumentsAsync</summary>
         public async Task ListDocumentsRequestObjectAsync()
         {
             // Snippet: ListDocumentsAsync(ListDocumentsRequest, CallSettings)
@@ -599,7 +599,7 @@ namespace Google.Cloud.Firestore.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for PartitionQuery</summary>
+        /// <summary>Snippet for PartitionQueryAsync</summary>
         public async Task PartitionQueryRequestObjectAsync()
         {
             // Snippet: PartitionQueryAsync(PartitionQueryRequest, CallSettings)
@@ -794,7 +794,7 @@ namespace Google.Cloud.Firestore.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListCollectionIds</summary>
+        /// <summary>Snippet for ListCollectionIdsAsync</summary>
         public async Task ListCollectionIdsRequestObjectAsync()
         {
             // Snippet: ListCollectionIdsAsync(ListCollectionIdsRequest, CallSettings)
@@ -884,7 +884,7 @@ namespace Google.Cloud.Firestore.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListCollectionIds</summary>
+        /// <summary>Snippet for ListCollectionIdsAsync</summary>
         public async Task ListCollectionIdsAsync()
         {
             // Snippet: ListCollectionIdsAsync(string, string, int?, CallSettings)

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.Snippets/CloudFunctionsServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.Snippets/CloudFunctionsServiceClientSnippets.g.cs
@@ -76,7 +76,7 @@ namespace Google.Cloud.Functions.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListFunctions</summary>
+        /// <summary>Snippet for ListFunctionsAsync</summary>
         public async Task ListFunctionsRequestObjectAsync()
         {
             // Snippet: ListFunctionsAsync(ListFunctionsRequest, CallSettings)

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.Snippets/GSuiteAddOnsClientSnippets.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.Snippets/GSuiteAddOnsClientSnippets.g.cs
@@ -406,7 +406,7 @@ namespace Google.Cloud.GSuiteAddOns.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDeployments</summary>
+        /// <summary>Snippet for ListDeploymentsAsync</summary>
         public async Task ListDeploymentsRequestObjectAsync()
         {
             // Snippet: ListDeploymentsAsync(ListDeploymentsRequest, CallSettings)
@@ -499,7 +499,7 @@ namespace Google.Cloud.GSuiteAddOns.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDeployments</summary>
+        /// <summary>Snippet for ListDeploymentsAsync</summary>
         public async Task ListDeploymentsAsync()
         {
             // Snippet: ListDeploymentsAsync(string, string, int?, CallSettings)
@@ -589,7 +589,7 @@ namespace Google.Cloud.GSuiteAddOns.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDeployments</summary>
+        /// <summary>Snippet for ListDeploymentsAsync</summary>
         public async Task ListDeploymentsResourceNamesAsync()
         {
             // Snippet: ListDeploymentsAsync(ProjectName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Gaming.V1/Google.Cloud.Gaming.V1.Snippets/GameServerClustersServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Gaming.V1/Google.Cloud.Gaming.V1.Snippets/GameServerClustersServiceClientSnippets.g.cs
@@ -76,7 +76,7 @@ namespace Google.Cloud.Gaming.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListGameServerClusters</summary>
+        /// <summary>Snippet for ListGameServerClustersAsync</summary>
         public async Task ListGameServerClustersRequestObjectAsync()
         {
             // Snippet: ListGameServerClustersAsync(ListGameServerClustersRequest, CallSettings)
@@ -171,7 +171,7 @@ namespace Google.Cloud.Gaming.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListGameServerClusters</summary>
+        /// <summary>Snippet for ListGameServerClustersAsync</summary>
         public async Task ListGameServerClustersAsync()
         {
             // Snippet: ListGameServerClustersAsync(string, string, int?, CallSettings)
@@ -261,7 +261,7 @@ namespace Google.Cloud.Gaming.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListGameServerClusters</summary>
+        /// <summary>Snippet for ListGameServerClustersAsync</summary>
         public async Task ListGameServerClustersResourceNamesAsync()
         {
             // Snippet: ListGameServerClustersAsync(RealmName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Gaming.V1/Google.Cloud.Gaming.V1.Snippets/GameServerConfigsServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Gaming.V1/Google.Cloud.Gaming.V1.Snippets/GameServerConfigsServiceClientSnippets.g.cs
@@ -76,7 +76,7 @@ namespace Google.Cloud.Gaming.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListGameServerConfigs</summary>
+        /// <summary>Snippet for ListGameServerConfigsAsync</summary>
         public async Task ListGameServerConfigsRequestObjectAsync()
         {
             // Snippet: ListGameServerConfigsAsync(ListGameServerConfigsRequest, CallSettings)
@@ -171,7 +171,7 @@ namespace Google.Cloud.Gaming.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListGameServerConfigs</summary>
+        /// <summary>Snippet for ListGameServerConfigsAsync</summary>
         public async Task ListGameServerConfigsAsync()
         {
             // Snippet: ListGameServerConfigsAsync(string, string, int?, CallSettings)
@@ -261,7 +261,7 @@ namespace Google.Cloud.Gaming.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListGameServerConfigs</summary>
+        /// <summary>Snippet for ListGameServerConfigsAsync</summary>
         public async Task ListGameServerConfigsResourceNamesAsync()
         {
             // Snippet: ListGameServerConfigsAsync(GameServerDeploymentName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Gaming.V1/Google.Cloud.Gaming.V1.Snippets/GameServerDeploymentsServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Gaming.V1/Google.Cloud.Gaming.V1.Snippets/GameServerDeploymentsServiceClientSnippets.g.cs
@@ -77,7 +77,7 @@ namespace Google.Cloud.Gaming.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListGameServerDeployments</summary>
+        /// <summary>Snippet for ListGameServerDeploymentsAsync</summary>
         public async Task ListGameServerDeploymentsRequestObjectAsync()
         {
             // Snippet: ListGameServerDeploymentsAsync(ListGameServerDeploymentsRequest, CallSettings)
@@ -172,7 +172,7 @@ namespace Google.Cloud.Gaming.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListGameServerDeployments</summary>
+        /// <summary>Snippet for ListGameServerDeploymentsAsync</summary>
         public async Task ListGameServerDeploymentsAsync()
         {
             // Snippet: ListGameServerDeploymentsAsync(string, string, int?, CallSettings)
@@ -262,7 +262,7 @@ namespace Google.Cloud.Gaming.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListGameServerDeployments</summary>
+        /// <summary>Snippet for ListGameServerDeploymentsAsync</summary>
         public async Task ListGameServerDeploymentsResourceNamesAsync()
         {
             // Snippet: ListGameServerDeploymentsAsync(LocationName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Gaming.V1/Google.Cloud.Gaming.V1.Snippets/RealmsServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Gaming.V1/Google.Cloud.Gaming.V1.Snippets/RealmsServiceClientSnippets.g.cs
@@ -77,7 +77,7 @@ namespace Google.Cloud.Gaming.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListRealms</summary>
+        /// <summary>Snippet for ListRealmsAsync</summary>
         public async Task ListRealmsRequestObjectAsync()
         {
             // Snippet: ListRealmsAsync(ListRealmsRequest, CallSettings)
@@ -172,7 +172,7 @@ namespace Google.Cloud.Gaming.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListRealms</summary>
+        /// <summary>Snippet for ListRealmsAsync</summary>
         public async Task ListRealmsAsync()
         {
             // Snippet: ListRealmsAsync(string, string, int?, CallSettings)
@@ -262,7 +262,7 @@ namespace Google.Cloud.Gaming.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListRealms</summary>
+        /// <summary>Snippet for ListRealmsAsync</summary>
         public async Task ListRealmsResourceNamesAsync()
         {
             // Snippet: ListRealmsAsync(LocationName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta.Snippets/GameServerClustersServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta.Snippets/GameServerClustersServiceClientSnippets.g.cs
@@ -76,7 +76,7 @@ namespace Google.Cloud.Gaming.V1Beta.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListGameServerClusters</summary>
+        /// <summary>Snippet for ListGameServerClustersAsync</summary>
         public async Task ListGameServerClustersRequestObjectAsync()
         {
             // Snippet: ListGameServerClustersAsync(ListGameServerClustersRequest, CallSettings)
@@ -171,7 +171,7 @@ namespace Google.Cloud.Gaming.V1Beta.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListGameServerClusters</summary>
+        /// <summary>Snippet for ListGameServerClustersAsync</summary>
         public async Task ListGameServerClustersAsync()
         {
             // Snippet: ListGameServerClustersAsync(string, string, int?, CallSettings)
@@ -261,7 +261,7 @@ namespace Google.Cloud.Gaming.V1Beta.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListGameServerClusters</summary>
+        /// <summary>Snippet for ListGameServerClustersAsync</summary>
         public async Task ListGameServerClustersResourceNamesAsync()
         {
             // Snippet: ListGameServerClustersAsync(RealmName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta.Snippets/GameServerConfigsServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta.Snippets/GameServerConfigsServiceClientSnippets.g.cs
@@ -76,7 +76,7 @@ namespace Google.Cloud.Gaming.V1Beta.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListGameServerConfigs</summary>
+        /// <summary>Snippet for ListGameServerConfigsAsync</summary>
         public async Task ListGameServerConfigsRequestObjectAsync()
         {
             // Snippet: ListGameServerConfigsAsync(ListGameServerConfigsRequest, CallSettings)
@@ -171,7 +171,7 @@ namespace Google.Cloud.Gaming.V1Beta.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListGameServerConfigs</summary>
+        /// <summary>Snippet for ListGameServerConfigsAsync</summary>
         public async Task ListGameServerConfigsAsync()
         {
             // Snippet: ListGameServerConfigsAsync(string, string, int?, CallSettings)
@@ -261,7 +261,7 @@ namespace Google.Cloud.Gaming.V1Beta.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListGameServerConfigs</summary>
+        /// <summary>Snippet for ListGameServerConfigsAsync</summary>
         public async Task ListGameServerConfigsResourceNamesAsync()
         {
             // Snippet: ListGameServerConfigsAsync(GameServerDeploymentName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta.Snippets/GameServerDeploymentsServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta.Snippets/GameServerDeploymentsServiceClientSnippets.g.cs
@@ -77,7 +77,7 @@ namespace Google.Cloud.Gaming.V1Beta.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListGameServerDeployments</summary>
+        /// <summary>Snippet for ListGameServerDeploymentsAsync</summary>
         public async Task ListGameServerDeploymentsRequestObjectAsync()
         {
             // Snippet: ListGameServerDeploymentsAsync(ListGameServerDeploymentsRequest, CallSettings)
@@ -172,7 +172,7 @@ namespace Google.Cloud.Gaming.V1Beta.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListGameServerDeployments</summary>
+        /// <summary>Snippet for ListGameServerDeploymentsAsync</summary>
         public async Task ListGameServerDeploymentsAsync()
         {
             // Snippet: ListGameServerDeploymentsAsync(string, string, int?, CallSettings)
@@ -262,7 +262,7 @@ namespace Google.Cloud.Gaming.V1Beta.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListGameServerDeployments</summary>
+        /// <summary>Snippet for ListGameServerDeploymentsAsync</summary>
         public async Task ListGameServerDeploymentsResourceNamesAsync()
         {
             // Snippet: ListGameServerDeploymentsAsync(LocationName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta.Snippets/RealmsServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta.Snippets/RealmsServiceClientSnippets.g.cs
@@ -77,7 +77,7 @@ namespace Google.Cloud.Gaming.V1Beta.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListRealms</summary>
+        /// <summary>Snippet for ListRealmsAsync</summary>
         public async Task ListRealmsRequestObjectAsync()
         {
             // Snippet: ListRealmsAsync(ListRealmsRequest, CallSettings)
@@ -172,7 +172,7 @@ namespace Google.Cloud.Gaming.V1Beta.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListRealms</summary>
+        /// <summary>Snippet for ListRealmsAsync</summary>
         public async Task ListRealmsAsync()
         {
             // Snippet: ListRealmsAsync(string, string, int?, CallSettings)
@@ -262,7 +262,7 @@ namespace Google.Cloud.Gaming.V1Beta.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListRealms</summary>
+        /// <summary>Snippet for ListRealmsAsync</summary>
         public async Task ListRealmsResourceNamesAsync()
         {
             // Snippet: ListRealmsAsync(LocationName, string, int?, CallSettings)

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.Snippets/GkeHubMembershipServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.Snippets/GkeHubMembershipServiceClientSnippets.g.cs
@@ -77,7 +77,7 @@ namespace Google.Cloud.GkeHub.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListMemberships</summary>
+        /// <summary>Snippet for ListMembershipsAsync</summary>
         public async Task ListMembershipsRequestObjectAsync()
         {
             // Snippet: ListMembershipsAsync(ListMembershipsRequest, CallSettings)
@@ -172,7 +172,7 @@ namespace Google.Cloud.GkeHub.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListMemberships</summary>
+        /// <summary>Snippet for ListMembershipsAsync</summary>
         public async Task ListMembershipsAsync()
         {
             // Snippet: ListMembershipsAsync(string, string, int?, CallSettings)

--- a/apis/Google.Cloud.Iot.V1/Google.Cloud.Iot.V1.Snippets/DeviceManagerClientSnippets.g.cs
+++ b/apis/Google.Cloud.Iot.V1/Google.Cloud.Iot.V1.Snippets/DeviceManagerClientSnippets.g.cs
@@ -408,7 +408,7 @@ namespace Google.Cloud.Iot.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDeviceRegistries</summary>
+        /// <summary>Snippet for ListDeviceRegistriesAsync</summary>
         public async Task ListDeviceRegistriesRequestObjectAsync()
         {
             // Snippet: ListDeviceRegistriesAsync(ListDeviceRegistriesRequest, CallSettings)
@@ -501,7 +501,7 @@ namespace Google.Cloud.Iot.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDeviceRegistries</summary>
+        /// <summary>Snippet for ListDeviceRegistriesAsync</summary>
         public async Task ListDeviceRegistriesAsync()
         {
             // Snippet: ListDeviceRegistriesAsync(string, string, int?, CallSettings)
@@ -591,7 +591,7 @@ namespace Google.Cloud.Iot.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDeviceRegistries</summary>
+        /// <summary>Snippet for ListDeviceRegistriesAsync</summary>
         public async Task ListDeviceRegistriesResourceNamesAsync()
         {
             // Snippet: ListDeviceRegistriesAsync(LocationName, string, int?, CallSettings)
@@ -1021,7 +1021,7 @@ namespace Google.Cloud.Iot.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDevices</summary>
+        /// <summary>Snippet for ListDevicesAsync</summary>
         public async Task ListDevicesRequestObjectAsync()
         {
             // Snippet: ListDevicesAsync(ListDevicesRequest, CallSettings)
@@ -1118,7 +1118,7 @@ namespace Google.Cloud.Iot.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDevices</summary>
+        /// <summary>Snippet for ListDevicesAsync</summary>
         public async Task ListDevicesAsync()
         {
             // Snippet: ListDevicesAsync(string, string, int?, CallSettings)
@@ -1208,7 +1208,7 @@ namespace Google.Cloud.Iot.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDevices</summary>
+        /// <summary>Snippet for ListDevicesAsync</summary>
         public async Task ListDevicesResourceNamesAsync()
         {
             // Snippet: ListDevicesAsync(RegistryName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.Snippets/KeyManagementServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.Snippets/KeyManagementServiceClientSnippets.g.cs
@@ -77,7 +77,7 @@ namespace Google.Cloud.Kms.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListKeyRings</summary>
+        /// <summary>Snippet for ListKeyRingsAsync</summary>
         public async Task ListKeyRingsRequestObjectAsync()
         {
             // Snippet: ListKeyRingsAsync(ListKeyRingsRequest, CallSettings)
@@ -172,7 +172,7 @@ namespace Google.Cloud.Kms.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListKeyRings</summary>
+        /// <summary>Snippet for ListKeyRingsAsync</summary>
         public async Task ListKeyRingsAsync()
         {
             // Snippet: ListKeyRingsAsync(string, string, int?, CallSettings)
@@ -262,7 +262,7 @@ namespace Google.Cloud.Kms.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListKeyRings</summary>
+        /// <summary>Snippet for ListKeyRingsAsync</summary>
         public async Task ListKeyRingsResourceNamesAsync()
         {
             // Snippet: ListKeyRingsAsync(LocationName, string, int?, CallSettings)
@@ -358,7 +358,7 @@ namespace Google.Cloud.Kms.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListCryptoKeys</summary>
+        /// <summary>Snippet for ListCryptoKeysAsync</summary>
         public async Task ListCryptoKeysRequestObjectAsync()
         {
             // Snippet: ListCryptoKeysAsync(ListCryptoKeysRequest, CallSettings)
@@ -454,7 +454,7 @@ namespace Google.Cloud.Kms.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListCryptoKeys</summary>
+        /// <summary>Snippet for ListCryptoKeysAsync</summary>
         public async Task ListCryptoKeysAsync()
         {
             // Snippet: ListCryptoKeysAsync(string, string, int?, CallSettings)
@@ -544,7 +544,7 @@ namespace Google.Cloud.Kms.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListCryptoKeys</summary>
+        /// <summary>Snippet for ListCryptoKeysAsync</summary>
         public async Task ListCryptoKeysResourceNamesAsync()
         {
             // Snippet: ListCryptoKeysAsync(KeyRingName, string, int?, CallSettings)
@@ -640,7 +640,7 @@ namespace Google.Cloud.Kms.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListCryptoKeyVersions</summary>
+        /// <summary>Snippet for ListCryptoKeyVersionsAsync</summary>
         public async Task ListCryptoKeyVersionsRequestObjectAsync()
         {
             // Snippet: ListCryptoKeyVersionsAsync(ListCryptoKeyVersionsRequest, CallSettings)
@@ -736,7 +736,7 @@ namespace Google.Cloud.Kms.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListCryptoKeyVersions</summary>
+        /// <summary>Snippet for ListCryptoKeyVersionsAsync</summary>
         public async Task ListCryptoKeyVersionsAsync()
         {
             // Snippet: ListCryptoKeyVersionsAsync(string, string, int?, CallSettings)
@@ -826,7 +826,7 @@ namespace Google.Cloud.Kms.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListCryptoKeyVersions</summary>
+        /// <summary>Snippet for ListCryptoKeyVersionsAsync</summary>
         public async Task ListCryptoKeyVersionsResourceNamesAsync()
         {
             // Snippet: ListCryptoKeyVersionsAsync(CryptoKeyName, string, int?, CallSettings)
@@ -921,7 +921,7 @@ namespace Google.Cloud.Kms.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListImportJobs</summary>
+        /// <summary>Snippet for ListImportJobsAsync</summary>
         public async Task ListImportJobsRequestObjectAsync()
         {
             // Snippet: ListImportJobsAsync(ListImportJobsRequest, CallSettings)
@@ -1016,7 +1016,7 @@ namespace Google.Cloud.Kms.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListImportJobs</summary>
+        /// <summary>Snippet for ListImportJobsAsync</summary>
         public async Task ListImportJobsAsync()
         {
             // Snippet: ListImportJobsAsync(string, string, int?, CallSettings)
@@ -1106,7 +1106,7 @@ namespace Google.Cloud.Kms.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListImportJobs</summary>
+        /// <summary>Snippet for ListImportJobsAsync</summary>
         public async Task ListImportJobsResourceNamesAsync()
         {
             // Snippet: ListImportJobsAsync(KeyRingName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.Snippets/ConfigServiceV2ClientSnippets.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.Snippets/ConfigServiceV2ClientSnippets.g.cs
@@ -74,7 +74,7 @@ namespace Google.Cloud.Logging.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListBuckets</summary>
+        /// <summary>Snippet for ListBucketsAsync</summary>
         public async Task ListBucketsRequestObjectAsync()
         {
             // Snippet: ListBucketsAsync(ListBucketsRequest, CallSettings)
@@ -167,7 +167,7 @@ namespace Google.Cloud.Logging.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListBuckets</summary>
+        /// <summary>Snippet for ListBucketsAsync</summary>
         public async Task ListBucketsAsync()
         {
             // Snippet: ListBucketsAsync(string, string, int?, CallSettings)
@@ -257,7 +257,7 @@ namespace Google.Cloud.Logging.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListBuckets</summary>
+        /// <summary>Snippet for ListBucketsAsync</summary>
         public async Task ListBucketsResourceNames1Async()
         {
             // Snippet: ListBucketsAsync(LocationName, string, int?, CallSettings)
@@ -347,7 +347,7 @@ namespace Google.Cloud.Logging.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListBuckets</summary>
+        /// <summary>Snippet for ListBucketsAsync</summary>
         public async Task ListBucketsResourceNames2Async()
         {
             // Snippet: ListBucketsAsync(OrganizationLocationName, string, int?, CallSettings)
@@ -437,7 +437,7 @@ namespace Google.Cloud.Logging.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListBuckets</summary>
+        /// <summary>Snippet for ListBucketsAsync</summary>
         public async Task ListBucketsResourceNames3Async()
         {
             // Snippet: ListBucketsAsync(FolderLocationName, string, int?, CallSettings)
@@ -527,7 +527,7 @@ namespace Google.Cloud.Logging.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListBuckets</summary>
+        /// <summary>Snippet for ListBucketsAsync</summary>
         public async Task ListBucketsResourceNames4Async()
         {
             // Snippet: ListBucketsAsync(BillingAccountLocationName, string, int?, CallSettings)
@@ -790,7 +790,7 @@ namespace Google.Cloud.Logging.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListViews</summary>
+        /// <summary>Snippet for ListViewsAsync</summary>
         public async Task ListViewsRequestObjectAsync()
         {
             // Snippet: ListViewsAsync(ListViewsRequest, CallSettings)
@@ -880,7 +880,7 @@ namespace Google.Cloud.Logging.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListViews</summary>
+        /// <summary>Snippet for ListViewsAsync</summary>
         public async Task ListViewsAsync()
         {
             // Snippet: ListViewsAsync(string, string, int?, CallSettings)
@@ -1113,7 +1113,7 @@ namespace Google.Cloud.Logging.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSinks</summary>
+        /// <summary>Snippet for ListSinksAsync</summary>
         public async Task ListSinksRequestObjectAsync()
         {
             // Snippet: ListSinksAsync(ListSinksRequest, CallSettings)
@@ -1206,7 +1206,7 @@ namespace Google.Cloud.Logging.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSinks</summary>
+        /// <summary>Snippet for ListSinksAsync</summary>
         public async Task ListSinksAsync()
         {
             // Snippet: ListSinksAsync(string, string, int?, CallSettings)
@@ -1296,7 +1296,7 @@ namespace Google.Cloud.Logging.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSinks</summary>
+        /// <summary>Snippet for ListSinksAsync</summary>
         public async Task ListSinksResourceNames1Async()
         {
             // Snippet: ListSinksAsync(ProjectName, string, int?, CallSettings)
@@ -1386,7 +1386,7 @@ namespace Google.Cloud.Logging.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSinks</summary>
+        /// <summary>Snippet for ListSinksAsync</summary>
         public async Task ListSinksResourceNames2Async()
         {
             // Snippet: ListSinksAsync(OrganizationName, string, int?, CallSettings)
@@ -1476,7 +1476,7 @@ namespace Google.Cloud.Logging.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSinks</summary>
+        /// <summary>Snippet for ListSinksAsync</summary>
         public async Task ListSinksResourceNames3Async()
         {
             // Snippet: ListSinksAsync(FolderName, string, int?, CallSettings)
@@ -1566,7 +1566,7 @@ namespace Google.Cloud.Logging.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSinks</summary>
+        /// <summary>Snippet for ListSinksAsync</summary>
         public async Task ListSinksResourceNames4Async()
         {
             // Snippet: ListSinksAsync(BillingAccountName, string, int?, CallSettings)
@@ -2174,7 +2174,7 @@ namespace Google.Cloud.Logging.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListExclusions</summary>
+        /// <summary>Snippet for ListExclusionsAsync</summary>
         public async Task ListExclusionsRequestObjectAsync()
         {
             // Snippet: ListExclusionsAsync(ListExclusionsRequest, CallSettings)
@@ -2267,7 +2267,7 @@ namespace Google.Cloud.Logging.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListExclusions</summary>
+        /// <summary>Snippet for ListExclusionsAsync</summary>
         public async Task ListExclusionsAsync()
         {
             // Snippet: ListExclusionsAsync(string, string, int?, CallSettings)
@@ -2357,7 +2357,7 @@ namespace Google.Cloud.Logging.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListExclusions</summary>
+        /// <summary>Snippet for ListExclusionsAsync</summary>
         public async Task ListExclusionsResourceNames1Async()
         {
             // Snippet: ListExclusionsAsync(ProjectName, string, int?, CallSettings)
@@ -2447,7 +2447,7 @@ namespace Google.Cloud.Logging.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListExclusions</summary>
+        /// <summary>Snippet for ListExclusionsAsync</summary>
         public async Task ListExclusionsResourceNames2Async()
         {
             // Snippet: ListExclusionsAsync(OrganizationName, string, int?, CallSettings)
@@ -2537,7 +2537,7 @@ namespace Google.Cloud.Logging.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListExclusions</summary>
+        /// <summary>Snippet for ListExclusionsAsync</summary>
         public async Task ListExclusionsResourceNames3Async()
         {
             // Snippet: ListExclusionsAsync(FolderName, string, int?, CallSettings)
@@ -2627,7 +2627,7 @@ namespace Google.Cloud.Logging.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListExclusions</summary>
+        /// <summary>Snippet for ListExclusionsAsync</summary>
         public async Task ListExclusionsResourceNames4Async()
         {
             // Snippet: ListExclusionsAsync(BillingAccountName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.Snippets/LoggingServiceV2ClientSnippets.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.Snippets/LoggingServiceV2ClientSnippets.g.cs
@@ -278,7 +278,7 @@ namespace Google.Cloud.Logging.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListLogEntries</summary>
+        /// <summary>Snippet for ListLogEntriesAsync</summary>
         public async Task ListLogEntriesRequestObjectAsync()
         {
             // Snippet: ListLogEntriesAsync(ListLogEntriesRequest, CallSettings)
@@ -381,7 +381,7 @@ namespace Google.Cloud.Logging.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListLogEntries</summary>
+        /// <summary>Snippet for ListLogEntriesAsync</summary>
         public async Task ListLogEntriesAsync()
         {
             // Snippet: ListLogEntriesAsync(IEnumerable<string>, string, string, string, int?, CallSettings)
@@ -481,7 +481,7 @@ namespace Google.Cloud.Logging.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListLogEntries</summary>
+        /// <summary>Snippet for ListLogEntriesAsync</summary>
         public async Task ListLogEntriesResourceNames1Async()
         {
             // Snippet: ListLogEntriesAsync(IEnumerable<ProjectName>, string, string, string, int?, CallSettings)
@@ -581,7 +581,7 @@ namespace Google.Cloud.Logging.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListLogEntries</summary>
+        /// <summary>Snippet for ListLogEntriesAsync</summary>
         public async Task ListLogEntriesResourceNames2Async()
         {
             // Snippet: ListLogEntriesAsync(IEnumerable<OrganizationName>, string, string, string, int?, CallSettings)
@@ -681,7 +681,7 @@ namespace Google.Cloud.Logging.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListLogEntries</summary>
+        /// <summary>Snippet for ListLogEntriesAsync</summary>
         public async Task ListLogEntriesResourceNames3Async()
         {
             // Snippet: ListLogEntriesAsync(IEnumerable<FolderName>, string, string, string, int?, CallSettings)
@@ -781,7 +781,7 @@ namespace Google.Cloud.Logging.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListLogEntries</summary>
+        /// <summary>Snippet for ListLogEntriesAsync</summary>
         public async Task ListLogEntriesResourceNames4Async()
         {
             // Snippet: ListLogEntriesAsync(IEnumerable<BillingAccountName>, string, string, string, int?, CallSettings)
@@ -876,7 +876,7 @@ namespace Google.Cloud.Logging.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListMonitoredResourceDescriptors</summary>
+        /// <summary>Snippet for ListMonitoredResourceDescriptorsAsync</summary>
         public async Task ListMonitoredResourceDescriptorsRequestObjectAsync()
         {
             // Snippet: ListMonitoredResourceDescriptorsAsync(ListMonitoredResourceDescriptorsRequest, CallSettings)
@@ -970,7 +970,7 @@ namespace Google.Cloud.Logging.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListLogs</summary>
+        /// <summary>Snippet for ListLogsAsync</summary>
         public async Task ListLogsRequestObjectAsync()
         {
             // Snippet: ListLogsAsync(ListLogsRequest, CallSettings)
@@ -1064,7 +1064,7 @@ namespace Google.Cloud.Logging.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListLogs</summary>
+        /// <summary>Snippet for ListLogsAsync</summary>
         public async Task ListLogsAsync()
         {
             // Snippet: ListLogsAsync(string, string, int?, CallSettings)
@@ -1154,7 +1154,7 @@ namespace Google.Cloud.Logging.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListLogs</summary>
+        /// <summary>Snippet for ListLogsAsync</summary>
         public async Task ListLogsResourceNames1Async()
         {
             // Snippet: ListLogsAsync(ProjectName, string, int?, CallSettings)
@@ -1244,7 +1244,7 @@ namespace Google.Cloud.Logging.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListLogs</summary>
+        /// <summary>Snippet for ListLogsAsync</summary>
         public async Task ListLogsResourceNames2Async()
         {
             // Snippet: ListLogsAsync(OrganizationName, string, int?, CallSettings)
@@ -1334,7 +1334,7 @@ namespace Google.Cloud.Logging.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListLogs</summary>
+        /// <summary>Snippet for ListLogsAsync</summary>
         public async Task ListLogsResourceNames3Async()
         {
             // Snippet: ListLogsAsync(FolderName, string, int?, CallSettings)
@@ -1424,7 +1424,7 @@ namespace Google.Cloud.Logging.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListLogs</summary>
+        /// <summary>Snippet for ListLogsAsync</summary>
         public async Task ListLogsResourceNames4Async()
         {
             // Snippet: ListLogsAsync(BillingAccountName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.Snippets/MetricsServiceV2ClientSnippets.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.Snippets/MetricsServiceV2ClientSnippets.g.cs
@@ -73,7 +73,7 @@ namespace Google.Cloud.Logging.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListLogMetrics</summary>
+        /// <summary>Snippet for ListLogMetricsAsync</summary>
         public async Task ListLogMetricsRequestObjectAsync()
         {
             // Snippet: ListLogMetricsAsync(ListLogMetricsRequest, CallSettings)
@@ -166,7 +166,7 @@ namespace Google.Cloud.Logging.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListLogMetrics</summary>
+        /// <summary>Snippet for ListLogMetricsAsync</summary>
         public async Task ListLogMetricsAsync()
         {
             // Snippet: ListLogMetricsAsync(string, string, int?, CallSettings)
@@ -256,7 +256,7 @@ namespace Google.Cloud.Logging.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListLogMetrics</summary>
+        /// <summary>Snippet for ListLogMetricsAsync</summary>
         public async Task ListLogMetricsResourceNamesAsync()
         {
             // Snippet: ListLogMetricsAsync(ProjectName, string, int?, CallSettings)

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.Snippets/ManagedIdentitiesServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.Snippets/ManagedIdentitiesServiceClientSnippets.g.cs
@@ -360,7 +360,7 @@ namespace Google.Cloud.ManagedIdentities.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDomains</summary>
+        /// <summary>Snippet for ListDomainsAsync</summary>
         public async Task ListDomainsRequestObjectAsync()
         {
             // Snippet: ListDomainsAsync(ListDomainsRequest, CallSettings)
@@ -455,7 +455,7 @@ namespace Google.Cloud.ManagedIdentities.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDomains</summary>
+        /// <summary>Snippet for ListDomainsAsync</summary>
         public async Task ListDomainsAsync()
         {
             // Snippet: ListDomainsAsync(string, string, int?, CallSettings)
@@ -545,7 +545,7 @@ namespace Google.Cloud.ManagedIdentities.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDomains</summary>
+        /// <summary>Snippet for ListDomainsAsync</summary>
         public async Task ListDomainsResourceNamesAsync()
         {
             // Snippet: ListDomainsAsync(LocationName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.Snippets/CloudMemcacheClientSnippets.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.Snippets/CloudMemcacheClientSnippets.g.cs
@@ -78,7 +78,7 @@ namespace Google.Cloud.Memcache.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListInstances</summary>
+        /// <summary>Snippet for ListInstancesAsync</summary>
         public async Task ListInstancesRequestObjectAsync()
         {
             // Snippet: ListInstancesAsync(ListInstancesRequest, CallSettings)
@@ -173,7 +173,7 @@ namespace Google.Cloud.Memcache.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListInstances</summary>
+        /// <summary>Snippet for ListInstancesAsync</summary>
         public async Task ListInstancesAsync()
         {
             // Snippet: ListInstancesAsync(string, string, int?, CallSettings)
@@ -263,7 +263,7 @@ namespace Google.Cloud.Memcache.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListInstances</summary>
+        /// <summary>Snippet for ListInstancesAsync</summary>
         public async Task ListInstancesResourceNamesAsync()
         {
             // Snippet: ListInstancesAsync(LocationName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.Snippets/CloudMemcacheClientSnippets.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.Snippets/CloudMemcacheClientSnippets.g.cs
@@ -78,7 +78,7 @@ namespace Google.Cloud.Memcache.V1Beta2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListInstances</summary>
+        /// <summary>Snippet for ListInstancesAsync</summary>
         public async Task ListInstancesRequestObjectAsync()
         {
             // Snippet: ListInstancesAsync(ListInstancesRequest, CallSettings)
@@ -173,7 +173,7 @@ namespace Google.Cloud.Memcache.V1Beta2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListInstances</summary>
+        /// <summary>Snippet for ListInstancesAsync</summary>
         public async Task ListInstancesAsync()
         {
             // Snippet: ListInstancesAsync(string, string, int?, CallSettings)
@@ -263,7 +263,7 @@ namespace Google.Cloud.Memcache.V1Beta2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListInstances</summary>
+        /// <summary>Snippet for ListInstancesAsync</summary>
         public async Task ListInstancesResourceNamesAsync()
         {
             // Snippet: ListInstancesAsync(LocationName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.Snippets/DataprocMetastoreClientSnippets.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.Snippets/DataprocMetastoreClientSnippets.g.cs
@@ -77,7 +77,7 @@ namespace Google.Cloud.Metastore.V1Alpha.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListServices</summary>
+        /// <summary>Snippet for ListServicesAsync</summary>
         public async Task ListServicesRequestObjectAsync()
         {
             // Snippet: ListServicesAsync(ListServicesRequest, CallSettings)
@@ -172,7 +172,7 @@ namespace Google.Cloud.Metastore.V1Alpha.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListServices</summary>
+        /// <summary>Snippet for ListServicesAsync</summary>
         public async Task ListServicesAsync()
         {
             // Snippet: ListServicesAsync(string, string, int?, CallSettings)
@@ -262,7 +262,7 @@ namespace Google.Cloud.Metastore.V1Alpha.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListServices</summary>
+        /// <summary>Snippet for ListServicesAsync</summary>
         public async Task ListServicesResourceNamesAsync()
         {
             // Snippet: ListServicesAsync(LocationName, string, int?, CallSettings)
@@ -956,7 +956,7 @@ namespace Google.Cloud.Metastore.V1Alpha.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListMetadataImports</summary>
+        /// <summary>Snippet for ListMetadataImportsAsync</summary>
         public async Task ListMetadataImportsRequestObjectAsync()
         {
             // Snippet: ListMetadataImportsAsync(ListMetadataImportsRequest, CallSettings)
@@ -1051,7 +1051,7 @@ namespace Google.Cloud.Metastore.V1Alpha.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListMetadataImports</summary>
+        /// <summary>Snippet for ListMetadataImportsAsync</summary>
         public async Task ListMetadataImportsAsync()
         {
             // Snippet: ListMetadataImportsAsync(string, string, int?, CallSettings)
@@ -1141,7 +1141,7 @@ namespace Google.Cloud.Metastore.V1Alpha.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListMetadataImports</summary>
+        /// <summary>Snippet for ListMetadataImportsAsync</summary>
         public async Task ListMetadataImportsResourceNamesAsync()
         {
             // Snippet: ListMetadataImportsAsync(ServiceName, string, int?, CallSettings)
@@ -1914,7 +1914,7 @@ namespace Google.Cloud.Metastore.V1Alpha.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListBackups</summary>
+        /// <summary>Snippet for ListBackupsAsync</summary>
         public async Task ListBackupsRequestObjectAsync()
         {
             // Snippet: ListBackupsAsync(ListBackupsRequest, CallSettings)
@@ -2009,7 +2009,7 @@ namespace Google.Cloud.Metastore.V1Alpha.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListBackups</summary>
+        /// <summary>Snippet for ListBackupsAsync</summary>
         public async Task ListBackupsAsync()
         {
             // Snippet: ListBackupsAsync(string, string, int?, CallSettings)
@@ -2099,7 +2099,7 @@ namespace Google.Cloud.Metastore.V1Alpha.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListBackups</summary>
+        /// <summary>Snippet for ListBackupsAsync</summary>
         public async Task ListBackupsResourceNamesAsync()
         {
             // Snippet: ListBackupsAsync(ServiceName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.Snippets/DataprocMetastoreClientSnippets.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.Snippets/DataprocMetastoreClientSnippets.g.cs
@@ -77,7 +77,7 @@ namespace Google.Cloud.Metastore.V1Beta.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListServices</summary>
+        /// <summary>Snippet for ListServicesAsync</summary>
         public async Task ListServicesRequestObjectAsync()
         {
             // Snippet: ListServicesAsync(ListServicesRequest, CallSettings)
@@ -172,7 +172,7 @@ namespace Google.Cloud.Metastore.V1Beta.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListServices</summary>
+        /// <summary>Snippet for ListServicesAsync</summary>
         public async Task ListServicesAsync()
         {
             // Snippet: ListServicesAsync(string, string, int?, CallSettings)
@@ -262,7 +262,7 @@ namespace Google.Cloud.Metastore.V1Beta.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListServices</summary>
+        /// <summary>Snippet for ListServicesAsync</summary>
         public async Task ListServicesResourceNamesAsync()
         {
             // Snippet: ListServicesAsync(LocationName, string, int?, CallSettings)
@@ -956,7 +956,7 @@ namespace Google.Cloud.Metastore.V1Beta.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListMetadataImports</summary>
+        /// <summary>Snippet for ListMetadataImportsAsync</summary>
         public async Task ListMetadataImportsRequestObjectAsync()
         {
             // Snippet: ListMetadataImportsAsync(ListMetadataImportsRequest, CallSettings)
@@ -1051,7 +1051,7 @@ namespace Google.Cloud.Metastore.V1Beta.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListMetadataImports</summary>
+        /// <summary>Snippet for ListMetadataImportsAsync</summary>
         public async Task ListMetadataImportsAsync()
         {
             // Snippet: ListMetadataImportsAsync(string, string, int?, CallSettings)
@@ -1141,7 +1141,7 @@ namespace Google.Cloud.Metastore.V1Beta.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListMetadataImports</summary>
+        /// <summary>Snippet for ListMetadataImportsAsync</summary>
         public async Task ListMetadataImportsResourceNamesAsync()
         {
             // Snippet: ListMetadataImportsAsync(ServiceName, string, int?, CallSettings)
@@ -1914,7 +1914,7 @@ namespace Google.Cloud.Metastore.V1Beta.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListBackups</summary>
+        /// <summary>Snippet for ListBackupsAsync</summary>
         public async Task ListBackupsRequestObjectAsync()
         {
             // Snippet: ListBackupsAsync(ListBackupsRequest, CallSettings)
@@ -2009,7 +2009,7 @@ namespace Google.Cloud.Metastore.V1Beta.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListBackups</summary>
+        /// <summary>Snippet for ListBackupsAsync</summary>
         public async Task ListBackupsAsync()
         {
             // Snippet: ListBackupsAsync(string, string, int?, CallSettings)
@@ -2099,7 +2099,7 @@ namespace Google.Cloud.Metastore.V1Beta.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListBackups</summary>
+        /// <summary>Snippet for ListBackupsAsync</summary>
         public async Task ListBackupsResourceNamesAsync()
         {
             // Snippet: ListBackupsAsync(ServiceName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/AlertPolicyServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/AlertPolicyServiceClientSnippets.g.cs
@@ -76,7 +76,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAlertPolicies</summary>
+        /// <summary>Snippet for ListAlertPoliciesAsync</summary>
         public async Task ListAlertPoliciesRequestObjectAsync()
         {
             // Snippet: ListAlertPoliciesAsync(ListAlertPoliciesRequest, CallSettings)
@@ -171,7 +171,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAlertPolicies</summary>
+        /// <summary>Snippet for ListAlertPoliciesAsync</summary>
         public async Task ListAlertPoliciesAsync()
         {
             // Snippet: ListAlertPoliciesAsync(string, string, int?, CallSettings)
@@ -261,7 +261,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAlertPolicies</summary>
+        /// <summary>Snippet for ListAlertPoliciesAsync</summary>
         public async Task ListAlertPoliciesResourceNames1Async()
         {
             // Snippet: ListAlertPoliciesAsync(ProjectName, string, int?, CallSettings)
@@ -351,7 +351,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAlertPolicies</summary>
+        /// <summary>Snippet for ListAlertPoliciesAsync</summary>
         public async Task ListAlertPoliciesResourceNames2Async()
         {
             // Snippet: ListAlertPoliciesAsync(OrganizationName, string, int?, CallSettings)
@@ -441,7 +441,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAlertPolicies</summary>
+        /// <summary>Snippet for ListAlertPoliciesAsync</summary>
         public async Task ListAlertPoliciesResourceNames3Async()
         {
             // Snippet: ListAlertPoliciesAsync(FolderName, string, int?, CallSettings)
@@ -531,7 +531,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAlertPolicies</summary>
+        /// <summary>Snippet for ListAlertPoliciesAsync</summary>
         public async Task ListAlertPoliciesResourceNames4Async()
         {
             // Snippet: ListAlertPoliciesAsync(IResourceName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/GroupServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/GroupServiceClientSnippets.g.cs
@@ -75,7 +75,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListGroups</summary>
+        /// <summary>Snippet for ListGroupsAsync</summary>
         public async Task ListGroupsRequestObjectAsync()
         {
             // Snippet: ListGroupsAsync(ListGroupsRequest, CallSettings)
@@ -169,7 +169,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListGroups</summary>
+        /// <summary>Snippet for ListGroupsAsync</summary>
         public async Task ListGroupsAsync()
         {
             // Snippet: ListGroupsAsync(string, string, int?, CallSettings)
@@ -259,7 +259,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListGroups</summary>
+        /// <summary>Snippet for ListGroupsAsync</summary>
         public async Task ListGroupsResourceNames1Async()
         {
             // Snippet: ListGroupsAsync(ProjectName, string, int?, CallSettings)
@@ -349,7 +349,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListGroups</summary>
+        /// <summary>Snippet for ListGroupsAsync</summary>
         public async Task ListGroupsResourceNames2Async()
         {
             // Snippet: ListGroupsAsync(OrganizationName, string, int?, CallSettings)
@@ -439,7 +439,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListGroups</summary>
+        /// <summary>Snippet for ListGroupsAsync</summary>
         public async Task ListGroupsResourceNames3Async()
         {
             // Snippet: ListGroupsAsync(FolderName, string, int?, CallSettings)
@@ -529,7 +529,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListGroups</summary>
+        /// <summary>Snippet for ListGroupsAsync</summary>
         public async Task ListGroupsResourceNames4Async()
         {
             // Snippet: ListGroupsAsync(IResourceName, string, int?, CallSettings)
@@ -1098,7 +1098,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListGroupMembers</summary>
+        /// <summary>Snippet for ListGroupMembersAsync</summary>
         public async Task ListGroupMembersRequestObjectAsync()
         {
             // Snippet: ListGroupMembersAsync(ListGroupMembersRequest, CallSettings)
@@ -1193,7 +1193,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListGroupMembers</summary>
+        /// <summary>Snippet for ListGroupMembersAsync</summary>
         public async Task ListGroupMembersAsync()
         {
             // Snippet: ListGroupMembersAsync(string, string, int?, CallSettings)
@@ -1283,7 +1283,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListGroupMembers</summary>
+        /// <summary>Snippet for ListGroupMembersAsync</summary>
         public async Task ListGroupMembersResourceNames1Async()
         {
             // Snippet: ListGroupMembersAsync(GroupName, string, int?, CallSettings)
@@ -1373,7 +1373,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListGroupMembers</summary>
+        /// <summary>Snippet for ListGroupMembersAsync</summary>
         public async Task ListGroupMembersResourceNames2Async()
         {
             // Snippet: ListGroupMembersAsync(IResourceName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/MetricServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/MetricServiceClientSnippets.g.cs
@@ -76,7 +76,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListMonitoredResourceDescriptors</summary>
+        /// <summary>Snippet for ListMonitoredResourceDescriptorsAsync</summary>
         public async Task ListMonitoredResourceDescriptorsRequestObjectAsync()
         {
             // Snippet: ListMonitoredResourceDescriptorsAsync(ListMonitoredResourceDescriptorsRequest, CallSettings)
@@ -170,7 +170,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListMonitoredResourceDescriptors</summary>
+        /// <summary>Snippet for ListMonitoredResourceDescriptorsAsync</summary>
         public async Task ListMonitoredResourceDescriptorsAsync()
         {
             // Snippet: ListMonitoredResourceDescriptorsAsync(string, string, int?, CallSettings)
@@ -260,7 +260,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListMonitoredResourceDescriptors</summary>
+        /// <summary>Snippet for ListMonitoredResourceDescriptorsAsync</summary>
         public async Task ListMonitoredResourceDescriptorsResourceNames1Async()
         {
             // Snippet: ListMonitoredResourceDescriptorsAsync(ProjectName, string, int?, CallSettings)
@@ -350,7 +350,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListMonitoredResourceDescriptors</summary>
+        /// <summary>Snippet for ListMonitoredResourceDescriptorsAsync</summary>
         public async Task ListMonitoredResourceDescriptorsResourceNames2Async()
         {
             // Snippet: ListMonitoredResourceDescriptorsAsync(OrganizationName, string, int?, CallSettings)
@@ -440,7 +440,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListMonitoredResourceDescriptors</summary>
+        /// <summary>Snippet for ListMonitoredResourceDescriptorsAsync</summary>
         public async Task ListMonitoredResourceDescriptorsResourceNames3Async()
         {
             // Snippet: ListMonitoredResourceDescriptorsAsync(FolderName, string, int?, CallSettings)
@@ -530,7 +530,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListMonitoredResourceDescriptors</summary>
+        /// <summary>Snippet for ListMonitoredResourceDescriptorsAsync</summary>
         public async Task ListMonitoredResourceDescriptorsResourceNames4Async()
         {
             // Snippet: ListMonitoredResourceDescriptorsAsync(IResourceName, string, int?, CallSettings)
@@ -738,7 +738,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListMetricDescriptors</summary>
+        /// <summary>Snippet for ListMetricDescriptorsAsync</summary>
         public async Task ListMetricDescriptorsRequestObjectAsync()
         {
             // Snippet: ListMetricDescriptorsAsync(ListMetricDescriptorsRequest, CallSettings)
@@ -832,7 +832,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListMetricDescriptors</summary>
+        /// <summary>Snippet for ListMetricDescriptorsAsync</summary>
         public async Task ListMetricDescriptorsAsync()
         {
             // Snippet: ListMetricDescriptorsAsync(string, string, int?, CallSettings)
@@ -922,7 +922,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListMetricDescriptors</summary>
+        /// <summary>Snippet for ListMetricDescriptorsAsync</summary>
         public async Task ListMetricDescriptorsResourceNames1Async()
         {
             // Snippet: ListMetricDescriptorsAsync(ProjectName, string, int?, CallSettings)
@@ -1012,7 +1012,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListMetricDescriptors</summary>
+        /// <summary>Snippet for ListMetricDescriptorsAsync</summary>
         public async Task ListMetricDescriptorsResourceNames2Async()
         {
             // Snippet: ListMetricDescriptorsAsync(OrganizationName, string, int?, CallSettings)
@@ -1102,7 +1102,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListMetricDescriptors</summary>
+        /// <summary>Snippet for ListMetricDescriptorsAsync</summary>
         public async Task ListMetricDescriptorsResourceNames3Async()
         {
             // Snippet: ListMetricDescriptorsAsync(FolderName, string, int?, CallSettings)
@@ -1192,7 +1192,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListMetricDescriptors</summary>
+        /// <summary>Snippet for ListMetricDescriptorsAsync</summary>
         public async Task ListMetricDescriptorsResourceNames4Async()
         {
             // Snippet: ListMetricDescriptorsAsync(IResourceName, string, int?, CallSettings)
@@ -1699,7 +1699,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTimeSeries</summary>
+        /// <summary>Snippet for ListTimeSeriesAsync</summary>
         public async Task ListTimeSeriesRequestObjectAsync()
         {
             // Snippet: ListTimeSeriesAsync(ListTimeSeriesRequest, CallSettings)
@@ -1801,7 +1801,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTimeSeries</summary>
+        /// <summary>Snippet for ListTimeSeriesAsync</summary>
         public async Task ListTimeSeriesAsync()
         {
             // Snippet: ListTimeSeriesAsync(string, string, TimeInterval, ListTimeSeriesRequest.Types.TimeSeriesView, string, int?, CallSettings)
@@ -1897,7 +1897,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTimeSeries</summary>
+        /// <summary>Snippet for ListTimeSeriesAsync</summary>
         public async Task ListTimeSeriesResourceNames1Async()
         {
             // Snippet: ListTimeSeriesAsync(ProjectName, string, TimeInterval, ListTimeSeriesRequest.Types.TimeSeriesView, string, int?, CallSettings)
@@ -1993,7 +1993,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTimeSeries</summary>
+        /// <summary>Snippet for ListTimeSeriesAsync</summary>
         public async Task ListTimeSeriesResourceNames2Async()
         {
             // Snippet: ListTimeSeriesAsync(OrganizationName, string, TimeInterval, ListTimeSeriesRequest.Types.TimeSeriesView, string, int?, CallSettings)
@@ -2089,7 +2089,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTimeSeries</summary>
+        /// <summary>Snippet for ListTimeSeriesAsync</summary>
         public async Task ListTimeSeriesResourceNames3Async()
         {
             // Snippet: ListTimeSeriesAsync(FolderName, string, TimeInterval, ListTimeSeriesRequest.Types.TimeSeriesView, string, int?, CallSettings)

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/NotificationChannelServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/NotificationChannelServiceClientSnippets.g.cs
@@ -74,7 +74,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListNotificationChannelDescriptors</summary>
+        /// <summary>Snippet for ListNotificationChannelDescriptorsAsync</summary>
         public async Task ListNotificationChannelDescriptorsRequestObjectAsync()
         {
             // Snippet: ListNotificationChannelDescriptorsAsync(ListNotificationChannelDescriptorsRequest, CallSettings)
@@ -167,7 +167,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListNotificationChannelDescriptors</summary>
+        /// <summary>Snippet for ListNotificationChannelDescriptorsAsync</summary>
         public async Task ListNotificationChannelDescriptorsAsync()
         {
             // Snippet: ListNotificationChannelDescriptorsAsync(string, string, int?, CallSettings)
@@ -257,7 +257,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListNotificationChannelDescriptors</summary>
+        /// <summary>Snippet for ListNotificationChannelDescriptorsAsync</summary>
         public async Task ListNotificationChannelDescriptorsResourceNames1Async()
         {
             // Snippet: ListNotificationChannelDescriptorsAsync(ProjectName, string, int?, CallSettings)
@@ -347,7 +347,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListNotificationChannelDescriptors</summary>
+        /// <summary>Snippet for ListNotificationChannelDescriptorsAsync</summary>
         public async Task ListNotificationChannelDescriptorsResourceNames2Async()
         {
             // Snippet: ListNotificationChannelDescriptorsAsync(OrganizationName, string, int?, CallSettings)
@@ -437,7 +437,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListNotificationChannelDescriptors</summary>
+        /// <summary>Snippet for ListNotificationChannelDescriptorsAsync</summary>
         public async Task ListNotificationChannelDescriptorsResourceNames3Async()
         {
             // Snippet: ListNotificationChannelDescriptorsAsync(FolderName, string, int?, CallSettings)
@@ -527,7 +527,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListNotificationChannelDescriptors</summary>
+        /// <summary>Snippet for ListNotificationChannelDescriptorsAsync</summary>
         public async Task ListNotificationChannelDescriptorsResourceNames4Async()
         {
             // Snippet: ListNotificationChannelDescriptorsAsync(IResourceName, string, int?, CallSettings)
@@ -736,7 +736,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListNotificationChannels</summary>
+        /// <summary>Snippet for ListNotificationChannelsAsync</summary>
         public async Task ListNotificationChannelsRequestObjectAsync()
         {
             // Snippet: ListNotificationChannelsAsync(ListNotificationChannelsRequest, CallSettings)
@@ -831,7 +831,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListNotificationChannels</summary>
+        /// <summary>Snippet for ListNotificationChannelsAsync</summary>
         public async Task ListNotificationChannelsAsync()
         {
             // Snippet: ListNotificationChannelsAsync(string, string, int?, CallSettings)
@@ -921,7 +921,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListNotificationChannels</summary>
+        /// <summary>Snippet for ListNotificationChannelsAsync</summary>
         public async Task ListNotificationChannelsResourceNames1Async()
         {
             // Snippet: ListNotificationChannelsAsync(ProjectName, string, int?, CallSettings)
@@ -1011,7 +1011,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListNotificationChannels</summary>
+        /// <summary>Snippet for ListNotificationChannelsAsync</summary>
         public async Task ListNotificationChannelsResourceNames2Async()
         {
             // Snippet: ListNotificationChannelsAsync(OrganizationName, string, int?, CallSettings)
@@ -1101,7 +1101,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListNotificationChannels</summary>
+        /// <summary>Snippet for ListNotificationChannelsAsync</summary>
         public async Task ListNotificationChannelsResourceNames3Async()
         {
             // Snippet: ListNotificationChannelsAsync(FolderName, string, int?, CallSettings)
@@ -1191,7 +1191,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListNotificationChannels</summary>
+        /// <summary>Snippet for ListNotificationChannelsAsync</summary>
         public async Task ListNotificationChannelsResourceNames4Async()
         {
             // Snippet: ListNotificationChannelsAsync(IResourceName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/QueryServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/QueryServiceClientSnippets.g.cs
@@ -69,7 +69,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for QueryTimeSeries</summary>
+        /// <summary>Snippet for QueryTimeSeriesAsync</summary>
         public async Task QueryTimeSeriesRequestObjectAsync()
         {
             // Snippet: QueryTimeSeriesAsync(QueryTimeSeriesRequest, CallSettings)

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/ServiceMonitoringServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/ServiceMonitoringServiceClientSnippets.g.cs
@@ -371,7 +371,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListServices</summary>
+        /// <summary>Snippet for ListServicesAsync</summary>
         public async Task ListServicesRequestObjectAsync()
         {
             // Snippet: ListServicesAsync(ListServicesRequest, CallSettings)
@@ -465,7 +465,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListServices</summary>
+        /// <summary>Snippet for ListServicesAsync</summary>
         public async Task ListServicesAsync()
         {
             // Snippet: ListServicesAsync(string, string, int?, CallSettings)
@@ -555,7 +555,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListServices</summary>
+        /// <summary>Snippet for ListServicesAsync</summary>
         public async Task ListServicesResourceNames1Async()
         {
             // Snippet: ListServicesAsync(ProjectName, string, int?, CallSettings)
@@ -645,7 +645,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListServices</summary>
+        /// <summary>Snippet for ListServicesAsync</summary>
         public async Task ListServicesResourceNames2Async()
         {
             // Snippet: ListServicesAsync(OrganizationName, string, int?, CallSettings)
@@ -735,7 +735,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListServices</summary>
+        /// <summary>Snippet for ListServicesAsync</summary>
         public async Task ListServicesResourceNames3Async()
         {
             // Snippet: ListServicesAsync(FolderName, string, int?, CallSettings)
@@ -825,7 +825,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListServices</summary>
+        /// <summary>Snippet for ListServicesAsync</summary>
         public async Task ListServicesResourceNames4Async()
         {
             // Snippet: ListServicesAsync(IResourceName, string, int?, CallSettings)
@@ -1336,7 +1336,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListServiceLevelObjectives</summary>
+        /// <summary>Snippet for ListServiceLevelObjectivesAsync</summary>
         public async Task ListServiceLevelObjectivesRequestObjectAsync()
         {
             // Snippet: ListServiceLevelObjectivesAsync(ListServiceLevelObjectivesRequest, CallSettings)
@@ -1431,7 +1431,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListServiceLevelObjectives</summary>
+        /// <summary>Snippet for ListServiceLevelObjectivesAsync</summary>
         public async Task ListServiceLevelObjectivesAsync()
         {
             // Snippet: ListServiceLevelObjectivesAsync(string, string, int?, CallSettings)
@@ -1521,7 +1521,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListServiceLevelObjectives</summary>
+        /// <summary>Snippet for ListServiceLevelObjectivesAsync</summary>
         public async Task ListServiceLevelObjectivesResourceNames1Async()
         {
             // Snippet: ListServiceLevelObjectivesAsync(ServiceName, string, int?, CallSettings)
@@ -1611,7 +1611,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListServiceLevelObjectives</summary>
+        /// <summary>Snippet for ListServiceLevelObjectivesAsync</summary>
         public async Task ListServiceLevelObjectivesResourceNames2Async()
         {
             // Snippet: ListServiceLevelObjectivesAsync(IResourceName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/UptimeCheckServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/UptimeCheckServiceClientSnippets.g.cs
@@ -74,7 +74,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListUptimeCheckConfigs</summary>
+        /// <summary>Snippet for ListUptimeCheckConfigsAsync</summary>
         public async Task ListUptimeCheckConfigsRequestObjectAsync()
         {
             // Snippet: ListUptimeCheckConfigsAsync(ListUptimeCheckConfigsRequest, CallSettings)
@@ -167,7 +167,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListUptimeCheckConfigs</summary>
+        /// <summary>Snippet for ListUptimeCheckConfigsAsync</summary>
         public async Task ListUptimeCheckConfigsAsync()
         {
             // Snippet: ListUptimeCheckConfigsAsync(string, string, int?, CallSettings)
@@ -257,7 +257,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListUptimeCheckConfigs</summary>
+        /// <summary>Snippet for ListUptimeCheckConfigsAsync</summary>
         public async Task ListUptimeCheckConfigsResourceNames1Async()
         {
             // Snippet: ListUptimeCheckConfigsAsync(ProjectName, string, int?, CallSettings)
@@ -347,7 +347,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListUptimeCheckConfigs</summary>
+        /// <summary>Snippet for ListUptimeCheckConfigsAsync</summary>
         public async Task ListUptimeCheckConfigsResourceNames2Async()
         {
             // Snippet: ListUptimeCheckConfigsAsync(OrganizationName, string, int?, CallSettings)
@@ -437,7 +437,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListUptimeCheckConfigs</summary>
+        /// <summary>Snippet for ListUptimeCheckConfigsAsync</summary>
         public async Task ListUptimeCheckConfigsResourceNames3Async()
         {
             // Snippet: ListUptimeCheckConfigsAsync(FolderName, string, int?, CallSettings)
@@ -527,7 +527,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListUptimeCheckConfigs</summary>
+        /// <summary>Snippet for ListUptimeCheckConfigsAsync</summary>
         public async Task ListUptimeCheckConfigsResourceNames4Async()
         {
             // Snippet: ListUptimeCheckConfigsAsync(IResourceName, string, int?, CallSettings)
@@ -1087,7 +1087,7 @@ namespace Google.Cloud.Monitoring.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListUptimeCheckIps</summary>
+        /// <summary>Snippet for ListUptimeCheckIpsAsync</summary>
         public async Task ListUptimeCheckIpsRequestObjectAsync()
         {
             // Snippet: ListUptimeCheckIpsAsync(ListUptimeCheckIpsRequest, CallSettings)

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.Snippets/HubServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.Snippets/HubServiceClientSnippets.g.cs
@@ -77,7 +77,7 @@ namespace Google.Cloud.NetworkConnectivity.V1Alpha1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListHubs</summary>
+        /// <summary>Snippet for ListHubsAsync</summary>
         public async Task ListHubsRequestObjectAsync()
         {
             // Snippet: ListHubsAsync(ListHubsRequest, CallSettings)
@@ -172,7 +172,7 @@ namespace Google.Cloud.NetworkConnectivity.V1Alpha1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListHubs</summary>
+        /// <summary>Snippet for ListHubsAsync</summary>
         public async Task ListHubsAsync()
         {
             // Snippet: ListHubsAsync(string, string, int?, CallSettings)
@@ -262,7 +262,7 @@ namespace Google.Cloud.NetworkConnectivity.V1Alpha1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListHubs</summary>
+        /// <summary>Snippet for ListHubsAsync</summary>
         public async Task ListHubsResourceNamesAsync()
         {
             // Snippet: ListHubsAsync(LocationName, string, int?, CallSettings)
@@ -956,7 +956,7 @@ namespace Google.Cloud.NetworkConnectivity.V1Alpha1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSpokes</summary>
+        /// <summary>Snippet for ListSpokesAsync</summary>
         public async Task ListSpokesRequestObjectAsync()
         {
             // Snippet: ListSpokesAsync(ListSpokesRequest, CallSettings)
@@ -1051,7 +1051,7 @@ namespace Google.Cloud.NetworkConnectivity.V1Alpha1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSpokes</summary>
+        /// <summary>Snippet for ListSpokesAsync</summary>
         public async Task ListSpokesAsync()
         {
             // Snippet: ListSpokesAsync(string, string, int?, CallSettings)
@@ -1141,7 +1141,7 @@ namespace Google.Cloud.NetworkConnectivity.V1Alpha1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSpokes</summary>
+        /// <summary>Snippet for ListSpokesAsync</summary>
         public async Task ListSpokesResourceNamesAsync()
         {
             // Snippet: ListSpokesAsync(LocationName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.Snippets/NotebookServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.Snippets/NotebookServiceClientSnippets.g.cs
@@ -72,7 +72,7 @@ namespace Google.Cloud.Notebooks.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListInstances</summary>
+        /// <summary>Snippet for ListInstancesAsync</summary>
         public async Task ListInstancesRequestObjectAsync()
         {
             // Snippet: ListInstancesAsync(ListInstancesRequest, CallSettings)
@@ -984,7 +984,7 @@ namespace Google.Cloud.Notebooks.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListEnvironments</summary>
+        /// <summary>Snippet for ListEnvironmentsAsync</summary>
         public async Task ListEnvironmentsRequestObjectAsync()
         {
             // Snippet: ListEnvironmentsAsync(ListEnvironmentsRequest, CallSettings)

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.Snippets/OrgPolicyClientSnippets.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.Snippets/OrgPolicyClientSnippets.g.cs
@@ -73,7 +73,7 @@ namespace Google.Cloud.OrgPolicy.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListConstraints</summary>
+        /// <summary>Snippet for ListConstraintsAsync</summary>
         public async Task ListConstraintsRequestObjectAsync()
         {
             // Snippet: ListConstraintsAsync(ListConstraintsRequest, CallSettings)
@@ -166,7 +166,7 @@ namespace Google.Cloud.OrgPolicy.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListConstraints</summary>
+        /// <summary>Snippet for ListConstraintsAsync</summary>
         public async Task ListConstraintsAsync()
         {
             // Snippet: ListConstraintsAsync(string, string, int?, CallSettings)
@@ -256,7 +256,7 @@ namespace Google.Cloud.OrgPolicy.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListConstraints</summary>
+        /// <summary>Snippet for ListConstraintsAsync</summary>
         public async Task ListConstraintsResourceNames1Async()
         {
             // Snippet: ListConstraintsAsync(ProjectName, string, int?, CallSettings)
@@ -346,7 +346,7 @@ namespace Google.Cloud.OrgPolicy.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListConstraints</summary>
+        /// <summary>Snippet for ListConstraintsAsync</summary>
         public async Task ListConstraintsResourceNames2Async()
         {
             // Snippet: ListConstraintsAsync(FolderName, string, int?, CallSettings)
@@ -436,7 +436,7 @@ namespace Google.Cloud.OrgPolicy.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListConstraints</summary>
+        /// <summary>Snippet for ListConstraintsAsync</summary>
         public async Task ListConstraintsResourceNames3Async()
         {
             // Snippet: ListConstraintsAsync(OrganizationName, string, int?, CallSettings)
@@ -529,7 +529,7 @@ namespace Google.Cloud.OrgPolicy.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListPolicies</summary>
+        /// <summary>Snippet for ListPoliciesAsync</summary>
         public async Task ListPoliciesRequestObjectAsync()
         {
             // Snippet: ListPoliciesAsync(ListPoliciesRequest, CallSettings)
@@ -622,7 +622,7 @@ namespace Google.Cloud.OrgPolicy.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListPolicies</summary>
+        /// <summary>Snippet for ListPoliciesAsync</summary>
         public async Task ListPoliciesAsync()
         {
             // Snippet: ListPoliciesAsync(string, string, int?, CallSettings)
@@ -712,7 +712,7 @@ namespace Google.Cloud.OrgPolicy.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListPolicies</summary>
+        /// <summary>Snippet for ListPoliciesAsync</summary>
         public async Task ListPoliciesResourceNames1Async()
         {
             // Snippet: ListPoliciesAsync(ProjectName, string, int?, CallSettings)
@@ -802,7 +802,7 @@ namespace Google.Cloud.OrgPolicy.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListPolicies</summary>
+        /// <summary>Snippet for ListPoliciesAsync</summary>
         public async Task ListPoliciesResourceNames2Async()
         {
             // Snippet: ListPoliciesAsync(FolderName, string, int?, CallSettings)
@@ -892,7 +892,7 @@ namespace Google.Cloud.OrgPolicy.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListPolicies</summary>
+        /// <summary>Snippet for ListPoliciesAsync</summary>
         public async Task ListPoliciesResourceNames3Async()
         {
             // Snippet: ListPoliciesAsync(OrganizationName, string, int?, CallSettings)

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.Snippets/OsConfigServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.Snippets/OsConfigServiceClientSnippets.g.cs
@@ -242,7 +242,7 @@ namespace Google.Cloud.OsConfig.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListPatchJobs</summary>
+        /// <summary>Snippet for ListPatchJobsAsync</summary>
         public async Task ListPatchJobsRequestObjectAsync()
         {
             // Snippet: ListPatchJobsAsync(ListPatchJobsRequest, CallSettings)
@@ -336,7 +336,7 @@ namespace Google.Cloud.OsConfig.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListPatchJobs</summary>
+        /// <summary>Snippet for ListPatchJobsAsync</summary>
         public async Task ListPatchJobsAsync()
         {
             // Snippet: ListPatchJobsAsync(string, string, int?, CallSettings)
@@ -426,7 +426,7 @@ namespace Google.Cloud.OsConfig.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListPatchJobs</summary>
+        /// <summary>Snippet for ListPatchJobsAsync</summary>
         public async Task ListPatchJobsResourceNamesAsync()
         {
             // Snippet: ListPatchJobsAsync(ProjectName, string, int?, CallSettings)
@@ -520,7 +520,7 @@ namespace Google.Cloud.OsConfig.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListPatchJobInstanceDetails</summary>
+        /// <summary>Snippet for ListPatchJobInstanceDetailsAsync</summary>
         public async Task ListPatchJobInstanceDetailsRequestObjectAsync()
         {
             // Snippet: ListPatchJobInstanceDetailsAsync(ListPatchJobInstanceDetailsRequest, CallSettings)
@@ -614,7 +614,7 @@ namespace Google.Cloud.OsConfig.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListPatchJobInstanceDetails</summary>
+        /// <summary>Snippet for ListPatchJobInstanceDetailsAsync</summary>
         public async Task ListPatchJobInstanceDetailsAsync()
         {
             // Snippet: ListPatchJobInstanceDetailsAsync(string, string, int?, CallSettings)
@@ -704,7 +704,7 @@ namespace Google.Cloud.OsConfig.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListPatchJobInstanceDetails</summary>
+        /// <summary>Snippet for ListPatchJobInstanceDetailsAsync</summary>
         public async Task ListPatchJobInstanceDetailsResourceNamesAsync()
         {
             // Snippet: ListPatchJobInstanceDetailsAsync(PatchJobName, string, int?, CallSettings)
@@ -983,7 +983,7 @@ namespace Google.Cloud.OsConfig.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListPatchDeployments</summary>
+        /// <summary>Snippet for ListPatchDeploymentsAsync</summary>
         public async Task ListPatchDeploymentsRequestObjectAsync()
         {
             // Snippet: ListPatchDeploymentsAsync(ListPatchDeploymentsRequest, CallSettings)
@@ -1076,7 +1076,7 @@ namespace Google.Cloud.OsConfig.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListPatchDeployments</summary>
+        /// <summary>Snippet for ListPatchDeploymentsAsync</summary>
         public async Task ListPatchDeploymentsAsync()
         {
             // Snippet: ListPatchDeploymentsAsync(string, string, int?, CallSettings)
@@ -1166,7 +1166,7 @@ namespace Google.Cloud.OsConfig.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListPatchDeployments</summary>
+        /// <summary>Snippet for ListPatchDeploymentsAsync</summary>
         public async Task ListPatchDeploymentsResourceNamesAsync()
         {
             // Snippet: ListPatchDeploymentsAsync(ProjectName, string, int?, CallSettings)

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/PublisherServiceApiClientSnippets.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/PublisherServiceApiClientSnippets.g.cs
@@ -405,7 +405,7 @@ namespace Google.Cloud.PubSub.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTopics</summary>
+        /// <summary>Snippet for ListTopicsAsync</summary>
         public async Task ListTopicsRequestObjectAsync()
         {
             // Snippet: ListTopicsAsync(ListTopicsRequest, CallSettings)
@@ -498,7 +498,7 @@ namespace Google.Cloud.PubSub.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTopics</summary>
+        /// <summary>Snippet for ListTopicsAsync</summary>
         public async Task ListTopicsAsync()
         {
             // Snippet: ListTopicsAsync(string, string, int?, CallSettings)
@@ -588,7 +588,7 @@ namespace Google.Cloud.PubSub.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTopics</summary>
+        /// <summary>Snippet for ListTopicsAsync</summary>
         public async Task ListTopicsResourceNamesAsync()
         {
             // Snippet: ListTopicsAsync(ProjectName, string, int?, CallSettings)
@@ -681,7 +681,7 @@ namespace Google.Cloud.PubSub.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTopicSubscriptions</summary>
+        /// <summary>Snippet for ListTopicSubscriptionsAsync</summary>
         public async Task ListTopicSubscriptionsRequestObjectAsync()
         {
             // Snippet: ListTopicSubscriptionsAsync(ListTopicSubscriptionsRequest, CallSettings)
@@ -774,7 +774,7 @@ namespace Google.Cloud.PubSub.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTopicSubscriptions</summary>
+        /// <summary>Snippet for ListTopicSubscriptionsAsync</summary>
         public async Task ListTopicSubscriptionsAsync()
         {
             // Snippet: ListTopicSubscriptionsAsync(string, string, int?, CallSettings)
@@ -864,7 +864,7 @@ namespace Google.Cloud.PubSub.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTopicSubscriptions</summary>
+        /// <summary>Snippet for ListTopicSubscriptionsAsync</summary>
         public async Task ListTopicSubscriptionsResourceNamesAsync()
         {
             // Snippet: ListTopicSubscriptionsAsync(TopicName, string, int?, CallSettings)
@@ -957,7 +957,7 @@ namespace Google.Cloud.PubSub.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTopicSnapshots</summary>
+        /// <summary>Snippet for ListTopicSnapshotsAsync</summary>
         public async Task ListTopicSnapshotsRequestObjectAsync()
         {
             // Snippet: ListTopicSnapshotsAsync(ListTopicSnapshotsRequest, CallSettings)
@@ -1050,7 +1050,7 @@ namespace Google.Cloud.PubSub.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTopicSnapshots</summary>
+        /// <summary>Snippet for ListTopicSnapshotsAsync</summary>
         public async Task ListTopicSnapshotsAsync()
         {
             // Snippet: ListTopicSnapshotsAsync(string, string, int?, CallSettings)
@@ -1140,7 +1140,7 @@ namespace Google.Cloud.PubSub.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTopicSnapshots</summary>
+        /// <summary>Snippet for ListTopicSnapshotsAsync</summary>
         public async Task ListTopicSnapshotsResourceNamesAsync()
         {
             // Snippet: ListTopicSnapshotsAsync(TopicName, string, int?, CallSettings)

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/SchemaServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/SchemaServiceClientSnippets.g.cs
@@ -263,7 +263,7 @@ namespace Google.Cloud.PubSub.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSchemas</summary>
+        /// <summary>Snippet for ListSchemasAsync</summary>
         public async Task ListSchemasRequestObjectAsync()
         {
             // Snippet: ListSchemasAsync(ListSchemasRequest, CallSettings)
@@ -357,7 +357,7 @@ namespace Google.Cloud.PubSub.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSchemas</summary>
+        /// <summary>Snippet for ListSchemasAsync</summary>
         public async Task ListSchemasAsync()
         {
             // Snippet: ListSchemasAsync(string, string, int?, CallSettings)
@@ -447,7 +447,7 @@ namespace Google.Cloud.PubSub.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSchemas</summary>
+        /// <summary>Snippet for ListSchemasAsync</summary>
         public async Task ListSchemasResourceNamesAsync()
         {
             // Snippet: ListSchemasAsync(ProjectName, string, int?, CallSettings)

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/SubscriberServiceApiClientSnippets.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/SubscriberServiceApiClientSnippets.g.cs
@@ -321,7 +321,7 @@ namespace Google.Cloud.PubSub.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSubscriptions</summary>
+        /// <summary>Snippet for ListSubscriptionsAsync</summary>
         public async Task ListSubscriptionsRequestObjectAsync()
         {
             // Snippet: ListSubscriptionsAsync(ListSubscriptionsRequest, CallSettings)
@@ -414,7 +414,7 @@ namespace Google.Cloud.PubSub.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSubscriptions</summary>
+        /// <summary>Snippet for ListSubscriptionsAsync</summary>
         public async Task ListSubscriptionsAsync()
         {
             // Snippet: ListSubscriptionsAsync(string, string, int?, CallSettings)
@@ -504,7 +504,7 @@ namespace Google.Cloud.PubSub.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSubscriptions</summary>
+        /// <summary>Snippet for ListSubscriptionsAsync</summary>
         public async Task ListSubscriptionsResourceNamesAsync()
         {
             // Snippet: ListSubscriptionsAsync(ProjectName, string, int?, CallSettings)
@@ -1207,7 +1207,7 @@ namespace Google.Cloud.PubSub.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSnapshots</summary>
+        /// <summary>Snippet for ListSnapshotsAsync</summary>
         public async Task ListSnapshotsRequestObjectAsync()
         {
             // Snippet: ListSnapshotsAsync(ListSnapshotsRequest, CallSettings)
@@ -1300,7 +1300,7 @@ namespace Google.Cloud.PubSub.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSnapshots</summary>
+        /// <summary>Snippet for ListSnapshotsAsync</summary>
         public async Task ListSnapshotsAsync()
         {
             // Snippet: ListSnapshotsAsync(string, string, int?, CallSettings)
@@ -1390,7 +1390,7 @@ namespace Google.Cloud.PubSub.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSnapshots</summary>
+        /// <summary>Snippet for ListSnapshotsAsync</summary>
         public async Task ListSnapshotsResourceNamesAsync()
         {
             // Snippet: ListSnapshotsAsync(ProjectName, string, int?, CallSettings)

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.Snippets/RecaptchaEnterpriseServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.Snippets/RecaptchaEnterpriseServiceClientSnippets.g.cs
@@ -295,7 +295,7 @@ namespace Google.Cloud.RecaptchaEnterprise.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListKeys</summary>
+        /// <summary>Snippet for ListKeysAsync</summary>
         public async Task ListKeysRequestObjectAsync()
         {
             // Snippet: ListKeysAsync(ListKeysRequest, CallSettings)

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.Snippets/RecaptchaEnterpriseServiceV1Beta1ClientSnippets.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.Snippets/RecaptchaEnterpriseServiceV1Beta1ClientSnippets.g.cs
@@ -295,7 +295,7 @@ namespace Google.Cloud.RecaptchaEnterprise.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListKeys</summary>
+        /// <summary>Snippet for ListKeysAsync</summary>
         public async Task ListKeysRequestObjectAsync()
         {
             // Snippet: ListKeysAsync(ListKeysRequest, CallSettings)

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.Snippets/CatalogServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.Snippets/CatalogServiceClientSnippets.g.cs
@@ -255,7 +255,7 @@ namespace Google.Cloud.RecommendationEngine.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListCatalogItems</summary>
+        /// <summary>Snippet for ListCatalogItemsAsync</summary>
         public async Task ListCatalogItemsRequestObjectAsync()
         {
             // Snippet: ListCatalogItemsAsync(ListCatalogItemsRequest, CallSettings)
@@ -350,7 +350,7 @@ namespace Google.Cloud.RecommendationEngine.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListCatalogItems</summary>
+        /// <summary>Snippet for ListCatalogItemsAsync</summary>
         public async Task ListCatalogItemsAsync()
         {
             // Snippet: ListCatalogItemsAsync(string, string, string, int?, CallSettings)
@@ -442,7 +442,7 @@ namespace Google.Cloud.RecommendationEngine.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListCatalogItems</summary>
+        /// <summary>Snippet for ListCatalogItemsAsync</summary>
         public async Task ListCatalogItemsResourceNamesAsync()
         {
             // Snippet: ListCatalogItemsAsync(CatalogName, string, string, int?, CallSettings)

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.Snippets/PredictionApiKeyRegistryClientSnippets.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.Snippets/PredictionApiKeyRegistryClientSnippets.g.cs
@@ -165,7 +165,7 @@ namespace Google.Cloud.RecommendationEngine.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListPredictionApiKeyRegistrations</summary>
+        /// <summary>Snippet for ListPredictionApiKeyRegistrationsAsync</summary>
         public async Task ListPredictionApiKeyRegistrationsRequestObjectAsync()
         {
             // Snippet: ListPredictionApiKeyRegistrationsAsync(ListPredictionApiKeyRegistrationsRequest, CallSettings)
@@ -258,7 +258,7 @@ namespace Google.Cloud.RecommendationEngine.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListPredictionApiKeyRegistrations</summary>
+        /// <summary>Snippet for ListPredictionApiKeyRegistrationsAsync</summary>
         public async Task ListPredictionApiKeyRegistrationsAsync()
         {
             // Snippet: ListPredictionApiKeyRegistrationsAsync(string, string, int?, CallSettings)
@@ -348,7 +348,7 @@ namespace Google.Cloud.RecommendationEngine.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListPredictionApiKeyRegistrations</summary>
+        /// <summary>Snippet for ListPredictionApiKeyRegistrationsAsync</summary>
         public async Task ListPredictionApiKeyRegistrationsResourceNamesAsync()
         {
             // Snippet: ListPredictionApiKeyRegistrationsAsync(EventStoreName, string, int?, CallSettings)

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.Snippets/PredictionServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.Snippets/PredictionServiceClientSnippets.g.cs
@@ -78,7 +78,7 @@ namespace Google.Cloud.RecommendationEngine.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for Predict</summary>
+        /// <summary>Snippet for PredictAsync</summary>
         public async Task PredictRequestObjectAsync()
         {
             // Snippet: PredictAsync(PredictRequest, CallSettings)
@@ -177,7 +177,7 @@ namespace Google.Cloud.RecommendationEngine.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for Predict</summary>
+        /// <summary>Snippet for PredictAsync</summary>
         public async Task PredictAsync()
         {
             // Snippet: PredictAsync(string, UserEvent, string, int?, CallSettings)
@@ -269,7 +269,7 @@ namespace Google.Cloud.RecommendationEngine.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for Predict</summary>
+        /// <summary>Snippet for PredictAsync</summary>
         public async Task PredictResourceNamesAsync()
         {
             // Snippet: PredictAsync(PlacementName, UserEvent, string, int?, CallSettings)

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.Snippets/UserEventServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.Snippets/UserEventServiceClientSnippets.g.cs
@@ -273,7 +273,7 @@ namespace Google.Cloud.RecommendationEngine.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListUserEvents</summary>
+        /// <summary>Snippet for ListUserEventsAsync</summary>
         public async Task ListUserEventsRequestObjectAsync()
         {
             // Snippet: ListUserEventsAsync(ListUserEventsRequest, CallSettings)
@@ -368,7 +368,7 @@ namespace Google.Cloud.RecommendationEngine.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListUserEvents</summary>
+        /// <summary>Snippet for ListUserEventsAsync</summary>
         public async Task ListUserEventsAsync()
         {
             // Snippet: ListUserEventsAsync(string, string, string, int?, CallSettings)
@@ -460,7 +460,7 @@ namespace Google.Cloud.RecommendationEngine.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListUserEvents</summary>
+        /// <summary>Snippet for ListUserEventsAsync</summary>
         public async Task ListUserEventsResourceNamesAsync()
         {
             // Snippet: ListUserEventsAsync(EventStoreName, string, string, int?, CallSettings)

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.Snippets/RecommenderClientSnippets.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.Snippets/RecommenderClientSnippets.g.cs
@@ -74,7 +74,7 @@ namespace Google.Cloud.Recommender.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListInsights</summary>
+        /// <summary>Snippet for ListInsightsAsync</summary>
         public async Task ListInsightsRequestObjectAsync()
         {
             // Snippet: ListInsightsAsync(ListInsightsRequest, CallSettings)
@@ -168,7 +168,7 @@ namespace Google.Cloud.Recommender.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListInsights</summary>
+        /// <summary>Snippet for ListInsightsAsync</summary>
         public async Task ListInsightsAsync()
         {
             // Snippet: ListInsightsAsync(string, string, int?, CallSettings)
@@ -258,7 +258,7 @@ namespace Google.Cloud.Recommender.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListInsights</summary>
+        /// <summary>Snippet for ListInsightsAsync</summary>
         public async Task ListInsightsResourceNamesAsync()
         {
             // Snippet: ListInsightsAsync(InsightTypeName, string, int?, CallSettings)
@@ -538,7 +538,7 @@ namespace Google.Cloud.Recommender.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListRecommendations</summary>
+        /// <summary>Snippet for ListRecommendationsAsync</summary>
         public async Task ListRecommendationsRequestObjectAsync()
         {
             // Snippet: ListRecommendationsAsync(ListRecommendationsRequest, CallSettings)
@@ -632,7 +632,7 @@ namespace Google.Cloud.Recommender.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListRecommendations</summary>
+        /// <summary>Snippet for ListRecommendationsAsync</summary>
         public async Task ListRecommendations1Async()
         {
             // Snippet: ListRecommendationsAsync(string, string, int?, CallSettings)
@@ -722,7 +722,7 @@ namespace Google.Cloud.Recommender.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListRecommendations</summary>
+        /// <summary>Snippet for ListRecommendationsAsync</summary>
         public async Task ListRecommendations1ResourceNamesAsync()
         {
             // Snippet: ListRecommendationsAsync(RecommenderName, string, int?, CallSettings)
@@ -813,7 +813,7 @@ namespace Google.Cloud.Recommender.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListRecommendations</summary>
+        /// <summary>Snippet for ListRecommendationsAsync</summary>
         public async Task ListRecommendations2Async()
         {
             // Snippet: ListRecommendationsAsync(string, string, string, int?, CallSettings)
@@ -905,7 +905,7 @@ namespace Google.Cloud.Recommender.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListRecommendations</summary>
+        /// <summary>Snippet for ListRecommendationsAsync</summary>
         public async Task ListRecommendations2ResourceNamesAsync()
         {
             // Snippet: ListRecommendationsAsync(RecommenderName, string, string, int?, CallSettings)

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.Snippets/CloudRedisClientSnippets.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.Snippets/CloudRedisClientSnippets.g.cs
@@ -75,7 +75,7 @@ namespace Google.Cloud.Redis.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListInstances</summary>
+        /// <summary>Snippet for ListInstancesAsync</summary>
         public async Task ListInstancesRequestObjectAsync()
         {
             // Snippet: ListInstancesAsync(ListInstancesRequest, CallSettings)
@@ -168,7 +168,7 @@ namespace Google.Cloud.Redis.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListInstances</summary>
+        /// <summary>Snippet for ListInstancesAsync</summary>
         public async Task ListInstancesAsync()
         {
             // Snippet: ListInstancesAsync(string, string, int?, CallSettings)
@@ -258,7 +258,7 @@ namespace Google.Cloud.Redis.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListInstances</summary>
+        /// <summary>Snippet for ListInstancesAsync</summary>
         public async Task ListInstancesResourceNamesAsync()
         {
             // Snippet: ListInstancesAsync(LocationName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.Snippets/CloudRedisClientSnippets.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.Snippets/CloudRedisClientSnippets.g.cs
@@ -75,7 +75,7 @@ namespace Google.Cloud.Redis.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListInstances</summary>
+        /// <summary>Snippet for ListInstancesAsync</summary>
         public async Task ListInstancesRequestObjectAsync()
         {
             // Snippet: ListInstancesAsync(ListInstancesRequest, CallSettings)
@@ -168,7 +168,7 @@ namespace Google.Cloud.Redis.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListInstances</summary>
+        /// <summary>Snippet for ListInstancesAsync</summary>
         public async Task ListInstancesAsync()
         {
             // Snippet: ListInstancesAsync(string, string, int?, CallSettings)
@@ -258,7 +258,7 @@ namespace Google.Cloud.Redis.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListInstances</summary>
+        /// <summary>Snippet for ListInstancesAsync</summary>
         public async Task ListInstancesResourceNamesAsync()
         {
             // Snippet: ListInstancesAsync(LocationName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.Snippets/CatalogServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.Snippets/CatalogServiceClientSnippets.g.cs
@@ -74,7 +74,7 @@ namespace Google.Cloud.Retail.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListCatalogs</summary>
+        /// <summary>Snippet for ListCatalogsAsync</summary>
         public async Task ListCatalogsRequestObjectAsync()
         {
             // Snippet: ListCatalogsAsync(ListCatalogsRequest, CallSettings)
@@ -167,7 +167,7 @@ namespace Google.Cloud.Retail.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListCatalogs</summary>
+        /// <summary>Snippet for ListCatalogsAsync</summary>
         public async Task ListCatalogsAsync()
         {
             // Snippet: ListCatalogsAsync(string, string, int?, CallSettings)
@@ -257,7 +257,7 @@ namespace Google.Cloud.Retail.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListCatalogs</summary>
+        /// <summary>Snippet for ListCatalogsAsync</summary>
         public async Task ListCatalogsResourceNamesAsync()
         {
             // Snippet: ListCatalogsAsync(LocationName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.Snippets/CloudSchedulerClientSnippets.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.Snippets/CloudSchedulerClientSnippets.g.cs
@@ -74,7 +74,7 @@ namespace Google.Cloud.Scheduler.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListJobs</summary>
+        /// <summary>Snippet for ListJobsAsync</summary>
         public async Task ListJobsRequestObjectAsync()
         {
             // Snippet: ListJobsAsync(ListJobsRequest, CallSettings)
@@ -167,7 +167,7 @@ namespace Google.Cloud.Scheduler.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListJobs</summary>
+        /// <summary>Snippet for ListJobsAsync</summary>
         public async Task ListJobsAsync()
         {
             // Snippet: ListJobsAsync(string, string, int?, CallSettings)
@@ -257,7 +257,7 @@ namespace Google.Cloud.Scheduler.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListJobs</summary>
+        /// <summary>Snippet for ListJobsAsync</summary>
         public async Task ListJobsResourceNamesAsync()
         {
             // Snippet: ListJobsAsync(LocationName, string, int?, CallSettings)

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.Snippets/SecretManagerServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.Snippets/SecretManagerServiceClientSnippets.g.cs
@@ -75,7 +75,7 @@ namespace Google.Cloud.SecretManager.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSecrets</summary>
+        /// <summary>Snippet for ListSecretsAsync</summary>
         public async Task ListSecretsRequestObjectAsync()
         {
             // Snippet: ListSecretsAsync(ListSecretsRequest, CallSettings)
@@ -168,7 +168,7 @@ namespace Google.Cloud.SecretManager.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSecrets</summary>
+        /// <summary>Snippet for ListSecretsAsync</summary>
         public async Task ListSecretsAsync()
         {
             // Snippet: ListSecretsAsync(string, string, int?, CallSettings)
@@ -258,7 +258,7 @@ namespace Google.Cloud.SecretManager.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSecrets</summary>
+        /// <summary>Snippet for ListSecretsAsync</summary>
         public async Task ListSecretsResourceNamesAsync()
         {
             // Snippet: ListSecretsAsync(ProjectName, string, int?, CallSettings)
@@ -781,7 +781,7 @@ namespace Google.Cloud.SecretManager.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSecretVersions</summary>
+        /// <summary>Snippet for ListSecretVersionsAsync</summary>
         public async Task ListSecretVersionsRequestObjectAsync()
         {
             // Snippet: ListSecretVersionsAsync(ListSecretVersionsRequest, CallSettings)
@@ -874,7 +874,7 @@ namespace Google.Cloud.SecretManager.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSecretVersions</summary>
+        /// <summary>Snippet for ListSecretVersionsAsync</summary>
         public async Task ListSecretVersionsAsync()
         {
             // Snippet: ListSecretVersionsAsync(string, string, int?, CallSettings)
@@ -964,7 +964,7 @@ namespace Google.Cloud.SecretManager.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSecretVersions</summary>
+        /// <summary>Snippet for ListSecretVersionsAsync</summary>
         public async Task ListSecretVersionsResourceNamesAsync()
         {
             // Snippet: ListSecretVersionsAsync(SecretName, string, int?, CallSettings)

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.Snippets/SecretManagerServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.Snippets/SecretManagerServiceClientSnippets.g.cs
@@ -75,7 +75,7 @@ namespace Google.Cloud.SecretManager.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSecrets</summary>
+        /// <summary>Snippet for ListSecretsAsync</summary>
         public async Task ListSecretsRequestObjectAsync()
         {
             // Snippet: ListSecretsAsync(ListSecretsRequest, CallSettings)
@@ -168,7 +168,7 @@ namespace Google.Cloud.SecretManager.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSecrets</summary>
+        /// <summary>Snippet for ListSecretsAsync</summary>
         public async Task ListSecretsAsync()
         {
             // Snippet: ListSecretsAsync(string, string, int?, CallSettings)
@@ -258,7 +258,7 @@ namespace Google.Cloud.SecretManager.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSecrets</summary>
+        /// <summary>Snippet for ListSecretsAsync</summary>
         public async Task ListSecretsResourceNamesAsync()
         {
             // Snippet: ListSecretsAsync(ProjectName, string, int?, CallSettings)
@@ -781,7 +781,7 @@ namespace Google.Cloud.SecretManager.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSecretVersions</summary>
+        /// <summary>Snippet for ListSecretVersionsAsync</summary>
         public async Task ListSecretVersionsRequestObjectAsync()
         {
             // Snippet: ListSecretVersionsAsync(ListSecretVersionsRequest, CallSettings)
@@ -874,7 +874,7 @@ namespace Google.Cloud.SecretManager.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSecretVersions</summary>
+        /// <summary>Snippet for ListSecretVersionsAsync</summary>
         public async Task ListSecretVersionsAsync()
         {
             // Snippet: ListSecretVersionsAsync(string, string, int?, CallSettings)
@@ -964,7 +964,7 @@ namespace Google.Cloud.SecretManager.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSecretVersions</summary>
+        /// <summary>Snippet for ListSecretVersionsAsync</summary>
         public async Task ListSecretVersionsResourceNamesAsync()
         {
             // Snippet: ListSecretVersionsAsync(SecretName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Security.PrivateCA.V1Beta1/Google.Cloud.Security.PrivateCA.V1Beta1.Snippets/CertificateAuthorityServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1Beta1/Google.Cloud.Security.PrivateCA.V1Beta1.Snippets/CertificateAuthorityServiceClientSnippets.g.cs
@@ -265,7 +265,7 @@ namespace Google.Cloud.Security.PrivateCA.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListCertificates</summary>
+        /// <summary>Snippet for ListCertificatesAsync</summary>
         public async Task ListCertificatesRequestObjectAsync()
         {
             // Snippet: ListCertificatesAsync(ListCertificatesRequest, CallSettings)
@@ -360,7 +360,7 @@ namespace Google.Cloud.Security.PrivateCA.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListCertificates</summary>
+        /// <summary>Snippet for ListCertificatesAsync</summary>
         public async Task ListCertificatesAsync()
         {
             // Snippet: ListCertificatesAsync(string, string, int?, CallSettings)
@@ -450,7 +450,7 @@ namespace Google.Cloud.Security.PrivateCA.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListCertificates</summary>
+        /// <summary>Snippet for ListCertificatesAsync</summary>
         public async Task ListCertificatesResourceNamesAsync()
         {
             // Snippet: ListCertificatesAsync(CertificateAuthorityName, string, int?, CallSettings)
@@ -1632,7 +1632,7 @@ namespace Google.Cloud.Security.PrivateCA.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListCertificateAuthorities</summary>
+        /// <summary>Snippet for ListCertificateAuthoritiesAsync</summary>
         public async Task ListCertificateAuthoritiesRequestObjectAsync()
         {
             // Snippet: ListCertificateAuthoritiesAsync(ListCertificateAuthoritiesRequest, CallSettings)
@@ -1727,7 +1727,7 @@ namespace Google.Cloud.Security.PrivateCA.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListCertificateAuthorities</summary>
+        /// <summary>Snippet for ListCertificateAuthoritiesAsync</summary>
         public async Task ListCertificateAuthoritiesAsync()
         {
             // Snippet: ListCertificateAuthoritiesAsync(string, string, int?, CallSettings)
@@ -1817,7 +1817,7 @@ namespace Google.Cloud.Security.PrivateCA.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListCertificateAuthorities</summary>
+        /// <summary>Snippet for ListCertificateAuthoritiesAsync</summary>
         public async Task ListCertificateAuthoritiesResourceNamesAsync()
         {
             // Snippet: ListCertificateAuthoritiesAsync(LocationName, string, int?, CallSettings)
@@ -2499,7 +2499,7 @@ namespace Google.Cloud.Security.PrivateCA.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListCertificateRevocationLists</summary>
+        /// <summary>Snippet for ListCertificateRevocationListsAsync</summary>
         public async Task ListCertificateRevocationListsRequestObjectAsync()
         {
             // Snippet: ListCertificateRevocationListsAsync(ListCertificateRevocationListsRequest, CallSettings)
@@ -2594,7 +2594,7 @@ namespace Google.Cloud.Security.PrivateCA.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListCertificateRevocationLists</summary>
+        /// <summary>Snippet for ListCertificateRevocationListsAsync</summary>
         public async Task ListCertificateRevocationListsAsync()
         {
             // Snippet: ListCertificateRevocationListsAsync(string, string, int?, CallSettings)
@@ -2684,7 +2684,7 @@ namespace Google.Cloud.Security.PrivateCA.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListCertificateRevocationLists</summary>
+        /// <summary>Snippet for ListCertificateRevocationListsAsync</summary>
         public async Task ListCertificateRevocationListsResourceNamesAsync()
         {
             // Snippet: ListCertificateRevocationListsAsync(CertificateAuthorityName, string, int?, CallSettings)
@@ -2996,7 +2996,7 @@ namespace Google.Cloud.Security.PrivateCA.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListReusableConfigs</summary>
+        /// <summary>Snippet for ListReusableConfigsAsync</summary>
         public async Task ListReusableConfigsRequestObjectAsync()
         {
             // Snippet: ListReusableConfigsAsync(ListReusableConfigsRequest, CallSettings)
@@ -3091,7 +3091,7 @@ namespace Google.Cloud.Security.PrivateCA.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListReusableConfigs</summary>
+        /// <summary>Snippet for ListReusableConfigsAsync</summary>
         public async Task ListReusableConfigsAsync()
         {
             // Snippet: ListReusableConfigsAsync(string, string, int?, CallSettings)
@@ -3181,7 +3181,7 @@ namespace Google.Cloud.Security.PrivateCA.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListReusableConfigs</summary>
+        /// <summary>Snippet for ListReusableConfigsAsync</summary>
         public async Task ListReusableConfigsResourceNamesAsync()
         {
             // Snippet: ListReusableConfigsAsync(LocationName, string, int?, CallSettings)

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.Snippets/SecurityCenterSettingsServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.Snippets/SecurityCenterSettingsServiceClientSnippets.g.cs
@@ -784,7 +784,7 @@ namespace Google.Cloud.SecurityCenter.Settings.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDetectors</summary>
+        /// <summary>Snippet for ListDetectorsAsync</summary>
         public async Task ListDetectorsRequestObjectAsync()
         {
             // Snippet: ListDetectorsAsync(ListDetectorsRequest, CallSettings)
@@ -878,7 +878,7 @@ namespace Google.Cloud.SecurityCenter.Settings.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDetectors</summary>
+        /// <summary>Snippet for ListDetectorsAsync</summary>
         public async Task ListDetectorsAsync()
         {
             // Snippet: ListDetectorsAsync(string, string, int?, CallSettings)
@@ -968,7 +968,7 @@ namespace Google.Cloud.SecurityCenter.Settings.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDetectors</summary>
+        /// <summary>Snippet for ListDetectorsAsync</summary>
         public async Task ListDetectorsResourceNamesAsync()
         {
             // Snippet: ListDetectorsAsync(OrganizationName, string, int?, CallSettings)
@@ -1061,7 +1061,7 @@ namespace Google.Cloud.SecurityCenter.Settings.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListComponents</summary>
+        /// <summary>Snippet for ListComponentsAsync</summary>
         public async Task ListComponentsRequestObjectAsync()
         {
             // Snippet: ListComponentsAsync(ListComponentsRequest, CallSettings)
@@ -1154,7 +1154,7 @@ namespace Google.Cloud.SecurityCenter.Settings.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListComponents</summary>
+        /// <summary>Snippet for ListComponentsAsync</summary>
         public async Task ListComponentsAsync()
         {
             // Snippet: ListComponentsAsync(string, string, int?, CallSettings)
@@ -1244,7 +1244,7 @@ namespace Google.Cloud.SecurityCenter.Settings.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListComponents</summary>
+        /// <summary>Snippet for ListComponentsAsync</summary>
         public async Task ListComponentsResourceNamesAsync()
         {
             // Snippet: ListComponentsAsync(OrganizationName, string, int?, CallSettings)

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.Snippets/SecurityCenterClientSnippets.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.Snippets/SecurityCenterClientSnippets.g.cs
@@ -867,7 +867,7 @@ namespace Google.Cloud.SecurityCenter.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for GroupAssets</summary>
+        /// <summary>Snippet for GroupAssetsAsync</summary>
         public async Task GroupAssetsRequestObjectAsync()
         {
             // Snippet: GroupAssetsAsync(GroupAssetsRequest, CallSettings)
@@ -971,7 +971,7 @@ namespace Google.Cloud.SecurityCenter.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for GroupFindings</summary>
+        /// <summary>Snippet for GroupFindingsAsync</summary>
         public async Task GroupFindingsRequestObjectAsync()
         {
             // Snippet: GroupFindingsAsync(GroupFindingsRequest, CallSettings)
@@ -1069,7 +1069,7 @@ namespace Google.Cloud.SecurityCenter.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for GroupFindings</summary>
+        /// <summary>Snippet for GroupFindingsAsync</summary>
         public async Task GroupFindingsAsync()
         {
             // Snippet: GroupFindingsAsync(string, string, string, int?, CallSettings)
@@ -1161,7 +1161,7 @@ namespace Google.Cloud.SecurityCenter.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for GroupFindings</summary>
+        /// <summary>Snippet for GroupFindingsAsync</summary>
         public async Task GroupFindingsResourceNamesAsync()
         {
             // Snippet: GroupFindingsAsync(SourceName, string, string, int?, CallSettings)
@@ -1260,7 +1260,7 @@ namespace Google.Cloud.SecurityCenter.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAssets</summary>
+        /// <summary>Snippet for ListAssetsAsync</summary>
         public async Task ListAssetsRequestObjectAsync()
         {
             // Snippet: ListAssetsAsync(ListAssetsRequest, CallSettings)
@@ -1366,7 +1366,7 @@ namespace Google.Cloud.SecurityCenter.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListFindings</summary>
+        /// <summary>Snippet for ListFindingsAsync</summary>
         public async Task ListFindingsRequestObjectAsync()
         {
             // Snippet: ListFindingsAsync(ListFindingsRequest, CallSettings)
@@ -1467,7 +1467,7 @@ namespace Google.Cloud.SecurityCenter.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListNotificationConfigs</summary>
+        /// <summary>Snippet for ListNotificationConfigsAsync</summary>
         public async Task ListNotificationConfigsRequestObjectAsync()
         {
             // Snippet: ListNotificationConfigsAsync(ListNotificationConfigsRequest, CallSettings)
@@ -1560,7 +1560,7 @@ namespace Google.Cloud.SecurityCenter.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListNotificationConfigs</summary>
+        /// <summary>Snippet for ListNotificationConfigsAsync</summary>
         public async Task ListNotificationConfigsAsync()
         {
             // Snippet: ListNotificationConfigsAsync(string, string, int?, CallSettings)
@@ -1650,7 +1650,7 @@ namespace Google.Cloud.SecurityCenter.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListNotificationConfigs</summary>
+        /// <summary>Snippet for ListNotificationConfigsAsync</summary>
         public async Task ListNotificationConfigsResourceNamesAsync()
         {
             // Snippet: ListNotificationConfigsAsync(OrganizationName, string, int?, CallSettings)
@@ -1743,7 +1743,7 @@ namespace Google.Cloud.SecurityCenter.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSources</summary>
+        /// <summary>Snippet for ListSourcesAsync</summary>
         public async Task ListSourcesRequestObjectAsync()
         {
             // Snippet: ListSourcesAsync(ListSourcesRequest, CallSettings)
@@ -1836,7 +1836,7 @@ namespace Google.Cloud.SecurityCenter.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSources</summary>
+        /// <summary>Snippet for ListSourcesAsync</summary>
         public async Task ListSourcesAsync()
         {
             // Snippet: ListSourcesAsync(string, string, int?, CallSettings)
@@ -1926,7 +1926,7 @@ namespace Google.Cloud.SecurityCenter.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSources</summary>
+        /// <summary>Snippet for ListSourcesAsync</summary>
         public async Task ListSourcesResourceNamesAsync()
         {
             // Snippet: ListSourcesAsync(OrganizationName, string, int?, CallSettings)

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.Snippets/SecurityCenterClientSnippets.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.Snippets/SecurityCenterClientSnippets.g.cs
@@ -929,7 +929,7 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for GroupAssets</summary>
+        /// <summary>Snippet for GroupAssetsAsync</summary>
         public async Task GroupAssetsRequestObjectAsync()
         {
             // Snippet: GroupAssetsAsync(GroupAssetsRequest, CallSettings)
@@ -1033,7 +1033,7 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for GroupFindings</summary>
+        /// <summary>Snippet for GroupFindingsAsync</summary>
         public async Task GroupFindingsRequestObjectAsync()
         {
             // Snippet: GroupFindingsAsync(GroupFindingsRequest, CallSettings)
@@ -1131,7 +1131,7 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for GroupFindings</summary>
+        /// <summary>Snippet for GroupFindingsAsync</summary>
         public async Task GroupFindingsAsync()
         {
             // Snippet: GroupFindingsAsync(string, string, string, int?, CallSettings)
@@ -1223,7 +1223,7 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for GroupFindings</summary>
+        /// <summary>Snippet for GroupFindingsAsync</summary>
         public async Task GroupFindingsResourceNamesAsync()
         {
             // Snippet: GroupFindingsAsync(SourceName, string, string, int?, CallSettings)
@@ -1322,7 +1322,7 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAssets</summary>
+        /// <summary>Snippet for ListAssetsAsync</summary>
         public async Task ListAssetsRequestObjectAsync()
         {
             // Snippet: ListAssetsAsync(ListAssetsRequest, CallSettings)
@@ -1420,7 +1420,7 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAssets</summary>
+        /// <summary>Snippet for ListAssetsAsync</summary>
         public async Task ListAssetsAsync()
         {
             // Snippet: ListAssetsAsync(string, string, int?, CallSettings)
@@ -1510,7 +1510,7 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListAssets</summary>
+        /// <summary>Snippet for ListAssetsAsync</summary>
         public async Task ListAssetsResourceNamesAsync()
         {
             // Snippet: ListAssetsAsync(OrganizationName, string, int?, CallSettings)
@@ -1608,7 +1608,7 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListFindings</summary>
+        /// <summary>Snippet for ListFindingsAsync</summary>
         public async Task ListFindingsRequestObjectAsync()
         {
             // Snippet: ListFindingsAsync(ListFindingsRequest, CallSettings)
@@ -1706,7 +1706,7 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListFindings</summary>
+        /// <summary>Snippet for ListFindingsAsync</summary>
         public async Task ListFindingsAsync()
         {
             // Snippet: ListFindingsAsync(string, string, int?, CallSettings)
@@ -1796,7 +1796,7 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListFindings</summary>
+        /// <summary>Snippet for ListFindingsAsync</summary>
         public async Task ListFindingsResourceNamesAsync()
         {
             // Snippet: ListFindingsAsync(SourceName, string, int?, CallSettings)
@@ -1889,7 +1889,7 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListNotificationConfigs</summary>
+        /// <summary>Snippet for ListNotificationConfigsAsync</summary>
         public async Task ListNotificationConfigsRequestObjectAsync()
         {
             // Snippet: ListNotificationConfigsAsync(ListNotificationConfigsRequest, CallSettings)
@@ -1982,7 +1982,7 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListNotificationConfigs</summary>
+        /// <summary>Snippet for ListNotificationConfigsAsync</summary>
         public async Task ListNotificationConfigsAsync()
         {
             // Snippet: ListNotificationConfigsAsync(string, string, int?, CallSettings)
@@ -2072,7 +2072,7 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListNotificationConfigs</summary>
+        /// <summary>Snippet for ListNotificationConfigsAsync</summary>
         public async Task ListNotificationConfigsResourceNamesAsync()
         {
             // Snippet: ListNotificationConfigsAsync(OrganizationName, string, int?, CallSettings)
@@ -2165,7 +2165,7 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSources</summary>
+        /// <summary>Snippet for ListSourcesAsync</summary>
         public async Task ListSourcesRequestObjectAsync()
         {
             // Snippet: ListSourcesAsync(ListSourcesRequest, CallSettings)
@@ -2258,7 +2258,7 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSources</summary>
+        /// <summary>Snippet for ListSourcesAsync</summary>
         public async Task ListSourcesAsync()
         {
             // Snippet: ListSourcesAsync(string, string, int?, CallSettings)
@@ -2348,7 +2348,7 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSources</summary>
+        /// <summary>Snippet for ListSourcesAsync</summary>
         public async Task ListSourcesResourceNamesAsync()
         {
             // Snippet: ListSourcesAsync(OrganizationName, string, int?, CallSettings)

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.Snippets/RegistrationServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.Snippets/RegistrationServiceClientSnippets.g.cs
@@ -176,7 +176,7 @@ namespace Google.Cloud.ServiceDirectory.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListNamespaces</summary>
+        /// <summary>Snippet for ListNamespacesAsync</summary>
         public async Task ListNamespacesRequestObjectAsync()
         {
             // Snippet: ListNamespacesAsync(ListNamespacesRequest, CallSettings)
@@ -271,7 +271,7 @@ namespace Google.Cloud.ServiceDirectory.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListNamespaces</summary>
+        /// <summary>Snippet for ListNamespacesAsync</summary>
         public async Task ListNamespacesAsync()
         {
             // Snippet: ListNamespacesAsync(string, string, int?, CallSettings)
@@ -361,7 +361,7 @@ namespace Google.Cloud.ServiceDirectory.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListNamespaces</summary>
+        /// <summary>Snippet for ListNamespacesAsync</summary>
         public async Task ListNamespacesResourceNamesAsync()
         {
             // Snippet: ListNamespacesAsync(LocationName, string, int?, CallSettings)
@@ -793,7 +793,7 @@ namespace Google.Cloud.ServiceDirectory.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListServices</summary>
+        /// <summary>Snippet for ListServicesAsync</summary>
         public async Task ListServicesRequestObjectAsync()
         {
             // Snippet: ListServicesAsync(ListServicesRequest, CallSettings)
@@ -888,7 +888,7 @@ namespace Google.Cloud.ServiceDirectory.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListServices</summary>
+        /// <summary>Snippet for ListServicesAsync</summary>
         public async Task ListServicesAsync()
         {
             // Snippet: ListServicesAsync(string, string, int?, CallSettings)
@@ -978,7 +978,7 @@ namespace Google.Cloud.ServiceDirectory.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListServices</summary>
+        /// <summary>Snippet for ListServicesAsync</summary>
         public async Task ListServicesResourceNamesAsync()
         {
             // Snippet: ListServicesAsync(NamespaceName, string, int?, CallSettings)
@@ -1410,7 +1410,7 @@ namespace Google.Cloud.ServiceDirectory.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListEndpoints</summary>
+        /// <summary>Snippet for ListEndpointsAsync</summary>
         public async Task ListEndpointsRequestObjectAsync()
         {
             // Snippet: ListEndpointsAsync(ListEndpointsRequest, CallSettings)
@@ -1505,7 +1505,7 @@ namespace Google.Cloud.ServiceDirectory.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListEndpoints</summary>
+        /// <summary>Snippet for ListEndpointsAsync</summary>
         public async Task ListEndpointsAsync()
         {
             // Snippet: ListEndpointsAsync(string, string, int?, CallSettings)
@@ -1595,7 +1595,7 @@ namespace Google.Cloud.ServiceDirectory.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListEndpoints</summary>
+        /// <summary>Snippet for ListEndpointsAsync</summary>
         public async Task ListEndpointsResourceNamesAsync()
         {
             // Snippet: ListEndpointsAsync(ServiceName, string, int?, CallSettings)

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.Snippets/RegistrationServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.Snippets/RegistrationServiceClientSnippets.g.cs
@@ -176,7 +176,7 @@ namespace Google.Cloud.ServiceDirectory.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListNamespaces</summary>
+        /// <summary>Snippet for ListNamespacesAsync</summary>
         public async Task ListNamespacesRequestObjectAsync()
         {
             // Snippet: ListNamespacesAsync(ListNamespacesRequest, CallSettings)
@@ -271,7 +271,7 @@ namespace Google.Cloud.ServiceDirectory.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListNamespaces</summary>
+        /// <summary>Snippet for ListNamespacesAsync</summary>
         public async Task ListNamespacesAsync()
         {
             // Snippet: ListNamespacesAsync(string, string, int?, CallSettings)
@@ -361,7 +361,7 @@ namespace Google.Cloud.ServiceDirectory.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListNamespaces</summary>
+        /// <summary>Snippet for ListNamespacesAsync</summary>
         public async Task ListNamespacesResourceNamesAsync()
         {
             // Snippet: ListNamespacesAsync(LocationName, string, int?, CallSettings)
@@ -793,7 +793,7 @@ namespace Google.Cloud.ServiceDirectory.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListServices</summary>
+        /// <summary>Snippet for ListServicesAsync</summary>
         public async Task ListServicesRequestObjectAsync()
         {
             // Snippet: ListServicesAsync(ListServicesRequest, CallSettings)
@@ -888,7 +888,7 @@ namespace Google.Cloud.ServiceDirectory.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListServices</summary>
+        /// <summary>Snippet for ListServicesAsync</summary>
         public async Task ListServicesAsync()
         {
             // Snippet: ListServicesAsync(string, string, int?, CallSettings)
@@ -978,7 +978,7 @@ namespace Google.Cloud.ServiceDirectory.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListServices</summary>
+        /// <summary>Snippet for ListServicesAsync</summary>
         public async Task ListServicesResourceNamesAsync()
         {
             // Snippet: ListServicesAsync(NamespaceName, string, int?, CallSettings)
@@ -1410,7 +1410,7 @@ namespace Google.Cloud.ServiceDirectory.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListEndpoints</summary>
+        /// <summary>Snippet for ListEndpointsAsync</summary>
         public async Task ListEndpointsRequestObjectAsync()
         {
             // Snippet: ListEndpointsAsync(ListEndpointsRequest, CallSettings)
@@ -1505,7 +1505,7 @@ namespace Google.Cloud.ServiceDirectory.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListEndpoints</summary>
+        /// <summary>Snippet for ListEndpointsAsync</summary>
         public async Task ListEndpointsAsync()
         {
             // Snippet: ListEndpointsAsync(string, string, int?, CallSettings)
@@ -1595,7 +1595,7 @@ namespace Google.Cloud.ServiceDirectory.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListEndpoints</summary>
+        /// <summary>Snippet for ListEndpointsAsync</summary>
         public async Task ListEndpointsResourceNamesAsync()
         {
             // Snippet: ListEndpointsAsync(ServiceName, string, int?, CallSettings)

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.Snippets/ServiceManagerClientSnippets.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.Snippets/ServiceManagerClientSnippets.g.cs
@@ -75,7 +75,7 @@ namespace Google.Cloud.ServiceManagement.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListServices</summary>
+        /// <summary>Snippet for ListServicesAsync</summary>
         public async Task ListServicesRequestObjectAsync()
         {
             // Snippet: ListServicesAsync(ListServicesRequest, CallSettings)
@@ -169,7 +169,7 @@ namespace Google.Cloud.ServiceManagement.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListServices</summary>
+        /// <summary>Snippet for ListServicesAsync</summary>
         public async Task ListServicesAsync()
         {
             // Snippet: ListServicesAsync(string, string, string, int?, CallSettings)
@@ -674,7 +674,7 @@ namespace Google.Cloud.ServiceManagement.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListServiceConfigs</summary>
+        /// <summary>Snippet for ListServiceConfigsAsync</summary>
         public async Task ListServiceConfigsRequestObjectAsync()
         {
             // Snippet: ListServiceConfigsAsync(ListServiceConfigsRequest, CallSettings)
@@ -764,7 +764,7 @@ namespace Google.Cloud.ServiceManagement.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListServiceConfigs</summary>
+        /// <summary>Snippet for ListServiceConfigsAsync</summary>
         public async Task ListServiceConfigsAsync()
         {
             // Snippet: ListServiceConfigsAsync(string, string, int?, CallSettings)
@@ -1122,7 +1122,7 @@ namespace Google.Cloud.ServiceManagement.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListServiceRollouts</summary>
+        /// <summary>Snippet for ListServiceRolloutsAsync</summary>
         public async Task ListServiceRolloutsRequestObjectAsync()
         {
             // Snippet: ListServiceRolloutsAsync(ListServiceRolloutsRequest, CallSettings)
@@ -1217,7 +1217,7 @@ namespace Google.Cloud.ServiceManagement.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListServiceRollouts</summary>
+        /// <summary>Snippet for ListServiceRolloutsAsync</summary>
         public async Task ListServiceRolloutsAsync()
         {
             // Snippet: ListServiceRolloutsAsync(string, string, string, int?, CallSettings)

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.Snippets/DatabaseAdminClientSnippets.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.Snippets/DatabaseAdminClientSnippets.g.cs
@@ -77,7 +77,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDatabases</summary>
+        /// <summary>Snippet for ListDatabasesAsync</summary>
         public async Task ListDatabasesRequestObjectAsync()
         {
             // Snippet: ListDatabasesAsync(ListDatabasesRequest, CallSettings)
@@ -170,7 +170,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDatabases</summary>
+        /// <summary>Snippet for ListDatabasesAsync</summary>
         public async Task ListDatabasesAsync()
         {
             // Snippet: ListDatabasesAsync(string, string, int?, CallSettings)
@@ -260,7 +260,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDatabases</summary>
+        /// <summary>Snippet for ListDatabasesAsync</summary>
         public async Task ListDatabasesResourceNamesAsync()
         {
             // Snippet: ListDatabasesAsync(InstanceName, string, int?, CallSettings)
@@ -1709,7 +1709,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListBackups</summary>
+        /// <summary>Snippet for ListBackupsAsync</summary>
         public async Task ListBackupsRequestObjectAsync()
         {
             // Snippet: ListBackupsAsync(ListBackupsRequest, CallSettings)
@@ -1803,7 +1803,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListBackups</summary>
+        /// <summary>Snippet for ListBackupsAsync</summary>
         public async Task ListBackupsAsync()
         {
             // Snippet: ListBackupsAsync(string, string, int?, CallSettings)
@@ -1893,7 +1893,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListBackups</summary>
+        /// <summary>Snippet for ListBackupsAsync</summary>
         public async Task ListBackupsResourceNamesAsync()
         {
             // Snippet: ListBackupsAsync(InstanceName, string, int?, CallSettings)
@@ -2184,7 +2184,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDatabaseOperations</summary>
+        /// <summary>Snippet for ListDatabaseOperationsAsync</summary>
         public async Task ListDatabaseOperationsRequestObjectAsync()
         {
             // Snippet: ListDatabaseOperationsAsync(ListDatabaseOperationsRequest, CallSettings)
@@ -2278,7 +2278,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDatabaseOperations</summary>
+        /// <summary>Snippet for ListDatabaseOperationsAsync</summary>
         public async Task ListDatabaseOperationsAsync()
         {
             // Snippet: ListDatabaseOperationsAsync(string, string, int?, CallSettings)
@@ -2368,7 +2368,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListDatabaseOperations</summary>
+        /// <summary>Snippet for ListDatabaseOperationsAsync</summary>
         public async Task ListDatabaseOperationsResourceNamesAsync()
         {
             // Snippet: ListDatabaseOperationsAsync(InstanceName, string, int?, CallSettings)
@@ -2462,7 +2462,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListBackupOperations</summary>
+        /// <summary>Snippet for ListBackupOperationsAsync</summary>
         public async Task ListBackupOperationsRequestObjectAsync()
         {
             // Snippet: ListBackupOperationsAsync(ListBackupOperationsRequest, CallSettings)
@@ -2556,7 +2556,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListBackupOperations</summary>
+        /// <summary>Snippet for ListBackupOperationsAsync</summary>
         public async Task ListBackupOperationsAsync()
         {
             // Snippet: ListBackupOperationsAsync(string, string, int?, CallSettings)
@@ -2646,7 +2646,7 @@ namespace Google.Cloud.Spanner.Admin.Database.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListBackupOperations</summary>
+        /// <summary>Snippet for ListBackupOperationsAsync</summary>
         public async Task ListBackupOperationsResourceNamesAsync()
         {
             // Snippet: ListBackupOperationsAsync(InstanceName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.Snippets/InstanceAdminClientSnippets.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.Snippets/InstanceAdminClientSnippets.g.cs
@@ -78,7 +78,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListInstanceConfigs</summary>
+        /// <summary>Snippet for ListInstanceConfigsAsync</summary>
         public async Task ListInstanceConfigsRequestObjectAsync()
         {
             // Snippet: ListInstanceConfigsAsync(ListInstanceConfigsRequest, CallSettings)
@@ -171,7 +171,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListInstanceConfigs</summary>
+        /// <summary>Snippet for ListInstanceConfigsAsync</summary>
         public async Task ListInstanceConfigsAsync()
         {
             // Snippet: ListInstanceConfigsAsync(string, string, int?, CallSettings)
@@ -261,7 +261,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListInstanceConfigs</summary>
+        /// <summary>Snippet for ListInstanceConfigsAsync</summary>
         public async Task ListInstanceConfigsResourceNamesAsync()
         {
             // Snippet: ListInstanceConfigsAsync(ProjectName, string, int?, CallSettings)
@@ -442,7 +442,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListInstances</summary>
+        /// <summary>Snippet for ListInstancesAsync</summary>
         public async Task ListInstancesRequestObjectAsync()
         {
             // Snippet: ListInstancesAsync(ListInstancesRequest, CallSettings)
@@ -536,7 +536,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListInstances</summary>
+        /// <summary>Snippet for ListInstancesAsync</summary>
         public async Task ListInstancesAsync()
         {
             // Snippet: ListInstancesAsync(string, string, int?, CallSettings)
@@ -626,7 +626,7 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListInstances</summary>
+        /// <summary>Snippet for ListInstancesAsync</summary>
         public async Task ListInstancesResourceNamesAsync()
         {
             // Snippet: ListInstancesAsync(ProjectName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.Snippets/SpannerClientSnippets.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.Snippets/SpannerClientSnippets.g.cs
@@ -350,7 +350,7 @@ namespace Google.Cloud.Spanner.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSessions</summary>
+        /// <summary>Snippet for ListSessionsAsync</summary>
         public async Task ListSessionsRequestObjectAsync()
         {
             // Snippet: ListSessionsAsync(ListSessionsRequest, CallSettings)
@@ -444,7 +444,7 @@ namespace Google.Cloud.Spanner.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSessions</summary>
+        /// <summary>Snippet for ListSessionsAsync</summary>
         public async Task ListSessionsAsync()
         {
             // Snippet: ListSessionsAsync(string, string, int?, CallSettings)
@@ -534,7 +534,7 @@ namespace Google.Cloud.Spanner.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListSessions</summary>
+        /// <summary>Snippet for ListSessionsAsync</summary>
         public async Task ListSessionsResourceNamesAsync()
         {
             // Snippet: ListSessionsAsync(DatabaseName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.Snippets/AdaptationClientSnippets.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.Snippets/AdaptationClientSnippets.g.cs
@@ -260,7 +260,7 @@ namespace Google.Cloud.Speech.V1P1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListPhraseSet</summary>
+        /// <summary>Snippet for ListPhraseSetAsync</summary>
         public async Task ListPhraseSetRequestObjectAsync()
         {
             // Snippet: ListPhraseSetAsync(ListPhraseSetRequest, CallSettings)
@@ -353,7 +353,7 @@ namespace Google.Cloud.Speech.V1P1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListPhraseSet</summary>
+        /// <summary>Snippet for ListPhraseSetAsync</summary>
         public async Task ListPhraseSetAsync()
         {
             // Snippet: ListPhraseSetAsync(string, string, int?, CallSettings)
@@ -443,7 +443,7 @@ namespace Google.Cloud.Speech.V1P1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListPhraseSet</summary>
+        /// <summary>Snippet for ListPhraseSetAsync</summary>
         public async Task ListPhraseSetResourceNamesAsync()
         {
             // Snippet: ListPhraseSetAsync(LocationName, string, int?, CallSettings)
@@ -873,7 +873,7 @@ namespace Google.Cloud.Speech.V1P1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListCustomClasses</summary>
+        /// <summary>Snippet for ListCustomClassesAsync</summary>
         public async Task ListCustomClassesRequestObjectAsync()
         {
             // Snippet: ListCustomClassesAsync(ListCustomClassesRequest, CallSettings)
@@ -966,7 +966,7 @@ namespace Google.Cloud.Speech.V1P1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListCustomClasses</summary>
+        /// <summary>Snippet for ListCustomClassesAsync</summary>
         public async Task ListCustomClassesAsync()
         {
             // Snippet: ListCustomClassesAsync(string, string, int?, CallSettings)
@@ -1056,7 +1056,7 @@ namespace Google.Cloud.Speech.V1P1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListCustomClasses</summary>
+        /// <summary>Snippet for ListCustomClassesAsync</summary>
         public async Task ListCustomClassesResourceNamesAsync()
         {
             // Snippet: ListCustomClassesAsync(LocationName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.Snippets/CompanyServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.Snippets/CompanyServiceClientSnippets.g.cs
@@ -405,7 +405,7 @@ namespace Google.Cloud.Talent.V4.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListCompanies</summary>
+        /// <summary>Snippet for ListCompaniesAsync</summary>
         public async Task ListCompaniesRequestObjectAsync()
         {
             // Snippet: ListCompaniesAsync(ListCompaniesRequest, CallSettings)
@@ -499,7 +499,7 @@ namespace Google.Cloud.Talent.V4.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListCompanies</summary>
+        /// <summary>Snippet for ListCompaniesAsync</summary>
         public async Task ListCompaniesAsync()
         {
             // Snippet: ListCompaniesAsync(string, string, int?, CallSettings)
@@ -589,7 +589,7 @@ namespace Google.Cloud.Talent.V4.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListCompanies</summary>
+        /// <summary>Snippet for ListCompaniesAsync</summary>
         public async Task ListCompaniesResourceNamesAsync()
         {
             // Snippet: ListCompaniesAsync(TenantName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.Snippets/JobServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.Snippets/JobServiceClientSnippets.g.cs
@@ -995,7 +995,7 @@ namespace Google.Cloud.Talent.V4.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListJobs</summary>
+        /// <summary>Snippet for ListJobsAsync</summary>
         public async Task ListJobsRequestObjectAsync()
         {
             // Snippet: ListJobsAsync(ListJobsRequest, CallSettings)
@@ -1091,7 +1091,7 @@ namespace Google.Cloud.Talent.V4.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListJobs</summary>
+        /// <summary>Snippet for ListJobsAsync</summary>
         public async Task ListJobsAsync()
         {
             // Snippet: ListJobsAsync(string, string, string, int?, CallSettings)
@@ -1183,7 +1183,7 @@ namespace Google.Cloud.Talent.V4.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListJobs</summary>
+        /// <summary>Snippet for ListJobsAsync</summary>
         public async Task ListJobsResourceNamesAsync()
         {
             // Snippet: ListJobsAsync(TenantName, string, string, int?, CallSettings)

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.Snippets/TenantServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.Snippets/TenantServiceClientSnippets.g.cs
@@ -405,7 +405,7 @@ namespace Google.Cloud.Talent.V4.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTenants</summary>
+        /// <summary>Snippet for ListTenantsAsync</summary>
         public async Task ListTenantsRequestObjectAsync()
         {
             // Snippet: ListTenantsAsync(ListTenantsRequest, CallSettings)
@@ -498,7 +498,7 @@ namespace Google.Cloud.Talent.V4.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTenants</summary>
+        /// <summary>Snippet for ListTenantsAsync</summary>
         public async Task ListTenantsAsync()
         {
             // Snippet: ListTenantsAsync(string, string, int?, CallSettings)
@@ -588,7 +588,7 @@ namespace Google.Cloud.Talent.V4.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTenants</summary>
+        /// <summary>Snippet for ListTenantsAsync</summary>
         public async Task ListTenantsResourceNamesAsync()
         {
             // Snippet: ListTenantsAsync(ProjectName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.Snippets/ApplicationServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.Snippets/ApplicationServiceClientSnippets.g.cs
@@ -402,7 +402,7 @@ namespace Google.Cloud.Talent.V4Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListApplications</summary>
+        /// <summary>Snippet for ListApplicationsAsync</summary>
         public async Task ListApplicationsRequestObjectAsync()
         {
             // Snippet: ListApplicationsAsync(ListApplicationsRequest, CallSettings)
@@ -495,7 +495,7 @@ namespace Google.Cloud.Talent.V4Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListApplications</summary>
+        /// <summary>Snippet for ListApplicationsAsync</summary>
         public async Task ListApplicationsAsync()
         {
             // Snippet: ListApplicationsAsync(string, string, int?, CallSettings)
@@ -585,7 +585,7 @@ namespace Google.Cloud.Talent.V4Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListApplications</summary>
+        /// <summary>Snippet for ListApplicationsAsync</summary>
         public async Task ListApplicationsResourceNamesAsync()
         {
             // Snippet: ListApplicationsAsync(ProfileName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.Snippets/CompanyServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.Snippets/CompanyServiceClientSnippets.g.cs
@@ -433,7 +433,7 @@ namespace Google.Cloud.Talent.V4Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListCompanies</summary>
+        /// <summary>Snippet for ListCompaniesAsync</summary>
         public async Task ListCompaniesRequestObjectAsync()
         {
             // Snippet: ListCompaniesAsync(ListCompaniesRequest, CallSettings)
@@ -527,7 +527,7 @@ namespace Google.Cloud.Talent.V4Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListCompanies</summary>
+        /// <summary>Snippet for ListCompaniesAsync</summary>
         public async Task ListCompaniesAsync()
         {
             // Snippet: ListCompaniesAsync(string, string, int?, CallSettings)
@@ -617,7 +617,7 @@ namespace Google.Cloud.Talent.V4Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListCompanies</summary>
+        /// <summary>Snippet for ListCompaniesAsync</summary>
         public async Task ListCompaniesResourceNames1Async()
         {
             // Snippet: ListCompaniesAsync(TenantName, string, int?, CallSettings)
@@ -707,7 +707,7 @@ namespace Google.Cloud.Talent.V4Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListCompanies</summary>
+        /// <summary>Snippet for ListCompaniesAsync</summary>
         public async Task ListCompaniesResourceNames2Async()
         {
             // Snippet: ListCompaniesAsync(ProjectName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.Snippets/JobServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.Snippets/JobServiceClientSnippets.g.cs
@@ -1060,7 +1060,7 @@ namespace Google.Cloud.Talent.V4Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListJobs</summary>
+        /// <summary>Snippet for ListJobsAsync</summary>
         public async Task ListJobsRequestObjectAsync()
         {
             // Snippet: ListJobsAsync(ListJobsRequest, CallSettings)
@@ -1156,7 +1156,7 @@ namespace Google.Cloud.Talent.V4Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListJobs</summary>
+        /// <summary>Snippet for ListJobsAsync</summary>
         public async Task ListJobsAsync()
         {
             // Snippet: ListJobsAsync(string, string, string, int?, CallSettings)
@@ -1248,7 +1248,7 @@ namespace Google.Cloud.Talent.V4Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListJobs</summary>
+        /// <summary>Snippet for ListJobsAsync</summary>
         public async Task ListJobsResourceNames1Async()
         {
             // Snippet: ListJobsAsync(TenantName, string, string, int?, CallSettings)
@@ -1340,7 +1340,7 @@ namespace Google.Cloud.Talent.V4Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListJobs</summary>
+        /// <summary>Snippet for ListJobsAsync</summary>
         public async Task ListJobsResourceNames2Async()
         {
             // Snippet: ListJobsAsync(ProjectName, string, string, int?, CallSettings)
@@ -1516,7 +1516,7 @@ namespace Google.Cloud.Talent.V4Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for SearchJobsForAlert</summary>
+        /// <summary>Snippet for SearchJobsForAlertAsync</summary>
         public async Task SearchJobsForAlertRequestObjectAsync()
         {
             // Snippet: SearchJobsForAlertAsync(SearchJobsRequest, CallSettings)

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.Snippets/ProfileServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.Snippets/ProfileServiceClientSnippets.g.cs
@@ -75,7 +75,7 @@ namespace Google.Cloud.Talent.V4Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListProfiles</summary>
+        /// <summary>Snippet for ListProfilesAsync</summary>
         public async Task ListProfilesRequestObjectAsync()
         {
             // Snippet: ListProfilesAsync(ListProfilesRequest, CallSettings)
@@ -170,7 +170,7 @@ namespace Google.Cloud.Talent.V4Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListProfiles</summary>
+        /// <summary>Snippet for ListProfilesAsync</summary>
         public async Task ListProfilesAsync()
         {
             // Snippet: ListProfilesAsync(string, string, int?, CallSettings)
@@ -260,7 +260,7 @@ namespace Google.Cloud.Talent.V4Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListProfiles</summary>
+        /// <summary>Snippet for ListProfilesAsync</summary>
         public async Task ListProfilesResourceNamesAsync()
         {
             // Snippet: ListProfilesAsync(TenantName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.Snippets/TenantServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.Snippets/TenantServiceClientSnippets.g.cs
@@ -403,7 +403,7 @@ namespace Google.Cloud.Talent.V4Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTenants</summary>
+        /// <summary>Snippet for ListTenantsAsync</summary>
         public async Task ListTenantsRequestObjectAsync()
         {
             // Snippet: ListTenantsAsync(ListTenantsRequest, CallSettings)
@@ -496,7 +496,7 @@ namespace Google.Cloud.Talent.V4Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTenants</summary>
+        /// <summary>Snippet for ListTenantsAsync</summary>
         public async Task ListTenantsAsync()
         {
             // Snippet: ListTenantsAsync(string, string, int?, CallSettings)
@@ -586,7 +586,7 @@ namespace Google.Cloud.Talent.V4Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTenants</summary>
+        /// <summary>Snippet for ListTenantsAsync</summary>
         public async Task ListTenantsResourceNamesAsync()
         {
             // Snippet: ListTenantsAsync(ProjectName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.Snippets/CloudTasksClientSnippets.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.Snippets/CloudTasksClientSnippets.g.cs
@@ -78,7 +78,7 @@ namespace Google.Cloud.Tasks.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListQueues</summary>
+        /// <summary>Snippet for ListQueuesAsync</summary>
         public async Task ListQueuesRequestObjectAsync()
         {
             // Snippet: ListQueuesAsync(ListQueuesRequest, CallSettings)
@@ -172,7 +172,7 @@ namespace Google.Cloud.Tasks.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListQueues</summary>
+        /// <summary>Snippet for ListQueuesAsync</summary>
         public async Task ListQueuesAsync()
         {
             // Snippet: ListQueuesAsync(string, string, int?, CallSettings)
@@ -262,7 +262,7 @@ namespace Google.Cloud.Tasks.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListQueues</summary>
+        /// <summary>Snippet for ListQueuesAsync</summary>
         public async Task ListQueuesResourceNamesAsync()
         {
             // Snippet: ListQueuesAsync(LocationName, string, int?, CallSettings)
@@ -1223,7 +1223,7 @@ namespace Google.Cloud.Tasks.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTasks</summary>
+        /// <summary>Snippet for ListTasksAsync</summary>
         public async Task ListTasksRequestObjectAsync()
         {
             // Snippet: ListTasksAsync(ListTasksRequest, CallSettings)
@@ -1317,7 +1317,7 @@ namespace Google.Cloud.Tasks.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTasks</summary>
+        /// <summary>Snippet for ListTasksAsync</summary>
         public async Task ListTasksAsync()
         {
             // Snippet: ListTasksAsync(string, string, int?, CallSettings)
@@ -1407,7 +1407,7 @@ namespace Google.Cloud.Tasks.V2.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTasks</summary>
+        /// <summary>Snippet for ListTasksAsync</summary>
         public async Task ListTasksResourceNamesAsync()
         {
             // Snippet: ListTasksAsync(QueueName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.Snippets/CloudTasksClientSnippets.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.Snippets/CloudTasksClientSnippets.g.cs
@@ -79,7 +79,7 @@ namespace Google.Cloud.Tasks.V2Beta3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListQueues</summary>
+        /// <summary>Snippet for ListQueuesAsync</summary>
         public async Task ListQueuesRequestObjectAsync()
         {
             // Snippet: ListQueuesAsync(ListQueuesRequest, CallSettings)
@@ -174,7 +174,7 @@ namespace Google.Cloud.Tasks.V2Beta3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListQueues</summary>
+        /// <summary>Snippet for ListQueuesAsync</summary>
         public async Task ListQueuesAsync()
         {
             // Snippet: ListQueuesAsync(string, string, int?, CallSettings)
@@ -264,7 +264,7 @@ namespace Google.Cloud.Tasks.V2Beta3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListQueues</summary>
+        /// <summary>Snippet for ListQueuesAsync</summary>
         public async Task ListQueuesResourceNamesAsync()
         {
             // Snippet: ListQueuesAsync(LocationName, string, int?, CallSettings)
@@ -1227,7 +1227,7 @@ namespace Google.Cloud.Tasks.V2Beta3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTasks</summary>
+        /// <summary>Snippet for ListTasksAsync</summary>
         public async Task ListTasksRequestObjectAsync()
         {
             // Snippet: ListTasksAsync(ListTasksRequest, CallSettings)
@@ -1321,7 +1321,7 @@ namespace Google.Cloud.Tasks.V2Beta3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTasks</summary>
+        /// <summary>Snippet for ListTasksAsync</summary>
         public async Task ListTasksAsync()
         {
             // Snippet: ListTasksAsync(string, string, int?, CallSettings)
@@ -1411,7 +1411,7 @@ namespace Google.Cloud.Tasks.V2Beta3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTasks</summary>
+        /// <summary>Snippet for ListTasksAsync</summary>
         public async Task ListTasksResourceNamesAsync()
         {
             // Snippet: ListTasksAsync(QueueName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.Snippets/TraceServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.Snippets/TraceServiceClientSnippets.g.cs
@@ -78,7 +78,7 @@ namespace Google.Cloud.Trace.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTraces</summary>
+        /// <summary>Snippet for ListTracesAsync</summary>
         public async Task ListTracesRequestObjectAsync()
         {
             // Snippet: ListTracesAsync(ListTracesRequest, CallSettings)
@@ -176,7 +176,7 @@ namespace Google.Cloud.Trace.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListTraces</summary>
+        /// <summary>Snippet for ListTracesAsync</summary>
         public async Task ListTracesAsync()
         {
             // Snippet: ListTracesAsync(string, string, int?, CallSettings)

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.Snippets/TranslationServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.Snippets/TranslationServiceClientSnippets.g.cs
@@ -745,7 +745,7 @@ namespace Google.Cloud.Translate.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListGlossaries</summary>
+        /// <summary>Snippet for ListGlossariesAsync</summary>
         public async Task ListGlossariesRequestObjectAsync()
         {
             // Snippet: ListGlossariesAsync(ListGlossariesRequest, CallSettings)
@@ -839,7 +839,7 @@ namespace Google.Cloud.Translate.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListGlossaries</summary>
+        /// <summary>Snippet for ListGlossariesAsync</summary>
         public async Task ListGlossariesAsync()
         {
             // Snippet: ListGlossariesAsync(string, string, int?, CallSettings)
@@ -929,7 +929,7 @@ namespace Google.Cloud.Translate.V3.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListGlossaries</summary>
+        /// <summary>Snippet for ListGlossariesAsync</summary>
         public async Task ListGlossariesResourceNamesAsync()
         {
             // Snippet: ListGlossariesAsync(LocationName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Video.Transcoder.V1Beta1/Google.Cloud.Video.Transcoder.V1Beta1.Snippets/TranscoderServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1Beta1/Google.Cloud.Video.Transcoder.V1Beta1.Snippets/TranscoderServiceClientSnippets.g.cs
@@ -166,7 +166,7 @@ namespace Google.Cloud.Video.Transcoder.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListJobs</summary>
+        /// <summary>Snippet for ListJobsAsync</summary>
         public async Task ListJobsRequestObjectAsync()
         {
             // Snippet: ListJobsAsync(ListJobsRequest, CallSettings)
@@ -259,7 +259,7 @@ namespace Google.Cloud.Video.Transcoder.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListJobs</summary>
+        /// <summary>Snippet for ListJobsAsync</summary>
         public async Task ListJobsAsync()
         {
             // Snippet: ListJobsAsync(string, string, int?, CallSettings)
@@ -349,7 +349,7 @@ namespace Google.Cloud.Video.Transcoder.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListJobs</summary>
+        /// <summary>Snippet for ListJobsAsync</summary>
         public async Task ListJobsResourceNamesAsync()
         {
             // Snippet: ListJobsAsync(LocationName, string, int?, CallSettings)
@@ -715,7 +715,7 @@ namespace Google.Cloud.Video.Transcoder.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListJobTemplates</summary>
+        /// <summary>Snippet for ListJobTemplatesAsync</summary>
         public async Task ListJobTemplatesRequestObjectAsync()
         {
             // Snippet: ListJobTemplatesAsync(ListJobTemplatesRequest, CallSettings)
@@ -808,7 +808,7 @@ namespace Google.Cloud.Video.Transcoder.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListJobTemplates</summary>
+        /// <summary>Snippet for ListJobTemplatesAsync</summary>
         public async Task ListJobTemplatesAsync()
         {
             // Snippet: ListJobTemplatesAsync(string, string, int?, CallSettings)
@@ -898,7 +898,7 @@ namespace Google.Cloud.Video.Transcoder.V1Beta1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListJobTemplates</summary>
+        /// <summary>Snippet for ListJobTemplatesAsync</summary>
         public async Task ListJobTemplatesResourceNamesAsync()
         {
             // Snippet: ListJobTemplatesAsync(LocationName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Snippets/ProductSearchClientSnippets.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Snippets/ProductSearchClientSnippets.g.cs
@@ -174,7 +174,7 @@ namespace Google.Cloud.Vision.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListProductSets</summary>
+        /// <summary>Snippet for ListProductSetsAsync</summary>
         public async Task ListProductSetsRequestObjectAsync()
         {
             // Snippet: ListProductSetsAsync(ListProductSetsRequest, CallSettings)
@@ -267,7 +267,7 @@ namespace Google.Cloud.Vision.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListProductSets</summary>
+        /// <summary>Snippet for ListProductSetsAsync</summary>
         public async Task ListProductSetsAsync()
         {
             // Snippet: ListProductSetsAsync(string, string, int?, CallSettings)
@@ -357,7 +357,7 @@ namespace Google.Cloud.Vision.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListProductSets</summary>
+        /// <summary>Snippet for ListProductSetsAsync</summary>
         public async Task ListProductSetsResourceNamesAsync()
         {
             // Snippet: ListProductSetsAsync(LocationName, string, int?, CallSettings)
@@ -787,7 +787,7 @@ namespace Google.Cloud.Vision.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListProducts</summary>
+        /// <summary>Snippet for ListProductsAsync</summary>
         public async Task ListProductsRequestObjectAsync()
         {
             // Snippet: ListProductsAsync(ListProductsRequest, CallSettings)
@@ -880,7 +880,7 @@ namespace Google.Cloud.Vision.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListProducts</summary>
+        /// <summary>Snippet for ListProductsAsync</summary>
         public async Task ListProductsAsync()
         {
             // Snippet: ListProductsAsync(string, string, int?, CallSettings)
@@ -970,7 +970,7 @@ namespace Google.Cloud.Vision.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListProducts</summary>
+        /// <summary>Snippet for ListProductsAsync</summary>
         public async Task ListProductsResourceNamesAsync()
         {
             // Snippet: ListProductsAsync(LocationName, string, int?, CallSettings)
@@ -1487,7 +1487,7 @@ namespace Google.Cloud.Vision.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListReferenceImages</summary>
+        /// <summary>Snippet for ListReferenceImagesAsync</summary>
         public async Task ListReferenceImagesRequestObjectAsync()
         {
             // Snippet: ListReferenceImagesAsync(ListReferenceImagesRequest, CallSettings)
@@ -1580,7 +1580,7 @@ namespace Google.Cloud.Vision.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListReferenceImages</summary>
+        /// <summary>Snippet for ListReferenceImagesAsync</summary>
         public async Task ListReferenceImagesAsync()
         {
             // Snippet: ListReferenceImagesAsync(string, string, int?, CallSettings)
@@ -1670,7 +1670,7 @@ namespace Google.Cloud.Vision.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListReferenceImages</summary>
+        /// <summary>Snippet for ListReferenceImagesAsync</summary>
         public async Task ListReferenceImagesResourceNamesAsync()
         {
             // Snippet: ListReferenceImagesAsync(ProductName, string, int?, CallSettings)
@@ -2036,7 +2036,7 @@ namespace Google.Cloud.Vision.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListProductsInProductSet</summary>
+        /// <summary>Snippet for ListProductsInProductSetAsync</summary>
         public async Task ListProductsInProductSetRequestObjectAsync()
         {
             // Snippet: ListProductsInProductSetAsync(ListProductsInProductSetRequest, CallSettings)
@@ -2129,7 +2129,7 @@ namespace Google.Cloud.Vision.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListProductsInProductSet</summary>
+        /// <summary>Snippet for ListProductsInProductSetAsync</summary>
         public async Task ListProductsInProductSetAsync()
         {
             // Snippet: ListProductsInProductSetAsync(string, string, int?, CallSettings)
@@ -2219,7 +2219,7 @@ namespace Google.Cloud.Vision.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListProductsInProductSet</summary>
+        /// <summary>Snippet for ListProductsInProductSetAsync</summary>
         public async Task ListProductsInProductSetResourceNamesAsync()
         {
             // Snippet: ListProductsInProductSetAsync(ProductSetName, string, int?, CallSettings)

--- a/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.Snippets/WebSecurityScannerClientSnippets.g.cs
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.Snippets/WebSecurityScannerClientSnippets.g.cs
@@ -159,7 +159,7 @@ namespace Google.Cloud.WebSecurityScanner.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListScanConfigs</summary>
+        /// <summary>Snippet for ListScanConfigsAsync</summary>
         public async Task ListScanConfigsRequestObjectAsync()
         {
             // Snippet: ListScanConfigsAsync(ListScanConfigsRequest, CallSettings)
@@ -338,7 +338,7 @@ namespace Google.Cloud.WebSecurityScanner.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListScanRuns</summary>
+        /// <summary>Snippet for ListScanRunsAsync</summary>
         public async Task ListScanRunsRequestObjectAsync()
         {
             // Snippet: ListScanRunsAsync(ListScanRunsRequest, CallSettings)
@@ -455,7 +455,7 @@ namespace Google.Cloud.WebSecurityScanner.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListCrawledUrls</summary>
+        /// <summary>Snippet for ListCrawledUrlsAsync</summary>
         public async Task ListCrawledUrlsRequestObjectAsync()
         {
             // Snippet: ListCrawledUrlsAsync(ListCrawledUrlsRequest, CallSettings)
@@ -576,7 +576,7 @@ namespace Google.Cloud.WebSecurityScanner.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListFindings</summary>
+        /// <summary>Snippet for ListFindingsAsync</summary>
         public async Task ListFindingsRequestObjectAsync()
         {
             // Snippet: ListFindingsAsync(ListFindingsRequest, CallSettings)

--- a/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.Snippets/ExecutionsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.Snippets/ExecutionsClientSnippets.g.cs
@@ -74,7 +74,7 @@ namespace Google.Cloud.Workflows.Executions.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListExecutions</summary>
+        /// <summary>Snippet for ListExecutionsAsync</summary>
         public async Task ListExecutionsRequestObjectAsync()
         {
             // Snippet: ListExecutionsAsync(ListExecutionsRequest, CallSettings)
@@ -168,7 +168,7 @@ namespace Google.Cloud.Workflows.Executions.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListExecutions</summary>
+        /// <summary>Snippet for ListExecutionsAsync</summary>
         public async Task ListExecutionsAsync()
         {
             // Snippet: ListExecutionsAsync(string, string, int?, CallSettings)
@@ -258,7 +258,7 @@ namespace Google.Cloud.Workflows.Executions.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListExecutions</summary>
+        /// <summary>Snippet for ListExecutionsAsync</summary>
         public async Task ListExecutionsResourceNamesAsync()
         {
             // Snippet: ListExecutionsAsync(WorkflowName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.Snippets/ExecutionsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.Snippets/ExecutionsClientSnippets.g.cs
@@ -74,7 +74,7 @@ namespace Google.Cloud.Workflows.Executions.V1Beta.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListExecutions</summary>
+        /// <summary>Snippet for ListExecutionsAsync</summary>
         public async Task ListExecutionsRequestObjectAsync()
         {
             // Snippet: ListExecutionsAsync(ListExecutionsRequest, CallSettings)
@@ -168,7 +168,7 @@ namespace Google.Cloud.Workflows.Executions.V1Beta.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListExecutions</summary>
+        /// <summary>Snippet for ListExecutionsAsync</summary>
         public async Task ListExecutionsAsync()
         {
             // Snippet: ListExecutionsAsync(string, string, int?, CallSettings)
@@ -258,7 +258,7 @@ namespace Google.Cloud.Workflows.Executions.V1Beta.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListExecutions</summary>
+        /// <summary>Snippet for ListExecutionsAsync</summary>
         public async Task ListExecutionsResourceNamesAsync()
         {
             // Snippet: ListExecutionsAsync(WorkflowName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.Snippets/WorkflowsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.Snippets/WorkflowsClientSnippets.g.cs
@@ -78,7 +78,7 @@ namespace Google.Cloud.Workflows.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListWorkflows</summary>
+        /// <summary>Snippet for ListWorkflowsAsync</summary>
         public async Task ListWorkflowsRequestObjectAsync()
         {
             // Snippet: ListWorkflowsAsync(ListWorkflowsRequest, CallSettings)
@@ -173,7 +173,7 @@ namespace Google.Cloud.Workflows.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListWorkflows</summary>
+        /// <summary>Snippet for ListWorkflowsAsync</summary>
         public async Task ListWorkflowsAsync()
         {
             // Snippet: ListWorkflowsAsync(string, string, int?, CallSettings)
@@ -263,7 +263,7 @@ namespace Google.Cloud.Workflows.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListWorkflows</summary>
+        /// <summary>Snippet for ListWorkflowsAsync</summary>
         public async Task ListWorkflowsResourceNamesAsync()
         {
             // Snippet: ListWorkflowsAsync(LocationName, string, int?, CallSettings)

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.Snippets/WorkflowsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.Snippets/WorkflowsClientSnippets.g.cs
@@ -78,7 +78,7 @@ namespace Google.Cloud.Workflows.V1Beta.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListWorkflows</summary>
+        /// <summary>Snippet for ListWorkflowsAsync</summary>
         public async Task ListWorkflowsRequestObjectAsync()
         {
             // Snippet: ListWorkflowsAsync(ListWorkflowsRequest, CallSettings)
@@ -173,7 +173,7 @@ namespace Google.Cloud.Workflows.V1Beta.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListWorkflows</summary>
+        /// <summary>Snippet for ListWorkflowsAsync</summary>
         public async Task ListWorkflowsAsync()
         {
             // Snippet: ListWorkflowsAsync(string, string, int?, CallSettings)
@@ -263,7 +263,7 @@ namespace Google.Cloud.Workflows.V1Beta.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListWorkflows</summary>
+        /// <summary>Snippet for ListWorkflowsAsync</summary>
         public async Task ListWorkflowsResourceNamesAsync()
         {
             // Snippet: ListWorkflowsAsync(LocationName, string, int?, CallSettings)

--- a/apis/Google.LongRunning/Google.LongRunning.Snippets/OperationsClientSnippets.g.cs
+++ b/apis/Google.LongRunning/Google.LongRunning.Snippets/OperationsClientSnippets.g.cs
@@ -70,7 +70,7 @@ namespace Google.LongRunning.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListOperations</summary>
+        /// <summary>Snippet for ListOperationsAsync</summary>
         public async Task ListOperationsRequestObjectAsync()
         {
             // Snippet: ListOperationsAsync(ListOperationsRequest, CallSettings)
@@ -161,7 +161,7 @@ namespace Google.LongRunning.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListOperations</summary>
+        /// <summary>Snippet for ListOperationsAsync</summary>
         public async Task ListOperationsAsync()
         {
             // Snippet: ListOperationsAsync(string, string, string, int?, CallSettings)

--- a/apis/Grafeas.V1/Grafeas.V1.Snippets/GrafeasClientSnippets.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.Snippets/GrafeasClientSnippets.g.cs
@@ -169,7 +169,7 @@ namespace Grafeas.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListOccurrences</summary>
+        /// <summary>Snippet for ListOccurrencesAsync</summary>
         public async Task ListOccurrencesRequestObjectAsync()
         {
             string endpoint = "";
@@ -266,7 +266,7 @@ namespace Grafeas.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListOccurrences</summary>
+        /// <summary>Snippet for ListOccurrencesAsync</summary>
         public async Task ListOccurrencesAsync()
         {
             string endpoint = "";
@@ -360,7 +360,7 @@ namespace Grafeas.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListOccurrences</summary>
+        /// <summary>Snippet for ListOccurrencesAsync</summary>
         public async Task ListOccurrencesResourceNamesAsync()
         {
             string endpoint = "";
@@ -1039,7 +1039,7 @@ namespace Grafeas.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListNotes</summary>
+        /// <summary>Snippet for ListNotesAsync</summary>
         public async Task ListNotesRequestObjectAsync()
         {
             string endpoint = "";
@@ -1136,7 +1136,7 @@ namespace Grafeas.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListNotes</summary>
+        /// <summary>Snippet for ListNotesAsync</summary>
         public async Task ListNotesAsync()
         {
             string endpoint = "";
@@ -1230,7 +1230,7 @@ namespace Grafeas.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListNotes</summary>
+        /// <summary>Snippet for ListNotesAsync</summary>
         public async Task ListNotesResourceNamesAsync()
         {
             string endpoint = "";
@@ -1729,7 +1729,7 @@ namespace Grafeas.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListNoteOccurrences</summary>
+        /// <summary>Snippet for ListNoteOccurrencesAsync</summary>
         public async Task ListNoteOccurrencesRequestObjectAsync()
         {
             string endpoint = "";
@@ -1826,7 +1826,7 @@ namespace Grafeas.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListNoteOccurrences</summary>
+        /// <summary>Snippet for ListNoteOccurrencesAsync</summary>
         public async Task ListNoteOccurrencesAsync()
         {
             string endpoint = "";
@@ -1920,7 +1920,7 @@ namespace Grafeas.V1.Snippets
             // End snippet
         }
 
-        /// <summary>Snippet for ListNoteOccurrences</summary>
+        /// <summary>Snippet for ListNoteOccurrencesAsync</summary>
         public async Task ListNoteOccurrencesResourceNamesAsync()
         {
             string endpoint = "";

--- a/toolversions.sh
+++ b/toolversions.sh
@@ -114,7 +114,12 @@ install_microgenerator() {
       exit 1
   esac
   
-  if [[ "$SYNTHTOOL_CACHE" != "" ]]
+  # If the CSHARP_GENERATOR_DIR env variable is set
+  # we use that as the generator root dir.
+  if [[ "$CSHARP_GENERATOR_DIR" != "" ]]
+  then
+    declare -r GENERATOR_ROOT=$CSHARP_GENERATOR_DIR
+  elif [[ "$SYNTHTOOL_CACHE" != "" ]]
   then
     declare -r GENERATOR_ROOT=$SYNTHTOOL_CACHE/gapic-generator-csharp
   else
@@ -127,8 +132,11 @@ install_microgenerator() {
   then
     echo "Skipping microgenerator fetch/build: already built, and running on Kokoro"
   else
+    if [[ "$CSHARP_GENERATOR_DIR" != "" ]]
+    then
+      echo "Skipping microgenerator fetch: an existing directory for the generator has been specified"
     # TODO: Use a specific tag, or even a NuGet package eventually
-    if [ -d $GENERATOR_ROOT ]
+    elif [ -d $GENERATOR_ROOT ]
     then
       git -C $GENERATOR_ROOT pull -q
     else


### PR DESCRIPTION
The first commit allows to run generation with a local copy of the generator.
The second commit contains regenerations due to googleapis/gapic-generator-csharp#318

This PR and googleapis/gapic-generator-csharp#318 should be merged roughly at the same time and in between autosynth runs.