### PR TITLE
Release Google.Cloud.Billing.Budgets.V1Beta1 version 1.0.0-beta03

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Bigtable.Common.V2](https://googleapis.dev/dotnet/Google.Cloud.Bigtable.Common.V2/2.0.0) | 2.0.0 | Common code used by Bigtable V2 APIs |
 | [Google.Cloud.Bigtable.V2](https://googleapis.dev/dotnet/Google.Cloud.Bigtable.V2/2.1.1) | 2.1.1 | [Google Bigtable](https://cloud.google.com/bigtable/) |
 | [Google.Cloud.Billing.Budgets.V1](https://googleapis.dev/dotnet/Google.Cloud.Billing.Budgets.V1/1.1.0) | 1.1.0 | [Cloud Billing Budget (V1 API)](https://cloud.google.com/billing/docs/how-to/budget-api-overview) |
-| [Google.Cloud.Billing.Budgets.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Billing.Budgets.V1Beta1/1.0.0-beta02) | 1.0.0-beta02 | [Cloud Billing Budget (V1Beta1 API)](https://cloud.google.com/billing/docs/how-to/budget-api-overview) |
+| [Google.Cloud.Billing.Budgets.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Billing.Budgets.V1Beta1/1.0.0-beta03) | 1.0.0-beta03 | [Cloud Billing Budget (V1Beta1 API)](https://cloud.google.com/billing/docs/how-to/budget-api-overview) |
 | [Google.Cloud.Billing.V1](https://googleapis.dev/dotnet/Google.Cloud.Billing.V1/2.1.0) | 2.1.0 | [Google Cloud Billing](https://cloud.google.com/billing/docs/) |
 | [Google.Cloud.BinaryAuthorization.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.BinaryAuthorization.V1Beta1/1.0.0-beta01) | 1.0.0-beta01 | [Binary Authorization](https://cloud.google.com/binary-authorization/docs/reference/rpc) |
 | [Google.Cloud.Channel.V1](https://googleapis.dev/dotnet/Google.Cloud.Channel.V1/1.0.0) | 1.0.0 | [Cloud Channel](https://cloud.google.com/channel/docs/) |

--- a/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1.csproj
+++ b/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Cloud Billing Budget API v1beta1. This API stores Cloud Billing budgets, which define a budget plan and the rules to execute as spend is tracked against that plan.</Description>

--- a/apis/Google.Cloud.Billing.Budgets.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.Billing.Budgets.V1Beta1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+# Version 1.0.0-beta03, released 2021-04-29
+
+- [Commit 4f20acd](https://github.com/googleapis/google-cloud-dotnet/commit/4f20acd):
+  - feat: Added support for configurable budget time period.
+  - fix: Updated some documentation links.
+- [Commit ab48b2b](https://github.com/googleapis/google-cloud-dotnet/commit/ab48b2b): docs: Update rules for currency_code in budget_amount.
+
 # Version 1.0.0-beta02, released 2020-11-17
 
 - [Commit d3c8166](https://github.com/googleapis/google-cloud-dotnet/commit/d3c8166): docs: Reworded comments for the new credit types filter

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -379,7 +379,7 @@
     },
     {
       "id": "Google.Cloud.Billing.Budgets.V1Beta1",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0-beta03",
       "type": "grpc",
       "productName": "Cloud Billing Budget",
       "productUrl": "https://cloud.google.com/billing/docs/how-to/budget-api-overview",

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -39,7 +39,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Bigtable.Common.V2](Google.Cloud.Bigtable.Common.V2/index.html) | 2.0.0 | Common code used by Bigtable V2 APIs |
 | [Google.Cloud.Bigtable.V2](Google.Cloud.Bigtable.V2/index.html) | 2.1.1 | [Google Bigtable](https://cloud.google.com/bigtable/) |
 | [Google.Cloud.Billing.Budgets.V1](Google.Cloud.Billing.Budgets.V1/index.html) | 1.1.0 | [Cloud Billing Budget (V1 API)](https://cloud.google.com/billing/docs/how-to/budget-api-overview) |
-| [Google.Cloud.Billing.Budgets.V1Beta1](Google.Cloud.Billing.Budgets.V1Beta1/index.html) | 1.0.0-beta02 | [Cloud Billing Budget (V1Beta1 API)](https://cloud.google.com/billing/docs/how-to/budget-api-overview) |
+| [Google.Cloud.Billing.Budgets.V1Beta1](Google.Cloud.Billing.Budgets.V1Beta1/index.html) | 1.0.0-beta03 | [Cloud Billing Budget (V1Beta1 API)](https://cloud.google.com/billing/docs/how-to/budget-api-overview) |
 | [Google.Cloud.Billing.V1](Google.Cloud.Billing.V1/index.html) | 2.1.0 | [Google Cloud Billing](https://cloud.google.com/billing/docs/) |
 | [Google.Cloud.BinaryAuthorization.V1Beta1](Google.Cloud.BinaryAuthorization.V1Beta1/index.html) | 1.0.0-beta01 | [Binary Authorization](https://cloud.google.com/binary-authorization/docs/reference/rpc) |
 | [Google.Cloud.Channel.V1](Google.Cloud.Channel.V1/index.html) | 1.0.0 | [Cloud Channel](https://cloud.google.com/channel/docs/) |


### PR DESCRIPTION
Changes in this release:

- [Commit 4f20acd](https://github.com/googleapis/google-cloud-dotnet/commit/4f20acd):
  - feat: Added support for configurable budget time period.
  - fix: Updated some documentation links.
- [Commit ab48b2b](https://github.com/googleapis/google-cloud-dotnet/commit/ab48b2b): docs: Update rules for currency_code in budget_amount.
