### PR TITLE
Generate GAPIC metadata files

### DIFF
--- a/generateapis.sh
+++ b/generateapis.sh
@@ -134,6 +134,7 @@ generate_microgenerator() {
   # but it won't generate anything for it.
   $PROTOC \
     --gapic_out=$API_TMP_DIR \
+    --gapic_opt=metadata \
     $SERVICE_CONFIG_OPTION \
     $COMMON_RESOURCES_OPTION \
     --plugin=protoc-gen-gapic=$GAPIC_PLUGIN \


### PR DESCRIPTION
This depends on https://github.com/googleapis/gapic-generator-csharp/pull/320

Once merged, API generation should be rerun manually to add all the
metadata files in a single pass rather than autosynth creating a
bunch of PRs.