### PR TITLE
Decouples Diagnostics from Google trace header.

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests.csproj
@@ -19,6 +19,7 @@
     <ProjectReference Include="..\..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.Tests\Google.Cloud.Diagnostics.Common.Tests.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Moq" Version="4.12.0" />

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/TestServerHelpers.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/TestServerHelpers.cs
@@ -94,8 +94,8 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
 
         public static TestServer GetTestServer(IWebHostBuilder hostBuilder) => new TestServer(hostBuilder);
 
-        public static TestServer GetTestServer<TStartup>() where TStartup : class =>
-            GetTestServer(GetHostBuilder<TStartup>());
+        public static TestServer GetTestServer<TStartup>(Action<IWebHostBuilder> configure = null) where TStartup : class =>
+            GetTestServer(GetHostBuilder<TStartup>(configure));
 
         public static IServiceProvider GetServices(TestServer server) => server.Host.Services;
 

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/Google.Cloud.Diagnostics.AspNetCore.Snippets.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/Google.Cloud.Diagnostics.AspNetCore.Snippets.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.Tests\Google.Cloud.Diagnostics.Common.Tests.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Moq" Version="4.12.0" />

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/StandaloneTraceSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/StandaloneTraceSnippets.cs
@@ -1,0 +1,109 @@
+﻿// Copyright 2021 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.ClientTesting;
+using Google.Cloud.Diagnostics.Common;
+using Google.Cloud.Diagnostics.Common.IntegrationTests;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
+{
+    public class StandaloneTraceSnippets
+    {
+        private static readonly string ProjectId = TestEnvironment.GetTestProjectId();
+
+        private static readonly TraceEntryPolling s_polling = new TraceEntryPolling();
+
+        private readonly string _testId;
+
+        private readonly Timestamp _startTime;
+
+        public StandaloneTraceSnippets()
+        {
+            _testId = IdGenerator.FromDateTime();
+            _startTime = Timestamp.FromDateTime(DateTime.UtcNow);
+
+            // The rate limiter instance is static and only set once.  If we do not reset it at the
+            // beginning of each tests the qps will not change.  This is dependent on the tests not
+            // running in parallel.
+            RateLimiter.Reset();
+        }
+
+        // Sample: Configure
+        public static IHostBuilder CreateHostBuilder() =>
+            Host.CreateDefaultBuilder()
+                .ConfigureServices(services =>
+                {
+                    services.AddGoogleTrace(options => options.ProjectId = ProjectId);
+                    // Register other services here if you need them.
+                });
+        // End sample
+
+        [Fact]
+        public async Task TraceAsync()
+        {
+            // Naming it like an instance variable so that it looks like that on sample code.
+            IHost _host = null;
+
+            try
+            {
+                // Sample: Start
+                _host = CreateHostBuilder().Build();
+                await _host.StartAsync();
+                // End sample
+
+                // Sample: IncomingContext
+                ITraceContext traceContext = GetTraceContextFromIncomingRequest();
+                var tracerFactory = _host.Services.GetRequiredService<Func<ITraceContext, IManagedTracer>>();
+                IManagedTracer tracer = tracerFactory(traceContext);
+                ContextTracerManager.SetCurrentTracer(tracer);
+                // End sample
+
+                // Let's just start a span with the test ID so we can find it faster.
+                // But we don't show this in sample code.
+                using (tracer.StartSpan(_testId))
+                {
+                    // Sample: Trace
+                    IManagedTracer currentTracer = _host.Services.GetRequiredService<IManagedTracer>();
+                    using (currentTracer.StartSpan("standalone_tracing"))
+                    {
+                        Console.WriteLine("Using Cloud Trace from a non ASP.NET Core app");
+                    }
+                    // End sample
+                }
+
+                var trace = s_polling.GetTrace(_testId, _startTime);
+                TraceEntryVerifiers.AssertParentChildSpan(trace, _testId, "standalone_tracing");
+                Assert.Equal(traceContext.TraceId, trace.TraceId);
+            }
+            finally
+            {
+                if (_host != null)
+                {
+                    await _host.StopAsync();
+                }
+            }
+        }
+
+        private static ITraceContext GetTraceContextFromIncomingRequest() =>
+            new SimpleTraceContext(TraceIdFactory.Create().NextId(), null, true);
+    }
+}
+
+

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/TraceSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/TraceSnippets.cs
@@ -17,6 +17,7 @@ using Google.Cloud.Diagnostics.Common;
 using Google.Cloud.Diagnostics.Common.IntegrationTests;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
@@ -151,6 +152,31 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
             Assert.False(response.Headers.Contains(TraceHeaderContext.TraceHeader));
         }
 
+        [Fact]
+        public async Task Traces_CustomTraceContext()
+        {
+            var uri = $"/TraceSamples/{nameof(TraceSamplesController.TraceHelloWorld)}/{_testId}";
+            var traceId = TraceIdFactory.Create().NextId();
+
+            using var server = GetTestServer<CustomTraceContextTestApplication.Startup>();
+            using var client = server.CreateClient();
+            var request = new HttpRequestMessage(HttpMethod.Get, uri)
+            {
+                Headers = { { "custom_trace_id", traceId } }
+            };
+            var response = await client.SendAsync(request);
+
+            var trace = s_polling.GetTrace(uri, _startTime);
+
+            TraceEntryVerifiers.AssertParentChildSpan(trace, uri, _testId);
+            TraceEntryVerifiers.AssertSpanLabelsContains(
+                trace.Spans.First(s => s.Name == uri), TraceEntryData.HttpGetSuccessLabels);
+            Assert.False(response.Headers.Contains(TraceHeaderContext.TraceHeader));
+
+            Assert.Equal(traceId, trace.TraceId);
+            Assert.True(response.Headers.Contains("custom_trace_id"));
+        }
+
         private void Troubleshooting()
         {
             // Not a test - just a sample.
@@ -201,9 +227,6 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
         // Sample: RegisterGoogleTracer
         public void ConfigureServices(IServiceCollection services)
         {
-            // The line below is needed for trace ids to be added to logs.
-            services.AddHttpContextAccessor();
-
             // Replace ProjectId with your Google Cloud Project ID.
             services.AddGoogleTrace(options =>
             {
@@ -273,14 +296,110 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
         // Sample: ConfigureHttpClient
         public void ConfigureServices(IServiceCollection services)
         {
-            // The line below is needed for trace ids to be added to logs.
-            services.AddHttpContextAccessor();
+            // Replace ProjectId with your Google Cloud Project ID.
+            services.AddGoogleTrace(options =>
+            {
+                options.ProjectId = ProjectId;
+            });
+
+            // Register an HttpClient for outgoing requests.
+            services.AddHttpClient("tracesOutgoing")
+                // The next call guarantees that trace information is propagated for outgoing
+                // requests that are already being traced.
+                .AddOutgoingGoogleTraceHandler();
+
+            // Add any other services your application requires, for instance,
+            // depending on the version of ASP.NET Core you are using, you may
+            // need one of the following:
+
+            // services.AddMvc();
+
+            // services.AddControllersWithViews();
+        }
+
+        public void Configure(IApplicationBuilder app)
+        {
+            // Use at the start of the request pipeline to ensure the entire request is traced.
+            app.UseGoogleTrace();
+
+            // Add any other configuration your application requires, for instance,
+            // depending on the verson of ASP.NET Core you are using, you may
+            // need one of the following:
+
+            //app.UseMvc(routes =>
+            //{
+            //    routes.MapRoute(
+            //        name: "default",
+            //        template: "{controller=Home}/{action=Index}/{id?}");
+            //});
+
+            //app.UseRouting();
+            //app.UseEndpoints(endpoints =>
+            //{
+            //    endpoints.MapControllerRoute(
+            //        name: "default",
+            //        pattern: "{controller=Home}/{action=Index}/{id?}");
+            //    endpoints.MapRazorPages();
+            //});
+        }
+        // End sample
+    }
+
+    internal class CustomTraceContextTestApplication
+    {
+        private static readonly string ProjectId = TestEnvironment.GetTestProjectId();
+
+        // To hide some implementation details from the
+        // sample code, like how we are overriding the methods.
+        internal class Startup : BaseStartup
+        {
+            private readonly CustomTraceContextTestApplication application = new CustomTraceContextTestApplication();
+
+            public override void ConfigureServices(IServiceCollection services)
+            {
+                application.ConfigureServices(services);
+                base.ConfigureServices(services);
+            }
+
+            public override void Configure(IApplicationBuilder app, ILoggerFactory loggerFactory)
+            {
+                application.Configure(app);
+                base.Configure(app, loggerFactory);
+            }
+        }
+
+        // Sample: CustomTraceContext
+        public void ConfigureServices(IServiceCollection services)
+        {
+            // Register a trace context provider method that inspects the request and
+            // extracts the trace context information.
+            services.AddScoped(CustomTraceContextProvider);
+            static ITraceContext CustomTraceContextProvider(IServiceProvider sp)
+            {
+                var accessor = sp.GetRequiredService<IHttpContextAccessor>();
+                string traceId = accessor.HttpContext?.Request?.Headers["custom_trace_id"];
+                return new SimpleTraceContext(traceId, null, null);
+            }
+
+            // Register a method that sets the updated trace context information on the response.
+            services.AddSingleton<Action<HttpResponse, ITraceContext>>(
+                (response, traceContext) => response.Headers.Add("custom_trace_id", traceContext.TraceId));
+
+            // Now you can register Google Trace normally.
 
             // Replace ProjectId with your Google Cloud Project ID.
             services.AddGoogleTrace(options =>
             {
                 options.ProjectId = ProjectId;
             });
+
+            // If your application is making outgoing HTTP requests then you configure
+            // your HTTP client for trace propagation as you normally would.
+            // If the trace context information should be propagated in a custom format
+            // then you register a method that sets the trace context information on the
+            // outgoing request.
+            services.AddSingleton<Action<HttpRequestMessage, ITraceContext>>(
+                (request, traceContext) => request.Headers.Add("custom_trace_id", traceContext.TraceId));
 
             // Register an HttpClient for outgoing requests.
             services.AddHttpClient("tracesOutgoing")

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Google.Cloud.Diagnostics.AspNetCore.Tests.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Google.Cloud.Diagnostics.AspNetCore.Tests.csproj
@@ -14,6 +14,7 @@
     <ProjectReference Include="..\..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.Tests\Google.Cloud.Diagnostics.Common.Tests.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Moq" Version="4.12.0" />

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Trace/CloudTraceExtensionTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Trace/CloudTraceExtensionTest.cs
@@ -45,8 +45,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Tests
             var request = context.Request;
             request.Headers[TraceHeaderContext.TraceHeader] = traceHeader;
 
-            var accessor = new HttpContextAccessor();
-            accessor.HttpContext = context;
+            var accessor = new HttpContextAccessor { HttpContext = context };
 
             var traceIdFactory = TraceIdFactory.Create();
 
@@ -63,16 +62,16 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Tests
         {
             var header = $"{_traceId}/{_spanId};o=1";
             var provider = CreateProviderForTraceHeaderContext(header);
-            var headerContext = CloudTraceExtension.CreateTraceHeaderContext(provider);
+            var headerContext = CloudTraceExtension.ProvideGoogleTraceHeaderContext(provider);
             Assert.Equal(TraceHeaderContext.FromHeader(header).ToString(), headerContext.ToString());
         }
 
         [Fact]
-        public void CreateTraceHeaderContext_UseBackUpFunc()
+        public void CreateTraceHeaderContext_UseShouldTraceFallback()
         {
             var header = $"{_traceId}/{_spanId};";
             var provider = CreateProviderForTraceHeaderContext(header);
-            var headerContext = CloudTraceExtension.CreateTraceHeaderContext(provider);
+            var headerContext = CloudTraceExtension.ProvideGoogleTraceHeaderContext(provider);
             Assert.Equal(TraceHeaderContext.FromHeader(header).ToString(), headerContext.ToString());
         }
 

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/docs/index.md
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/docs/index.md
@@ -247,3 +247,34 @@ that is propagated in a `custom_trace_id` header. This is of no use in the real 
 
 {{sample:Trace.CustomTraceContext}}
 
+## Using Google Trace in applications not based in ASP.NET Core
+
+If you want to use Google Cloud Trace in applications not based on ASP.NET Core you may use the
+`Google.Cloud.Diagnostics.Common` package directly and .NET's dependency injection mechanism.
+You can read more about .NET dependency injection in non ASP.NET Core apps in the
+[Microsoft documentation](https://docs.microsoft.com/en-us/dotnet/core/extensions/dependency-injection-usage).
+
+Note that this is useful for both installed applications and services that process incoming messages
+other than HTTP requests, such as a service reacting to Pub/Sub messages.
+
+Following you'll see a very simplified example of how you could set up Google Cloud Trace for these
+types of applications.
+
+- Configure Google Cloud Trace. You can set tracing options the same as you would do for ASP.NET Core apps.
+
+{{sample:StandaloneTrace.Configure}}
+
+- Build and start a `Microsoft.Extensions.Hosting.IHost`.
+
+{{sample:StandaloneTrace.Start}}
+
+- Create a tracing context when appropiate, for instance, when you receive a Pub/Sub message. You can create
+an empty tracing context (with all null values) if there's none. The tracer will create a tracing context
+depending on configuration options like QPS, etc.
+
+{{sample:StandaloneTrace.IncomingContext}}
+
+- Trace normally in your code
+
+{{sample:StandaloneTrace.Trace}}
+

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Trace/ManagedTracerFactoryTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Trace/ManagedTracerFactoryTest.cs
@@ -14,7 +14,6 @@
 
 using Moq;
 using Xunit;
-
 using TraceProto = Google.Cloud.Trace.V1.Trace;
 
 namespace Google.Cloud.Diagnostics.Common.Tests
@@ -32,13 +31,13 @@ namespace Google.Cloud.Diagnostics.Common.Tests
         private static readonly IConsumer<TraceProto> s_comsumer = new Mock<IConsumer<TraceProto>>().Object;
 
         /// <summary>A trace header that will say to trace.</summary>
-        private static readonly TraceHeaderContext s_headerTrue = TraceHeaderContext.Create(TraceId, SpanId, true);
+        private static readonly ITraceContext s_headerTrue = new SimpleTraceContext(TraceId, SpanId, true);
 
         /// <summary>A trace header that will have no information about whether to trace or not.</summary>
-        private static readonly TraceHeaderContext s_headerNull = TraceHeaderContext.Create(null, null, null);
+        private static readonly ITraceContext s_headerNull = new SimpleTraceContext(null, null, null);
 
         /// <summary>A trace header that will say not to trace.</summary>
-        private static readonly TraceHeaderContext s_headerFalse = TraceHeaderContext.Create(null, null, false);
+        private static readonly ITraceContext s_headerFalse = new SimpleTraceContext(null, null, false);
 
         /// <summary>A managed tracer factory that has an option factory that will always suggest trace.</summary>
         private static readonly ManagedTracerFactory s_tracerFactoryNoLimit = CreateFactory(TraceOptionsFactory.AlwaysTrace);

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/CloudTraceExtensions.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/CloudTraceExtensions.cs
@@ -1,0 +1,67 @@
+﻿// Copyright 2021 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using Google.Cloud.Trace.V1;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Net.Http;
+
+namespace Google.Cloud.Diagnostics.Common
+{
+    /// <summary>
+    /// Extension methods for registering Google Cloud Trace for
+    /// dependency injection.
+    /// </summary>
+    public static class CloudTraceExtensions
+    {
+        /// <summary>
+        /// Configures Google Cloud Trace for dependency injection.
+        /// </summary>
+        public static IServiceCollection AddGoogleTrace(
+            this IServiceCollection services, Action<TraceServiceOptions> setupAction)
+        {
+            GaxPreconditions.CheckNotNull(services, nameof(services));
+            GaxPreconditions.CheckNotNull(setupAction, nameof(setupAction));
+
+            var serviceOptions = new TraceServiceOptions();
+            setupAction(serviceOptions);
+
+            var client = serviceOptions.Client ?? TraceServiceClient.Create();
+            var options = serviceOptions.Options ?? TraceOptions.Create();
+            var projectId = Project.GetAndCheckProjectId(serviceOptions.ProjectId);
+
+            var consumer = ManagedTracer.CreateConsumer(client, options);
+            var tracerFactory = ManagedTracer.CreateFactory(projectId, consumer, options);
+
+            services.AddSingleton(tracerFactory);
+            services.AddSingleton(ManagedTracer.CreateDelegatingTracer(ContextTracerManager.GetCurrentTracer));
+
+            // On .Net Standard 2.0 or higher, we can use the System.Net.Http.IHttpClientFactory defined in Microsoft.Extensions.Http,
+            // for which we need a DelegatingHandler with no InnerHandler set. This is the recommended way.
+            // It should be registered as follows.
+            return services.AddTransient(UnchainedTraceHeaderPropagatingHandlerFactory);
+        }
+
+        /// <summary>
+        /// Returns an <see cref="UnchainedTraceHeaderPropagatingHandler"/> configured with the user specified trace context 
+        /// outgoing propagator. If user code has not specified a trace context outgoing propagator, the Google header will
+        /// be propagated.
+        /// </summary>
+        internal static UnchainedTraceHeaderPropagatingHandler UnchainedTraceHeaderPropagatingHandlerFactory(IServiceProvider serviceProvider) =>
+            serviceProvider.GetService<Action<HttpRequestMessage, ITraceContext>>() is Action<HttpRequestMessage, ITraceContext> traceContextOutgoingPropagator ?
+                new UnchainedTraceHeaderPropagatingHandler(ContextTracerManager.GetCurrentTracer, traceContextOutgoingPropagator) :
+                new UnchainedTraceHeaderPropagatingHandler(ContextTracerManager.GetCurrentTracer);
+    }
+}

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/ContextTracerManager.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/ContextTracerManager.cs
@@ -43,5 +43,12 @@ namespace Google.Cloud.Diagnostics.Common
         {
             return CurrentTracer ?? NullManagedTracer.Instance;
         }
+
+        /// <summary>
+        /// Gets the current <see cref="ITraceContext"/> as defined by the <see cref="GetCurrentTracer"/>
+        /// or null if the current trace context is not known at the time.
+        /// </summary>
+        public static ITraceContext GetCurrentTraceContext() =>
+            SimpleTraceContext.FromTracer(GetCurrentTracer());
     }
 }

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/ITraceContext.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/ITraceContext.cs
@@ -1,0 +1,45 @@
+﻿// Copyright 2021 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Google.Cloud.Diagnostics.Common
+{
+    /// <summary>
+    /// A trace context.
+    /// </summary>
+    public interface ITraceContext
+    {
+        /// <summary>The trace id or null if none is available.</summary>
+        /// <remarks>
+        /// This corresponds to the trace_id field of the Trace message in the API.
+        /// See https://cloud.google.com/trace/docs/reference/v2/rpc/google.devtools.cloudtrace.v1#trace
+        /// for more information.
+        /// </remarks>
+        string TraceId { get; }
+
+        /// <summary>The span id or null if none is available.</summary>
+        /// <remarks>
+        /// This corresponds to the span_id field of the TraceSpan message in the API.
+        /// See https://cloud.google.com/trace/docs/reference/v2/rpc/google.devtools.cloudtrace.v1#tracespan
+        /// for more information.
+        /// </remarks>
+        ulong? SpanId { get; }
+
+        /// <summary>
+        /// Whether this request should be traced or not.
+        /// May be null, which means that there's not enough information to know
+        /// whether this request should be traced or not.
+        /// </summary>
+        bool? ShouldTrace { get; }
+    }
+}

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/ManagedTracer.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/ManagedTracer.cs
@@ -45,7 +45,22 @@ namespace Google.Cloud.Diagnostics.Common
         /// <param name="projectId">The Google Cloud Platform project ID. Must not be null</param>
         /// <param name="consumer">The trace consumer.  Must not be null.</param>
         /// <param name="options">Trace options. Must not be null.</param>
-        public static Func<TraceHeaderContext, IManagedTracer> CreateTracerFactory(string projectId, IConsumer<TraceProto> consumer, TraceOptions options)
+        /// <remarks>
+        /// This method has been made obsolete. You should use <see cref="CreateFactory(string, IConsumer{TraceProto}, TraceOptions)"/>
+        /// instead. The function returned by <see cref="CreateFactory(string, IConsumer{TraceProto}, TraceOptions)"/>
+        /// will accept any <see cref="ITraceContext"/> as input and not just <see cref="TraceHeaderContext"/>.
+        /// </remarks>
+        [Obsolete("Please use ManagedTracer.CreateFactory instead which only differs in that the returned factory will accept any ITraceContext as input.")]
+        public static Func<TraceHeaderContext, IManagedTracer> CreateTracerFactory(string projectId, IConsumer<TraceProto> consumer, TraceOptions options) =>
+            CreateFactory(projectId, consumer, options);
+
+        /// <summary>
+        /// Create a factory to generate an <see cref="IManagedTracer"/> from an <see cref="ITraceContext"/>.
+        /// </summary>
+        /// <param name="projectId">The Google Cloud Platform project ID. Must not be null</param>
+        /// <param name="consumer">The trace consumer.  Must not be null.</param>
+        /// <param name="options">Trace options. Must not be null.</param>
+        public static Func<ITraceContext, IManagedTracer> CreateFactory(string projectId, IConsumer<TraceProto> consumer, TraceOptions options)
         {
             GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
             GaxPreconditions.CheckNotNull(consumer, nameof(consumer));
@@ -61,6 +76,6 @@ namespace Google.Cloud.Diagnostics.Common
         /// that is retrieved from the given function on each method call.
         /// </summary>
         public static IManagedTracer CreateDelegatingTracer(Func<IManagedTracer> tracerFactory) 
-            => new DelegatingTracer(GaxPreconditions.CheckNotNull(tracerFactory, nameof(tracerFactory)));        
+            => new DelegatingTracer(GaxPreconditions.CheckNotNull(tracerFactory, nameof(tracerFactory)));
     }
 }

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/ManagedTracerFactory.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/ManagedTracerFactory.cs
@@ -19,7 +19,7 @@ namespace Google.Cloud.Diagnostics.Common
 {
     /// <summary>
     /// A factory that will generate <see cref="IManagedTracer"/>s from 
-    /// <see cref="TraceHeaderContext"/>s.  If the <see cref="TraceHeaderContext"/> does not provide
+    /// <see cref="ITraceContext"/>s. If the <see cref="ITraceContext"/> does not provide
     /// the needed context to determine the proper <see cref="IManagedTracer"/> then the given
     /// <see cref="ITraceOptionsFactory"/> will decide.
     /// </summary>
@@ -36,7 +36,7 @@ namespace Google.Cloud.Diagnostics.Common
         /// <param name="projectId">The Google Cloud Platform project ID. Must not be null.</param>
         /// <param name="consumer">A trace consumer for the tracer. Must not be null.</param>
         /// <param name="optionsFactory">An options factory to fall back to if the
-        /// <see cref="TraceHeaderContext"/> does not provide enough context. Must not be null.</param>
+        /// <see cref="ITraceContext"/> does not provide enough context. Must not be null.</param>
         /// <param name="traceIdFactory">A trace Id factory. Must not be null.</param>
         internal ManagedTracerFactory(
             string projectId,
@@ -52,22 +52,22 @@ namespace Google.Cloud.Diagnostics.Common
         }
 
         /// <inheritdoc />
-        public IManagedTracer CreateTracer(TraceHeaderContext headerContext)
+        internal IManagedTracer CreateTracer(ITraceContext traceContext)
         {
-            GaxPreconditions.CheckNotNull(headerContext, nameof(headerContext));
-            if (!ShouldTrace(headerContext))
+            GaxPreconditions.CheckNotNull(traceContext, nameof(traceContext));
+            if (!ShouldTrace(traceContext))
             {
                 return NullManagedTracer.Instance;
             }
-            var traceId = headerContext.TraceId ?? _traceIdFactory.NextId();
-            return SimpleManagedTracer.Create(_consumer, _projectId, traceId, headerContext.SpanId);
+            var traceId = traceContext.TraceId ?? _traceIdFactory.NextId();
+            return SimpleManagedTracer.Create(_consumer, _projectId, traceId, traceContext.SpanId);
         }
 
         /// <summary>
-        /// True if the tracing should occur. Decision based on a <see cref="TraceHeaderContext"/>
+        /// True if the tracing should occur. Decision based on a <see cref="ITraceContext"/>
         /// and an <see cref="ITraceOptionsFactory"/>.
         /// </summary>
-        internal bool ShouldTrace(TraceHeaderContext headerContext) =>
-            headerContext.ShouldTrace ?? _optionsFactory.CreateOptions().ShouldTrace;
+        internal bool ShouldTrace(ITraceContext traceContext) =>
+            traceContext.ShouldTrace ?? _optionsFactory.CreateOptions().ShouldTrace;
     }
 }

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/SimpleTraceContext.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/SimpleTraceContext.cs
@@ -1,0 +1,41 @@
+﻿// Copyright 2021 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Google.Cloud.Diagnostics.Common
+{
+    /// <summary>
+    /// Simple implementation of <see cref="ITraceContext"/>.
+    /// </summary>
+    public sealed class SimpleTraceContext : ITraceContext
+    {
+        /// <summary>
+        /// Creates a new instance of <see cref="SimpleTraceContext"/>.
+        /// </summary>
+        public SimpleTraceContext(string traceId, ulong? spanId, bool? shouldTrace) =>
+            (TraceId, SpanId, ShouldTrace) = (traceId, spanId, shouldTrace);
+
+        /// <inheritdoc/>
+        public string TraceId { get; }
+
+        /// <inheritdoc/>
+        public ulong? SpanId { get; }
+
+        /// <inheritdoc/>
+        public bool? ShouldTrace { get; }
+
+        internal static SimpleTraceContext FromTracer(IManagedTracer tracer) =>
+            // If IManagedTracer returns a non-null traceId it's because the request should be traced.
+            tracer?.GetCurrentTraceId() is string traceId ? new SimpleTraceContext(traceId, tracer.GetCurrentSpanId(), true) : null;
+    }
+}

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/TraceHeaderContext.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/TraceHeaderContext.cs
@@ -18,15 +18,14 @@ using System.Text.RegularExpressions;
 namespace Google.Cloud.Diagnostics.Common
 {
     /// <summary>
-    /// Context from the Cloud Trace Header.
+    /// Context from the Google Cloud Trace Header.
     /// </summary>
-    /// 
     /// <remarks>
     /// A trace can be forced by passing information along in the trace header ("X-Cloud-Trace-Context").
     /// The trace id, parent span id and whether or not to trace can be set.
     /// See: https://cloud.google.com/trace/docs/faq#how_do_i_force_a_request_to_be_traced
     /// </remarks>
-    public sealed class TraceHeaderContext
+    public sealed class TraceHeaderContext : ITraceContext
     {
         private static readonly TraceIdFactory _traceIdFactory = TraceIdFactory.Create();
 
@@ -47,16 +46,13 @@ namespace Google.Cloud.Diagnostics.Common
         internal static readonly Regex TraceHeaderRegex =
             new Regex(@"^([A-Fa-f0-9]{32})/([0-9]+)(?:;o=([0-1]))?$", RegexOptions.Compiled);
 
-        /// <summary>Gets the trace id or null if none is available.</summary>
+        /// <inheritdoc/>
         public string TraceId { get; }
 
-        /// <summary>Gets the span id or null if none is available.</summary>
+        /// <inheritdoc/>
         public ulong? SpanId { get; }
 
-        /// <summary>
-        /// True if the request should be traced, false if it should not be.
-        /// Null if the trace header does not indicate whether or not it should be traced.
-        /// </summary>
+        /// <inheritdoc/>
         public bool? ShouldTrace { get; }
 
         /// <summary>

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/TraceHeaderPropagatingHandler.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/TraceHeaderPropagatingHandler.cs
@@ -50,9 +50,22 @@ namespace Google.Cloud.Diagnostics.Common
         /// <param name="innerHandler">The inner handler to delegate to. May be null, in which
         /// case a new <see cref="HttpClientHandler"/> will be used.</param>
         public TraceHeaderPropagatingHandler(Func<IManagedTracer> managedTracerFactory, HttpMessageHandler innerHandler = null)
-            :base(managedTracerFactory)
-        {
+            :this(managedTracerFactory, null, innerHandler)
+        { }
+
+        /// <summary>
+        /// Constructs a new instance using the given delegate to obtain the "current" tracer
+        /// on each request.
+        /// </summary>
+        /// <param name="managedTracerFactory">A delegate used to obtain the "current" tracer
+        /// for each request. The delegate should therefore be thread-safe.</param>
+        /// <param name="traceContextPropagator">The trace context propagator used to set the trace context on the outgoing
+        /// HTTP request. May be null, in which case the Google Trace Header will be set.</param>
+        /// <param name="innerHandler">The inner handler to delegate to. May be null, in which
+        /// case a new <see cref="HttpClientHandler"/> will be used.</param>
+        public TraceHeaderPropagatingHandler(
+            Func<IManagedTracer> managedTracerFactory, Action<HttpRequestMessage, ITraceContext> traceContextPropagator, HttpMessageHandler innerHandler = null)
+            : base(managedTracerFactory, traceContextPropagator) =>
             InnerHandler = innerHandler ?? new HttpClientHandler();
-        }
     }
 }

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/TraceServiceOptions.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Trace/TraceServiceOptions.cs
@@ -1,0 +1,40 @@
+﻿// Copyright 2021 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Trace.V1;
+
+namespace Google.Cloud.Diagnostics.Common
+{
+    /// <summary>
+    /// Options for initializing tracing.
+    /// </summary>
+    public sealed class TraceServiceOptions
+    {
+        /// <summary>
+        /// The Google Cloud Platform project ID. If unspecified and running on GAE or GCE the project
+        /// ID will be detected from the platform.
+        /// </summary>
+        public string ProjectId { get; set; }
+
+        /// <summary>
+        /// Trace options. May be null.
+        /// </summary>
+        public TraceOptions Options { get; set; }
+
+        /// <summary>
+        /// A client to send traces with. May be null.
+        /// </summary>
+        public TraceServiceClient Client { get; set; }
+    }
+}

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -714,7 +714,8 @@
         "Google.Cloud.Diagnostics.Common.IntegrationTests": "project",
         "Google.Cloud.Diagnostics.Common.Tests": "project",
         "Microsoft.AspNetCore.Mvc": "2.1.3",
-        "Microsoft.AspNetCore.TestHost": "2.1.1"
+        "Microsoft.AspNetCore.TestHost": "2.1.1",
+        "Microsoft.Extensions.Hosting": "3.0.0"
       },
       "additionalAnalyzerTestDependencies": {
         "Microsoft.AspNetCore.Mvc.Core": "1.0.4",


### PR DESCRIPTION
Also makes it easier to use the Diagnostics libraries from other than ASP.NET Core applications.

Closes #5897.
Towards #5360 and #6367

As usual, probably better to review one commit at a time.
I'll probably merge this PR in two feature commits though, one for decoupling and another for non ASP.NET Core.