### PR TITLE
Release Google.Cloud.Speech.V1 version 2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Spanner.Data](https://googleapis.dev/dotnet/Google.Cloud.Spanner.Data/3.8.0) | 3.8.0 | Google ADO.NET Provider for Google Cloud Spanner |
 | [Google.Cloud.Spanner.Common.V1](https://googleapis.dev/dotnet/Google.Cloud.Spanner.Common.V1/3.8.0) | 3.8.0 | Common resource names used by all Spanner V1 APIs |
 | [Google.Cloud.Spanner.V1](https://googleapis.dev/dotnet/Google.Cloud.Spanner.V1/3.8.0) | 3.8.0 | [Google Cloud Spanner](https://cloud.google.com/spanner/) |
-| [Google.Cloud.Speech.V1](https://googleapis.dev/dotnet/Google.Cloud.Speech.V1/2.1.0) | 2.1.0 | [Google Cloud Speech (V1 API)](https://cloud.google.com/speech) |
+| [Google.Cloud.Speech.V1](https://googleapis.dev/dotnet/Google.Cloud.Speech.V1/2.2.0) | 2.2.0 | [Google Cloud Speech (V1 API)](https://cloud.google.com/speech) |
 | [Google.Cloud.Speech.V1P1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Speech.V1P1Beta1/2.0.0-beta04) | 2.0.0-beta04 | [Google Cloud Speech (V1P1Beta1 API)](https://cloud.google.com/speech) |
 | [Google.Cloud.Storage.V1](https://googleapis.dev/dotnet/Google.Cloud.Storage.V1/3.4.0) | 3.4.0 | [Google Cloud Storage](https://cloud.google.com/storage/) |
 | [Google.Cloud.Talent.V4](https://googleapis.dev/dotnet/Google.Cloud.Talent.V4/1.0.0) | 1.0.0 | [Google Cloud Talent Solution (V4 API)](https://cloud.google.com/talent-solution/) |

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.csproj
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Speech API, which performs speech recognition.</Description>
@@ -11,9 +11,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Speech.V1/docs/history.md
+++ b/apis/Google.Cloud.Speech.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 2.2.0, released 2021-05-26
+
+No API surface changes; just dependency updates.
+
 # Version 2.1.0, released 2020-11-10
 
 - [Commit 0790924](https://github.com/googleapis/google-cloud-dotnet/commit/0790924): fix: Add gRPC compatibility constructors

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2201,7 +2201,7 @@
       "protoPath": "google/cloud/speech/v1",
       "productName": "Google Cloud Speech",
       "productUrl": "https://cloud.google.com/speech",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Speech API, which performs speech recognition.",
@@ -2209,9 +2209,9 @@
         "Speech"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.2.0",
-        "Google.LongRunning": "2.1.0",
-        "Grpc.Core": "2.31.0"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Google.LongRunning": "2.2.0",
+        "Grpc.Core": "2.36.4"
       }
     },
     {

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -131,7 +131,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Spanner.Data](Google.Cloud.Spanner.Data/index.html) | 3.8.0 | Google ADO.NET Provider for Google Cloud Spanner |
 | [Google.Cloud.Spanner.Common.V1](Google.Cloud.Spanner.Common.V1/index.html) | 3.8.0 | Common resource names used by all Spanner V1 APIs |
 | [Google.Cloud.Spanner.V1](Google.Cloud.Spanner.V1/index.html) | 3.8.0 | [Google Cloud Spanner](https://cloud.google.com/spanner/) |
-| [Google.Cloud.Speech.V1](Google.Cloud.Speech.V1/index.html) | 2.1.0 | [Google Cloud Speech (V1 API)](https://cloud.google.com/speech) |
+| [Google.Cloud.Speech.V1](Google.Cloud.Speech.V1/index.html) | 2.2.0 | [Google Cloud Speech (V1 API)](https://cloud.google.com/speech) |
 | [Google.Cloud.Speech.V1P1Beta1](Google.Cloud.Speech.V1P1Beta1/index.html) | 2.0.0-beta04 | [Google Cloud Speech (V1P1Beta1 API)](https://cloud.google.com/speech) |
 | [Google.Cloud.Storage.V1](Google.Cloud.Storage.V1/index.html) | 3.4.0 | [Google Cloud Storage](https://cloud.google.com/storage/) |
 | [Google.Cloud.Talent.V4](Google.Cloud.Talent.V4/index.html) | 1.0.0 | [Google Cloud Talent Solution (V4 API)](https://cloud.google.com/talent-solution/) |


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
