### PR TITLE
Release Google.Cloud.Logging.Log4Net version 3.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Iot.V1](https://googleapis.dev/dotnet/Google.Cloud.Iot.V1/1.1.0) | 1.1.0 | [Cloud IoT](https://cloud.google.com/iot/docs/reference/cloudiot/rest) |
 | [Google.Cloud.Kms.V1](https://googleapis.dev/dotnet/Google.Cloud.Kms.V1/2.2.0) | 2.2.0 | [Google Cloud Key Management Service](https://cloud.google.com/kms/) |
 | [Google.Cloud.Language.V1](https://googleapis.dev/dotnet/Google.Cloud.Language.V1/2.2.0) | 2.2.0 | [Google Cloud Natural Language](https://cloud.google.com/natural-language) |
-| [Google.Cloud.Logging.Log4Net](https://googleapis.dev/dotnet/Google.Cloud.Logging.Log4Net/3.2.0) | 3.2.0 | Log4Net client library for the Google Cloud Logging API |
+| [Google.Cloud.Logging.Log4Net](https://googleapis.dev/dotnet/Google.Cloud.Logging.Log4Net/3.3.0) | 3.3.0 | Log4Net client library for the Google Cloud Logging API |
 | [Google.Cloud.Logging.NLog](https://googleapis.dev/dotnet/Google.Cloud.Logging.NLog/3.3.0) | 3.3.0 | NLog target for the Google Cloud Logging API |
 | [Google.Cloud.Logging.Type](https://googleapis.dev/dotnet/Google.Cloud.Logging.Type/3.2.0) | 3.2.0 | Version-agnostic types for the Google Cloud Logging API |
 | [Google.Cloud.Logging.V2](https://googleapis.dev/dotnet/Google.Cloud.Logging.V2/3.3.0) | 3.3.0 | [Google Cloud Logging](https://cloud.google.com/logging/) |

--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.IntegrationTests/Google.Cloud.Logging.Log4Net.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.IntegrationTests/Google.Cloud.Logging.Log4Net.IntegrationTests.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.3.0, 4.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Logging.Log4Net\Google.Cloud.Logging.Log4Net.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />

--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Snippets/Google.Cloud.Logging.Log4Net.Snippets.csproj
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Snippets/Google.Cloud.Logging.Log4Net.Snippets.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.3.0, 4.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Logging.Log4Net\Google.Cloud.Logging.Log4Net.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />

--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Tests/Google.Cloud.Logging.Log4Net.Tests.csproj
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Tests/Google.Cloud.Logging.Log4Net.Tests.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.3.0, 4.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Logging.Log4Net\Google.Cloud.Logging.Log4Net.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />

--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.csproj
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.2.0</Version>
+    <Version>3.3.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Log4Net client library for the Google Cloud Logging API.</Description>
@@ -11,10 +11,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.DevTools.Common" Version="[2.0.0, 3.0.0)" />
-    <PackageReference Include="Google.Cloud.Logging.V2" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.DevTools.Common" Version="[2.1.0, 3.0.0)" />
+    <PackageReference Include="Google.Cloud.Logging.V2" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="log4net" Version="2.0.12" />

--- a/apis/Google.Cloud.Logging.Log4Net/docs/history.md
+++ b/apis/Google.Cloud.Logging.Log4Net/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 3.3.0, released 2021-05-26
+
+No API surface changes; just dependency updates.
+
 # Version 3.2.0, released 2020-11-19
 
 No API surface changes, but this release updates dependencies.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1189,7 +1189,7 @@
     },
     {
       "id": "Google.Cloud.Logging.Log4Net",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "type": "other",
       "metadataType": "INTEGRATION",
       "targetFrameworks": "netstandard2.0;net461",
@@ -1201,14 +1201,14 @@
         "Stackdriver"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.2.0",
-        "Google.Cloud.DevTools.Common": "2.0.0",
-        "Google.Cloud.Logging.V2": "3.2.0",
-        "Grpc.Core": "2.31.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Google.Cloud.DevTools.Common": "2.1.0",
+        "Google.Cloud.Logging.V2": "3.3.0",
+        "Grpc.Core": "2.36.4",
         "log4net": "2.0.12"
       },
       "testDependencies": {
-        "Google.Api.Gax.Testing": "3.2.0"
+        "Google.Api.Gax.Testing": "3.3.0"
       }
     },
     {

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -80,7 +80,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Iot.V1](Google.Cloud.Iot.V1/index.html) | 1.1.0 | [Cloud IoT](https://cloud.google.com/iot/docs/reference/cloudiot/rest) |
 | [Google.Cloud.Kms.V1](Google.Cloud.Kms.V1/index.html) | 2.2.0 | [Google Cloud Key Management Service](https://cloud.google.com/kms/) |
 | [Google.Cloud.Language.V1](Google.Cloud.Language.V1/index.html) | 2.2.0 | [Google Cloud Natural Language](https://cloud.google.com/natural-language) |
-| [Google.Cloud.Logging.Log4Net](Google.Cloud.Logging.Log4Net/index.html) | 3.2.0 | Log4Net client library for the Google Cloud Logging API |
+| [Google.Cloud.Logging.Log4Net](Google.Cloud.Logging.Log4Net/index.html) | 3.3.0 | Log4Net client library for the Google Cloud Logging API |
 | [Google.Cloud.Logging.NLog](Google.Cloud.Logging.NLog/index.html) | 3.3.0 | NLog target for the Google Cloud Logging API |
 | [Google.Cloud.Logging.Type](Google.Cloud.Logging.Type/index.html) | 3.2.0 | Version-agnostic types for the Google Cloud Logging API |
 | [Google.Cloud.Logging.V2](Google.Cloud.Logging.V2/index.html) | 3.3.0 | [Google Cloud Logging](https://cloud.google.com/logging/) |


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
