### PR TITLE
Release Google.Cloud.Redis.V1Beta1 version 2.0.0-beta04

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.RecommendationEngine.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.RecommendationEngine.V1Beta1/1.0.0-beta02) | 1.0.0-beta02 | [Recommendations AI](https://cloud.google.com/recommendations) |
 | [Google.Cloud.Recommender.V1](https://googleapis.dev/dotnet/Google.Cloud.Recommender.V1/2.5.0) | 2.5.0 | [Google Cloud Recommender](https://cloud.google.com/recommender/) |
 | [Google.Cloud.Redis.V1](https://googleapis.dev/dotnet/Google.Cloud.Redis.V1/2.2.0) | 2.2.0 | [Google Cloud Memorystore for Redis (V1 API)](https://cloud.google.com/memorystore/) |
-| [Google.Cloud.Redis.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Redis.V1Beta1/2.0.0-beta03) | 2.0.0-beta03 | [Google Cloud Memorystore for Redis (V1Beta1 API)](https://cloud.google.com/memorystore/) |
+| [Google.Cloud.Redis.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Redis.V1Beta1/2.0.0-beta04) | 2.0.0-beta04 | [Google Cloud Memorystore for Redis (V1Beta1 API)](https://cloud.google.com/memorystore/) |
 | [Google.Cloud.Retail.V2](https://googleapis.dev/dotnet/Google.Cloud.Retail.V2/1.1.0) | 1.1.0 | [Retail](https://cloud.google.com/retail/docs) |
 | [Google.Cloud.Scheduler.V1](https://googleapis.dev/dotnet/Google.Cloud.Scheduler.V1/2.1.0) | 2.1.0 | [Google Cloud Scheduler](https://cloud.google.com/scheduler/) |
 | [Google.Cloud.SecretManager.V1](https://googleapis.dev/dotnet/Google.Cloud.SecretManager.V1/1.4.0) | 1.4.0 | [Secret Manager (V1 API)](https://cloud.google.com/secret-manager) |

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.csproj
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta03</Version>
+    <Version>2.0.0-beta04</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to administer Cloud Memorystore for Redis (V1 Beta 1 API).</Description>
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />

--- a/apis/Google.Cloud.Redis.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.Redis.V1Beta1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 2.0.0-beta04, released 2021-05-26
+
+No API surface changes; just dependency updates.
+
 # Version 2.0.0-beta03, released 2020-11-16
 
 - [Commit 0ca05f5](https://github.com/googleapis/google-cloud-dotnet/commit/0ca05f5): chore: Regenerate all APIs using protoc 3.13 and Grpc.Tools 2.31

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1777,12 +1777,12 @@
       "protoPath": "google/cloud/redis/v1beta1",
       "productName": "Google Cloud Memorystore for Redis",
       "productUrl": "https://cloud.google.com/memorystore/",
-      "version": "2.0.0-beta03",
+      "version": "2.0.0-beta04",
       "releaseLevelOverride": "beta",
       "type": "grpc",
       "description": "Recommended Google client library to administer Cloud Memorystore for Redis (V1 Beta 1 API).",
       "dependencies": {
-        "Google.LongRunning": "2.1.0"
+        "Google.LongRunning": "2.2.0"
       },
       "tags": [
         "Redis",

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -111,7 +111,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.RecommendationEngine.V1Beta1](Google.Cloud.RecommendationEngine.V1Beta1/index.html) | 1.0.0-beta02 | [Recommendations AI](https://cloud.google.com/recommendations) |
 | [Google.Cloud.Recommender.V1](Google.Cloud.Recommender.V1/index.html) | 2.5.0 | [Google Cloud Recommender](https://cloud.google.com/recommender/) |
 | [Google.Cloud.Redis.V1](Google.Cloud.Redis.V1/index.html) | 2.2.0 | [Google Cloud Memorystore for Redis (V1 API)](https://cloud.google.com/memorystore/) |
-| [Google.Cloud.Redis.V1Beta1](Google.Cloud.Redis.V1Beta1/index.html) | 2.0.0-beta03 | [Google Cloud Memorystore for Redis (V1Beta1 API)](https://cloud.google.com/memorystore/) |
+| [Google.Cloud.Redis.V1Beta1](Google.Cloud.Redis.V1Beta1/index.html) | 2.0.0-beta04 | [Google Cloud Memorystore for Redis (V1Beta1 API)](https://cloud.google.com/memorystore/) |
 | [Google.Cloud.Retail.V2](Google.Cloud.Retail.V2/index.html) | 1.1.0 | [Retail](https://cloud.google.com/retail/docs) |
 | [Google.Cloud.Scheduler.V1](Google.Cloud.Scheduler.V1/index.html) | 2.1.0 | [Google Cloud Scheduler](https://cloud.google.com/scheduler/) |
 | [Google.Cloud.SecretManager.V1](Google.Cloud.SecretManager.V1/index.html) | 1.4.0 | [Secret Manager (V1 API)](https://cloud.google.com/secret-manager) |


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
