### PR TITLE
Release Google.Cloud.DocumentAI.V1 version 1.0.0-beta02

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Dialogflow.Cx.V3](https://googleapis.dev/dotnet/Google.Cloud.Dialogflow.Cx.V3/1.1.0) | 1.1.0 | [Dialogflow](https://cloud.google.com/dialogflow/cx/docs) |
 | [Google.Cloud.Dialogflow.V2](https://googleapis.dev/dotnet/Google.Cloud.Dialogflow.V2/3.2.0) | 3.2.0 | [Google Cloud Dialogflow](https://cloud.google.com/dialogflow-enterprise/) |
 | [Google.Cloud.Dlp.V2](https://googleapis.dev/dotnet/Google.Cloud.Dlp.V2/3.1.0) | 3.1.0 | [Google Cloud Data Loss Prevention](https://cloud.google.com/dlp/) |
-| [Google.Cloud.DocumentAI.V1](https://googleapis.dev/dotnet/Google.Cloud.DocumentAI.V1/1.0.0-beta01) | 1.0.0-beta01 | [Cloud Document AI (V1 API)](https://cloud.google.com/solutions/document-ai) |
+| [Google.Cloud.DocumentAI.V1](https://googleapis.dev/dotnet/Google.Cloud.DocumentAI.V1/1.0.0-beta02) | 1.0.0-beta02 | [Cloud Document AI (V1 API)](https://cloud.google.com/solutions/document-ai) |
 | [Google.Cloud.DocumentAI.V1Beta2](https://googleapis.dev/dotnet/Google.Cloud.DocumentAI.V1Beta2/1.0.0-beta02) | 1.0.0-beta02 | [Cloud Document AI (V1Beta2 API)](https://cloud.google.com/solutions/document-ai) |
 | [Google.Cloud.Domains.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Domains.V1Beta1/1.0.0-beta01) | 1.0.0-beta01 | [Cloud Domains](https://cloud.google.com/domains/) |
 | [Google.Cloud.ErrorReporting.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.ErrorReporting.V1Beta1/2.0.0-beta04) | 2.0.0-beta04 | [Google Cloud Error Reporting](https://cloud.google.com/error-reporting/) |

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.csproj
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Document AI API (v1), which is a service to parse structured information from unstructured or semi-structured documents using state-of-the-art Google AI such as natural language, computer vision, translation, and AutoML.</Description>

--- a/apis/Google.Cloud.DocumentAI.V1/docs/history.md
+++ b/apis/Google.Cloud.DocumentAI.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.0.0-beta02, released 2021-04-29
+
+- [Commit 64c687d](https://github.com/googleapis/google-cloud-dotnet/commit/64c687d): feat: add confidence field to the PageAnchor.PageRef in document.proto.
+
 # Version 1.0.0-beta01, released 2021-03-18
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -820,7 +820,7 @@
     },
     {
       "id": "Google.Cloud.DocumentAI.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Cloud Document AI",
       "productUrl": "https://cloud.google.com/solutions/document-ai",

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -60,7 +60,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Dialogflow.Cx.V3](Google.Cloud.Dialogflow.Cx.V3/index.html) | 1.1.0 | [Dialogflow](https://cloud.google.com/dialogflow/cx/docs) |
 | [Google.Cloud.Dialogflow.V2](Google.Cloud.Dialogflow.V2/index.html) | 3.2.0 | [Google Cloud Dialogflow](https://cloud.google.com/dialogflow-enterprise/) |
 | [Google.Cloud.Dlp.V2](Google.Cloud.Dlp.V2/index.html) | 3.1.0 | [Google Cloud Data Loss Prevention](https://cloud.google.com/dlp/) |
-| [Google.Cloud.DocumentAI.V1](Google.Cloud.DocumentAI.V1/index.html) | 1.0.0-beta01 | [Cloud Document AI (V1 API)](https://cloud.google.com/solutions/document-ai) |
+| [Google.Cloud.DocumentAI.V1](Google.Cloud.DocumentAI.V1/index.html) | 1.0.0-beta02 | [Cloud Document AI (V1 API)](https://cloud.google.com/solutions/document-ai) |
 | [Google.Cloud.DocumentAI.V1Beta2](Google.Cloud.DocumentAI.V1Beta2/index.html) | 1.0.0-beta02 | [Cloud Document AI (V1Beta2 API)](https://cloud.google.com/solutions/document-ai) |
 | [Google.Cloud.Domains.V1Beta1](Google.Cloud.Domains.V1Beta1/index.html) | 1.0.0-beta01 | [Cloud Domains](https://cloud.google.com/domains/) |
 | [Google.Cloud.ErrorReporting.V1Beta1](Google.Cloud.ErrorReporting.V1Beta1/index.html) | 2.0.0-beta04 | [Google Cloud Error Reporting](https://cloud.google.com/error-reporting/) |


### PR DESCRIPTION

Changes in this release:

- [Commit 64c687d](https://github.com/googleapis/google-cloud-dotnet/commit/64c687d): feat: add confidence field to the PageAnchor.PageRef in document.proto.
