### PR TITLE
Release Google.Cloud.DevTools.Common version 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Datastore.Admin.V1](https://googleapis.dev/dotnet/Google.Cloud.Datastore.Admin.V1/1.1.0) | 1.1.0 | Cloud Datastore |
 | [Google.Cloud.Datastore.V1](https://googleapis.dev/dotnet/Google.Cloud.Datastore.V1/3.2.0) | 3.2.0 | [Google Cloud Datastore](https://cloud.google.com/datastore/docs/concepts/overview) |
 | [Google.Cloud.Debugger.V2](https://googleapis.dev/dotnet/Google.Cloud.Debugger.V2/2.2.0) | 2.2.0 | [Google Cloud Debugger](https://cloud.google.com/debugger/) |
-| [Google.Cloud.DevTools.Common](https://googleapis.dev/dotnet/Google.Cloud.DevTools.Common/2.0.0) | 2.0.0 | Common Protocol Buffer messages for Google Cloud Developer Tools APIs |
+| [Google.Cloud.DevTools.Common](https://googleapis.dev/dotnet/Google.Cloud.DevTools.Common/2.1.0) | 2.1.0 | Common Protocol Buffer messages for Google Cloud Developer Tools APIs |
 | [Google.Cloud.DevTools.ContainerAnalysis.V1](https://googleapis.dev/dotnet/Google.Cloud.DevTools.ContainerAnalysis.V1/2.1.0) | 2.1.0 | [Google Container Analysis](https://cloud.google.com/container-registry/docs/container-analysis/) |
 | [Google.Cloud.Diagnostics.AspNetCore](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.AspNetCore/4.2.0) | 4.2.0 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core |
 | [Google.Cloud.Diagnostics.AspNetCore3](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.AspNetCore3/4.2.0) | 4.2.0 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core 3 |

--- a/apis/Google.Cloud.DevTools.Common/Google.Cloud.DevTools.Common/Google.Cloud.DevTools.Common.csproj
+++ b/apis/Google.Cloud.DevTools.Common/Google.Cloud.DevTools.Common/Google.Cloud.DevTools.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Common Protocol Buffer messages for Google Cloud Developer Tools APIs.</Description>
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.CommonProtos" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Google.Api.CommonProtos" Version="[2.3.0, 3.0.0)" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.DevTools.Common/docs/history.md
+++ b/apis/Google.Cloud.DevTools.Common/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 2.1.0, released 2021-05-25
+
+No API surface changes; just dependency updates.
+
 # Version 2.0.0, released 2020-03-17
 
 No API surface changes compared with 2.0.0-beta01, just dependency

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -652,7 +652,7 @@
     },
     {
       "id": "Google.Cloud.DevTools.Common",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "type": "other",
       "targetFrameworks": "netstandard2.0;net461",
       "testTargetFrameworks": "netcoreapp2.1;net461",
@@ -661,7 +661,7 @@
         "Tools"
       ],
       "dependencies": {
-        "Google.Api.CommonProtos": "2.2.0"
+        "Google.Api.CommonProtos": "2.3.0"
       }
     },
     {

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -54,7 +54,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Datastore.Admin.V1](Google.Cloud.Datastore.Admin.V1/index.html) | 1.1.0 | Cloud Datastore |
 | [Google.Cloud.Datastore.V1](Google.Cloud.Datastore.V1/index.html) | 3.2.0 | [Google Cloud Datastore](https://cloud.google.com/datastore/docs/concepts/overview) |
 | [Google.Cloud.Debugger.V2](Google.Cloud.Debugger.V2/index.html) | 2.2.0 | [Google Cloud Debugger](https://cloud.google.com/debugger/) |
-| [Google.Cloud.DevTools.Common](Google.Cloud.DevTools.Common/index.html) | 2.0.0 | Common Protocol Buffer messages for Google Cloud Developer Tools APIs |
+| [Google.Cloud.DevTools.Common](Google.Cloud.DevTools.Common/index.html) | 2.1.0 | Common Protocol Buffer messages for Google Cloud Developer Tools APIs |
 | [Google.Cloud.DevTools.ContainerAnalysis.V1](Google.Cloud.DevTools.ContainerAnalysis.V1/index.html) | 2.1.0 | [Google Container Analysis](https://cloud.google.com/container-registry/docs/container-analysis/) |
 | [Google.Cloud.Diagnostics.AspNetCore](Google.Cloud.Diagnostics.AspNetCore/index.html) | 4.2.0 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core |
 | [Google.Cloud.Diagnostics.AspNetCore3](Google.Cloud.Diagnostics.AspNetCore3/index.html) | 4.2.0 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core 3 |


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
