### PR TITLE
Release Google.Cloud.Storage.V1 version 3.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Spanner.V1](https://googleapis.dev/dotnet/Google.Cloud.Spanner.V1/3.8.0) | 3.8.0 | [Google Cloud Spanner](https://cloud.google.com/spanner/) |
 | [Google.Cloud.Speech.V1](https://googleapis.dev/dotnet/Google.Cloud.Speech.V1/2.2.0) | 2.2.0 | [Google Cloud Speech (V1 API)](https://cloud.google.com/speech) |
 | [Google.Cloud.Speech.V1P1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Speech.V1P1Beta1/2.0.0-beta04) | 2.0.0-beta04 | [Google Cloud Speech (V1P1Beta1 API)](https://cloud.google.com/speech) |
-| [Google.Cloud.Storage.V1](https://googleapis.dev/dotnet/Google.Cloud.Storage.V1/3.4.0) | 3.4.0 | [Google Cloud Storage](https://cloud.google.com/storage/) |
+| [Google.Cloud.Storage.V1](https://googleapis.dev/dotnet/Google.Cloud.Storage.V1/3.5.0) | 3.5.0 | [Google Cloud Storage](https://cloud.google.com/storage/) |
 | [Google.Cloud.Talent.V4](https://googleapis.dev/dotnet/Google.Cloud.Talent.V4/1.1.0) | 1.1.0 | [Google Cloud Talent Solution (V4 API)](https://cloud.google.com/talent-solution/) |
 | [Google.Cloud.Talent.V4Beta1](https://googleapis.dev/dotnet/Google.Cloud.Talent.V4Beta1/2.0.0-beta04) | 2.0.0-beta04 | [Google Cloud Talent Solution (V4Beta1 API)](https://cloud.google.com/talent-solution/) |
 | [Google.Cloud.Tasks.V2](https://googleapis.dev/dotnet/Google.Cloud.Tasks.V2/2.1.0) | 2.1.0 | [Google Cloud Tasks (V2 API)](https://cloud.google.com/tasks/) |

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/Google.Cloud.Storage.V1.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/Google.Cloud.Storage.V1.IntegrationTests.csproj
@@ -7,8 +7,8 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Google.Apis.Iam.v1" Version="[1.49.0.2151, 2.0.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Apis.Iam.v1" Version="[1.51.0.2330, 2.0.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\..\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1.csproj" />
     <ProjectReference Include="..\Google.Cloud.Storage.V1\Google.Cloud.Storage.V1.csproj" />

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Snippets/Google.Cloud.Storage.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Snippets/Google.Cloud.Storage.V1.Snippets.csproj
@@ -7,8 +7,8 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Google.Apis.Iam.v1" Version="[1.49.0.2151, 2.0.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Apis.Iam.v1" Version="[1.51.0.2330, 2.0.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\..\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1.csproj" />
     <ProjectReference Include="..\Google.Cloud.Storage.V1\Google.Cloud.Storage.V1.csproj" />

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/Google.Cloud.Storage.V1.Tests.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/Google.Cloud.Storage.V1.Tests.csproj
@@ -7,8 +7,8 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Google.Apis.Iam.v1" Version="[1.49.0.2151, 2.0.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Apis.Iam.v1" Version="[1.51.0.2330, 2.0.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\..\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1.csproj" />
     <ProjectReference Include="..\Google.Cloud.Storage.V1\Google.Cloud.Storage.V1.csproj" />

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.4.0</Version>
+    <Version>3.5.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Storage API. It wraps the Google.Apis.Storage.v1 client library, making common operations simpler in client code. Google Cloud Storage stores and retrieves potentially large, immutable data objects.</Description>
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Rest" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Google.Apis.Storage.v1" Version="[1.49.0.2151, 2.0.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Rest" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Apis.Storage.v1" Version="[1.51.0.2234, 2.0.0.0)" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Storage.V1/docs/history.md
+++ b/apis/Google.Cloud.Storage.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 3.5.0, released 2021-05-26
+
+No API surface changes; just dependency updates.
+
 # Version 3.4.0, released 2021-01-18
 
 - [Commit 421ad3f](https://github.com/googleapis/google-cloud-dotnet/commit/421ad3f): Update Google.Apis.Storage.v1 dependency.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2236,16 +2236,16 @@
       "id": "Google.Cloud.Storage.V1",
       "productName": "Google Cloud Storage",
       "productUrl": "https://cloud.google.com/storage/",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "type": "rest",
       "description": "Recommended Google client library to access the Google Cloud Storage API. It wraps the Google.Apis.Storage.v1 client library, making common operations simpler in client code. Google Cloud Storage stores and retrieves potentially large, immutable data objects.",
       "dependencies": {
-        "Google.Api.Gax.Rest": "3.2.0",
-        "Google.Apis.Storage.v1": "1.49.0.2151"
+        "Google.Api.Gax.Rest": "3.3.0",
+        "Google.Apis.Storage.v1": "1.51.0.2234"
       },
       "testDependencies": {
-        "Google.Api.Gax.Testing": "3.2.0",
-        "Google.Apis.Iam.v1": "1.49.0.2151",
+        "Google.Api.Gax.Testing": "3.3.0",
+        "Google.Apis.Iam.v1": "1.51.0.2330",
         "Google.Cloud.PubSub.V1": "project"
       },
       "tags": [

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -133,7 +133,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Spanner.V1](Google.Cloud.Spanner.V1/index.html) | 3.8.0 | [Google Cloud Spanner](https://cloud.google.com/spanner/) |
 | [Google.Cloud.Speech.V1](Google.Cloud.Speech.V1/index.html) | 2.2.0 | [Google Cloud Speech (V1 API)](https://cloud.google.com/speech) |
 | [Google.Cloud.Speech.V1P1Beta1](Google.Cloud.Speech.V1P1Beta1/index.html) | 2.0.0-beta04 | [Google Cloud Speech (V1P1Beta1 API)](https://cloud.google.com/speech) |
-| [Google.Cloud.Storage.V1](Google.Cloud.Storage.V1/index.html) | 3.4.0 | [Google Cloud Storage](https://cloud.google.com/storage/) |
+| [Google.Cloud.Storage.V1](Google.Cloud.Storage.V1/index.html) | 3.5.0 | [Google Cloud Storage](https://cloud.google.com/storage/) |
 | [Google.Cloud.Talent.V4](Google.Cloud.Talent.V4/index.html) | 1.1.0 | [Google Cloud Talent Solution (V4 API)](https://cloud.google.com/talent-solution/) |
 | [Google.Cloud.Talent.V4Beta1](Google.Cloud.Talent.V4Beta1/index.html) | 2.0.0-beta04 | [Google Cloud Talent Solution (V4Beta1 API)](https://cloud.google.com/talent-solution/) |
 | [Google.Cloud.Tasks.V2](Google.Cloud.Tasks.V2/index.html) | 2.1.0 | [Google Cloud Tasks (V2 API)](https://cloud.google.com/tasks/) |


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
