### PR TITLE
Simplify how we run smoke tests

### DIFF
--- a/NEWAPI.md
+++ b/NEWAPI.md
@@ -240,15 +240,18 @@ Once you've reviewed the smoke tests, enable the API in the
 [Cloud Console API
 dashboard](https://console.cloud.google.com/apis/dashboard) and then
 run them with release manager. To run the smoke tests, use the
-`smoke-test` command, specifying the package ID and the name of your
-project:
+`smoke-test` command, specifying the package ID. This uses the
+`TEST_PROJECT` environment variable, in the same way as the other
+integration tests, so set that environment variable first if it's
+not already set.
 
 ```sh
-./prepare-release.sh smoke-test Google.Cloud.Dialogflow.Cx.V3 my-project-id
+$ export TEST_PROJECT=your-project-id
+$ ./prepare-release.sh smoke-test Google.Cloud.Dialogflow.Cx.V3
 ```
 
 Note that this assumes you have application default credentials
-configured for the specified project.
+configured for the test project.
 
 If the smoke test fails first time, it's worth looking into. In
 particular, if it's an RPC with a *location* path segment, we

--- a/runintegrationtests.sh
+++ b/runintegrationtests.sh
@@ -137,7 +137,7 @@ do
     # run it via ReleaseManager
     echo "Running $testdir"
     dotnet run -p ../tools/Google.Cloud.Tools.ReleaseManager -- \
-    smoke-test $(dirname $testdir) $TEST_PROJECT \
+      smoke-test $(dirname $testdir) \
       || echo "$testdir" >> $FAILURE_TEMP_FILE
   elif [[ "$testdir" =~ SmokeTests ]]
   then

--- a/tools/Google.Cloud.Tools.ReleaseManager/SmokeTestCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/SmokeTestCommand.cs
@@ -29,16 +29,21 @@ namespace Google.Cloud.Tools.ReleaseManager
     public class SmokeTestCommand : CommandBase
     {
         private const string TestTargetFramework = "netcoreapp2.1";
+        private const string TestProjectEnvironmentVariable = "TEST_PROJECT";
 
         public SmokeTestCommand()
-            : base("smoke-test", "Runs smoke tests for a package", "id", "project-id")
+            : base("smoke-test", "Runs smoke tests for a package", "id")
         {
         }
 
         protected override void ExecuteImpl(string[] args)
         {
             string id = args[0];
-            string projectId = args[1];
+            string projectId = Environment.GetEnvironmentVariable(TestProjectEnvironmentVariable);
+            if (string.IsNullOrEmpty(projectId))
+            {
+                throw new UserErrorException($"Environment variable {TestProjectEnvironmentVariable} must be set before running smoke tests");
+            }
 
             var smokeTests = LoadSmokeTests(id);
             if (smokeTests.Count == 0)


### PR DESCRIPTION
We already have the TEST_PROJECT environment variable, so there's no
need to specify the project ID every time we want to run smoke tests.