### PR TITLE
Release Google.Cloud.Notebooks.V1Beta1 version 1.0.0-beta03

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Metastore.V1Beta](https://googleapis.dev/dotnet/Google.Cloud.Metastore.V1Beta/1.0.0-beta01) | 1.0.0-beta01 | [Dataproc Metastore (V1Beta API)](https://cloud.google.com/dataproc-metastore/docs) |
 | [Google.Cloud.Monitoring.V3](https://googleapis.dev/dotnet/Google.Cloud.Monitoring.V3/2.3.0) | 2.3.0 | [Google Cloud Monitoring](https://cloud.google.com/monitoring/api/v3/) |
 | [Google.Cloud.NetworkConnectivity.V1Alpha1](https://googleapis.dev/dotnet/Google.Cloud.NetworkConnectivity.V1Alpha1/1.0.0-alpha02) | 1.0.0-alpha02 | [Network Connectivity](https://cloud.google.com/network-connectivity/docs/apis) |
-| [Google.Cloud.Notebooks.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Notebooks.V1Beta1/1.0.0-beta02) | 1.0.0-beta02 | [AI Platform Notebooks](https://cloud.google.com/ai-platform-notebooks) |
+| [Google.Cloud.Notebooks.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Notebooks.V1Beta1/1.0.0-beta03) | 1.0.0-beta03 | [AI Platform Notebooks](https://cloud.google.com/ai-platform-notebooks) |
 | [Google.Cloud.OrgPolicy.V1](https://googleapis.dev/dotnet/Google.Cloud.OrgPolicy.V1/2.1.0) | 2.1.0 | OrgPolicy API messages |
 | [Google.Cloud.OrgPolicy.V2](https://googleapis.dev/dotnet/Google.Cloud.OrgPolicy.V2/1.0.0) | 1.0.0 | [Organization Policy](https://cloud.google.com/resource-manager/docs/organization-policy/overview) |
 | [Google.Cloud.OsConfig.V1](https://googleapis.dev/dotnet/Google.Cloud.OsConfig.V1/1.2.0) | 1.2.0 | [Google Cloud OS Config (V1 API)](https://cloud.google.com/compute/docs/osconfig/rest) |

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.csproj
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AI Platform Notebooks API (beta), which is used to manage notebook resources in Google Cloud.</Description>
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />

--- a/apis/Google.Cloud.Notebooks.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.0.0-beta03, released 2021-05-26
+
+No API surface changes; just dependency updates.
+
 # Version 1.0.0-beta02, released 2020-11-18
 
 - [Commit 0ca05f5](https://github.com/googleapis/google-cloud-dotnet/commit/0ca05f5): chore: Regenerate all APIs using protoc 3.13 and Grpc.Tools 2.31

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1451,7 +1451,7 @@
     },
     {
       "id": "Google.Cloud.Notebooks.V1Beta1",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0-beta03",
       "type": "grpc",
       "productName": "AI Platform Notebooks",
       "productUrl": "https://cloud.google.com/ai-platform-notebooks",
@@ -1461,7 +1461,7 @@
         "notebooks"
       ],
       "dependencies": {
-        "Google.LongRunning": "2.1.0"
+        "Google.LongRunning": "2.2.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/notebooks/v1beta1"

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -93,7 +93,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Metastore.V1Beta](Google.Cloud.Metastore.V1Beta/index.html) | 1.0.0-beta01 | [Dataproc Metastore (V1Beta API)](https://cloud.google.com/dataproc-metastore/docs) |
 | [Google.Cloud.Monitoring.V3](Google.Cloud.Monitoring.V3/index.html) | 2.3.0 | [Google Cloud Monitoring](https://cloud.google.com/monitoring/api/v3/) |
 | [Google.Cloud.NetworkConnectivity.V1Alpha1](Google.Cloud.NetworkConnectivity.V1Alpha1/index.html) | 1.0.0-alpha02 | [Network Connectivity](https://cloud.google.com/network-connectivity/docs/apis) |
-| [Google.Cloud.Notebooks.V1Beta1](Google.Cloud.Notebooks.V1Beta1/index.html) | 1.0.0-beta02 | [AI Platform Notebooks](https://cloud.google.com/ai-platform-notebooks) |
+| [Google.Cloud.Notebooks.V1Beta1](Google.Cloud.Notebooks.V1Beta1/index.html) | 1.0.0-beta03 | [AI Platform Notebooks](https://cloud.google.com/ai-platform-notebooks) |
 | [Google.Cloud.OrgPolicy.V1](Google.Cloud.OrgPolicy.V1/index.html) | 2.1.0 | OrgPolicy API messages |
 | [Google.Cloud.OrgPolicy.V2](Google.Cloud.OrgPolicy.V2/index.html) | 1.0.0 | [Organization Policy](https://cloud.google.com/resource-manager/docs/organization-policy/overview) |
 | [Google.Cloud.OsConfig.V1](Google.Cloud.OsConfig.V1/index.html) | 1.2.0 | [Google Cloud OS Config (V1 API)](https://cloud.google.com/compute/docs/osconfig/rest) |


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
