### PR TITLE
Release Google.Cloud.Iam.V1 version 2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Gaming.V1Beta](https://googleapis.dev/dotnet/Google.Cloud.Gaming.V1Beta/1.0.0-beta07) | 1.0.0-beta07 | [Google Cloud for Games](https://cloud.google.com/solutions/gaming) |
 | [Google.Cloud.GkeHub.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.GkeHub.V1Beta1/1.0.0-beta02) | 1.0.0-beta02 | [GKE Hub](https://cloud.google.com/anthos/multicluster-management/connect/registering-a-cluster) |
 | [Google.Cloud.Iam.Credentials.V1](https://googleapis.dev/dotnet/Google.Cloud.Iam.Credentials.V1/1.1.0) | 1.1.0 | [IAM Service Account Credentials](https://cloud.google.com/iam/docs/reference/credentials/rest) |
-| [Google.Cloud.Iam.V1](https://googleapis.dev/dotnet/Google.Cloud.Iam.V1/2.1.0) | 2.1.0 | [Google Cloud Identity and Access Management (IAM)](https://cloud.google.com/iam/) |
+| [Google.Cloud.Iam.V1](https://googleapis.dev/dotnet/Google.Cloud.Iam.V1/2.2.0) | 2.2.0 | [Google Cloud Identity and Access Management (IAM)](https://cloud.google.com/iam/) |
 | [Google.Cloud.Iot.V1](https://googleapis.dev/dotnet/Google.Cloud.Iot.V1/1.1.0) | 1.1.0 | [Cloud IoT](https://cloud.google.com/iot/docs/reference/cloudiot/rest) |
 | [Google.Cloud.Kms.V1](https://googleapis.dev/dotnet/Google.Cloud.Kms.V1/2.2.0) | 2.2.0 | [Google Cloud Key Management Service](https://cloud.google.com/kms/) |
 | [Google.Cloud.Language.V1](https://googleapis.dev/dotnet/Google.Cloud.Language.V1/2.1.0) | 2.1.0 | [Google Cloud Natural Language](https://cloud.google.com/natural-language) |

--- a/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.csproj
+++ b/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>gRPC services for the Google Identity and Access Management API. This library is typically used as a dependency for other API client libraries.</Description>
@@ -11,8 +11,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Iam.V1/docs/history.md
+++ b/apis/Google.Cloud.Iam.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 2.2.0, released 2021-05-26
+
+No API surface changes; just dependency updates.
+
 # Version 2.1.0, released 2020-10-19
 
 - [Commit 0790924](https://github.com/googleapis/google-cloud-dotnet/commit/0790924): fix: Add gRPC compatibility constructors

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1117,7 +1117,7 @@
       "protoPath": "google/iam/v1",
       "productName": "Google Cloud Identity and Access Management (IAM)",
       "productUrl": "https://cloud.google.com/iam/",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "type": "grpc",
       "metadataType": "CORE",
       "description": "gRPC services for the Google Identity and Access Management API. This library is typically used as a dependency for other API client libraries.",
@@ -1127,8 +1127,8 @@
         "Access"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.2.0",
-        "Grpc.Core": "2.31.0"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Grpc.Core": "2.36.4"
       }
     },
     {

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -76,7 +76,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Gaming.V1Beta](Google.Cloud.Gaming.V1Beta/index.html) | 1.0.0-beta07 | [Google Cloud for Games](https://cloud.google.com/solutions/gaming) |
 | [Google.Cloud.GkeHub.V1Beta1](Google.Cloud.GkeHub.V1Beta1/index.html) | 1.0.0-beta02 | [GKE Hub](https://cloud.google.com/anthos/multicluster-management/connect/registering-a-cluster) |
 | [Google.Cloud.Iam.Credentials.V1](Google.Cloud.Iam.Credentials.V1/index.html) | 1.1.0 | [IAM Service Account Credentials](https://cloud.google.com/iam/docs/reference/credentials/rest) |
-| [Google.Cloud.Iam.V1](Google.Cloud.Iam.V1/index.html) | 2.1.0 | [Google Cloud Identity and Access Management (IAM)](https://cloud.google.com/iam/) |
+| [Google.Cloud.Iam.V1](Google.Cloud.Iam.V1/index.html) | 2.2.0 | [Google Cloud Identity and Access Management (IAM)](https://cloud.google.com/iam/) |
 | [Google.Cloud.Iot.V1](Google.Cloud.Iot.V1/index.html) | 1.1.0 | [Cloud IoT](https://cloud.google.com/iot/docs/reference/cloudiot/rest) |
 | [Google.Cloud.Kms.V1](Google.Cloud.Kms.V1/index.html) | 2.2.0 | [Google Cloud Key Management Service](https://cloud.google.com/kms/) |
 | [Google.Cloud.Language.V1](Google.Cloud.Language.V1/index.html) | 2.1.0 | [Google Cloud Natural Language](https://cloud.google.com/natural-language) |


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
