### PR TITLE
Release Google.Cloud.Bigtable.V2 version 2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.BigQuery.Storage.V1](https://googleapis.dev/dotnet/Google.Cloud.BigQuery.Storage.V1/2.2.0) | 2.2.0 | [Google BigQuery Storage](https://cloud.google.com/bigquery/docs/reference/storage/) |
 | [Google.Cloud.Bigtable.Admin.V2](https://googleapis.dev/dotnet/Google.Cloud.Bigtable.Admin.V2/2.4.0) | 2.4.0 | [Google Cloud Bigtable Administration](https://cloud.google.com/bigtable/) |
 | [Google.Cloud.Bigtable.Common.V2](https://googleapis.dev/dotnet/Google.Cloud.Bigtable.Common.V2/2.0.0) | 2.0.0 | Common code used by Bigtable V2 APIs |
-| [Google.Cloud.Bigtable.V2](https://googleapis.dev/dotnet/Google.Cloud.Bigtable.V2/2.1.1) | 2.1.1 | [Google Bigtable](https://cloud.google.com/bigtable/) |
+| [Google.Cloud.Bigtable.V2](https://googleapis.dev/dotnet/Google.Cloud.Bigtable.V2/2.2.0) | 2.2.0 | [Google Bigtable](https://cloud.google.com/bigtable/) |
 | [Google.Cloud.Billing.Budgets.V1](https://googleapis.dev/dotnet/Google.Cloud.Billing.Budgets.V1/1.1.0) | 1.1.0 | [Cloud Billing Budget (V1 API)](https://cloud.google.com/billing/docs/how-to/budget-api-overview) |
 | [Google.Cloud.Billing.Budgets.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Billing.Budgets.V1Beta1/1.0.0-beta03) | 1.0.0-beta03 | [Cloud Billing Budget (V1Beta1 API)](https://cloud.google.com/billing/docs/how-to/budget-api-overview) |
 | [Google.Cloud.Billing.V1](https://googleapis.dev/dotnet/Google.Cloud.Billing.V1/2.1.0) | 2.1.0 | [Google Cloud Billing](https://cloud.google.com/billing/docs/) |

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.IntegrationTests/Google.Cloud.Bigtable.V2.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.IntegrationTests/Google.Cloud.Bigtable.V2.IntegrationTests.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[3.3.0, 4.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.Bigtable.Admin.V2\Google.Cloud.Bigtable.Admin.V2\Google.Cloud.Bigtable.Admin.V2.csproj" />
     <ProjectReference Include="..\Google.Cloud.Bigtable.V2\Google.Cloud.Bigtable.V2.csproj" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Snippets/Google.Cloud.Bigtable.V2.Snippets.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Snippets/Google.Cloud.Bigtable.V2.Snippets.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[3.3.0, 4.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.Bigtable.Admin.V2\Google.Cloud.Bigtable.Admin.V2\Google.Cloud.Bigtable.Admin.V2.csproj" />
     <ProjectReference Include="..\Google.Cloud.Bigtable.V2\Google.Cloud.Bigtable.V2.csproj" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/Google.Cloud.Bigtable.V2.Tests.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/Google.Cloud.Bigtable.V2.Tests.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[3.3.0, 4.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.Bigtable.Admin.V2\Google.Cloud.Bigtable.Admin.V2\Google.Cloud.Bigtable.Admin.V2.csproj" />
     <ProjectReference Include="..\Google.Cloud.Bigtable.V2\Google.Cloud.Bigtable.V2.csproj" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.1</Version>
+    <Version>2.2.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Bigtable API.</Description>
@@ -11,10 +11,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.Gcp" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Gcp" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Bigtable.Common.V2" Version="[2.0.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Bigtable.V2/docs/history.md
+++ b/apis/Google.Cloud.Bigtable.V2/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+# Version 2.2.0, released 2021-05-05
+
+- [Commit 9f5f0aa](https://github.com/googleapis/google-cloud-dotnet/commit/9f5f0aa): fix: Regenerate server-streaming calls with Google request params. Fixes [issue 6310](https://github.com/googleapis/google-cloud-dotnet/issues/6310).
+- [Commit 1b91d27](https://github.com/googleapis/google-cloud-dotnet/commit/1b91d27): feat: migrate bigtable retry/timeout settings to gRPC's service configs
+
 # Version 2.1.1, released 2020-12-02
 
 - [Commit ef17912](https://github.com/googleapis/google-cloud-dotnet/commit/ef17912): feat: Reduce the gRPC keepalive time from 1 minute to 30 seconds

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -339,7 +339,7 @@
       "protoPath": "google/bigtable/v2",
       "productName": "Google Bigtable",
       "productUrl": "https://cloud.google.com/bigtable/",
-      "version": "2.1.1",
+      "version": "2.2.0",
       "commonResourcesConfig": "apis/Google.Cloud.Bigtable.Common.V2/CommonResourcesConfig.json",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
@@ -348,13 +348,13 @@
         "Bigtable"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.Gcp": "3.2.0",
-        "Google.Api.Gax.Grpc.GrpcCore": "3.2.0",
+        "Google.Api.Gax.Grpc.Gcp": "3.3.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
         "Google.Cloud.Bigtable.Common.V2": "2.0.0",
-        "Grpc.Core": "2.31.0"
+        "Grpc.Core": "2.36.4"
       },
       "testDependencies": {
-        "Google.Api.Gax.Grpc.Testing": "3.2.0",
+        "Google.Api.Gax.Grpc.Testing": "3.3.0",
         "Google.Cloud.Bigtable.Admin.V2": "project"
       }
     },

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -37,7 +37,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.BigQuery.Storage.V1](Google.Cloud.BigQuery.Storage.V1/index.html) | 2.2.0 | [Google BigQuery Storage](https://cloud.google.com/bigquery/docs/reference/storage/) |
 | [Google.Cloud.Bigtable.Admin.V2](Google.Cloud.Bigtable.Admin.V2/index.html) | 2.4.0 | [Google Cloud Bigtable Administration](https://cloud.google.com/bigtable/) |
 | [Google.Cloud.Bigtable.Common.V2](Google.Cloud.Bigtable.Common.V2/index.html) | 2.0.0 | Common code used by Bigtable V2 APIs |
-| [Google.Cloud.Bigtable.V2](Google.Cloud.Bigtable.V2/index.html) | 2.1.1 | [Google Bigtable](https://cloud.google.com/bigtable/) |
+| [Google.Cloud.Bigtable.V2](Google.Cloud.Bigtable.V2/index.html) | 2.2.0 | [Google Bigtable](https://cloud.google.com/bigtable/) |
 | [Google.Cloud.Billing.Budgets.V1](Google.Cloud.Billing.Budgets.V1/index.html) | 1.1.0 | [Cloud Billing Budget (V1 API)](https://cloud.google.com/billing/docs/how-to/budget-api-overview) |
 | [Google.Cloud.Billing.Budgets.V1Beta1](Google.Cloud.Billing.Budgets.V1Beta1/index.html) | 1.0.0-beta03 | [Cloud Billing Budget (V1Beta1 API)](https://cloud.google.com/billing/docs/how-to/budget-api-overview) |
 | [Google.Cloud.Billing.V1](Google.Cloud.Billing.V1/index.html) | 2.1.0 | [Google Cloud Billing](https://cloud.google.com/billing/docs/) |


### PR DESCRIPTION

Changes in this release:

- [Commit 9f5f0aa](https://github.com/googleapis/google-cloud-dotnet/commit/9f5f0aa): fix: Regenerate server-streaming calls with Google request params. Fixes [issue 6310](https://github.com/googleapis/google-cloud-dotnet/issues/6310).
- [Commit 1b91d27](https://github.com/googleapis/google-cloud-dotnet/commit/1b91d27): feat: migrate bigtable retry/timeout settings to gRPC's service configs
