### PR TITLE
Release Google.Area120.Tables.V1Alpha1 version 1.0.0-alpha03

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Each package name links to the documentation for that package.
 | [Google.Analytics.Data.V1Alpha](https://googleapis.dev/dotnet/Google.Analytics.Data.V1Alpha/1.0.0-alpha04) | 1.0.0-alpha04 | [Google Analytics Data (V1Alpha API)](https://developers.google.com/analytics) |
 | [Google.Analytics.Data.V1Beta](https://googleapis.dev/dotnet/Google.Analytics.Data.V1Beta/1.0.0-beta02) | 1.0.0-beta02 | [Google Analytics Data (V1Beta API)](https://developers.google.com/analytics) |
 | [Google.Apps.Script.Type](https://googleapis.dev/dotnet/Google.Apps.Script.Type/1.0.0-beta01) | 1.0.0-beta01 | Version-agnostic types for Apps Script APIs |
-| [Google.Area120.Tables.V1Alpha1](https://googleapis.dev/dotnet/Google.Area120.Tables.V1Alpha1/1.0.0-alpha02) | 1.0.0-alpha02 | Google Area 120 Tables |
+| [Google.Area120.Tables.V1Alpha1](https://googleapis.dev/dotnet/Google.Area120.Tables.V1Alpha1/1.0.0-alpha03) | 1.0.0-alpha03 | Google Area 120 Tables |
 | [Google.Cloud.AccessApproval.V1](https://googleapis.dev/dotnet/Google.Cloud.AccessApproval.V1/1.0.0) | 1.0.0 | [Access Approval](https://cloud.google.com/access-approval/docs/) |
 | [Google.Cloud.ApiGateway.V1](https://googleapis.dev/dotnet/Google.Cloud.ApiGateway.V1/1.0.0-beta01) | 1.0.0-beta01 | [API Gateway](https://cloud.google.com/api-gateway/docs) |
 | [Google.Cloud.AppEngine.V1](https://googleapis.dev/dotnet/Google.Cloud.AppEngine.V1/1.0.0) | 1.0.0 | [App Engine Audit Data](https://cloud.google.com/appengine) |

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.csproj
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha02</Version>
+    <Version>1.0.0-alpha03</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Area 120 Tables API</Description>

--- a/apis/Google.Area120.Tables.V1Alpha1/docs/history.md
+++ b/apis/Google.Area120.Tables.V1Alpha1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.0.0-alpha03, released 2021-04-28
+
+- [Commit 294f56e](https://github.com/googleapis/google-cloud-dotnet/commit/294f56e): feat: Added ListWorkspaces, GetWorkspace, BatchDeleteRows APIs.
+
 # Version 1.0.0-alpha02, released 2020-11-19
 
 - [Commit 0ca05f5](https://github.com/googleapis/google-cloud-dotnet/commit/0ca05f5): chore: Regenerate all APIs using protoc 3.13 and Grpc.Tools 2.31

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -59,7 +59,7 @@
     },
     {
       "id": "Google.Area120.Tables.V1Alpha1",
-      "version": "1.0.0-alpha02",
+      "version": "1.0.0-alpha03",
       "type": "grpc",
       "productName": "Google Area 120 Tables",
       "description": "Recommended Google client library to access the Area 120 Tables API",

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -22,7 +22,7 @@ Each package name links to the documentation for that package.
 | [Google.Analytics.Data.V1Alpha](Google.Analytics.Data.V1Alpha/index.html) | 1.0.0-alpha04 | [Google Analytics Data (V1Alpha API)](https://developers.google.com/analytics) |
 | [Google.Analytics.Data.V1Beta](Google.Analytics.Data.V1Beta/index.html) | 1.0.0-beta02 | [Google Analytics Data (V1Beta API)](https://developers.google.com/analytics) |
 | [Google.Apps.Script.Type](Google.Apps.Script.Type/index.html) | 1.0.0-beta01 | Version-agnostic types for Apps Script APIs |
-| [Google.Area120.Tables.V1Alpha1](Google.Area120.Tables.V1Alpha1/index.html) | 1.0.0-alpha02 | Google Area 120 Tables |
+| [Google.Area120.Tables.V1Alpha1](Google.Area120.Tables.V1Alpha1/index.html) | 1.0.0-alpha03 | Google Area 120 Tables |
 | [Google.Cloud.AccessApproval.V1](Google.Cloud.AccessApproval.V1/index.html) | 1.0.0 | [Access Approval](https://cloud.google.com/access-approval/docs/) |
 | [Google.Cloud.ApiGateway.V1](Google.Cloud.ApiGateway.V1/index.html) | 1.0.0-beta01 | [API Gateway](https://cloud.google.com/api-gateway/docs) |
 | [Google.Cloud.AppEngine.V1](Google.Cloud.AppEngine.V1/index.html) | 1.0.0 | [App Engine Audit Data](https://cloud.google.com/appengine) |


### PR DESCRIPTION

Changes in this release:

- [Commit 294f56e](https://github.com/googleapis/google-cloud-dotnet/commit/294f56e): feat: Added ListWorkspaces, GetWorkspace, BatchDeleteRows APIs.
