### PR TITLE
Release Google.Cloud.WebSecurityScanner.V1 version 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.VpcAccess.V1](https://googleapis.dev/dotnet/Google.Cloud.VpcAccess.V1/1.0.0-beta01) | 1.0.0-beta01 | [Serverless VPC Access](https://cloud.google.com/vpc/docs/) |
 | [Google.Cloud.WebRisk.V1](https://googleapis.dev/dotnet/Google.Cloud.WebRisk.V1/1.2.0) | 1.2.0 | [Google Cloud Web Risk (V1 API)](https://cloud.google.com/web-risk/) |
 | [Google.Cloud.WebRisk.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.WebRisk.V1Beta1/2.0.0-beta04) | 2.0.0-beta04 | [Google Cloud Web Risk (V1Beta1 API)](https://cloud.google.com/web-risk/) |
-| [Google.Cloud.WebSecurityScanner.V1](https://googleapis.dev/dotnet/Google.Cloud.WebSecurityScanner.V1/1.0.0) | 1.0.0 | [Web Security Scanner](https://cloud.google.com/security-command-center/docs/concepts-web-security-scanner-overview) |
+| [Google.Cloud.WebSecurityScanner.V1](https://googleapis.dev/dotnet/Google.Cloud.WebSecurityScanner.V1/1.1.0) | 1.1.0 | [Web Security Scanner](https://cloud.google.com/security-command-center/docs/concepts-web-security-scanner-overview) |
 | [Google.Cloud.Workflows.Common.V1](https://googleapis.dev/dotnet/Google.Cloud.Workflows.Common.V1/1.0.0) | 1.0.0 | Common resource names used by all Workflows V1 APIs |
 | [Google.Cloud.Workflows.Common.V1Beta](https://googleapis.dev/dotnet/Google.Cloud.Workflows.Common.V1Beta/1.0.0-beta01) | 1.0.0-beta01 | Common resource names used by all Workflows V1Beta APIs |
 | [Google.Cloud.Workflows.Executions.V1](https://googleapis.dev/dotnet/Google.Cloud.Workflows.Executions.V1/1.0.0) | 1.0.0 | [Workflow Executions (V1 API)](https://cloud.google.com/workflows/docs/apis) |

--- a/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.csproj
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Web Security Scanner API, which scans your Compute and App Engine apps for common web vulnerabilities.</Description>
@@ -11,8 +11,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.WebSecurityScanner.V1/docs/history.md
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.1.0, released 2021-05-26
+
+No API surface changes; just dependency updates.
+
 # Version 1.0.0, released 2021-01-20
 
 No API changes since 1.0.0-beta01.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2541,7 +2541,7 @@
     },
     {
       "id": "Google.Cloud.WebSecurityScanner.V1",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "grpc",
       "productName": "Web Security Scanner",
       "productUrl": "https://cloud.google.com/security-command-center/docs/concepts-web-security-scanner-overview",
@@ -2551,8 +2551,8 @@
         "scanner"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.2.0",
-        "Grpc.Core": "2.31.0"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Grpc.Core": "2.36.4"
       },
       "generator": "micro",
       "protoPath": "google/cloud/websecurityscanner/v1"

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -150,7 +150,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.VpcAccess.V1](Google.Cloud.VpcAccess.V1/index.html) | 1.0.0-beta01 | [Serverless VPC Access](https://cloud.google.com/vpc/docs/) |
 | [Google.Cloud.WebRisk.V1](Google.Cloud.WebRisk.V1/index.html) | 1.2.0 | [Google Cloud Web Risk (V1 API)](https://cloud.google.com/web-risk/) |
 | [Google.Cloud.WebRisk.V1Beta1](Google.Cloud.WebRisk.V1Beta1/index.html) | 2.0.0-beta04 | [Google Cloud Web Risk (V1Beta1 API)](https://cloud.google.com/web-risk/) |
-| [Google.Cloud.WebSecurityScanner.V1](Google.Cloud.WebSecurityScanner.V1/index.html) | 1.0.0 | [Web Security Scanner](https://cloud.google.com/security-command-center/docs/concepts-web-security-scanner-overview) |
+| [Google.Cloud.WebSecurityScanner.V1](Google.Cloud.WebSecurityScanner.V1/index.html) | 1.1.0 | [Web Security Scanner](https://cloud.google.com/security-command-center/docs/concepts-web-security-scanner-overview) |
 | [Google.Cloud.Workflows.Common.V1](Google.Cloud.Workflows.Common.V1/index.html) | 1.0.0 | Common resource names used by all Workflows V1 APIs |
 | [Google.Cloud.Workflows.Common.V1Beta](Google.Cloud.Workflows.Common.V1Beta/index.html) | 1.0.0-beta01 | Common resource names used by all Workflows V1Beta APIs |
 | [Google.Cloud.Workflows.Executions.V1](Google.Cloud.Workflows.Executions.V1/index.html) | 1.0.0 | [Workflow Executions (V1 API)](https://cloud.google.com/workflows/docs/apis) |


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
