### PR TITLE
Release Google.Cloud.Dataproc.V1 version 3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.DataCatalog.V1](https://googleapis.dev/dotnet/Google.Cloud.DataCatalog.V1/1.1.0) | 1.1.0 | [Data Catalog](https://cloud.google.com/data-catalog/docs) |
 | [Google.Cloud.DataLabeling.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.DataLabeling.V1Beta1/1.0.0-beta01) | 1.0.0-beta01 | [Data Labeling](https://cloud.google.com/ai-platform/data-labeling/docs) |
 | [Google.Cloud.DataQnA.V1Alpha](https://googleapis.dev/dotnet/Google.Cloud.DataQnA.V1Alpha/1.0.0-alpha01) | 1.0.0-alpha01 | [Data QnA](https://cloud.google.com/bigquery/docs/dataqna) |
-| [Google.Cloud.Dataproc.V1](https://googleapis.dev/dotnet/Google.Cloud.Dataproc.V1/3.0.0) | 3.0.0 | [Google Cloud Dataproc](https://cloud.google.com/dataproc/docs/concepts/overview) |
+| [Google.Cloud.Dataproc.V1](https://googleapis.dev/dotnet/Google.Cloud.Dataproc.V1/3.1.0) | 3.1.0 | [Google Cloud Dataproc](https://cloud.google.com/dataproc/docs/concepts/overview) |
 | [Google.Cloud.Datastore.Admin.V1](https://googleapis.dev/dotnet/Google.Cloud.Datastore.Admin.V1/1.0.0) | 1.0.0 | Cloud Datastore |
 | [Google.Cloud.Datastore.V1](https://googleapis.dev/dotnet/Google.Cloud.Datastore.V1/3.1.0) | 3.1.0 | [Google Cloud Datastore](https://cloud.google.com/datastore/docs/concepts/overview) |
 | [Google.Cloud.Debugger.V2](https://googleapis.dev/dotnet/Google.Cloud.Debugger.V2/2.1.0) | 2.1.0 | [Google Cloud Debugger](https://cloud.google.com/debugger/) |

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.csproj
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0</Version>
+    <Version>3.1.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Dataproc API, which manages Hadoop-based clusters and jobs on Google Cloud Platform.</Description>
@@ -11,9 +11,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Dataproc.V1/docs/history.md
+++ b/apis/Google.Cloud.Dataproc.V1/docs/history.md
@@ -1,5 +1,19 @@
 # Version history
 
+# Version 3.1.0, released 2021-04-29
+
+- [Commit d429843](https://github.com/googleapis/google-cloud-dotnet/commit/d429843):
+  - feat: The new start and stop cluster methods.
+  - feat: The ability to specify a metastore config in a cluster.
+  - feat: The ability to specify a (BETA) GKE cluster when creating a Dataproc cluster.
+  - feat: The ability to configure the behavior for private IPv6 cluster networking.
+  - feat: The ability to specify node affinity groups for clusters.
+  - feat: The ability to specify shielded VM configurations for clusters.
+  - feat: Support for service-account based secure multi-tenancy.
+  - feat: The ability to specify cluster labels for picking which cluster should run a job.
+  - feat: Components for DOCKER, DRUID, FLINK, HBASE, RANGER, and SOLR
+  - feat: The ability to specify a DAG timeout for workflows.
+
 # Version 3.0.0, released 2020-11-17
 
 - [Commit 0ca05f5](https://github.com/googleapis/google-cloud-dotnet/commit/0ca05f5): chore: Regenerate all APIs using protoc 3.13 and Grpc.Tools 2.31

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -557,7 +557,7 @@
       "protoPath": "google/cloud/dataproc/v1",
       "productName": "Google Cloud Dataproc",
       "productUrl": "https://cloud.google.com/dataproc/docs/concepts/overview",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Dataproc API, which manages Hadoop-based clusters and jobs on Google Cloud Platform.",
       "tags": [
@@ -565,9 +565,9 @@
         "Hadoop"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.2.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
         "Google.LongRunning": "2.1.0",
-        "Grpc.Core": "2.31.0"
+        "Grpc.Core": "2.36.4"
       }
     },
     {

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -48,7 +48,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.DataCatalog.V1](Google.Cloud.DataCatalog.V1/index.html) | 1.1.0 | [Data Catalog](https://cloud.google.com/data-catalog/docs) |
 | [Google.Cloud.DataLabeling.V1Beta1](Google.Cloud.DataLabeling.V1Beta1/index.html) | 1.0.0-beta01 | [Data Labeling](https://cloud.google.com/ai-platform/data-labeling/docs) |
 | [Google.Cloud.DataQnA.V1Alpha](Google.Cloud.DataQnA.V1Alpha/index.html) | 1.0.0-alpha01 | [Data QnA](https://cloud.google.com/bigquery/docs/dataqna) |
-| [Google.Cloud.Dataproc.V1](Google.Cloud.Dataproc.V1/index.html) | 3.0.0 | [Google Cloud Dataproc](https://cloud.google.com/dataproc/docs/concepts/overview) |
+| [Google.Cloud.Dataproc.V1](Google.Cloud.Dataproc.V1/index.html) | 3.1.0 | [Google Cloud Dataproc](https://cloud.google.com/dataproc/docs/concepts/overview) |
 | [Google.Cloud.Datastore.Admin.V1](Google.Cloud.Datastore.Admin.V1/index.html) | 1.0.0 | Cloud Datastore |
 | [Google.Cloud.Datastore.V1](Google.Cloud.Datastore.V1/index.html) | 3.1.0 | [Google Cloud Datastore](https://cloud.google.com/datastore/docs/concepts/overview) |
 | [Google.Cloud.Debugger.V2](Google.Cloud.Debugger.V2/index.html) | 2.1.0 | [Google Cloud Debugger](https://cloud.google.com/debugger/) |


### PR DESCRIPTION

Changes in this release:

- [Commit d429843](https://github.com/googleapis/google-cloud-dotnet/commit/d429843):
  - feat: The new start and stop cluster methods.
  - feat: The ability to specify a metastore config in a cluster.
  - feat: The ability to specify a (BETA) GKE cluster when creating a Dataproc cluster.
  - feat: The ability to configure the behavior for private IPv6 cluster networking.
  - feat: The ability to specify node affinity groups for clusters.
  - feat: The ability to specify shielded VM configurations for clusters.
  - feat: Support for service-account based secure multi-tenancy.
  - feat: The ability to specify cluster labels for picking which cluster should run a job.
  - feat: Components for DOCKER, DRUID, FLINK, HBASE, RANGER, and SOLR
  - feat: The ability to specify a DAG timeout for workflows.
