### PR TITLE
feat(spanner): add option to return read timestamp

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/TimestampBoundTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/TimestampBoundTests.cs
@@ -29,7 +29,8 @@ namespace Google.Cloud.Spanner.Data.Tests
             TimestampBound.OfExactStaleness(TimeSpan.FromHours(1)),
             TimestampBound.OfMinReadTimestamp(new DateTime(1999, 12, 31, 3, 33, 33, DateTimeKind.Utc)),
             TimestampBound.OfReadTimestamp(new DateTime(1999, 12, 31, 3, 33, 33, DateTimeKind.Utc)),
-            TimestampBound.Strong
+            TimestampBound.Strong,
+            TimestampBound.Strong.WithReturnReadTimestamp(true)
         };
 
         [Theory]
@@ -71,6 +72,20 @@ namespace Google.Cloud.Spanner.Data.Tests
         {
             var bound = TimestampBound.OfReadTimestamp(new DateTime(1970, 1, 1, 0, 0, 10, DateTimeKind.Utc));
             AssertProtoConversion(new ReadOnly { ReadTimestamp = new Timestamp { Seconds = 10 } }, bound);
+        }
+
+        [Fact]
+        public void ToTransactionOptions_WithReturnReadTimestamp()
+        {
+            var bound = TimestampBound.OfReadTimestamp(new DateTime(1970, 1, 1, 0, 0, 10, DateTimeKind.Utc)).WithReturnReadTimestamp(true);
+            AssertProtoConversion(new ReadOnly { ReadTimestamp = new Timestamp { Seconds = 10 }, ReturnReadTimestamp = true }, bound);
+        }
+
+        [Fact]
+        public void ToTransactionOptions_WithoutReturnReadTimestamp()
+        {
+            var bound = TimestampBound.OfReadTimestamp(new DateTime(1970, 1, 1, 0, 0, 10, DateTimeKind.Utc));
+            AssertProtoConversion(new ReadOnly { ReadTimestamp = new Timestamp { Seconds = 10 }, ReturnReadTimestamp = false }, bound);
         }
 
         [Theory]
@@ -123,6 +138,7 @@ namespace Google.Cloud.Spanner.Data.Tests
             var read = TimestampBound.OfReadTimestamp(timestamp1);
             var exactStaleness = TimestampBound.OfExactStaleness(staleness1);
             var maxStaleness = TimestampBound.OfMaxStaleness(staleness1);
+            var returnReadTimestamp = TimestampBound.Strong.WithReturnReadTimestamp(true);
 
             EqualityTester.AssertEqual(strong,
                 new[] { strong },
@@ -142,6 +158,10 @@ namespace Google.Cloud.Spanner.Data.Tests
 
             EqualityTester.AssertEqual(maxStaleness,
                 new[] { TimestampBound.OfMaxStaleness(staleness1) },
+                new[] { strong, minRead, read, exactStaleness, TimestampBound.OfMaxStaleness(staleness2) });
+
+            EqualityTester.AssertEqual(returnReadTimestamp,
+                new[] { returnReadTimestamp },
                 new[] { strong, minRead, read, exactStaleness, TimestampBound.OfMaxStaleness(staleness2) });
         }
 

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.ExecutableCommand.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.ExecutableCommand.cs
@@ -140,7 +140,7 @@ namespace Google.Cloud.Spanner.Data
                 // When the data reader is closed, we may need to dispose of the connection.
                 IDisposable resourceToClose = (behavior & CommandBehavior.CloseConnection) == CommandBehavior.CloseConnection ? Connection : null;
 
-                return new SpannerDataReader(Connection.Logger, resultSet, resourceToClose, conversionOptions, enableGetSchemaTable, CommandTimeout);
+                return new SpannerDataReader(Connection.Logger, resultSet, Transaction?.ReadTimestamp, resourceToClose, conversionOptions, enableGetSchemaTable, CommandTimeout);
             }
 
             internal async Task<IReadOnlyList<CommandPartition>> GetReaderPartitionsAsync(long? partitionSizeBytes, long? maxPartitions, CancellationToken cancellationToken)

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerTransaction.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerTransaction.cs
@@ -417,6 +417,12 @@ namespace Google.Cloud.Spanner.Data
             _session.TransactionId.ToBase64(),
             TimestampBound);
 
+        /// <summary>
+        /// The read timestamp of the read-only transaction if
+        /// <see cref="TimestampBound.ReturnReadTimestamp" /> is true, else <c>null</c>.
+        /// </summary>
+        public Timestamp ReadTimestamp => _session.ReadTimestamp;
+
         /// <inheritdoc />
         protected override void Dispose(bool disposing)
         {

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPool.DetachedSessionPool.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPool.DetachedSessionPool.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -23,7 +24,7 @@ namespace Google.Cloud.Spanner.V1
     {
         /// <summary>
         /// A "session pool" for sessions that aren't really pooled. This is used by
-        /// <see cref="SessionPool.CreateDetachedSession(SessionName, Protobuf.ByteString, TransactionOptions.ModeOneofCase)"/>.
+        /// <see cref="SessionPool.CreateDetachedSession(SessionName, Protobuf.ByteString, TransactionOptions.ModeOneofCase, Timestamp)"/>.
         /// We need to have it in *a* pool so that we can use <see cref="PooledSession"/>, and we need to be able to
         /// delete the session if requested (so we need to know our parent), but that's all.
         /// </summary>

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPool.TargetedSessionPool.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPool.TargetedSessionPool.cs
@@ -447,7 +447,7 @@ namespace Google.Cloud.Spanner.V1
                         .WithExpiration(Expiration.FromTimeout(Options.Timeout))
                         .WithCancellationToken(cancellationToken);
                     var transaction = await session.BeginTransactionAsync(request, callSettings).ConfigureAwait(false);
-                    return session.WithTransaction(transaction.Id, options.ModeCase);
+                    return session.WithTransaction(transaction.Id, options.ModeCase, transaction.ReadTimestamp);
                 }
                 finally
                 {


### PR DESCRIPTION
For snapshot read-only transactions, it's possible to get the backend to return the [`read_timestamp`](https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#google.spanner.v1.Transaction). This PR introduces a `TimestampBound.ReturnReadTimestamp` property so that users can opt into returning the timestamp.