### PR TITLE
Release Google.Cloud.ServiceManagement.V1 version 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.ServiceControl.V1](https://googleapis.dev/dotnet/Google.Cloud.ServiceControl.V1/1.0.0) | 1.0.0 | [Service Control](https://cloud.google.com/service-infrastructure/docs/service-control/reference/rpc) |
 | [Google.Cloud.ServiceDirectory.V1](https://googleapis.dev/dotnet/Google.Cloud.ServiceDirectory.V1/1.0.0) | 1.0.0 | [Service Directory (V1 API)](https://cloud.google.com/service-directory/) |
 | [Google.Cloud.ServiceDirectory.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.ServiceDirectory.V1Beta1/1.0.0-beta03) | 1.0.0-beta03 | [Service Directory (V1Beta1 API)](https://cloud.google.com/service-directory/) |
-| [Google.Cloud.ServiceManagement.V1](https://googleapis.dev/dotnet/Google.Cloud.ServiceManagement.V1/1.0.0) | 1.0.0 | [Service Management](https://cloud.google.com/service-infrastructure/docs/service-management/reference/rpc) |
+| [Google.Cloud.ServiceManagement.V1](https://googleapis.dev/dotnet/Google.Cloud.ServiceManagement.V1/1.1.0) | 1.1.0 | [Service Management](https://cloud.google.com/service-infrastructure/docs/service-management/reference/rpc) |
 | [Google.Cloud.Spanner.Admin.Database.V1](https://googleapis.dev/dotnet/Google.Cloud.Spanner.Admin.Database.V1/3.7.0) | 3.7.0 | [Google Cloud Spanner Database Administration](https://cloud.google.com/spanner/) |
 | [Google.Cloud.Spanner.Admin.Instance.V1](https://googleapis.dev/dotnet/Google.Cloud.Spanner.Admin.Instance.V1/3.7.0) | 3.7.0 | [Google Cloud Spanner Instance Administration](https://cloud.google.com/spanner/) |
 | [Google.Cloud.Spanner.Data](https://googleapis.dev/dotnet/Google.Cloud.Spanner.Data/3.7.0) | 3.7.0 | Google ADO.NET Provider for Google Cloud Spanner |

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.csproj
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Service Management API, which allows service producers to publish their services on Google Cloud Platform so that they can be discovered and used by service consumers.</Description>
@@ -11,9 +11,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.ServiceManagement.V1/docs/history.md
+++ b/apis/Google.Cloud.ServiceManagement.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.1.0, released 2021-04-29
+
+No API surface changes; minor update due to dependencies
+
 # Version 1.0.0, released 2020-11-18
 
 First GA release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1961,7 +1961,7 @@
     },
     {
       "id": "Google.Cloud.ServiceManagement.V1",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "grpc",
       "productName": "Service Management",
       "productUrl": "https://cloud.google.com/service-infrastructure/docs/service-management/reference/rpc",
@@ -1972,9 +1972,9 @@
         "management"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.2.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
         "Google.LongRunning": "2.1.0",
-        "Grpc.Core": "2.31.0"
+        "Grpc.Core": "2.36.4"
       },
       "generator": "micro",
       "protoPath": "google/api/servicemanagement/v1"

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -118,7 +118,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.ServiceControl.V1](Google.Cloud.ServiceControl.V1/index.html) | 1.0.0 | [Service Control](https://cloud.google.com/service-infrastructure/docs/service-control/reference/rpc) |
 | [Google.Cloud.ServiceDirectory.V1](Google.Cloud.ServiceDirectory.V1/index.html) | 1.0.0 | [Service Directory (V1 API)](https://cloud.google.com/service-directory/) |
 | [Google.Cloud.ServiceDirectory.V1Beta1](Google.Cloud.ServiceDirectory.V1Beta1/index.html) | 1.0.0-beta03 | [Service Directory (V1Beta1 API)](https://cloud.google.com/service-directory/) |
-| [Google.Cloud.ServiceManagement.V1](Google.Cloud.ServiceManagement.V1/index.html) | 1.0.0 | [Service Management](https://cloud.google.com/service-infrastructure/docs/service-management/reference/rpc) |
+| [Google.Cloud.ServiceManagement.V1](Google.Cloud.ServiceManagement.V1/index.html) | 1.1.0 | [Service Management](https://cloud.google.com/service-infrastructure/docs/service-management/reference/rpc) |
 | [Google.Cloud.Spanner.Admin.Database.V1](Google.Cloud.Spanner.Admin.Database.V1/index.html) | 3.7.0 | [Google Cloud Spanner Database Administration](https://cloud.google.com/spanner/) |
 | [Google.Cloud.Spanner.Admin.Instance.V1](Google.Cloud.Spanner.Admin.Instance.V1/index.html) | 3.7.0 | [Google Cloud Spanner Instance Administration](https://cloud.google.com/spanner/) |
 | [Google.Cloud.Spanner.Data](Google.Cloud.Spanner.Data/index.html) | 3.7.0 | Google ADO.NET Provider for Google Cloud Spanner |


### PR DESCRIPTION

Changes in this release:

No API surface changes; minor update due to dependencies
