### PR TITLE
Release Google.Cloud.Speech.V1P1Beta1 version 2.0.0-beta04

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Spanner.Common.V1](https://googleapis.dev/dotnet/Google.Cloud.Spanner.Common.V1/3.7.0) | 3.7.0 | Common resource names used by all Spanner V1 APIs |
 | [Google.Cloud.Spanner.V1](https://googleapis.dev/dotnet/Google.Cloud.Spanner.V1/3.7.0) | 3.7.0 | [Google Cloud Spanner](https://cloud.google.com/spanner/) |
 | [Google.Cloud.Speech.V1](https://googleapis.dev/dotnet/Google.Cloud.Speech.V1/2.1.0) | 2.1.0 | [Google Cloud Speech (V1 API)](https://cloud.google.com/speech) |
-| [Google.Cloud.Speech.V1P1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Speech.V1P1Beta1/2.0.0-beta03) | 2.0.0-beta03 | [Google Cloud Speech (V1P1Beta1 API)](https://cloud.google.com/speech) |
+| [Google.Cloud.Speech.V1P1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Speech.V1P1Beta1/2.0.0-beta04) | 2.0.0-beta04 | [Google Cloud Speech (V1P1Beta1 API)](https://cloud.google.com/speech) |
 | [Google.Cloud.Storage.V1](https://googleapis.dev/dotnet/Google.Cloud.Storage.V1/3.4.0) | 3.4.0 | [Google Cloud Storage](https://cloud.google.com/storage/) |
 | [Google.Cloud.Talent.V4](https://googleapis.dev/dotnet/Google.Cloud.Talent.V4/1.0.0) | 1.0.0 | [Google Cloud Talent Solution (V4 API)](https://cloud.google.com/talent-solution/) |
 | [Google.Cloud.Talent.V4Beta1](https://googleapis.dev/dotnet/Google.Cloud.Talent.V4Beta1/2.0.0-beta04) | 2.0.0-beta04 | [Google Cloud Talent Solution (V4Beta1 API)](https://cloud.google.com/talent-solution/) |

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.csproj
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta03</Version>
+    <Version>2.0.0-beta04</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google client library to access the Google Cloud Speech API version v1p1beta1 with upcoming features.</Description>

--- a/apis/Google.Cloud.Speech.V1P1Beta1/docs/history.md
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+# Version 2.0.0-beta04, released 2021-04-29
+
+- [Commit e9b8f84](https://github.com/googleapis/google-cloud-dotnet/commit/e9b8f84): feat: add webm opus support.
+- [Commit 582d15d](https://github.com/googleapis/google-cloud-dotnet/commit/582d15d): feat: Support for spoken punctuation and spoken emojis.
+- [Commit d8fd61b](https://github.com/googleapis/google-cloud-dotnet/commit/d8fd61b): feat: Support output transcript to GCS for LongRunningRecognize.
+- [Commit 20f02d4](https://github.com/googleapis/google-cloud-dotnet/commit/20f02d4): feat: Support output transcript to GCS for LongRunningRecognize.
+- [Commit 872b52e](https://github.com/googleapis/google-cloud-dotnet/commit/872b52e): feat: Support Model Adaptation.
+
 # Version 2.0.0-beta03, released 2020-11-18
 
 - [Commit 0ca05f5](https://github.com/googleapis/google-cloud-dotnet/commit/0ca05f5): chore: Regenerate all APIs using protoc 3.13 and Grpc.Tools 2.31

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2115,7 +2115,7 @@
       "protoPath": "google/cloud/speech/v1p1beta1",
       "productName": "Google Cloud Speech",
       "productUrl": "https://cloud.google.com/speech",
-      "version": "2.0.0-beta03",
+      "version": "2.0.0-beta04",
       "releaseLevelOverride": "beta",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -125,7 +125,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Spanner.Common.V1](Google.Cloud.Spanner.Common.V1/index.html) | 3.7.0 | Common resource names used by all Spanner V1 APIs |
 | [Google.Cloud.Spanner.V1](Google.Cloud.Spanner.V1/index.html) | 3.7.0 | [Google Cloud Spanner](https://cloud.google.com/spanner/) |
 | [Google.Cloud.Speech.V1](Google.Cloud.Speech.V1/index.html) | 2.1.0 | [Google Cloud Speech (V1 API)](https://cloud.google.com/speech) |
-| [Google.Cloud.Speech.V1P1Beta1](Google.Cloud.Speech.V1P1Beta1/index.html) | 2.0.0-beta03 | [Google Cloud Speech (V1P1Beta1 API)](https://cloud.google.com/speech) |
+| [Google.Cloud.Speech.V1P1Beta1](Google.Cloud.Speech.V1P1Beta1/index.html) | 2.0.0-beta04 | [Google Cloud Speech (V1P1Beta1 API)](https://cloud.google.com/speech) |
 | [Google.Cloud.Storage.V1](Google.Cloud.Storage.V1/index.html) | 3.4.0 | [Google Cloud Storage](https://cloud.google.com/storage/) |
 | [Google.Cloud.Talent.V4](Google.Cloud.Talent.V4/index.html) | 1.0.0 | [Google Cloud Talent Solution (V4 API)](https://cloud.google.com/talent-solution/) |
 | [Google.Cloud.Talent.V4Beta1](Google.Cloud.Talent.V4Beta1/index.html) | 2.0.0-beta04 | [Google Cloud Talent Solution (V4Beta1 API)](https://cloud.google.com/talent-solution/) |


### PR DESCRIPTION

Changes in this release:

- [Commit e9b8f84](https://github.com/googleapis/google-cloud-dotnet/commit/e9b8f84): feat: add webm opus support.
- [Commit 582d15d](https://github.com/googleapis/google-cloud-dotnet/commit/582d15d): feat: Support for spoken punctuation and spoken emojis.
- [Commit d8fd61b](https://github.com/googleapis/google-cloud-dotnet/commit/d8fd61b): feat: Support output transcript to GCS for LongRunningRecognize.
- [Commit 20f02d4](https://github.com/googleapis/google-cloud-dotnet/commit/20f02d4): feat: Support output transcript to GCS for LongRunningRecognize.
- [Commit 872b52e](https://github.com/googleapis/google-cloud-dotnet/commit/872b52e): feat: Support Model Adaptation.
