### PR TITLE
Release Google.Cloud.Firestore version 2.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Domains.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Domains.V1Beta1/1.0.0-beta01) | 1.0.0-beta01 | [Cloud Domains](https://cloud.google.com/domains/) |
 | [Google.Cloud.ErrorReporting.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.ErrorReporting.V1Beta1/2.0.0-beta03) | 2.0.0-beta03 | [Google Cloud Error Reporting](https://cloud.google.com/error-reporting/) |
 | [Google.Cloud.Firestore.Admin.V1](https://googleapis.dev/dotnet/Google.Cloud.Firestore.Admin.V1/2.1.0) | 2.1.0 | [Firestore Administration (e.g. index management)](https://firebase.google.com) |
-| [Google.Cloud.Firestore](https://googleapis.dev/dotnet/Google.Cloud.Firestore/2.3.0) | 2.3.0 | [Firestore high-level library](https://firebase.google.com/docs/firestore/) |
+| [Google.Cloud.Firestore](https://googleapis.dev/dotnet/Google.Cloud.Firestore/2.3.1) | 2.3.1 | [Firestore high-level library](https://firebase.google.com/docs/firestore/) |
 | [Google.Cloud.Firestore.V1](https://googleapis.dev/dotnet/Google.Cloud.Firestore.V1/2.2.0) | 2.2.0 | [Firestore low-level API access](https://firebase.google.com) |
 | [Google.Cloud.Functions.V1](https://googleapis.dev/dotnet/Google.Cloud.Functions.V1/1.0.0) | 1.0.0 | [Cloud Functions](https://cloud.google.com/functions) |
 | [Google.Cloud.Gaming.V1](https://googleapis.dev/dotnet/Google.Cloud.Gaming.V1/1.0.0) | 1.0.0 | [Game Services](https://cloud.google.com/solutions/gaming) |

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/FirestoreDbBuilder.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/FirestoreDbBuilder.cs
@@ -185,10 +185,15 @@ namespace Google.Cloud.Firestore
             // copied our existing value in here, we'd recurse infinitely (until we overflowed the stack).
             return new FirestoreDbBuilder
             {
+                // Properties used to build the FirestoreClient
                 Endpoint = hostAndPort,
                 Settings = settings,
+                ChannelCredentials = ChannelCredentials.Insecure,
+                // FirestoreDb-specific properties
                 ProjectId = ProjectId,
-                ChannelCredentials = ChannelCredentials.Insecure
+                DatabaseId = DatabaseId,
+                ConverterRegistry = ConverterRegistry,
+                WarningLogger = WarningLogger
             };
         }
     }

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Google.Cloud.Firestore.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Google.Cloud.Firestore.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.3.0</Version>
+    <Version>2.3.1</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Firestore API.</Description>

--- a/apis/Google.Cloud.Firestore/docs/history.md
+++ b/apis/Google.Cloud.Firestore/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+# Version 2.3.1, released 2021-04-06
+
+- [Commit 62182ca](https://github.com/googleapis/google-cloud-dotnet/commit/62182ca): fix: Propagate properties in FirestoreDbBuilder when using the emulator. Fixes [issue 6313](https://github.com/googleapis/google-cloud-dotnet/issues/6313)
+
+(No API surface change, as expected in a patch release.)
+
 # Version 2.3.0, released 2020-11-18
 
 No API surface change - just dependencies, and a GA release of the new serialization attribute from 2.3.0-beta01.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -899,7 +899,7 @@
       "productName": "Firestore",
       "productUrl": "https://firebase.google.com/docs/firestore/",
       "listingDescription": "Firestore high-level library",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "type": "other",
       "targetFrameworks": "netstandard2.0;net461",
       "testTargetFrameworks": "netcoreapp2.1;net461",

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -64,7 +64,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Domains.V1Beta1](Google.Cloud.Domains.V1Beta1/index.html) | 1.0.0-beta01 | [Cloud Domains](https://cloud.google.com/domains/) |
 | [Google.Cloud.ErrorReporting.V1Beta1](Google.Cloud.ErrorReporting.V1Beta1/index.html) | 2.0.0-beta03 | [Google Cloud Error Reporting](https://cloud.google.com/error-reporting/) |
 | [Google.Cloud.Firestore.Admin.V1](Google.Cloud.Firestore.Admin.V1/index.html) | 2.1.0 | [Firestore Administration (e.g. index management)](https://firebase.google.com) |
-| [Google.Cloud.Firestore](Google.Cloud.Firestore/index.html) | 2.3.0 | [Firestore high-level library](https://firebase.google.com/docs/firestore/) |
+| [Google.Cloud.Firestore](Google.Cloud.Firestore/index.html) | 2.3.1 | [Firestore high-level library](https://firebase.google.com/docs/firestore/) |
 | [Google.Cloud.Firestore.V1](Google.Cloud.Firestore.V1/index.html) | 2.2.0 | [Firestore low-level API access](https://firebase.google.com) |
 | [Google.Cloud.Functions.V1](Google.Cloud.Functions.V1/index.html) | 1.0.0 | [Cloud Functions](https://cloud.google.com/functions) |
 | [Google.Cloud.Gaming.V1](Google.Cloud.Gaming.V1/index.html) | 1.0.0 | [Game Services](https://cloud.google.com/solutions/gaming) |


### PR DESCRIPTION

Changes in this release:

- [Commit 62182ca](https://github.com/googleapis/google-cloud-dotnet/commit/62182ca): fix: Propagate properties in FirestoreDbBuilder when using the emulator. Fixes [issue 6313](https://github.com/googleapis/google-cloud-dotnet/issues/6313)

(No API surface change, as expected in a patch release.)
