### PR TITLE
Remove codecov reporting

### DIFF
--- a/.kokoro/runintegrationtests.sh
+++ b/.kokoro/runintegrationtests.sh
@@ -39,11 +39,12 @@ rm -rf coverage
 echo "Available disk space after removing old coverage"
 df -h
 
+# Note: we still use the presence of a codecov token to determine whether or not to
+# run coverage, even though we don't upload to codecov.
+# TODO: Use an environment variable instead.
 if [[ -f "$SECRETS_LOCATION/codecov-token" ]]
 then
- export CODECOV_TOKEN=$(cat "$SECRETS_LOCATION/codecov-token")
  script_flags=--coverage
- report_flags="--upload $report_flags"
 fi
 
 # Build the libraries and run unit tests, optionally with coverage.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 
 [![GitHub Actions status](https://img.shields.io/github/workflow/status/googleapis/google-cloud-dotnet/Build%20push)](https://github.com/googleapis/google-cloud-dotnet/actions?query=workflow%3A%22Build+push%22)
 [![Appveyor build status](https://ci.appveyor.com/api/projects/status/hkkyregfhh5m4d2u?svg=true)](https://ci.appveyor.com/project/googleapis/google-cloud-dotnet)
-[![Coverage Status](https://codecov.io/gh/googleapis/google-cloud-dotnet/branch/master/graph/badge.svg)](https://codecov.io/gh/googleapis/google-cloud-dotnet)
 
 * [Homepage](https://cloud.google.com/dotnet/)
 * [API Documentation](http://googleapis.github.io/google-cloud-dotnet/docs/)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,0 @@
-coverage:
-  status:
-    # For overall status
-    project:
-      default:
-        # Allow coverage to drop by 2% before complaining
-        threshold: 2

--- a/createcoveragereport.sh
+++ b/createcoveragereport.sh
@@ -20,7 +20,6 @@ fi
 install_dotcover
 install_reportgenerator
 
-codecov_params=
 upload_report=false
 while (( "$#" )); do
   if [[ "$1" == "--upload" ]]
@@ -29,15 +28,15 @@ while (( "$#" )); do
   elif [[ "$1" == "--upload_reportname" ]]
   then
     shift
-    codecov_params="$codecov_params --flag $1"
+    # No further actions right now
   elif [[ "$1" == "--upload_commit" ]]
   then
     shift
-    codecov_params="$codecov_params --c $1"
+    # No further actions right now
   elif [[ "$1" == "--upload_build" ]]
   then
     shift
-    codecov_params="$codecov_params --b $1"
+    # No further actions right now
   else
     echo "Unexpected param: $1"
     exit 1
@@ -64,11 +63,5 @@ $REPORTGENERATOR \
 
 if [[ "$upload_report" = true ]]
 then
-  # -y option to confirm all prompts.
-  # --no-progress to avoid our log file being spammed with download progress
-  choco install codecov -y --no-progress
-
-  # Assume we've created the coverage file by this point. If we haven't, there should already have been an error.
-  # Pass whatever parameters we recieved.
-  codecov -f "coverage/coverage-filtered.xml" $codecov_params
+  echo "Code coverage report uploading currently disabled."
 fi


### PR DESCRIPTION
We still want to run the tests with coverage enabled in one CI
build, but for the moment the results won't be reported to anywhere
public.

Temporarily, the simplest way of configuring a CI build to perform
coverage testing is still to detect the presence of a codecov token,
but that can be improved (e.g. to use an environment variable) later.