### PR TITLE
Release GSuite AddOns libraries version 1.0.0-beta01

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Each package name links to the documentation for that package.
 | [Google.Analytics.Admin.V1Alpha](https://googleapis.dev/dotnet/Google.Analytics.Admin.V1Alpha/1.0.0-alpha05) | 1.0.0-alpha05 | [Analytics Admin](https://developers.google.com/analytics) |
 | [Google.Analytics.Data.V1Alpha](https://googleapis.dev/dotnet/Google.Analytics.Data.V1Alpha/1.0.0-alpha04) | 1.0.0-alpha04 | [Google Analytics Data (V1Alpha API)](https://developers.google.com/analytics) |
 | [Google.Analytics.Data.V1Beta](https://googleapis.dev/dotnet/Google.Analytics.Data.V1Beta/1.0.0-beta02) | 1.0.0-beta02 | [Google Analytics Data (V1Beta API)](https://developers.google.com/analytics) |
+| [Google.Apps.Script.Type](https://googleapis.dev/dotnet/Google.Apps.Script.Type/1.0.0-beta01) | 1.0.0-beta01 | Version-agnostic types for Apps Script APIs |
 | [Google.Area120.Tables.V1Alpha1](https://googleapis.dev/dotnet/Google.Area120.Tables.V1Alpha1/1.0.0-alpha02) | 1.0.0-alpha02 | Google Area 120 Tables |
 | [Google.Cloud.AccessApproval.V1](https://googleapis.dev/dotnet/Google.Cloud.AccessApproval.V1/1.0.0) | 1.0.0 | [Access Approval](https://cloud.google.com/access-approval/docs/) |
 | [Google.Cloud.ApiGateway.V1](https://googleapis.dev/dotnet/Google.Cloud.ApiGateway.V1/1.0.0-beta01) | 1.0.0-beta01 | [API Gateway](https://cloud.google.com/api-gateway/docs) |
@@ -64,6 +65,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Firestore](https://googleapis.dev/dotnet/Google.Cloud.Firestore/2.3.1) | 2.3.1 | [Firestore high-level library](https://firebase.google.com/docs/firestore/) |
 | [Google.Cloud.Firestore.V1](https://googleapis.dev/dotnet/Google.Cloud.Firestore.V1/2.2.0) | 2.2.0 | [Firestore low-level API access](https://firebase.google.com) |
 | [Google.Cloud.Functions.V1](https://googleapis.dev/dotnet/Google.Cloud.Functions.V1/1.0.0) | 1.0.0 | [Cloud Functions](https://cloud.google.com/functions) |
+| [Google.Cloud.GSuiteAddOns.V1](https://googleapis.dev/dotnet/Google.Cloud.GSuiteAddOns.V1/1.0.0-beta01) | 1.0.0-beta01 | [Google Workspace Add-ons](https://developers.google.com/gsuite/add-ons/overview) |
 | [Google.Cloud.Gaming.V1](https://googleapis.dev/dotnet/Google.Cloud.Gaming.V1/1.0.0) | 1.0.0 | [Game Services](https://cloud.google.com/solutions/gaming) |
 | [Google.Cloud.Gaming.V1Beta](https://googleapis.dev/dotnet/Google.Cloud.Gaming.V1Beta/1.0.0-beta06) | 1.0.0-beta06 | [Google Cloud for Games](https://cloud.google.com/solutions/gaming) |
 | [Google.Cloud.GkeHub.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.GkeHub.V1Beta1/1.0.0-beta01) | 1.0.0-beta01 | [GKE Hub](https://cloud.google.com/anthos/multicluster-management/connect/registering-a-cluster) |

--- a/apis/Google.Apps.Script.Type/.repo-metadata.json
+++ b/apis/Google.Apps.Script.Type/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+  "distribution_name": "Google.Apps.Script.Type",
+  "release_level": "beta",
+  "client_documentation": "https://googleapis.dev/dotnet/Google.Apps.Script.Type/latest",
+  "library_type": "OTHER"
+}

--- a/apis/Google.Apps.Script.Type/Google.Apps.Script.Type/Google.Apps.Script.Type.csproj
+++ b/apis/Google.Apps.Script.Type/Google.Apps.Script.Type/Google.Apps.Script.Type.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta00</Version>
+    <Version>1.0.0-beta01</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Version-agnostic types for Apps Script APIs.</Description>

--- a/apis/Google.Apps.Script.Type/docs/history.md
+++ b/apis/Google.Apps.Script.Type/docs/history.md
@@ -1,0 +1,5 @@
+# Version history
+
+# Version 1.0.0-beta01, released 2021-04-28
+
+Initial release.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+  "distribution_name": "Google.Cloud.GSuiteAddOns.V1",
+  "release_level": "beta",
+  "client_documentation": "https://googleapis.dev/dotnet/Google.Cloud.GSuiteAddOns.V1/latest",
+  "library_type": "GAPIC_AUTO"
+}

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.csproj
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta00</Version>
+    <Version>1.0.0-beta01</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Workspace Add-ons API</Description>

--- a/apis/Google.Cloud.GSuiteAddOns.V1/docs/history.md
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/docs/history.md
@@ -1,0 +1,5 @@
+# Version history
+
+# Version 1.0.0-beta01, released 2021-04-28
+
+Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -44,7 +44,7 @@
     },
     {
       "id": "Google.Apps.Script.Type",
-      "version": "1.0.0-beta00",
+      "version": "1.0.0-beta01",
       "targetFrameworks": "netstandard2.0;net461",
       "type": "other",
       "description": "Version-agnostic types for Apps Script APIs.",
@@ -986,7 +986,7 @@
     },
     {
       "id": "Google.Cloud.GSuiteAddOns.V1",
-      "version": "1.0.0-beta00",
+      "version": "1.0.0-beta01",
       "type": "grpc",
       "productName": "Google Workspace Add-ons",
       "productUrl": "https://developers.google.com/gsuite/add-ons/overview",

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -21,6 +21,7 @@ Each package name links to the documentation for that package.
 | [Google.Analytics.Admin.V1Alpha](Google.Analytics.Admin.V1Alpha/index.html) | 1.0.0-alpha05 | [Analytics Admin](https://developers.google.com/analytics) |
 | [Google.Analytics.Data.V1Alpha](Google.Analytics.Data.V1Alpha/index.html) | 1.0.0-alpha04 | [Google Analytics Data (V1Alpha API)](https://developers.google.com/analytics) |
 | [Google.Analytics.Data.V1Beta](Google.Analytics.Data.V1Beta/index.html) | 1.0.0-beta02 | [Google Analytics Data (V1Beta API)](https://developers.google.com/analytics) |
+| [Google.Apps.Script.Type](Google.Apps.Script.Type/index.html) | 1.0.0-beta01 | Version-agnostic types for Apps Script APIs |
 | [Google.Area120.Tables.V1Alpha1](Google.Area120.Tables.V1Alpha1/index.html) | 1.0.0-alpha02 | Google Area 120 Tables |
 | [Google.Cloud.AccessApproval.V1](Google.Cloud.AccessApproval.V1/index.html) | 1.0.0 | [Access Approval](https://cloud.google.com/access-approval/docs/) |
 | [Google.Cloud.ApiGateway.V1](Google.Cloud.ApiGateway.V1/index.html) | 1.0.0-beta01 | [API Gateway](https://cloud.google.com/api-gateway/docs) |
@@ -67,6 +68,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Firestore](Google.Cloud.Firestore/index.html) | 2.3.1 | [Firestore high-level library](https://firebase.google.com/docs/firestore/) |
 | [Google.Cloud.Firestore.V1](Google.Cloud.Firestore.V1/index.html) | 2.2.0 | [Firestore low-level API access](https://firebase.google.com) |
 | [Google.Cloud.Functions.V1](Google.Cloud.Functions.V1/index.html) | 1.0.0 | [Cloud Functions](https://cloud.google.com/functions) |
+| [Google.Cloud.GSuiteAddOns.V1](Google.Cloud.GSuiteAddOns.V1/index.html) | 1.0.0-beta01 | [Google Workspace Add-ons](https://developers.google.com/gsuite/add-ons/overview) |
 | [Google.Cloud.Gaming.V1](Google.Cloud.Gaming.V1/index.html) | 1.0.0 | [Game Services](https://cloud.google.com/solutions/gaming) |
 | [Google.Cloud.Gaming.V1Beta](Google.Cloud.Gaming.V1Beta/index.html) | 1.0.0-beta06 | [Google Cloud for Games](https://cloud.google.com/solutions/gaming) |
 | [Google.Cloud.GkeHub.V1Beta1](Google.Cloud.GkeHub.V1Beta1/index.html) | 1.0.0-beta01 | [GKE Hub](https://cloud.google.com/anthos/multicluster-management/connect/registering-a-cluster) |


### PR DESCRIPTION

Changes in Google.Apps.Script.Type version 1.0.0-beta01:

Initial release.

Changes in Google.Cloud.GSuiteAddOns.V1 version 1.0.0-beta01:

Initial release.

Packages in this release:
- Release Google.Apps.Script.Type version 1.0.0-beta01
- Release Google.Cloud.GSuiteAddOns.V1 version 1.0.0-beta01
