### PR TITLE
Release Google.Cloud.Vision.V1 version 2.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Translation.V2](https://googleapis.dev/dotnet/Google.Cloud.Translation.V2/2.0.0) | 2.0.0 | [Google Cloud Translation (V2 API)](https://cloud.google.com/translate/) |
 | [Google.Cloud.Video.Transcoder.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Video.Transcoder.V1Beta1/1.0.0-beta01) | 1.0.0-beta01 | [Transcoder](https://cloud.google.com/transcoder/docs) |
 | [Google.Cloud.VideoIntelligence.V1](https://googleapis.dev/dotnet/Google.Cloud.VideoIntelligence.V1/2.1.0) | 2.1.0 | [Google Cloud Video Intelligence](https://cloud.google.com/video-intelligence) |
-| [Google.Cloud.Vision.V1](https://googleapis.dev/dotnet/Google.Cloud.Vision.V1/2.2.0) | 2.2.0 | [Google Cloud Vision](https://cloud.google.com/vision) |
+| [Google.Cloud.Vision.V1](https://googleapis.dev/dotnet/Google.Cloud.Vision.V1/2.3.0) | 2.3.0 | [Google Cloud Vision](https://cloud.google.com/vision) |
 | [Google.Cloud.WebRisk.V1](https://googleapis.dev/dotnet/Google.Cloud.WebRisk.V1/1.1.0) | 1.1.0 | [Google Cloud Web Risk (V1 API)](https://cloud.google.com/web-risk/) |
 | [Google.Cloud.WebRisk.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.WebRisk.V1Beta1/2.0.0-beta03) | 2.0.0-beta03 | [Google Cloud Web Risk (V1Beta1 API)](https://cloud.google.com/web-risk/) |
 | [Google.Cloud.WebSecurityScanner.V1](https://googleapis.dev/dotnet/Google.Cloud.WebSecurityScanner.V1/1.0.0) | 1.0.0 | [Web Security Scanner](https://cloud.google.com/security-command-center/docs/concepts-web-security-scanner-overview) |

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.csproj
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.2.0</Version>
+    <Version>2.3.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Vision API, which integrates Google Vision features, including image labeling, face, logo, and landmark detection, optical character recognition (OCR), and detection of explicit content, into applications.</Description>
@@ -11,9 +11,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Vision.V1/docs/history.md
+++ b/apis/Google.Cloud.Vision.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 2.3.0, released 2021-04-29
+
+- [Commit c94c761](https://github.com/googleapis/google-cloud-dotnet/commit/c94c761): fix: sync vision v1 protos to get extra FaceAnnotation Landmark Types
+
 # Version 2.2.0, released 2020-12-01
 
 - [Commit 12811f6](https://github.com/googleapis/google-cloud-dotnet/commit/12811f6):

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2349,7 +2349,7 @@
       "protoPath": "google/cloud/vision/v1",
       "productName": "Google Cloud Vision",
       "productUrl": "https://cloud.google.com/vision",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Vision API, which integrates Google Vision features, including image labeling, face, logo, and landmark detection, optical character recognition (OCR), and detection of explicit content, into applications.",
@@ -2357,9 +2357,9 @@
         "Vision"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.2.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
         "Google.LongRunning": "2.1.0",
-        "Grpc.Core": "2.31.0"
+        "Grpc.Core": "2.36.4"
       }
     },
     {

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -138,7 +138,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Translation.V2](Google.Cloud.Translation.V2/index.html) | 2.0.0 | [Google Cloud Translation (V2 API)](https://cloud.google.com/translate/) |
 | [Google.Cloud.Video.Transcoder.V1Beta1](Google.Cloud.Video.Transcoder.V1Beta1/index.html) | 1.0.0-beta01 | [Transcoder](https://cloud.google.com/transcoder/docs) |
 | [Google.Cloud.VideoIntelligence.V1](Google.Cloud.VideoIntelligence.V1/index.html) | 2.1.0 | [Google Cloud Video Intelligence](https://cloud.google.com/video-intelligence) |
-| [Google.Cloud.Vision.V1](Google.Cloud.Vision.V1/index.html) | 2.2.0 | [Google Cloud Vision](https://cloud.google.com/vision) |
+| [Google.Cloud.Vision.V1](Google.Cloud.Vision.V1/index.html) | 2.3.0 | [Google Cloud Vision](https://cloud.google.com/vision) |
 | [Google.Cloud.WebRisk.V1](Google.Cloud.WebRisk.V1/index.html) | 1.1.0 | [Google Cloud Web Risk (V1 API)](https://cloud.google.com/web-risk/) |
 | [Google.Cloud.WebRisk.V1Beta1](Google.Cloud.WebRisk.V1Beta1/index.html) | 2.0.0-beta03 | [Google Cloud Web Risk (V1Beta1 API)](https://cloud.google.com/web-risk/) |
 | [Google.Cloud.WebSecurityScanner.V1](Google.Cloud.WebSecurityScanner.V1/index.html) | 1.0.0 | [Web Security Scanner](https://cloud.google.com/security-command-center/docs/concepts-web-security-scanner-overview) |


### PR DESCRIPTION

Changes in this release:

- [Commit c94c761](https://github.com/googleapis/google-cloud-dotnet/commit/c94c761): fix: sync vision v1 protos to get extra FaceAnnotation Landmark Types
