### PR TITLE
Release Google.Cloud.AccessApproval.V1 version 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Each package name links to the documentation for that package.
 | [Google.Analytics.Data.V1Beta](https://googleapis.dev/dotnet/Google.Analytics.Data.V1Beta/1.0.0-beta03) | 1.0.0-beta03 | [Google Analytics Data (V1Beta API)](https://developers.google.com/analytics) |
 | [Google.Apps.Script.Type](https://googleapis.dev/dotnet/Google.Apps.Script.Type/1.0.0-beta01) | 1.0.0-beta01 | Version-agnostic types for Apps Script APIs |
 | [Google.Area120.Tables.V1Alpha1](https://googleapis.dev/dotnet/Google.Area120.Tables.V1Alpha1/1.0.0-alpha03) | 1.0.0-alpha03 | Google Area 120 Tables |
-| [Google.Cloud.AccessApproval.V1](https://googleapis.dev/dotnet/Google.Cloud.AccessApproval.V1/1.0.0) | 1.0.0 | [Access Approval](https://cloud.google.com/access-approval/docs/) |
+| [Google.Cloud.AccessApproval.V1](https://googleapis.dev/dotnet/Google.Cloud.AccessApproval.V1/1.1.0) | 1.1.0 | [Access Approval](https://cloud.google.com/access-approval/docs/) |
 | [Google.Cloud.ApiGateway.V1](https://googleapis.dev/dotnet/Google.Cloud.ApiGateway.V1/1.0.0) | 1.0.0 | [API Gateway](https://cloud.google.com/api-gateway/docs) |
 | [Google.Cloud.AppEngine.V1](https://googleapis.dev/dotnet/Google.Cloud.AppEngine.V1/1.1.0) | 1.1.0 | [App Engine Audit Data](https://cloud.google.com/appengine) |
 | [Google.Cloud.ArtifactRegistry.V1Beta2](https://googleapis.dev/dotnet/Google.Cloud.ArtifactRegistry.V1Beta2/1.0.0-beta01) | 1.0.0-beta01 | [Artifact Registry](https://cloud.google.com/artifact-registry) |

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.csproj
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>An API for controlling access to data by Google personnel.</Description>
@@ -11,8 +11,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.AccessApproval.V1/docs/history.md
+++ b/apis/Google.Cloud.AccessApproval.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.1.0, released 2021-05-25
+
+No API surface changes; just dependency updates.
+
 # Version 1.0.0, released 2021-01-18
 
 No API changes since 1.0.0-beta02.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -72,7 +72,7 @@
     },
     {
       "id": "Google.Cloud.AccessApproval.V1",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "grpc",
       "productName": "Access Approval",
       "productUrl": "https://cloud.google.com/access-approval/docs/",
@@ -82,8 +82,8 @@
         "approval"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.2.0",
-        "Grpc.Core": "2.31.0"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Grpc.Core": "2.36.4"
       },
       "generator": "micro",
       "protoPath": "google/cloud/accessapproval/v1"

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -23,7 +23,7 @@ Each package name links to the documentation for that package.
 | [Google.Analytics.Data.V1Beta](Google.Analytics.Data.V1Beta/index.html) | 1.0.0-beta03 | [Google Analytics Data (V1Beta API)](https://developers.google.com/analytics) |
 | [Google.Apps.Script.Type](Google.Apps.Script.Type/index.html) | 1.0.0-beta01 | Version-agnostic types for Apps Script APIs |
 | [Google.Area120.Tables.V1Alpha1](Google.Area120.Tables.V1Alpha1/index.html) | 1.0.0-alpha03 | Google Area 120 Tables |
-| [Google.Cloud.AccessApproval.V1](Google.Cloud.AccessApproval.V1/index.html) | 1.0.0 | [Access Approval](https://cloud.google.com/access-approval/docs/) |
+| [Google.Cloud.AccessApproval.V1](Google.Cloud.AccessApproval.V1/index.html) | 1.1.0 | [Access Approval](https://cloud.google.com/access-approval/docs/) |
 | [Google.Cloud.ApiGateway.V1](Google.Cloud.ApiGateway.V1/index.html) | 1.0.0 | [API Gateway](https://cloud.google.com/api-gateway/docs) |
 | [Google.Cloud.AppEngine.V1](Google.Cloud.AppEngine.V1/index.html) | 1.1.0 | [App Engine Audit Data](https://cloud.google.com/appengine) |
 | [Google.Cloud.ArtifactRegistry.V1Beta2](Google.Cloud.ArtifactRegistry.V1Beta2/index.html) | 1.0.0-beta01 | [Artifact Registry](https://cloud.google.com/artifact-registry) |


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
