### PR TITLE
Release Google.Cloud.Video.Transcoder.V1Beta1 version 1.0.0-beta02

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Trace.V2](https://googleapis.dev/dotnet/Google.Cloud.Trace.V2/2.2.0) | 2.2.0 | [Google Cloud Trace (V2 API)](https://cloud.google.com/trace/) |
 | [Google.Cloud.Translate.V3](https://googleapis.dev/dotnet/Google.Cloud.Translate.V3/2.2.0) | 2.2.0 | [Google Cloud Translation (V3 API)](https://cloud.google.com/translate/) |
 | [Google.Cloud.Translation.V2](https://googleapis.dev/dotnet/Google.Cloud.Translation.V2/2.1.0) | 2.1.0 | [Google Cloud Translation (V2 API)](https://cloud.google.com/translate/) |
-| [Google.Cloud.Video.Transcoder.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Video.Transcoder.V1Beta1/1.0.0-beta01) | 1.0.0-beta01 | [Transcoder](https://cloud.google.com/transcoder/docs) |
+| [Google.Cloud.Video.Transcoder.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Video.Transcoder.V1Beta1/1.0.0-beta02) | 1.0.0-beta02 | [Transcoder](https://cloud.google.com/transcoder/docs) |
 | [Google.Cloud.VideoIntelligence.V1](https://googleapis.dev/dotnet/Google.Cloud.VideoIntelligence.V1/2.2.0) | 2.2.0 | [Google Cloud Video Intelligence](https://cloud.google.com/video-intelligence) |
 | [Google.Cloud.Vision.V1](https://googleapis.dev/dotnet/Google.Cloud.Vision.V1/2.3.0) | 2.3.0 | [Google Cloud Vision](https://cloud.google.com/vision) |
 | [Google.Cloud.VpcAccess.V1](https://googleapis.dev/dotnet/Google.Cloud.VpcAccess.V1/1.0.0-beta01) | 1.0.0-beta01 | [Serverless VPC Access](https://cloud.google.com/vpc/docs/) |

--- a/apis/Google.Cloud.Video.Transcoder.V1Beta1/Google.Cloud.Video.Transcoder.V1Beta1/Google.Cloud.Video.Transcoder.V1Beta1.csproj
+++ b/apis/Google.Cloud.Video.Transcoder.V1Beta1/Google.Cloud.Video.Transcoder.V1Beta1/Google.Cloud.Video.Transcoder.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Transcoder API version v1beta1, which converts video files into formats suitable for consumer distribution.</Description>

--- a/apis/Google.Cloud.Video.Transcoder.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.Video.Transcoder.V1Beta1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.0.0-beta02, released 2021-05-26
+
+No API surface changes; just dependency updates.
+
 # Version 1.0.0-beta01, released 2021-01-25
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2430,7 +2430,7 @@
     },
     {
       "id": "Google.Cloud.Video.Transcoder.V1Beta1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Transcoder",
       "productUrl": "https://cloud.google.com/transcoder/docs",

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -144,7 +144,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Trace.V2](Google.Cloud.Trace.V2/index.html) | 2.2.0 | [Google Cloud Trace (V2 API)](https://cloud.google.com/trace/) |
 | [Google.Cloud.Translate.V3](Google.Cloud.Translate.V3/index.html) | 2.2.0 | [Google Cloud Translation (V3 API)](https://cloud.google.com/translate/) |
 | [Google.Cloud.Translation.V2](Google.Cloud.Translation.V2/index.html) | 2.1.0 | [Google Cloud Translation (V2 API)](https://cloud.google.com/translate/) |
-| [Google.Cloud.Video.Transcoder.V1Beta1](Google.Cloud.Video.Transcoder.V1Beta1/index.html) | 1.0.0-beta01 | [Transcoder](https://cloud.google.com/transcoder/docs) |
+| [Google.Cloud.Video.Transcoder.V1Beta1](Google.Cloud.Video.Transcoder.V1Beta1/index.html) | 1.0.0-beta02 | [Transcoder](https://cloud.google.com/transcoder/docs) |
 | [Google.Cloud.VideoIntelligence.V1](Google.Cloud.VideoIntelligence.V1/index.html) | 2.2.0 | [Google Cloud Video Intelligence](https://cloud.google.com/video-intelligence) |
 | [Google.Cloud.Vision.V1](Google.Cloud.Vision.V1/index.html) | 2.3.0 | [Google Cloud Vision](https://cloud.google.com/vision) |
 | [Google.Cloud.VpcAccess.V1](Google.Cloud.VpcAccess.V1/index.html) | 1.0.0-beta01 | [Serverless VPC Access](https://cloud.google.com/vpc/docs/) |


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
