### PR TITLE
Release Google.Cloud.Trace.V1 version 2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Tasks.V2Beta3](https://googleapis.dev/dotnet/Google.Cloud.Tasks.V2Beta3/2.0.0-beta05) | 2.0.0-beta05 | [Google Cloud Tasks (V2Beta3 API)](https://cloud.google.com/tasks/) |
 | [Google.Cloud.TextToSpeech.V1](https://googleapis.dev/dotnet/Google.Cloud.TextToSpeech.V1/2.2.0) | 2.2.0 | [Google Cloud Text-to-Speech (V1 API)](https://cloud.google.com/text-to-speech) |
 | [Google.Cloud.TextToSpeech.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.TextToSpeech.V1Beta1/1.0.0-beta01) | 1.0.0-beta01 | [Google Cloud Text-to-Speech (V1Beta1 API)](https://cloud.google.com/text-to-speech) |
-| [Google.Cloud.Trace.V1](https://googleapis.dev/dotnet/Google.Cloud.Trace.V1/2.1.0) | 2.1.0 | [Google Cloud Trace (V1 API)](https://cloud.google.com/trace/) |
+| [Google.Cloud.Trace.V1](https://googleapis.dev/dotnet/Google.Cloud.Trace.V1/2.2.0) | 2.2.0 | [Google Cloud Trace (V1 API)](https://cloud.google.com/trace/) |
 | [Google.Cloud.Trace.V2](https://googleapis.dev/dotnet/Google.Cloud.Trace.V2/2.1.0) | 2.1.0 | [Google Cloud Trace (V2 API)](https://cloud.google.com/trace/) |
 | [Google.Cloud.Translate.V3](https://googleapis.dev/dotnet/Google.Cloud.Translate.V3/2.1.0) | 2.1.0 | [Google Cloud Translation (V3 API)](https://cloud.google.com/translate/) |
 | [Google.Cloud.Translation.V2](https://googleapis.dev/dotnet/Google.Cloud.Translation.V2/2.0.0) | 2.0.0 | [Google Cloud Translation (V2 API)](https://cloud.google.com/translate/) |

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.csproj
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Trace API, which sends and retrieves trace data from Google Cloud Trace. Data is generated and available by default for all App Engine applications. Data from other applications can be written to Cloud Trace for display, reporting, and analysis.</Description>
@@ -11,8 +11,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Trace.V1/docs/history.md
+++ b/apis/Google.Cloud.Trace.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 2.2.0, released 2021-05-26
+
+No API surface changes; just dependency updates.
+
 # Version 2.1.0, released 2020-11-11
 
 - [Commit 0790924](https://github.com/googleapis/google-cloud-dotnet/commit/0790924): fix: Add gRPC compatibility constructors

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2363,12 +2363,12 @@
       "protoPath": "google/devtools/cloudtrace/v1",
       "productName": "Google Cloud Trace",
       "productUrl": "https://cloud.google.com/trace/",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Trace API, which sends and retrieves trace data from Google Cloud Trace. Data is generated and available by default for all App Engine applications. Data from other applications can be written to Cloud Trace for display, reporting, and analysis.",
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.2.0",
-        "Grpc.Core": "2.31.0"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Grpc.Core": "2.36.4"
       },
       "tags": [
         "Tracing",

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -140,7 +140,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Tasks.V2Beta3](Google.Cloud.Tasks.V2Beta3/index.html) | 2.0.0-beta05 | [Google Cloud Tasks (V2Beta3 API)](https://cloud.google.com/tasks/) |
 | [Google.Cloud.TextToSpeech.V1](Google.Cloud.TextToSpeech.V1/index.html) | 2.2.0 | [Google Cloud Text-to-Speech (V1 API)](https://cloud.google.com/text-to-speech) |
 | [Google.Cloud.TextToSpeech.V1Beta1](Google.Cloud.TextToSpeech.V1Beta1/index.html) | 1.0.0-beta01 | [Google Cloud Text-to-Speech (V1Beta1 API)](https://cloud.google.com/text-to-speech) |
-| [Google.Cloud.Trace.V1](Google.Cloud.Trace.V1/index.html) | 2.1.0 | [Google Cloud Trace (V1 API)](https://cloud.google.com/trace/) |
+| [Google.Cloud.Trace.V1](Google.Cloud.Trace.V1/index.html) | 2.2.0 | [Google Cloud Trace (V1 API)](https://cloud.google.com/trace/) |
 | [Google.Cloud.Trace.V2](Google.Cloud.Trace.V2/index.html) | 2.1.0 | [Google Cloud Trace (V2 API)](https://cloud.google.com/trace/) |
 | [Google.Cloud.Translate.V3](Google.Cloud.Translate.V3/index.html) | 2.1.0 | [Google Cloud Translation (V3 API)](https://cloud.google.com/translate/) |
 | [Google.Cloud.Translation.V2](Google.Cloud.Translation.V2/index.html) | 2.0.0 | [Google Cloud Translation (V2 API)](https://cloud.google.com/translate/) |


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
