### PR TITLE
Release Google.Cloud.BigQuery.DataTransfer.V1 version 3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.AssuredWorkloads.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.AssuredWorkloads.V1Beta1/1.0.0-beta04) | 1.0.0-beta04 | [Assured Workloads](https://cloud.google.com/assured-workloads/docs) |
 | [Google.Cloud.AutoML.V1](https://googleapis.dev/dotnet/Google.Cloud.AutoML.V1/2.2.0) | 2.2.0 | [Google AutoML](https://cloud.google.com/automl/) |
 | [Google.Cloud.BigQuery.Connection.V1](https://googleapis.dev/dotnet/Google.Cloud.BigQuery.Connection.V1/1.2.0) | 1.2.0 | [BigQuery Connection](https://cloud.google.com/bigquery/docs/reference/bigqueryconnection) |
-| [Google.Cloud.BigQuery.DataTransfer.V1](https://googleapis.dev/dotnet/Google.Cloud.BigQuery.DataTransfer.V1/3.0.0) | 3.0.0 | [Google BigQuery Data Transfer](https://cloud.google.com/bigquery/transfer/) |
+| [Google.Cloud.BigQuery.DataTransfer.V1](https://googleapis.dev/dotnet/Google.Cloud.BigQuery.DataTransfer.V1/3.1.0) | 3.1.0 | [Google BigQuery Data Transfer](https://cloud.google.com/bigquery/transfer/) |
 | [Google.Cloud.BigQuery.Reservation.V1](https://googleapis.dev/dotnet/Google.Cloud.BigQuery.Reservation.V1/1.1.0) | 1.1.0 | [BigQuery Reservation](https://cloud.google.com/bigquery/docs/reference/reservations) |
 | [Google.Cloud.BigQuery.V2](https://googleapis.dev/dotnet/Google.Cloud.BigQuery.V2/2.2.0) | 2.2.0 | [Google BigQuery](https://cloud.google.com/bigquery/) |
 | [Google.Cloud.BigQuery.Storage.V1](https://googleapis.dev/dotnet/Google.Cloud.BigQuery.Storage.V1/2.2.0) | 2.2.0 | [Google BigQuery Storage](https://cloud.google.com/bigquery/docs/reference/storage/) |

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0</Version>
+    <Version>3.1.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery Data Transfer API, which transfers data from partner SaaS applications to Google BigQuery on a scheduled, managed basis.</Description>
@@ -11,8 +11,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 3.1.0, released 2021-05-25
+
+- [Commit 3717e0d](https://github.com/googleapis/google-cloud-dotnet/commit/3717e0d): Regenerate all APIs with generator change for deprecation
+
 # Version 3.0.0, released 2020-09-28
 
 - [Commit 924f350](https://github.com/googleapis/google-cloud-dotnet/commit/924f350): fix!: Remove obsolete `Datasource` code

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -232,12 +232,12 @@
       "protoPath": "google/cloud/bigquery/datatransfer/v1",
       "productName": "Google BigQuery Data Transfer",
       "productUrl": "https://cloud.google.com/bigquery/transfer/",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the BigQuery Data Transfer API, which transfers data from partner SaaS applications to Google BigQuery on a scheduled, managed basis.",
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.2.0",
-        "Grpc.Core": "2.31.0"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Grpc.Core": "2.36.4"
       },
       "tags": [
         "BigQuery",

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -31,7 +31,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.AssuredWorkloads.V1Beta1](Google.Cloud.AssuredWorkloads.V1Beta1/index.html) | 1.0.0-beta04 | [Assured Workloads](https://cloud.google.com/assured-workloads/docs) |
 | [Google.Cloud.AutoML.V1](Google.Cloud.AutoML.V1/index.html) | 2.2.0 | [Google AutoML](https://cloud.google.com/automl/) |
 | [Google.Cloud.BigQuery.Connection.V1](Google.Cloud.BigQuery.Connection.V1/index.html) | 1.2.0 | [BigQuery Connection](https://cloud.google.com/bigquery/docs/reference/bigqueryconnection) |
-| [Google.Cloud.BigQuery.DataTransfer.V1](Google.Cloud.BigQuery.DataTransfer.V1/index.html) | 3.0.0 | [Google BigQuery Data Transfer](https://cloud.google.com/bigquery/transfer/) |
+| [Google.Cloud.BigQuery.DataTransfer.V1](Google.Cloud.BigQuery.DataTransfer.V1/index.html) | 3.1.0 | [Google BigQuery Data Transfer](https://cloud.google.com/bigquery/transfer/) |
 | [Google.Cloud.BigQuery.Reservation.V1](Google.Cloud.BigQuery.Reservation.V1/index.html) | 1.1.0 | [BigQuery Reservation](https://cloud.google.com/bigquery/docs/reference/reservations) |
 | [Google.Cloud.BigQuery.V2](Google.Cloud.BigQuery.V2/index.html) | 2.2.0 | [Google BigQuery](https://cloud.google.com/bigquery/) |
 | [Google.Cloud.BigQuery.Storage.V1](Google.Cloud.BigQuery.Storage.V1/index.html) | 2.2.0 | [Google BigQuery Storage](https://cloud.google.com/bigquery/docs/reference/storage/) |


### PR DESCRIPTION

Changes in this release:

- [Commit 3717e0d](https://github.com/googleapis/google-cloud-dotnet/commit/3717e0d): Regenerate all APIs with generator change for deprecation
