### PR TITLE
tests: Fixes flakiness by diferenciating some error messages.

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/ErrorReporting/ErrorReportingTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/ErrorReporting/ErrorReportingTest.cs
@@ -78,13 +78,13 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         public async Task LogsMultipleExceptions()
         {
             await Assert.ThrowsAsync<Exception>(() =>
-                _client.GetAsync($"/ErrorReporting/{nameof(ErrorReportingController.ThrowsException)}/{_testId}"));
+                _client.GetAsync($"/ErrorReporting/{nameof(ErrorReportingController.ThrowsException)}/{_testId}_0"));
             await Assert.ThrowsAsync<ArgumentException>(() =>
                 _client.GetAsync($"/ErrorReporting/{nameof(ErrorReportingController.ThrowsArgumentException)}/{_testId}"));
             await Assert.ThrowsAsync<Exception>(() =>
-                _client.GetAsync($"/ErrorReporting/{nameof(ErrorReportingController.ThrowsException)}/{_testId}"));
+                _client.GetAsync($"/ErrorReporting/{nameof(ErrorReportingController.ThrowsException)}/{_testId}_1"));
             await Assert.ThrowsAsync<Exception>(() =>
-                _client.GetAsync($"/ErrorReporting/{nameof(ErrorReportingController.ThrowsException)}/{_testId}"));
+                _client.GetAsync($"/ErrorReporting/{nameof(ErrorReportingController.ThrowsException)}/{_testId}_2"));
 
             var errorEvents = ErrorEventEntryVerifiers.VerifyMany(s_polling, _testId, 4);
 


### PR DESCRIPTION
Seems like the Error Reporting backend has started to detect duplicates and report them as one. The flaky test was provoking the same error several times in a very short period of time so those were being assumed duplicates and not reported. That behaviour is not entirely unreasonable.