### PR TITLE
Release Workflows V1Beta libraries version 1.0.0-beta02

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,11 +147,11 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.WebRisk.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.WebRisk.V1Beta1/2.0.0-beta04) | 2.0.0-beta04 | [Google Cloud Web Risk (V1Beta1 API)](https://cloud.google.com/web-risk/) |
 | [Google.Cloud.WebSecurityScanner.V1](https://googleapis.dev/dotnet/Google.Cloud.WebSecurityScanner.V1/1.1.0) | 1.1.0 | [Web Security Scanner](https://cloud.google.com/security-command-center/docs/concepts-web-security-scanner-overview) |
 | [Google.Cloud.Workflows.Common.V1](https://googleapis.dev/dotnet/Google.Cloud.Workflows.Common.V1/1.0.0) | 1.0.0 | Common resource names used by all Workflows V1 APIs |
-| [Google.Cloud.Workflows.Common.V1Beta](https://googleapis.dev/dotnet/Google.Cloud.Workflows.Common.V1Beta/1.0.0-beta01) | 1.0.0-beta01 | Common resource names used by all Workflows V1Beta APIs |
+| [Google.Cloud.Workflows.Common.V1Beta](https://googleapis.dev/dotnet/Google.Cloud.Workflows.Common.V1Beta/1.0.0-beta02) | 1.0.0-beta02 | Common resource names used by all Workflows V1Beta APIs |
 | [Google.Cloud.Workflows.Executions.V1](https://googleapis.dev/dotnet/Google.Cloud.Workflows.Executions.V1/1.0.0) | 1.0.0 | [Workflow Executions (V1 API)](https://cloud.google.com/workflows/docs/apis) |
-| [Google.Cloud.Workflows.Executions.V1Beta](https://googleapis.dev/dotnet/Google.Cloud.Workflows.Executions.V1Beta/1.0.0-beta01) | 1.0.0-beta01 | [Workflow Executions (V1Beta API)](https://cloud.google.com/workflows/docs/apis) |
+| [Google.Cloud.Workflows.Executions.V1Beta](https://googleapis.dev/dotnet/Google.Cloud.Workflows.Executions.V1Beta/1.0.0-beta02) | 1.0.0-beta02 | [Workflow Executions (V1Beta API)](https://cloud.google.com/workflows/docs/apis) |
 | [Google.Cloud.Workflows.V1](https://googleapis.dev/dotnet/Google.Cloud.Workflows.V1/1.0.0) | 1.0.0 | [Workflows (V1 API)](https://cloud.google.com/workflows/docs/apis) |
-| [Google.Cloud.Workflows.V1Beta](https://googleapis.dev/dotnet/Google.Cloud.Workflows.V1Beta/1.0.0-beta01) | 1.0.0-beta01 | [Workflows (V1Beta API)](https://cloud.google.com/workflows/docs/apis) |
+| [Google.Cloud.Workflows.V1Beta](https://googleapis.dev/dotnet/Google.Cloud.Workflows.V1Beta/1.0.0-beta02) | 1.0.0-beta02 | [Workflows (V1Beta API)](https://cloud.google.com/workflows/docs/apis) |
 | [Google.Identity.AccessContextManager.Type](https://googleapis.dev/dotnet/Google.Identity.AccessContextManager.Type/1.0.0) | 1.0.0 | Version-agnostic types for the Google Identity Access Context Manager API |
 | [Google.Identity.AccessContextManager.V1](https://googleapis.dev/dotnet/Google.Identity.AccessContextManager.V1/1.1.0) | 1.1.0 | Protocol buffer types for the Google Identity Access Context Manager API V1 |
 | [Google.LongRunning](https://googleapis.dev/dotnet/Google.LongRunning/2.2.0) | 2.2.0 | Support for the Long-Running Operations API pattern |

--- a/apis/Google.Cloud.Workflows.Common.V1Beta/Google.Cloud.Workflows.Common.V1Beta/Google.Cloud.Workflows.Common.V1Beta.csproj
+++ b/apis/Google.Cloud.Workflows.Common.V1Beta/Google.Cloud.Workflows.Common.V1Beta/Google.Cloud.Workflows.Common.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Common resource names used by all Workflows V1Beta APIs</Description>
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax" Version="[3.3.0, 4.0.0)" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.csproj
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Workflow Executions API v1beta, used to manage user-provided workflows.</Description>

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/docs/history.md
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.0.0-beta02, released 2021-05-26
+
+No API surface changes; just dependency updates.
+
 # Version 1.0.0-beta01, released 2020-10-14
 
 Initial beta release.

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.csproj
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Workflows API v1beta.</Description>
@@ -13,7 +13,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.Workflows.Common.V1Beta\Google.Cloud.Workflows.Common.V1Beta\Google.Cloud.Workflows.Common.V1Beta.csproj" />
-    <PackageReference Include="Google.LongRunning" Version="[2.0.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />

--- a/apis/Google.Cloud.Workflows.V1Beta/docs/history.md
+++ b/apis/Google.Cloud.Workflows.V1Beta/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.0.0-beta02, released 2021-05-26
+
+No API surface changes; just dependency updates.
+
 # Version 1.0.0-beta01, released 2020-10-14
 
 Initial beta release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2575,13 +2575,13 @@
       "id": "Google.Cloud.Workflows.Common.V1Beta",
       "type": "other",
       "targetFrameworks": "netstandard2.0;net461",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "description": "Common resource names used by all Workflows V1Beta APIs",
       "tags": [
         "Spanner"
       ],
       "dependencies": {
-        "Google.Api.Gax": "3.2.0"
+        "Google.Api.Gax": "3.3.0"
       },
       "noVersionHistory": true
     },
@@ -2606,7 +2606,7 @@
     },
     {
       "id": "Google.Cloud.Workflows.Executions.V1Beta",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "commonResourcesConfig": "apis/Google.Cloud.Workflows.Common.V1Beta/CommonResourcesConfig.json",
       "type": "grpc",
       "productName": "Workflow Executions",
@@ -2643,7 +2643,7 @@
     },
     {
       "id": "Google.Cloud.Workflows.V1Beta",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "commonResourcesConfig": "apis/Google.Cloud.Workflows.Common.V1Beta/CommonResourcesConfig.json",
       "type": "grpc",
       "productName": "Workflows",
@@ -2654,7 +2654,7 @@
       ],
       "dependencies": {
         "Google.Cloud.Workflows.Common.V1Beta": "project",
-        "Google.LongRunning": "2.0.0"
+        "Google.LongRunning": "2.2.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/workflows/v1beta"

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -152,11 +152,11 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.WebRisk.V1Beta1](Google.Cloud.WebRisk.V1Beta1/index.html) | 2.0.0-beta04 | [Google Cloud Web Risk (V1Beta1 API)](https://cloud.google.com/web-risk/) |
 | [Google.Cloud.WebSecurityScanner.V1](Google.Cloud.WebSecurityScanner.V1/index.html) | 1.1.0 | [Web Security Scanner](https://cloud.google.com/security-command-center/docs/concepts-web-security-scanner-overview) |
 | [Google.Cloud.Workflows.Common.V1](Google.Cloud.Workflows.Common.V1/index.html) | 1.0.0 | Common resource names used by all Workflows V1 APIs |
-| [Google.Cloud.Workflows.Common.V1Beta](Google.Cloud.Workflows.Common.V1Beta/index.html) | 1.0.0-beta01 | Common resource names used by all Workflows V1Beta APIs |
+| [Google.Cloud.Workflows.Common.V1Beta](Google.Cloud.Workflows.Common.V1Beta/index.html) | 1.0.0-beta02 | Common resource names used by all Workflows V1Beta APIs |
 | [Google.Cloud.Workflows.Executions.V1](Google.Cloud.Workflows.Executions.V1/index.html) | 1.0.0 | [Workflow Executions (V1 API)](https://cloud.google.com/workflows/docs/apis) |
-| [Google.Cloud.Workflows.Executions.V1Beta](Google.Cloud.Workflows.Executions.V1Beta/index.html) | 1.0.0-beta01 | [Workflow Executions (V1Beta API)](https://cloud.google.com/workflows/docs/apis) |
+| [Google.Cloud.Workflows.Executions.V1Beta](Google.Cloud.Workflows.Executions.V1Beta/index.html) | 1.0.0-beta02 | [Workflow Executions (V1Beta API)](https://cloud.google.com/workflows/docs/apis) |
 | [Google.Cloud.Workflows.V1](Google.Cloud.Workflows.V1/index.html) | 1.0.0 | [Workflows (V1 API)](https://cloud.google.com/workflows/docs/apis) |
-| [Google.Cloud.Workflows.V1Beta](Google.Cloud.Workflows.V1Beta/index.html) | 1.0.0-beta01 | [Workflows (V1Beta API)](https://cloud.google.com/workflows/docs/apis) |
+| [Google.Cloud.Workflows.V1Beta](Google.Cloud.Workflows.V1Beta/index.html) | 1.0.0-beta02 | [Workflows (V1Beta API)](https://cloud.google.com/workflows/docs/apis) |
 | [Google.Identity.AccessContextManager.Type](Google.Identity.AccessContextManager.Type/index.html) | 1.0.0 | Version-agnostic types for the Google Identity Access Context Manager API |
 | [Google.Identity.AccessContextManager.V1](Google.Identity.AccessContextManager.V1/index.html) | 1.1.0 | Protocol buffer types for the Google Identity Access Context Manager API V1 |
 | [Google.LongRunning](Google.LongRunning/index.html) | 2.2.0 | Support for the Long-Running Operations API pattern |


### PR DESCRIPTION

Changes in Google.Cloud.Workflows.Executions.V1Beta version 1.0.0-beta02:

No API surface changes; just dependency updates.

Changes in Google.Cloud.Workflows.V1Beta version 1.0.0-beta02:

No API surface changes; just dependency updates.

Packages in this release:
- Release Google.Cloud.Workflows.Common.V1Beta version 1.0.0-beta02
- Release Google.Cloud.Workflows.Executions.V1Beta version 1.0.0-beta02
- Release Google.Cloud.Workflows.V1Beta version 1.0.0-beta02
