### PR TITLE
Release Google.Cloud.Dlp.V2 version 3.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Diagnostics.Common](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.Common/4.2.0) | 4.2.0 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries Common Components |
 | [Google.Cloud.Dialogflow.Cx.V3](https://googleapis.dev/dotnet/Google.Cloud.Dialogflow.Cx.V3/1.1.0) | 1.1.0 | [Dialogflow](https://cloud.google.com/dialogflow/cx/docs) |
 | [Google.Cloud.Dialogflow.V2](https://googleapis.dev/dotnet/Google.Cloud.Dialogflow.V2/3.2.0) | 3.2.0 | [Google Cloud Dialogflow](https://cloud.google.com/dialogflow-enterprise/) |
-| [Google.Cloud.Dlp.V2](https://googleapis.dev/dotnet/Google.Cloud.Dlp.V2/3.1.0) | 3.1.0 | [Google Cloud Data Loss Prevention](https://cloud.google.com/dlp/) |
+| [Google.Cloud.Dlp.V2](https://googleapis.dev/dotnet/Google.Cloud.Dlp.V2/3.2.0) | 3.2.0 | [Google Cloud Data Loss Prevention](https://cloud.google.com/dlp/) |
 | [Google.Cloud.DocumentAI.V1](https://googleapis.dev/dotnet/Google.Cloud.DocumentAI.V1/1.0.0-beta02) | 1.0.0-beta02 | [Cloud Document AI (V1 API)](https://cloud.google.com/solutions/document-ai) |
 | [Google.Cloud.DocumentAI.V1Beta2](https://googleapis.dev/dotnet/Google.Cloud.DocumentAI.V1Beta2/1.0.0-beta02) | 1.0.0-beta02 | [Cloud Document AI (V1Beta2 API)](https://cloud.google.com/solutions/document-ai) |
 | [Google.Cloud.Domains.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Domains.V1Beta1/1.0.0-beta01) | 1.0.0-beta01 | [Cloud Domains](https://cloud.google.com/domains/) |

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.csproj
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.1.0</Version>
+    <Version>3.2.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Data Loss Prevention API, which provides methods for detection of privacy-sensitive fragments in text, images, and Google Cloud Platform storage repositories.</Description>
@@ -11,8 +11,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Dlp.V2/docs/history.md
+++ b/apis/Google.Cloud.Dlp.V2/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 3.2.0, released 2021-05-25
+
+No API surface changes; just dependency updates.
+
 # Version 3.1.0, released 2020-10-19
 
 - [Commit 18f5adb](https://github.com/googleapis/google-cloud-dotnet/commit/18f5adb): Fix: retrieve job config for risk analysis jobs. Docs: clarify timespan config for BigQuery and Datastore.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -823,12 +823,12 @@
       "protoPath": "google/privacy/dlp/v2",
       "productName": "Google Cloud Data Loss Prevention",
       "productUrl": "https://cloud.google.com/dlp/",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Data Loss Prevention API, which provides methods for detection of privacy-sensitive fragments in text, images, and Google Cloud Platform storage repositories.",
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.2.0",
-        "Grpc.Core": "2.31.0"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Grpc.Core": "2.36.4"
       },
       "tags": [
         "DLP",

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -61,7 +61,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Diagnostics.Common](Google.Cloud.Diagnostics.Common/index.html) | 4.2.0 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries Common Components |
 | [Google.Cloud.Dialogflow.Cx.V3](Google.Cloud.Dialogflow.Cx.V3/index.html) | 1.1.0 | [Dialogflow](https://cloud.google.com/dialogflow/cx/docs) |
 | [Google.Cloud.Dialogflow.V2](Google.Cloud.Dialogflow.V2/index.html) | 3.2.0 | [Google Cloud Dialogflow](https://cloud.google.com/dialogflow-enterprise/) |
-| [Google.Cloud.Dlp.V2](Google.Cloud.Dlp.V2/index.html) | 3.1.0 | [Google Cloud Data Loss Prevention](https://cloud.google.com/dlp/) |
+| [Google.Cloud.Dlp.V2](Google.Cloud.Dlp.V2/index.html) | 3.2.0 | [Google Cloud Data Loss Prevention](https://cloud.google.com/dlp/) |
 | [Google.Cloud.DocumentAI.V1](Google.Cloud.DocumentAI.V1/index.html) | 1.0.0-beta02 | [Cloud Document AI (V1 API)](https://cloud.google.com/solutions/document-ai) |
 | [Google.Cloud.DocumentAI.V1Beta2](Google.Cloud.DocumentAI.V1Beta2/index.html) | 1.0.0-beta02 | [Cloud Document AI (V1Beta2 API)](https://cloud.google.com/solutions/document-ai) |
 | [Google.Cloud.Domains.V1Beta1](Google.Cloud.Domains.V1Beta1/index.html) | 1.0.0-beta01 | [Cloud Domains](https://cloud.google.com/domains/) |


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
