### PR TITLE
Release Google.Cloud.Retail.V2 version 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Recommender.V1](https://googleapis.dev/dotnet/Google.Cloud.Recommender.V1/2.5.0) | 2.5.0 | [Google Cloud Recommender](https://cloud.google.com/recommender/) |
 | [Google.Cloud.Redis.V1](https://googleapis.dev/dotnet/Google.Cloud.Redis.V1/2.1.0) | 2.1.0 | [Google Cloud Memorystore for Redis (V1 API)](https://cloud.google.com/memorystore/) |
 | [Google.Cloud.Redis.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Redis.V1Beta1/2.0.0-beta03) | 2.0.0-beta03 | [Google Cloud Memorystore for Redis (V1Beta1 API)](https://cloud.google.com/memorystore/) |
-| [Google.Cloud.Retail.V2](https://googleapis.dev/dotnet/Google.Cloud.Retail.V2/1.0.0) | 1.0.0 | [Retail](https://cloud.google.com/retail/docs) |
+| [Google.Cloud.Retail.V2](https://googleapis.dev/dotnet/Google.Cloud.Retail.V2/1.1.0) | 1.1.0 | [Retail](https://cloud.google.com/retail/docs) |
 | [Google.Cloud.Scheduler.V1](https://googleapis.dev/dotnet/Google.Cloud.Scheduler.V1/2.1.0) | 2.1.0 | [Google Cloud Scheduler](https://cloud.google.com/scheduler/) |
 | [Google.Cloud.SecretManager.V1](https://googleapis.dev/dotnet/Google.Cloud.SecretManager.V1/1.3.0) | 1.3.0 | [Secret Manager (V1 API)](https://cloud.google.com/secret-manager) |
 | [Google.Cloud.SecretManager.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.SecretManager.V1Beta1/2.0.0-beta03) | 2.0.0-beta03 | [Secret Manager (V1Beta1 API)](https://cloud.google.com/secret-manager) |

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.csproj
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Cloud Retail service enables customers to build end-to-end personalized recommendation systems without requiring a high level of expertise in machine learning, recommendation system, or Google Cloud.</Description>
@@ -11,9 +11,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Retail.V2/docs/history.md
+++ b/apis/Google.Cloud.Retail.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+# Version 1.1.0, released 2021-04-29
+
+- [Commit 91fa8df](https://github.com/googleapis/google-cloud-dotnet/commit/91fa8df): docs: Put resource paths in code spans and use absolute URLs
+
+Note: no API surface changes, but still a minor version bump due to dependency updates.
+
 # Version 1.0.0, released 2021-01-20
 
 No API changes since 1.0.0-beta01.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1736,7 +1736,7 @@
     },
     {
       "id": "Google.Cloud.Retail.V2",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "grpc",
       "productName": "Retail",
       "productUrl": "https://cloud.google.com/retail/docs",
@@ -1745,9 +1745,9 @@
         "retail"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.2.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
         "Google.LongRunning": "2.1.0",
-        "Grpc.Core": "2.31.0"
+        "Grpc.Core": "2.36.4"
       },
       "generator": "micro",
       "protoPath": "google/cloud/retail/v2"

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -107,7 +107,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Recommender.V1](Google.Cloud.Recommender.V1/index.html) | 2.5.0 | [Google Cloud Recommender](https://cloud.google.com/recommender/) |
 | [Google.Cloud.Redis.V1](Google.Cloud.Redis.V1/index.html) | 2.1.0 | [Google Cloud Memorystore for Redis (V1 API)](https://cloud.google.com/memorystore/) |
 | [Google.Cloud.Redis.V1Beta1](Google.Cloud.Redis.V1Beta1/index.html) | 2.0.0-beta03 | [Google Cloud Memorystore for Redis (V1Beta1 API)](https://cloud.google.com/memorystore/) |
-| [Google.Cloud.Retail.V2](Google.Cloud.Retail.V2/index.html) | 1.0.0 | [Retail](https://cloud.google.com/retail/docs) |
+| [Google.Cloud.Retail.V2](Google.Cloud.Retail.V2/index.html) | 1.1.0 | [Retail](https://cloud.google.com/retail/docs) |
 | [Google.Cloud.Scheduler.V1](Google.Cloud.Scheduler.V1/index.html) | 2.1.0 | [Google Cloud Scheduler](https://cloud.google.com/scheduler/) |
 | [Google.Cloud.SecretManager.V1](Google.Cloud.SecretManager.V1/index.html) | 1.3.0 | [Secret Manager (V1 API)](https://cloud.google.com/secret-manager) |
 | [Google.Cloud.SecretManager.V1Beta1](Google.Cloud.SecretManager.V1Beta1/index.html) | 2.0.0-beta03 | [Secret Manager (V1Beta1 API)](https://cloud.google.com/secret-manager) |


### PR DESCRIPTION

Changes in this release:

- [Commit 91fa8df](https://github.com/googleapis/google-cloud-dotnet/commit/91fa8df): docs: Put resource paths in code spans and use absolute URLs

Note: no API surface changes, but still a minor version bump due to dependency updates.
