### PR TITLE
Release Google.Analytics.Admin.V1Alpha version 1.0.0-alpha06

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Each package name links to the documentation for that package.
 
 | Package | Latest version | Description |
 |---------|----------------|-------------|
-| [Google.Analytics.Admin.V1Alpha](https://googleapis.dev/dotnet/Google.Analytics.Admin.V1Alpha/1.0.0-alpha05) | 1.0.0-alpha05 | [Analytics Admin](https://developers.google.com/analytics) |
+| [Google.Analytics.Admin.V1Alpha](https://googleapis.dev/dotnet/Google.Analytics.Admin.V1Alpha/1.0.0-alpha06) | 1.0.0-alpha06 | [Analytics Admin](https://developers.google.com/analytics) |
 | [Google.Analytics.Data.V1Alpha](https://googleapis.dev/dotnet/Google.Analytics.Data.V1Alpha/1.0.0-alpha04) | 1.0.0-alpha04 | [Google Analytics Data (V1Alpha API)](https://developers.google.com/analytics) |
 | [Google.Analytics.Data.V1Beta](https://googleapis.dev/dotnet/Google.Analytics.Data.V1Beta/1.0.0-beta02) | 1.0.0-beta02 | [Google Analytics Data (V1Beta API)](https://developers.google.com/analytics) |
 | [Google.Apps.Script.Type](https://googleapis.dev/dotnet/Google.Apps.Script.Type/1.0.0-beta01) | 1.0.0-beta01 | Version-agnostic types for Apps Script APIs |

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha05</Version>
+    <Version>1.0.0-alpha06</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Analytics Admin API (v1alpha)</Description>

--- a/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
+++ b/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+# Version 1.0.0-alpha06, released 2021-04-28
+
+- [Commit b01d59c](https://github.com/googleapis/google-cloud-dotnet/commit/b01d59c):
+  - fix!: remove `CreateIosAppDataStream`, `CreateAndroidAppDataStream` methods from the API
+  - feat: add `SearchChangeHistoryEvents` method to the API
+  - fix!: update `DeleteProperty` method to return the deleted property data as `Property` type instead of returning an empty response
+  - feat: add `ActorType`, `ActionType`, `ChangeHistoryResourceType`, `ChangeHistoryEvent`, `ChangeHistoryChange` types used by `SearchChangeHistoryEvents` method
+  - fix!: update `time_zone` field of `Property` type to be required
+  - feat: add `delete_time`, `expire_time` output only fields to `Property` type
+  - fix!: remove `deleted` field from `Property` type
+
 # Version 1.0.0-alpha05, released 2021-04-14
 
 - [Commit 6904fb8](https://github.com/googleapis/google-cloud-dotnet/commit/6904fb8): fix: add `https://www.googleapis.com/auth/analytics.edit` OAuth2 scope to the list of acceptable scopes for all read only methods of the Admin API docs: update the documentation of the `update_mask` field used by Update() methods

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2,7 +2,7 @@
   "apis": [
     {
       "id": "Google.Analytics.Admin.V1Alpha",
-      "version": "1.0.0-alpha05",
+      "version": "1.0.0-alpha06",
       "type": "grpc",
       "productName": "Analytics Admin",
       "productUrl": "https://developers.google.com/analytics",

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -18,7 +18,7 @@ Each package name links to the documentation for that package.
 
 | Package | Latest version | Description |
 |---------|----------------|-------------|
-| [Google.Analytics.Admin.V1Alpha](Google.Analytics.Admin.V1Alpha/index.html) | 1.0.0-alpha05 | [Analytics Admin](https://developers.google.com/analytics) |
+| [Google.Analytics.Admin.V1Alpha](Google.Analytics.Admin.V1Alpha/index.html) | 1.0.0-alpha06 | [Analytics Admin](https://developers.google.com/analytics) |
 | [Google.Analytics.Data.V1Alpha](Google.Analytics.Data.V1Alpha/index.html) | 1.0.0-alpha04 | [Google Analytics Data (V1Alpha API)](https://developers.google.com/analytics) |
 | [Google.Analytics.Data.V1Beta](Google.Analytics.Data.V1Beta/index.html) | 1.0.0-beta02 | [Google Analytics Data (V1Beta API)](https://developers.google.com/analytics) |
 | [Google.Apps.Script.Type](Google.Apps.Script.Type/index.html) | 1.0.0-beta01 | Version-agnostic types for Apps Script APIs |


### PR DESCRIPTION

Changes in this release:

- [Commit b01d59c](https://github.com/googleapis/google-cloud-dotnet/commit/b01d59c):
  - fix!: remove `CreateIosAppDataStream`, `CreateAndroidAppDataStream` methods from the API
  - feat: add `SearchChangeHistoryEvents` method to the API
  - fix!: update `DeleteProperty` method to return the deleted property data as `Property` type instead of returning an empty response
  - feat: add `ActorType`, `ActionType`, `ChangeHistoryResourceType`, `ChangeHistoryEvent`, `ChangeHistoryChange` types used by `SearchChangeHistoryEvents` method
  - fix!: update `time_zone` field of `Property` type to be required
  - feat: add `delete_time`, `expire_time` output only fields to `Property` type
  - fix!: remove `deleted` field from `Property` type
