### PR TITLE
Release Google.Cloud.WebRisk.V1Beta1 version 2.0.0-beta04

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Vision.V1](https://googleapis.dev/dotnet/Google.Cloud.Vision.V1/2.3.0) | 2.3.0 | [Google Cloud Vision](https://cloud.google.com/vision) |
 | [Google.Cloud.VpcAccess.V1](https://googleapis.dev/dotnet/Google.Cloud.VpcAccess.V1/1.0.0-beta01) | 1.0.0-beta01 | [Serverless VPC Access](https://cloud.google.com/vpc/docs/) |
 | [Google.Cloud.WebRisk.V1](https://googleapis.dev/dotnet/Google.Cloud.WebRisk.V1/1.2.0) | 1.2.0 | [Google Cloud Web Risk (V1 API)](https://cloud.google.com/web-risk/) |
-| [Google.Cloud.WebRisk.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.WebRisk.V1Beta1/2.0.0-beta03) | 2.0.0-beta03 | [Google Cloud Web Risk (V1Beta1 API)](https://cloud.google.com/web-risk/) |
+| [Google.Cloud.WebRisk.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.WebRisk.V1Beta1/2.0.0-beta04) | 2.0.0-beta04 | [Google Cloud Web Risk (V1Beta1 API)](https://cloud.google.com/web-risk/) |
 | [Google.Cloud.WebSecurityScanner.V1](https://googleapis.dev/dotnet/Google.Cloud.WebSecurityScanner.V1/1.0.0) | 1.0.0 | [Web Security Scanner](https://cloud.google.com/security-command-center/docs/concepts-web-security-scanner-overview) |
 | [Google.Cloud.Workflows.Common.V1](https://googleapis.dev/dotnet/Google.Cloud.Workflows.Common.V1/1.0.0) | 1.0.0 | Common resource names used by all Workflows V1 APIs |
 | [Google.Cloud.Workflows.Common.V1Beta](https://googleapis.dev/dotnet/Google.Cloud.Workflows.Common.V1Beta/1.0.0-beta01) | 1.0.0-beta01 | Common resource names used by all Workflows V1Beta APIs |

--- a/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1.csproj
+++ b/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta03</Version>
+    <Version>2.0.0-beta04</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Web Risk API v1beta1.</Description>

--- a/apis/Google.Cloud.WebRisk.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.WebRisk.V1Beta1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 2.0.0-beta04, released 2021-05-26
+
+No API surface changes; just dependency updates.
+
 # Version 2.0.0-beta03, released 2020-11-18
 
 - [Commit 0ca05f5](https://github.com/googleapis/google-cloud-dotnet/commit/0ca05f5): chore: Regenerate all APIs using protoc 3.13 and Grpc.Tools 2.31

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2526,7 +2526,7 @@
       "protoPath": "google/cloud/webrisk/v1beta1",
       "productName": "Google Cloud Web Risk",
       "productUrl": "https://cloud.google.com/web-risk/",
-      "version": "2.0.0-beta03",
+      "version": "2.0.0-beta04",
       "releaseLevelOverride": "beta",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Web Risk API v1beta1.",

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -149,7 +149,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Vision.V1](Google.Cloud.Vision.V1/index.html) | 2.3.0 | [Google Cloud Vision](https://cloud.google.com/vision) |
 | [Google.Cloud.VpcAccess.V1](Google.Cloud.VpcAccess.V1/index.html) | 1.0.0-beta01 | [Serverless VPC Access](https://cloud.google.com/vpc/docs/) |
 | [Google.Cloud.WebRisk.V1](Google.Cloud.WebRisk.V1/index.html) | 1.2.0 | [Google Cloud Web Risk (V1 API)](https://cloud.google.com/web-risk/) |
-| [Google.Cloud.WebRisk.V1Beta1](Google.Cloud.WebRisk.V1Beta1/index.html) | 2.0.0-beta03 | [Google Cloud Web Risk (V1Beta1 API)](https://cloud.google.com/web-risk/) |
+| [Google.Cloud.WebRisk.V1Beta1](Google.Cloud.WebRisk.V1Beta1/index.html) | 2.0.0-beta04 | [Google Cloud Web Risk (V1Beta1 API)](https://cloud.google.com/web-risk/) |
 | [Google.Cloud.WebSecurityScanner.V1](Google.Cloud.WebSecurityScanner.V1/index.html) | 1.0.0 | [Web Security Scanner](https://cloud.google.com/security-command-center/docs/concepts-web-security-scanner-overview) |
 | [Google.Cloud.Workflows.Common.V1](Google.Cloud.Workflows.Common.V1/index.html) | 1.0.0 | Common resource names used by all Workflows V1 APIs |
 | [Google.Cloud.Workflows.Common.V1Beta](Google.Cloud.Workflows.Common.V1Beta/index.html) | 1.0.0-beta01 | Common resource names used by all Workflows V1Beta APIs |


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
