### PR TITLE
Release Google.Cloud.PolicyTroubleshooter.V1 version 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.OsLogin.V1](https://googleapis.dev/dotnet/Google.Cloud.OsLogin.V1/2.2.0) | 2.2.0 | [Google Cloud OS Login (V1 API)](https://cloud.google.com/compute/docs/instances/managing-instance-access) |
 | [Google.Cloud.OsLogin.V1Beta](https://googleapis.dev/dotnet/Google.Cloud.OsLogin.V1Beta/2.0.0-beta04) | 2.0.0-beta04 | [Google Cloud OS Login (V1Beta API)](https://cloud.google.com/compute/docs/instances/managing-instance-access) |
 | [Google.Cloud.PhishingProtection.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.PhishingProtection.V1Beta1/1.0.0-beta04) | 1.0.0-beta04 | [Cloud Phishing Protection](https://cloud.google.com/phishing-protection/) |
-| [Google.Cloud.PolicyTroubleshooter.V1](https://googleapis.dev/dotnet/Google.Cloud.PolicyTroubleshooter.V1/1.0.0) | 1.0.0 | [Policy Troubleshooter](https://cloud.google.com/iam/docs/reference/policytroubleshooter/rest) |
+| [Google.Cloud.PolicyTroubleshooter.V1](https://googleapis.dev/dotnet/Google.Cloud.PolicyTroubleshooter.V1/1.1.0) | 1.1.0 | [Policy Troubleshooter](https://cloud.google.com/iam/docs/reference/policytroubleshooter/rest) |
 | [Google.Cloud.PrivateCatalog.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.PrivateCatalog.V1Beta1/1.0.0-beta01) | 1.0.0-beta01 | [Cloud Private Catalog](https://cloud.google.com/private-catalog/docs/) |
 | [Google.Cloud.Profiler.V2](https://googleapis.dev/dotnet/Google.Cloud.Profiler.V2/1.0.0) | 1.0.0 | [Cloud Profiler](https://cloud.google.com/profiler/) |
 | [Google.Cloud.PubSub.V1](https://googleapis.dev/dotnet/Google.Cloud.PubSub.V1/2.4.0) | 2.4.0 | [Cloud Pub/Sub](https://cloud.google.com/pubsub/) |

--- a/apis/Google.Cloud.PolicyTroubleshooter.V1/Google.Cloud.PolicyTroubleshooter.V1/Google.Cloud.PolicyTroubleshooter.V1.csproj
+++ b/apis/Google.Cloud.PolicyTroubleshooter.V1/Google.Cloud.PolicyTroubleshooter.V1/Google.Cloud.PolicyTroubleshooter.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google IAM Policy Troubleshooter API.</Description>
@@ -11,9 +11,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.PolicyTroubleshooter.V1/docs/history.md
+++ b/apis/Google.Cloud.PolicyTroubleshooter.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.1.0, released 2021-05-26
+
+No API surface changes; just dependency updates.
+
 # Version 1.0.0, released 2020-11-09
 
 - [Commit 0ca05f5](https://github.com/googleapis/google-cloud-dotnet/commit/0ca05f5): chore: Regenerate all APIs using protoc 3.13 and Grpc.Tools 2.31

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1613,7 +1613,7 @@
     },
     {
       "id": "Google.Cloud.PolicyTroubleshooter.V1",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "grpc",
       "productName": "Policy Troubleshooter",
       "productUrl": "https://cloud.google.com/iam/docs/reference/policytroubleshooter/rest",
@@ -1623,9 +1623,9 @@
         "diagnostics"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.2.0",
-        "Google.Cloud.Iam.V1": "2.1.0",
-        "Grpc.Core": "2.31.0"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Google.Cloud.Iam.V1": "2.2.0",
+        "Grpc.Core": "2.36.4"
       },
       "generator": "micro",
       "protoPath": "google/cloud/policytroubleshooter/v1"

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -102,7 +102,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.OsLogin.V1](Google.Cloud.OsLogin.V1/index.html) | 2.2.0 | [Google Cloud OS Login (V1 API)](https://cloud.google.com/compute/docs/instances/managing-instance-access) |
 | [Google.Cloud.OsLogin.V1Beta](Google.Cloud.OsLogin.V1Beta/index.html) | 2.0.0-beta04 | [Google Cloud OS Login (V1Beta API)](https://cloud.google.com/compute/docs/instances/managing-instance-access) |
 | [Google.Cloud.PhishingProtection.V1Beta1](Google.Cloud.PhishingProtection.V1Beta1/index.html) | 1.0.0-beta04 | [Cloud Phishing Protection](https://cloud.google.com/phishing-protection/) |
-| [Google.Cloud.PolicyTroubleshooter.V1](Google.Cloud.PolicyTroubleshooter.V1/index.html) | 1.0.0 | [Policy Troubleshooter](https://cloud.google.com/iam/docs/reference/policytroubleshooter/rest) |
+| [Google.Cloud.PolicyTroubleshooter.V1](Google.Cloud.PolicyTroubleshooter.V1/index.html) | 1.1.0 | [Policy Troubleshooter](https://cloud.google.com/iam/docs/reference/policytroubleshooter/rest) |
 | [Google.Cloud.PrivateCatalog.V1Beta1](Google.Cloud.PrivateCatalog.V1Beta1/index.html) | 1.0.0-beta01 | [Cloud Private Catalog](https://cloud.google.com/private-catalog/docs/) |
 | [Google.Cloud.Profiler.V2](Google.Cloud.Profiler.V2/index.html) | 1.0.0 | [Cloud Profiler](https://cloud.google.com/profiler/) |
 | [Google.Cloud.PubSub.V1](Google.Cloud.PubSub.V1/index.html) | 2.4.0 | [Cloud Pub/Sub](https://cloud.google.com/pubsub/) |


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
