### PR TITLE
Release Google.Cloud.VideoIntelligence.V1 version 2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Translate.V3](https://googleapis.dev/dotnet/Google.Cloud.Translate.V3/2.1.0) | 2.1.0 | [Google Cloud Translation (V3 API)](https://cloud.google.com/translate/) |
 | [Google.Cloud.Translation.V2](https://googleapis.dev/dotnet/Google.Cloud.Translation.V2/2.0.0) | 2.0.0 | [Google Cloud Translation (V2 API)](https://cloud.google.com/translate/) |
 | [Google.Cloud.Video.Transcoder.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Video.Transcoder.V1Beta1/1.0.0-beta01) | 1.0.0-beta01 | [Transcoder](https://cloud.google.com/transcoder/docs) |
-| [Google.Cloud.VideoIntelligence.V1](https://googleapis.dev/dotnet/Google.Cloud.VideoIntelligence.V1/2.1.0) | 2.1.0 | [Google Cloud Video Intelligence](https://cloud.google.com/video-intelligence) |
+| [Google.Cloud.VideoIntelligence.V1](https://googleapis.dev/dotnet/Google.Cloud.VideoIntelligence.V1/2.2.0) | 2.2.0 | [Google Cloud Video Intelligence](https://cloud.google.com/video-intelligence) |
 | [Google.Cloud.Vision.V1](https://googleapis.dev/dotnet/Google.Cloud.Vision.V1/2.3.0) | 2.3.0 | [Google Cloud Vision](https://cloud.google.com/vision) |
 | [Google.Cloud.WebRisk.V1](https://googleapis.dev/dotnet/Google.Cloud.WebRisk.V1/1.1.0) | 1.1.0 | [Google Cloud Web Risk (V1 API)](https://cloud.google.com/web-risk/) |
 | [Google.Cloud.WebRisk.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.WebRisk.V1Beta1/2.0.0-beta03) | 2.0.0-beta03 | [Google Cloud Web Risk (V1Beta1 API)](https://cloud.google.com/web-risk/) |

--- a/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1.csproj
+++ b/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Video Intelligence API.</Description>
@@ -11,9 +11,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.0.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.VideoIntelligence.V1/docs/history.md
+++ b/apis/Google.Cloud.VideoIntelligence.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 2.2.0, released 2021-04-29
+
+- [Commit dc219ec](https://github.com/googleapis/google-cloud-dotnet/commit/dc219ec): feat: Introduce tracks and thumbnails fields for FaceDetectionAnnotations proto.
+
 # Version 2.1.0, released 2020-10-05
 
 - [Commit dfb141a](https://github.com/googleapis/google-cloud-dotnet/commit/dfb141a): feat: GA launch for PersonDetection and FaceDetection features.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2330,7 +2330,7 @@
       "protoPath": "google/cloud/videointelligence/v1",
       "productName": "Google Cloud Video Intelligence",
       "productUrl": "https://cloud.google.com/video-intelligence",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Video Intelligence API.",
@@ -2338,9 +2338,9 @@
         "VideoIntelligence"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.2.0",
-        "Google.LongRunning": "2.0.0",
-        "Grpc.Core": "2.31.0"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Google.LongRunning": "2.1.0",
+        "Grpc.Core": "2.36.4"
       }
     },
     {

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -137,7 +137,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Translate.V3](Google.Cloud.Translate.V3/index.html) | 2.1.0 | [Google Cloud Translation (V3 API)](https://cloud.google.com/translate/) |
 | [Google.Cloud.Translation.V2](Google.Cloud.Translation.V2/index.html) | 2.0.0 | [Google Cloud Translation (V2 API)](https://cloud.google.com/translate/) |
 | [Google.Cloud.Video.Transcoder.V1Beta1](Google.Cloud.Video.Transcoder.V1Beta1/index.html) | 1.0.0-beta01 | [Transcoder](https://cloud.google.com/transcoder/docs) |
-| [Google.Cloud.VideoIntelligence.V1](Google.Cloud.VideoIntelligence.V1/index.html) | 2.1.0 | [Google Cloud Video Intelligence](https://cloud.google.com/video-intelligence) |
+| [Google.Cloud.VideoIntelligence.V1](Google.Cloud.VideoIntelligence.V1/index.html) | 2.2.0 | [Google Cloud Video Intelligence](https://cloud.google.com/video-intelligence) |
 | [Google.Cloud.Vision.V1](Google.Cloud.Vision.V1/index.html) | 2.3.0 | [Google Cloud Vision](https://cloud.google.com/vision) |
 | [Google.Cloud.WebRisk.V1](Google.Cloud.WebRisk.V1/index.html) | 1.1.0 | [Google Cloud Web Risk (V1 API)](https://cloud.google.com/web-risk/) |
 | [Google.Cloud.WebRisk.V1Beta1](Google.Cloud.WebRisk.V1Beta1/index.html) | 2.0.0-beta03 | [Google Cloud Web Risk (V1Beta1 API)](https://cloud.google.com/web-risk/) |


### PR DESCRIPTION

Changes in this release:

- [Commit dc219ec](https://github.com/googleapis/google-cloud-dotnet/commit/dc219ec): feat: Introduce tracks and thumbnails fields for FaceDetectionAnnotations proto.
