### PR TITLE
test: enable integration tests for NUMERIC on emulator

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/AllTypesTableFixture.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/AllTypesTableFixture.cs
@@ -30,49 +30,25 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
 
         protected override void CreateTable()
         {
-            // The emulator doesn't yet support the NUMERIC type.
-            if (RunningOnEmulator)
-            {
-                ExecuteDdl($@"CREATE TABLE {TableName}(
-                              K                   STRING(MAX) NOT NULL,
-                              BoolValue           BOOL,
-                              Int64Value          INT64,
-                              Float64Value        FLOAT64,
-                              StringValue         STRING(MAX),
-                              BytesValue          BYTES(MAX),
-                              TimestampValue      TIMESTAMP,
-                              DateValue           DATE,
-                              BoolArrayValue      ARRAY<BOOL>,
-                              Int64ArrayValue     ARRAY<INT64>,
-                              Float64ArrayValue   ARRAY<FLOAT64>,
-                              StringArrayValue    ARRAY < STRING(MAX) >,
-                              BytesArrayValue     ARRAY < BYTES(MAX) >,
-                              TimestampArrayValue ARRAY<TIMESTAMP>,
-                              DateArrayValue      ARRAY<DATE>,
-                            ) PRIMARY KEY(K)");
-            }
-            else
-            {
-                ExecuteDdl($@"CREATE TABLE {TableName}(
-                              K                   STRING(MAX) NOT NULL,
-                              BoolValue           BOOL,
-                              Int64Value          INT64,
-                              Float64Value        FLOAT64,
-                              NumericValue        NUMERIC,
-                              StringValue         STRING(MAX),
-                              BytesValue          BYTES(MAX),
-                              TimestampValue      TIMESTAMP,
-                              DateValue           DATE,
-                              BoolArrayValue      ARRAY<BOOL>,
-                              Int64ArrayValue     ARRAY<INT64>,
-                              Float64ArrayValue   ARRAY<FLOAT64>,
-                              NumericArrayValue   ARRAY<NUMERIC>,
-                              StringArrayValue    ARRAY < STRING(MAX) >,
-                              BytesArrayValue     ARRAY < BYTES(MAX) >,
-                              TimestampArrayValue ARRAY<TIMESTAMP>,
-                              DateArrayValue      ARRAY<DATE>,
-                            ) PRIMARY KEY(K)");
-            }
+            ExecuteDdl($@"CREATE TABLE {TableName}(
+                            K                   STRING(MAX) NOT NULL,
+                            BoolValue           BOOL,
+                            Int64Value          INT64,
+                            Float64Value        FLOAT64,
+                            NumericValue        NUMERIC,
+                            StringValue         STRING(MAX),
+                            BytesValue          BYTES(MAX),
+                            TimestampValue      TIMESTAMP,
+                            DateValue           DATE,
+                            BoolArrayValue      ARRAY<BOOL>,
+                            Int64ArrayValue     ARRAY<INT64>,
+                            Float64ArrayValue   ARRAY<FLOAT64>,
+                            NumericArrayValue   ARRAY<NUMERIC>,
+                            StringArrayValue    ARRAY < STRING(MAX) >,
+                            BytesArrayValue     ARRAY < BYTES(MAX) >,
+                            TimestampArrayValue ARRAY<TIMESTAMP>,
+                            DateArrayValue      ARRAY<DATE>,
+                        ) PRIMARY KEY(K)");
         }
     }
 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/WriteTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/WriteTests.cs
@@ -130,21 +130,16 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 { "BytesValue", SpannerDbType.Bytes, new byte[] { 4, 5, 6 } },
                 { "TimestampValue", SpannerDbType.Timestamp, testTimestamp },
                 { "DateValue", SpannerDbType.Date, testDate },
+                { "NumericValue", SpannerDbType.Numeric, SpannerNumeric.Parse("2.0") },
                 { "BoolArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Bool), bArray },
                 { "Int64ArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Int64), lArray },
                 { "Float64ArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Float64), dArray },
                 { "StringArrayValue", SpannerDbType.ArrayOf(SpannerDbType.String), sArray },
                 { "BytesArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Bytes), bArrayArray },
                 { "TimestampArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Timestamp), tmArray },
-                { "DateArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Date), dtArray }
+                { "DateArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Date), dtArray },
+                { "NumericArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Numeric), nArray }
             };
-
-            // The emulator doesn't yet support the NUMERIC type.
-            if (!_fixture.RunningOnEmulator)
-            {
-                parameters.Add("NumericValue", SpannerDbType.Numeric, SpannerNumeric.Parse("2.0"));
-                parameters.Add("NumericArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Numeric), nArray);
-            }
 
             Assert.Equal(1, await InsertAsync(parameters));
             await WithLastRowAsync(reader =>
@@ -158,6 +153,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 Assert.Equal(new byte[] { 4, 5, 6 }, reader.GetFieldValue<byte[]>(reader.GetOrdinal("BytesValue")));
                 Assert.Equal(testTimestamp, reader.GetFieldValue<DateTime>(reader.GetOrdinal("TimestampValue")));
                 Assert.Equal(testDate, reader.GetFieldValue<DateTime>(reader.GetOrdinal("DateValue")));
+                Assert.Equal(SpannerNumeric.Parse("2.0"), reader.GetFieldValue<SpannerNumeric>(reader.GetOrdinal("NumericValue")));
                 Assert.Equal(bArray, reader.GetFieldValue<bool?[]>(reader.GetOrdinal("BoolArrayValue")));
                 Assert.Equal(lArray, reader.GetFieldValue<long?[]>(reader.GetOrdinal("Int64ArrayValue")));
                 Assert.Equal(dArray, reader.GetFieldValue<double?[]>(reader.GetOrdinal("Float64ArrayValue")));
@@ -165,11 +161,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 Assert.Equal(bArrayArray, reader.GetFieldValue<string[]>(reader.GetOrdinal("BytesArrayValue")));
                 Assert.Equal(tmArray, reader.GetFieldValue<DateTime?[]>(reader.GetOrdinal("TimestampArrayValue")));
                 Assert.Equal(dtArray, reader.GetFieldValue<DateTime?[]>(reader.GetOrdinal("DateArrayValue")));
-                if (!_fixture.RunningOnEmulator)
-                {
-                    Assert.Equal(SpannerNumeric.Parse("2.0"), reader.GetFieldValue<SpannerNumeric>(reader.GetOrdinal("NumericValue")));
-                    Assert.Equal(nArray, reader.GetFieldValue<SpannerNumeric?[]>(reader.GetOrdinal("NumericArrayValue")));
-                }
+                Assert.Equal(nArray, reader.GetFieldValue<SpannerNumeric?[]>(reader.GetOrdinal("NumericArrayValue")));
             });
         }
 
@@ -248,14 +240,9 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 { "StringArrayValue", SpannerDbType.ArrayOf(SpannerDbType.String), new string[0] },
                 { "BytesArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Bytes), new byte[0][] },
                 { "TimestampArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Timestamp), new DateTime[0] },
-                { "DateArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Date), new DateTime[0] }
+                { "DateArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Date), new DateTime[0] },
+                { "NumericArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Numeric), new SpannerNumeric[0] }
             };
-
-            // The emulator doesn't yet support the NUMERIC type.
-            if (!_fixture.RunningOnEmulator)
-            {
-                parameters.Add("NumericArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Numeric), new SpannerNumeric[0]);
-            }
 
             Assert.Equal(1, await InsertAsync(parameters));
             await WithLastRowAsync(reader =>
@@ -268,10 +255,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 Assert.Equal(
                     new DateTime[] { }, reader.GetFieldValue<DateTime[]>(reader.GetOrdinal("TimestampArrayValue")));
                 Assert.Equal(new DateTime[] { }, reader.GetFieldValue<DateTime[]>(reader.GetOrdinal("DateArrayValue")));
-                if (!_fixture.RunningOnEmulator)
-                {
-                    Assert.Equal(new SpannerNumeric[] { }, reader.GetFieldValue<SpannerNumeric[]>(reader.GetOrdinal("NumericArrayValue")));
-                }
+                Assert.Equal(new SpannerNumeric[] { }, reader.GetFieldValue<SpannerNumeric[]>(reader.GetOrdinal("NumericArrayValue")));
             });
         }
 
@@ -342,21 +326,16 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 { "BytesValue", SpannerDbType.Bytes, null },
                 { "TimestampValue", SpannerDbType.Timestamp, null },
                 { "DateValue", SpannerDbType.Date, null },
+                { "NumericValue", SpannerDbType.Numeric, null },
                 { "BoolArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Bool), null },
                 { "Int64ArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Int64), null },
                 { "Float64ArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Float64), null },
                 { "StringArrayValue", SpannerDbType.ArrayOf(SpannerDbType.String), null },
                 { "BytesArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Bytes), null },
                 { "TimestampArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Timestamp), null },
-                { "DateArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Date), null }
+                { "DateArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Date), null },
+                { "NumericArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Numeric), null }
             };
-
-            // The emulator doesn't yet support the NUMERIC type.
-            if (!_fixture.RunningOnEmulator)
-            {
-                parameters.Add("NumericValue", SpannerDbType.Numeric, null);
-                parameters.Add("NumericArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Numeric), null);
-            }
 
             Assert.Equal(1, await InsertAsync(parameters));
             await WithLastRowAsync(reader =>
@@ -368,6 +347,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 Assert.True(reader.IsDBNull(reader.GetOrdinal("BytesValue")));
                 Assert.True(reader.IsDBNull(reader.GetOrdinal("TimestampValue")));
                 Assert.True(reader.IsDBNull(reader.GetOrdinal("DateValue")));
+                Assert.True(reader.IsDBNull(reader.GetOrdinal("NumericValue")));
                 Assert.True(reader.IsDBNull(reader.GetOrdinal("BoolArrayValue")));
                 Assert.True(reader.IsDBNull(reader.GetOrdinal("Int64ArrayValue")));
                 Assert.True(reader.IsDBNull(reader.GetOrdinal("Float64ArrayValue")));
@@ -375,11 +355,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 Assert.True(reader.IsDBNull(reader.GetOrdinal("BytesArrayValue")));
                 Assert.True(reader.IsDBNull(reader.GetOrdinal("TimestampArrayValue")));
                 Assert.True(reader.IsDBNull(reader.GetOrdinal("DateArrayValue")));
-                if (!_fixture.RunningOnEmulator)
-                {
-                    Assert.True(reader.IsDBNull(reader.GetOrdinal("NumericValue")));
-                    Assert.True(reader.IsDBNull(reader.GetOrdinal("NumericArrayValue")));
-                }
+                Assert.True(reader.IsDBNull(reader.GetOrdinal("NumericArrayValue")));
             });
         }
 


### PR DESCRIPTION
The emulator now supports the `NUMERIC` column, and tests that use `NUMERIC` should not make any difference between running on real Spanner and the emulator.