### PR TITLE
Release Google.Cloud.ServiceDirectory.V1Beta1 version 1.0.0-beta04

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.SecurityCenter.V1P1Beta1](https://googleapis.dev/dotnet/Google.Cloud.SecurityCenter.V1P1Beta1/2.0.0-beta05) | 2.0.0-beta05 | [Google Cloud Security Command Center (V1P1Beta1 API)](https://cloud.google.com/security-command-center/) |
 | [Google.Cloud.ServiceControl.V1](https://googleapis.dev/dotnet/Google.Cloud.ServiceControl.V1/1.1.0) | 1.1.0 | [Service Control](https://cloud.google.com/service-infrastructure/docs/service-control/reference/rpc) |
 | [Google.Cloud.ServiceDirectory.V1](https://googleapis.dev/dotnet/Google.Cloud.ServiceDirectory.V1/1.1.0) | 1.1.0 | [Service Directory (V1 API)](https://cloud.google.com/service-directory/) |
-| [Google.Cloud.ServiceDirectory.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.ServiceDirectory.V1Beta1/1.0.0-beta03) | 1.0.0-beta03 | [Service Directory (V1Beta1 API)](https://cloud.google.com/service-directory/) |
+| [Google.Cloud.ServiceDirectory.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.ServiceDirectory.V1Beta1/1.0.0-beta04) | 1.0.0-beta04 | [Service Directory (V1Beta1 API)](https://cloud.google.com/service-directory/) |
 | [Google.Cloud.ServiceManagement.V1](https://googleapis.dev/dotnet/Google.Cloud.ServiceManagement.V1/1.1.0) | 1.1.0 | [Service Management](https://cloud.google.com/service-infrastructure/docs/service-management/reference/rpc) |
 | [Google.Cloud.ServiceUsage.V1](https://googleapis.dev/dotnet/Google.Cloud.ServiceUsage.V1/1.0.0-beta01) | 1.0.0-beta01 | [Service Usage](https://cloud.google.com/service-usage/docs/) |
 | [Google.Cloud.Shell.V1](https://googleapis.dev/dotnet/Google.Cloud.Shell.V1/1.0.0-beta01) | 1.0.0-beta01 | [Cloud Shell](https://cloud.google.com/shell/) |

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.csproj
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta03</Version>
+    <Version>1.0.0-beta04</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Service Directory API version v1beta1.</Description>
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.1.0, 3.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.0.0-beta04, released 2021-05-26
+
+No API surface changes; just dependency updates.
+
 # Version 1.0.0-beta03, released 2020-11-18
 
 - [Commit 0ca05f5](https://github.com/googleapis/google-cloud-dotnet/commit/0ca05f5): chore: Regenerate all APIs using protoc 3.13 and Grpc.Tools 2.31

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2021,11 +2021,11 @@
       "protoPath": "google/cloud/servicedirectory/v1beta1",
       "productName": "Service Directory",
       "productUrl": "https://cloud.google.com/service-directory/",
-      "version": "1.0.0-beta03",
+      "version": "1.0.0-beta04",
       "type": "grpc",
       "description": "Recommended Google client library to access the Service Directory API version v1beta1.",
       "dependencies": {
-        "Google.Cloud.Iam.V1": "2.1.0"
+        "Google.Cloud.Iam.V1": "2.2.0"
       },
       "tags": [
         "services"

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -122,7 +122,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.SecurityCenter.V1P1Beta1](Google.Cloud.SecurityCenter.V1P1Beta1/index.html) | 2.0.0-beta05 | [Google Cloud Security Command Center (V1P1Beta1 API)](https://cloud.google.com/security-command-center/) |
 | [Google.Cloud.ServiceControl.V1](Google.Cloud.ServiceControl.V1/index.html) | 1.1.0 | [Service Control](https://cloud.google.com/service-infrastructure/docs/service-control/reference/rpc) |
 | [Google.Cloud.ServiceDirectory.V1](Google.Cloud.ServiceDirectory.V1/index.html) | 1.1.0 | [Service Directory (V1 API)](https://cloud.google.com/service-directory/) |
-| [Google.Cloud.ServiceDirectory.V1Beta1](Google.Cloud.ServiceDirectory.V1Beta1/index.html) | 1.0.0-beta03 | [Service Directory (V1Beta1 API)](https://cloud.google.com/service-directory/) |
+| [Google.Cloud.ServiceDirectory.V1Beta1](Google.Cloud.ServiceDirectory.V1Beta1/index.html) | 1.0.0-beta04 | [Service Directory (V1Beta1 API)](https://cloud.google.com/service-directory/) |
 | [Google.Cloud.ServiceManagement.V1](Google.Cloud.ServiceManagement.V1/index.html) | 1.1.0 | [Service Management](https://cloud.google.com/service-infrastructure/docs/service-management/reference/rpc) |
 | [Google.Cloud.ServiceUsage.V1](Google.Cloud.ServiceUsage.V1/index.html) | 1.0.0-beta01 | [Service Usage](https://cloud.google.com/service-usage/docs/) |
 | [Google.Cloud.Shell.V1](Google.Cloud.Shell.V1/index.html) | 1.0.0-beta01 | [Cloud Shell](https://cloud.google.com/shell/) |


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
