### PR TITLE
Release Google.Cloud.GkeHub.V1Beta1 version 1.0.0-beta02

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.GSuiteAddOns.V1](https://googleapis.dev/dotnet/Google.Cloud.GSuiteAddOns.V1/1.0.0-beta01) | 1.0.0-beta01 | [Google Workspace Add-ons](https://developers.google.com/gsuite/add-ons/overview) |
 | [Google.Cloud.Gaming.V1](https://googleapis.dev/dotnet/Google.Cloud.Gaming.V1/1.0.0) | 1.0.0 | [Game Services](https://cloud.google.com/solutions/gaming) |
 | [Google.Cloud.Gaming.V1Beta](https://googleapis.dev/dotnet/Google.Cloud.Gaming.V1Beta/1.0.0-beta06) | 1.0.0-beta06 | [Google Cloud for Games](https://cloud.google.com/solutions/gaming) |
-| [Google.Cloud.GkeHub.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.GkeHub.V1Beta1/1.0.0-beta01) | 1.0.0-beta01 | [GKE Hub](https://cloud.google.com/anthos/multicluster-management/connect/registering-a-cluster) |
+| [Google.Cloud.GkeHub.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.GkeHub.V1Beta1/1.0.0-beta02) | 1.0.0-beta02 | [GKE Hub](https://cloud.google.com/anthos/multicluster-management/connect/registering-a-cluster) |
 | [Google.Cloud.Iam.Credentials.V1](https://googleapis.dev/dotnet/Google.Cloud.Iam.Credentials.V1/1.0.0) | 1.0.0 | [IAM Service Account Credentials](https://cloud.google.com/iam/docs/reference/credentials/rest) |
 | [Google.Cloud.Iam.V1](https://googleapis.dev/dotnet/Google.Cloud.Iam.V1/2.1.0) | 2.1.0 | [Google Cloud Identity and Access Management (IAM)](https://cloud.google.com/iam/) |
 | [Google.Cloud.Iot.V1](https://googleapis.dev/dotnet/Google.Cloud.Iot.V1/1.1.0) | 1.1.0 | [Cloud IoT](https://cloud.google.com/iot/docs/reference/cloudiot/rest) |

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.csproj
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the GKE Hub API, version v1beta1.</Description>

--- a/apis/Google.Cloud.GkeHub.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+# Version 1.0.0-beta02, released 2021-04-29
+
+- [Commit a204405](https://github.com/googleapis/google-cloud-dotnet/commit/a204405): chore: Use correct markdown for code block
+- [Commit aea1356](https://github.com/googleapis/google-cloud-dotnet/commit/aea1356): feat: Update Membership API v1beta1 proto
+
 # Version 1.0.0-beta01, released 2021-01-25
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1040,7 +1040,7 @@
     },
     {
       "id": "Google.Cloud.GkeHub.V1Beta1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "GKE Hub",
       "productUrl": "https://cloud.google.com/anthos/multicluster-management/connect/registering-a-cluster",

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -71,7 +71,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.GSuiteAddOns.V1](Google.Cloud.GSuiteAddOns.V1/index.html) | 1.0.0-beta01 | [Google Workspace Add-ons](https://developers.google.com/gsuite/add-ons/overview) |
 | [Google.Cloud.Gaming.V1](Google.Cloud.Gaming.V1/index.html) | 1.0.0 | [Game Services](https://cloud.google.com/solutions/gaming) |
 | [Google.Cloud.Gaming.V1Beta](Google.Cloud.Gaming.V1Beta/index.html) | 1.0.0-beta06 | [Google Cloud for Games](https://cloud.google.com/solutions/gaming) |
-| [Google.Cloud.GkeHub.V1Beta1](Google.Cloud.GkeHub.V1Beta1/index.html) | 1.0.0-beta01 | [GKE Hub](https://cloud.google.com/anthos/multicluster-management/connect/registering-a-cluster) |
+| [Google.Cloud.GkeHub.V1Beta1](Google.Cloud.GkeHub.V1Beta1/index.html) | 1.0.0-beta02 | [GKE Hub](https://cloud.google.com/anthos/multicluster-management/connect/registering-a-cluster) |
 | [Google.Cloud.Iam.Credentials.V1](Google.Cloud.Iam.Credentials.V1/index.html) | 1.0.0 | [IAM Service Account Credentials](https://cloud.google.com/iam/docs/reference/credentials/rest) |
 | [Google.Cloud.Iam.V1](Google.Cloud.Iam.V1/index.html) | 2.1.0 | [Google Cloud Identity and Access Management (IAM)](https://cloud.google.com/iam/) |
 | [Google.Cloud.Iot.V1](Google.Cloud.Iot.V1/index.html) | 1.1.0 | [Cloud IoT](https://cloud.google.com/iot/docs/reference/cloudiot/rest) |


### PR DESCRIPTION

Changes in this release:

- [Commit a204405](https://github.com/googleapis/google-cloud-dotnet/commit/a204405): chore: Use correct markdown for code block
- [Commit aea1356](https://github.com/googleapis/google-cloud-dotnet/commit/aea1356): feat: Update Membership API v1beta1 proto
