### PR TITLE
Indicate non-Cloud packages in link canonicalizer

### DIFF
--- a/tools/Google.Cloud.Tools.CanonicalLinkFunction/Function.cs
+++ b/tools/Google.Cloud.Tools.CanonicalLinkFunction/Function.cs
@@ -44,7 +44,7 @@ namespace Google.Cloud.Tools.CanonicalLinkFunction
             }
 
             string url = Canonicalizer.GetUrl(package, page);
-            await response.WriteAsync(url);
+            await response.WriteAsync(url ?? "");
         }
     }
 }

--- a/tools/Google.Cloud.Tools.Common/ApiMetadata.cs
+++ b/tools/Google.Cloud.Tools.Common/ApiMetadata.cs
@@ -23,6 +23,23 @@ namespace Google.Cloud.Tools.Common
 {
     public class ApiMetadata
     {
+        /// <summary>
+        /// Packages that should be treated as Cloud packages even though they don't start with Google.Cloud
+        /// </summary>
+        private static readonly HashSet<string> PseudoCloudPackages = new HashSet<string>
+        {
+            // Long-running operations API. Not strictly GCP-specific, but reasonable to host on DevSite.
+            // (A little like GAX.)
+            "Google.LongRunning",
+            // The "interface" for Google.Cloud.DevTools.ContainerAnalysis.V1
+            "Grafeas.V1",
+            // Common types used by Google.Cloud.GSuiteAddOns.V1
+            "Google.Apps.Script.Type",
+            // Actually GCP-specific; should probably have a Google.Cloud prefix, but it's too late now.
+            "Google.Identity.AccessContextManager.V1",
+            "Google.Identity.AccessContextManager.Type"
+        };
+
         // Pattern to extract the underlying API version from the package name.
         private static readonly Regex PackageIdVersionPattern = new Regex(@"\.V[1-9]\d*[-A-Za-z0-9]*$");
         private static readonly Regex PrereleaseApiPattern = new Regex(@"^V[1-9]\d*[^\d]+.*$");
@@ -162,6 +179,13 @@ namespace Google.Cloud.Tools.Common
         /// option set to refer to a single file in a common package containing common resource names.
         /// </summary>
         public string CommonResourcesConfig { get; set; }
+
+        /// <summary>
+        /// Indicates whether the given package name denotes a Cloud API, documented on cloud.google.com.
+        /// Note that this is only expected to "know" about API libraries, not support libraries (GAX, protobuf etc).
+        /// </summary>
+        /// <param name="package">The name of the package, e.g. Google.Cloud.Storage.V1</param>
+        public static bool IsCloudPackage(string package) => package.StartsWith("Google.Cloud.") || PseudoCloudPackages.Contains(package);
 
         // TODO: Optimize to do this lazily if it's ever an issue
         [JsonIgnore]

--- a/tools/Google.Cloud.Tools.GenerateCanonicalLinks.Tests/CanonicalizerTest.cs
+++ b/tools/Google.Cloud.Tools.GenerateCanonicalLinks.Tests/CanonicalizerTest.cs
@@ -42,12 +42,21 @@ namespace Google.Cloud.Tools.GenerateCanonicalLinks.Tests
         // TODO: Types in Google.Cloud.Diagnostics.AspNetCore (and AspNetCore3) namespaces. Currently not published at all on googleapis.dev...
         [InlineData("Google.Cloud.Diagnostics.AspNetCore", "api/Google.Cloud.Diagnostics.Common.ContextTracerManager.html", "Google.Cloud.Diagnostics.Common/latest/Google.Cloud.Diagnostics.Common.ContextTracerManager")]
         [InlineData("Google.Cloud.Diagnostics.AspNetCore3", "api/Google.Cloud.Diagnostics.Common.ContextTracerManager.html", "Google.Cloud.Diagnostics.Common/latest/Google.Cloud.Diagnostics.Common.ContextTracerManager")]
+        [InlineData("Google.Cloud.OsLogin.V1", "api/Google.Cloud.OsLogin.Common.OperatingSystemType.html", "Google.Cloud.OsLogin.Common/latest/Google.Cloud.OsLogin.Common.OperatingSystemType")]
+        [InlineData("Google.Cloud.Debugger.V2", "api/Google.Cloud.DevTools.Source.V1.AliasContext.html", "Google.Cloud.DevTools.Common/latest/Google.Cloud.DevTools.Source.V1.AliasContext")]
         public void GetUrl(string package, string page, string expectedSuffix)
         {
             var actualUrl = Canonicalizer.GetUrl(package, page);
+            Assert.NotNull(actualUrl);
             Assert.StartsWith(Canonicalizer.CloudSitePrefix, actualUrl);
             var actualSuffix = actualUrl[Canonicalizer.CloudSitePrefix.Length..];
             Assert.Equal(expectedSuffix, actualSuffix);
         }
+
+        [Theory]
+        [InlineData("Google.Area120.Tables.V1Alpha1", "api/Google.Area120.Tables.V1Alpha1.BatchCreateRowsRequest.html")]
+        [InlineData("Google.Analytics.Data.V1Alpha", "api/Google.Analytics.Data.V1Alpha.AlphaAnalyticsData.html")]
+        public void GetUrl_NotOnDevsite(string package, string page) =>
+            Assert.Null(Canonicalizer.GetUrl(package, page));
     }
 }

--- a/tools/Google.Cloud.Tools.GenerateCanonicalLinks/Google.Cloud.Tools.GenerateCanonicalLinks.csproj
+++ b/tools/Google.Cloud.Tools.GenerateCanonicalLinks/Google.Cloud.Tools.GenerateCanonicalLinks.csproj
@@ -5,4 +5,8 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Google.Cloud.Tools.Common\Google.Cloud.Tools.Common.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/tools/Google.Cloud.Tools.PostProcessDevSite/Program.cs
+++ b/tools/Google.Cloud.Tools.PostProcessDevSite/Program.cs
@@ -42,22 +42,7 @@ namespace Google.Cloud.Tools.PostProcessDevSite
     /// </summary>
     class Program
     {
-        /// <summary>
-        /// Packages that should be treated as Cloud packages even though they don't start with Google.Cloud
-        /// </summary>
-        private static readonly HashSet<string> PseudoCloudPackages = new HashSet<string>
-        {
-            // Long-running operations API. Not strictly GCP-specific, but reasonable to host on DevSite.
-            // (A little like GAX.)
-            "Google.LongRunning",
-            // The "interface" for Google.Cloud.DevTools.ContainerAnalysis.V1
-            "Grafeas.V1",
-            // Common types used by Google.Cloud.GSuiteAddOns.V1
-            "Google.Apps.Script.Type",
-            // Actually GCP-specific; should probably have a Google.Cloud prefix, but it's too late now.
-            "Google.Identity.AccessContextManager.V1",
-            "Google.Identity.AccessContextManager.Type"
-        };
+
 
         /// <summary>
         /// The package/API ID
@@ -98,8 +83,6 @@ namespace Google.Cloud.Tools.PostProcessDevSite
             _apiIds = _apiCatalog.CreateIdHashSet();
         }
 
-        private bool IsCloudPackage => _apiId.StartsWith("Google.Cloud.") || PseudoCloudPackages.Contains(_apiId);
-
         private void Execute()
         {
             if (Directory.Exists(_devSiteRoot))
@@ -108,7 +91,7 @@ namespace Google.Cloud.Tools.PostProcessDevSite
             }
             // Non-Cloud packages shouldn't be uploaded to devsite.
             // This is indicated to later stages by the absence of the devsite output directory.
-            if (!IsCloudPackage)
+            if (!ApiMetadata.IsCloudPackage(_apiId))
             {
                 return;
             }


### PR DESCRIPTION
cc @tbpg 

(Note: the updated Cloud Function has not yet been deployed.)