### PR TITLE
First proper pass at link canonicalization

### DIFF
--- a/docs/Google.Cloud.DocTools.sln
+++ b/docs/Google.Cloud.DocTools.sln
@@ -31,9 +31,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Tools.Regenera
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Tools.DocfxMetadata", "..\tools\Google.Cloud.Tools.DocfxMetadata\Google.Cloud.Tools.DocfxMetadata.csproj", "{150FE2B7-0DEA-4EEE-A47B-30A2DE7D397E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Tools.GenerateCanonicalLinks", "..\tools\Google.Cloud.Tools.GenerateCanonicalLinks\Google.Cloud.Tools.GenerateCanonicalLinks.csproj", "{49D50464-CB7E-4FBF-AE53-B34C42BD5B15}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Tools.GenerateCanonicalLinks", "..\tools\Google.Cloud.Tools.GenerateCanonicalLinks\Google.Cloud.Tools.GenerateCanonicalLinks.csproj", "{49D50464-CB7E-4FBF-AE53-B34C42BD5B15}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Tools.CanonicalLinkFunction", "..\tools\Google.Cloud.Tools.CanonicalLinkFunction\Google.Cloud.Tools.CanonicalLinkFunction.csproj", "{C42A623C-F5C8-43A4-9842-F8D8D6206626}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Tools.GenerateCanonicalLinks.Tests", "..\tools\Google.Cloud.Tools.GenerateCanonicalLinks.Tests\Google.Cloud.Tools.GenerateCanonicalLinks.Tests.csproj", "{17CF0C6A-F06E-4FB7-988B-97E6A36571D6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -237,6 +239,18 @@ Global
 		{C42A623C-F5C8-43A4-9842-F8D8D6206626}.Release|x64.Build.0 = Release|Any CPU
 		{C42A623C-F5C8-43A4-9842-F8D8D6206626}.Release|x86.ActiveCfg = Release|Any CPU
 		{C42A623C-F5C8-43A4-9842-F8D8D6206626}.Release|x86.Build.0 = Release|Any CPU
+		{17CF0C6A-F06E-4FB7-988B-97E6A36571D6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{17CF0C6A-F06E-4FB7-988B-97E6A36571D6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{17CF0C6A-F06E-4FB7-988B-97E6A36571D6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{17CF0C6A-F06E-4FB7-988B-97E6A36571D6}.Debug|x64.Build.0 = Debug|Any CPU
+		{17CF0C6A-F06E-4FB7-988B-97E6A36571D6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{17CF0C6A-F06E-4FB7-988B-97E6A36571D6}.Debug|x86.Build.0 = Debug|Any CPU
+		{17CF0C6A-F06E-4FB7-988B-97E6A36571D6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{17CF0C6A-F06E-4FB7-988B-97E6A36571D6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{17CF0C6A-F06E-4FB7-988B-97E6A36571D6}.Release|x64.ActiveCfg = Release|Any CPU
+		{17CF0C6A-F06E-4FB7-988B-97E6A36571D6}.Release|x64.Build.0 = Release|Any CPU
+		{17CF0C6A-F06E-4FB7-988B-97E6A36571D6}.Release|x86.ActiveCfg = Release|Any CPU
+		{17CF0C6A-F06E-4FB7-988B-97E6A36571D6}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/tools/Google.Cloud.Tools.GenerateCanonicalLinks.Tests/CanonicalizerTest.cs
+++ b/tools/Google.Cloud.Tools.GenerateCanonicalLinks.Tests/CanonicalizerTest.cs
@@ -1,0 +1,53 @@
+﻿// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+
+namespace Google.Cloud.Tools.GenerateCanonicalLinks.Tests
+{
+    public class CanonicalizerTest
+    {
+        [Theory]
+        [InlineData("Google.Cloud.CloudBuild.V1", "api/Google.Cloud.CloudBuild.V1.Artifacts.Types.ArtifactObjects.html", "Google.Cloud.CloudBuild.V1/latest/Google.Cloud.CloudBuild.V1.Artifacts.Types.ArtifactObjects")]
+        [InlineData("Google.Cloud.CloudBuild.V1", "history.html", "Google.Cloud.CloudBuild.V1/latest/history")]
+        [InlineData("Google.Cloud.CloudBuild.V1", "api/Google.LongRunning.Operation-2.html", "Google.LongRunning/latest/Google.LongRunning.Operation-2")]
+        [InlineData("Google.Cloud.CloudBuild.V1", "api/Google.LongRunning.html", "Google.LongRunning/latest/Google.LongRunning")]
+        [InlineData("Google.Cloud.CloudBuild.V1", "api/Grpc.Core.html", "Grpc.Core/latest/Grpc.Core")]
+        [InlineData("Google.Cloud.CloudBuild.V1", "api/Google.Api.Gax.CloudRunPlatformDetails.html", "Google.Api.Gax/latest/Google.Api.Gax.CloudRunPlatformDetails")]
+        [InlineData("Google.Cloud.CloudBuild.V1", "api/Google.Api.Gax.Grpc.ApiCall-2.html", "Google.Api.Gax/latest/Google.Api.Gax.Grpc.ApiCall-2")]
+        [InlineData("Google.Cloud.CloudBuild.V1", "api/Google.Type.CalendarPeriod.html", "Google.Api.CommonProtos/latest/Google.Type.CalendarPeriod")]
+        [InlineData("Google.Cloud.CloudBuild.V1", "api/Google.Api.Advice.html", "Google.Api.CommonProtos/latest/Google.Api.Advice")]
+        [InlineData("Google.Cloud.Storage.V1", "api/Google.Cloud.Storage.V1.CreateNotificationOptions.html", "Google.Cloud.Storage.V1/latest/Google.Cloud.Storage.V1.CreateNotificationOptions")]
+        [InlineData("Google.Apis.Auth", "api/Google.Apis.Auth.OAuth2.GoogleCredential.html", "Google.Apis/latest/Google.Apis.Auth.OAuth2.GoogleCredential")]
+        [InlineData("Google.Cloud.Spanner.V1", "api/Google.Protobuf.ByteString.html", "Google.Protobuf/latest/Google.Protobuf.ByteString")]
+        [InlineData("Google.Apis.Core", "api/Google.Apis.ISerializer.html", "Google.Apis/latest/Google.Apis.ISerializer")]
+        [InlineData("Google.Apis", "api/Google.Apis.ETagAction.html", "Google.Apis/latest/Google.Apis.ETagAction")]
+        [InlineData("Google.Apis", "api/Google.Apis.Download.DownloadStatus.html", "Google.Apis/latest/Google.Apis.Download.DownloadStatus")]
+        [InlineData("Google.Cloud.Asset.V1", "api/Google.Cloud.Iam.V1.AuditConfigDelta.html", "Google.Cloud.Iam.V1/latest/Google.Cloud.Iam.V1.AuditConfigDelta")]
+        [InlineData("Google.Cloud.Logging.V2", "api/Google.Cloud.Logging.Type.HttpRequest.html", "Google.Cloud.Logging.Type/latest/Google.Cloud.Logging.Type.HttpRequest")]
+        [InlineData("Google.Cloud.Firestore", "api/Google.Cloud.Firestore.V1.Firestore.html", "Google.Cloud.Firestore.V1/latest/Google.Cloud.Firestore.V1.Firestore")]
+        [InlineData("Google.Cloud.Asset.V1", "api/Google.Cloud.OrgPolicy.V1.Policy.html", "Google.Cloud.OrgPolicy.V1/latest/Google.Cloud.OrgPolicy.V1.Policy")]
+        [InlineData("Google.Cloud.Asset.V1", "api/Google.Identity.AccessContextManager.Type.DeviceEncryptionStatus.html", "Google.Identity.AccessContextManager.Type/latest/Google.Identity.AccessContextManager.Type.DeviceEncryptionStatus")]
+        // TODO: Types in Google.Cloud.Diagnostics.AspNetCore (and AspNetCore3) namespaces. Currently not published at all on googleapis.dev...
+        [InlineData("Google.Cloud.Diagnostics.AspNetCore", "api/Google.Cloud.Diagnostics.Common.ContextTracerManager.html", "Google.Cloud.Diagnostics.Common/latest/Google.Cloud.Diagnostics.Common.ContextTracerManager")]
+        [InlineData("Google.Cloud.Diagnostics.AspNetCore3", "api/Google.Cloud.Diagnostics.Common.ContextTracerManager.html", "Google.Cloud.Diagnostics.Common/latest/Google.Cloud.Diagnostics.Common.ContextTracerManager")]
+        public void GetUrl(string package, string page, string expectedSuffix)
+        {
+            var actualUrl = Canonicalizer.GetUrl(package, page);
+            Assert.StartsWith(Canonicalizer.CloudSitePrefix, actualUrl);
+            var actualSuffix = actualUrl[Canonicalizer.CloudSitePrefix.Length..];
+            Assert.Equal(expectedSuffix, actualSuffix);
+        }
+    }
+}

--- a/tools/Google.Cloud.Tools.GenerateCanonicalLinks.Tests/Google.Cloud.Tools.GenerateCanonicalLinks.Tests.csproj
+++ b/tools/Google.Cloud.Tools.GenerateCanonicalLinks.Tests/Google.Cloud.Tools.GenerateCanonicalLinks.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Google.Cloud.Tools.GenerateCanonicalLinks\Google.Cloud.Tools.GenerateCanonicalLinks.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tools/Google.Cloud.Tools.GenerateCanonicalLinks/Canonicalizer.cs
+++ b/tools/Google.Cloud.Tools.GenerateCanonicalLinks/Canonicalizer.cs
@@ -12,12 +12,52 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace Google.Cloud.Tools.GenerateCanonicalLinks
 {
     public static class Canonicalizer
     {
+        public const string CloudSitePrefix = "https://cloud.google.com/dotnet/docs/reference/";
+
+        // Note: list rather than a dictionary, as order is important.
+        private static readonly List<(string prefix, string package)> Prefixes = new List<(string, string)>
+        {
+            { ("Grpc", "Grpc.Core") },
+            { ("Google.Protobuf", "Google.Protobuf") },
+            { ("Google.Api.Gax", "Google.Api.Gax") },
+            // Google.Apis and Google.Apis.Core contain some types in the Google namespace and some in
+            // the Google.Apis namespace, then some sub-namespaces. We want to be able to distinguish between
+            // those and things like Google.Apis.Storage.V1.
+            { ("Google.ApplicationContext", "Google.Apis") },
+            { ("Google.GoogleApiException", "Google.Apis") },
+            { ("Google.Apis.Discovery", "Google.Apis") },
+            { ("Google.Apis.Download", "Google.Apis") },
+            { ("Google.Apis.ETagAction", "Google.Apis") },
+            { ("Google.Apis.ISerializer", "Google.Apis") },
+            { ("Google.Apis.Http", "Google.Apis") },
+            { ("Google.Apis.Json", "Google.Apis") },
+            { ("Google.Apis.Logging", "Google.Apis") },
+            { ("Google.Apis.Requests", "Google.Apis") },
+            { ("Google.Apis.Services", "Google.Apis") },
+            { ("Google.Apis.Upload", "Google.Apis") },
+            { ("Google.Apis.Testing", "Google.Apis") },
+            { ("Google.Apis.Util", "Google.Apis") },
+            { ("Google.Apis", "Google.Apis") },
+            { ("Google.Cloud.Diagnostics.Common", "Google.Cloud.Diagnostics.Common") },
+            { ("Google.LongRunning", "Google.LongRunning") },
+            // To avoid using putting V1 protos in Google.Cloud.Firestore.
+            { ("Google.Cloud.Firestore.V1", "Google.Cloud.Firestore.V1") },
+
+            // Google.Api.CommonProtos also contains a bunch of types in various namespaces
+            { ("Google.Api", "Google.Api.CommonProtos") },
+            { ("Google.Rpc", "Google.Api.CommonProtos") },
+            { ("Google.Type", "Google.Api.CommonProtos") },
+        };
+
         /// <summary>
         /// Returns the canonical link for the given page
         /// </summary>
@@ -43,10 +83,45 @@ namespace Google.Cloud.Tools.GenerateCanonicalLinks
                 page = page[..^5];
             }
 
-            // For now, just take the final segment.
+            // DevSite URLs are flattened - user guides are mixed with API reference docs
             page = page.Split('/').Last();
 
-            return $"https://cloud.google.com/dotnet/docs/reference/{package}/latest/{page}";
+            package = MaybeAdjustPackage(package, page);
+
+            return $"{CloudSitePrefix}{package}/latest/{page}";
+        }
+
+        private static string MaybeAdjustPackage(string package, string page)
+        {
+            // We've hardcoded a bunch of packages which are hard to handle otherwise.
+            var overriddenPackage = Prefixes.FirstOrDefault(pair => page.StartsWith(pair.prefix + ".") || page == pair.prefix).package;
+            if (overriddenPackage is object)
+            {
+                return overriddenPackage;
+            }
+            // If the page looks like it's genuinely in the package, that's probably fine.
+            if (page.StartsWith(package))
+            {
+                return package;
+            }
+
+            // May be a guide, may be a type from a different package.
+            var parts = page.Split('.');
+            // Single-part pages are always guides.
+            if (parts.Length == 1)
+            {
+                return package;
+            }
+
+            // Hmm. Looks like it's a reference from the actual package to somewhere else that we haven't configured. That's awkward.
+            // For API protos, we can effectively guess the package by finding the first namespace element that starts with "V" and then a digit, or "Type".
+            var finalPartOfPackage = parts.FirstOrDefault(part => part == "Type" || Regex.IsMatch(part, @"V[\d].*"));
+            if (finalPartOfPackage is null)
+            {
+                throw new ArgumentException($"Unable to determine real package for page {page} in package {package}");
+            }
+            int packageParts = Array.IndexOf(parts, finalPartOfPackage) + 1;
+            return string.Join(".", parts.Take(packageParts));
         }
     }
 }


### PR DESCRIPTION
This is ludicrously complicated, but that's because the packages in
googleapis.dev just try to include everything that's needed... and
because some of our packages (e.g. Google.Apis and Google.Apis.Core)
aren't brilliant in terms of consistency.

There may still be corner cases that I'm missing. Ideally we'll run
a long-running test that checks the validity of these before doing
anything irreversible.