### PR TITLE
Release Google.Cloud.Debugger.V2 version 2.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Dataproc.V1](https://googleapis.dev/dotnet/Google.Cloud.Dataproc.V1/3.1.0) | 3.1.0 | [Google Cloud Dataproc](https://cloud.google.com/dataproc/docs/concepts/overview) |
 | [Google.Cloud.Datastore.Admin.V1](https://googleapis.dev/dotnet/Google.Cloud.Datastore.Admin.V1/1.1.0) | 1.1.0 | Cloud Datastore |
 | [Google.Cloud.Datastore.V1](https://googleapis.dev/dotnet/Google.Cloud.Datastore.V1/3.2.0) | 3.2.0 | [Google Cloud Datastore](https://cloud.google.com/datastore/docs/concepts/overview) |
-| [Google.Cloud.Debugger.V2](https://googleapis.dev/dotnet/Google.Cloud.Debugger.V2/2.2.0) | 2.2.0 | [Google Cloud Debugger](https://cloud.google.com/debugger/) |
+| [Google.Cloud.Debugger.V2](https://googleapis.dev/dotnet/Google.Cloud.Debugger.V2/2.3.0) | 2.3.0 | [Google Cloud Debugger](https://cloud.google.com/debugger/) |
 | [Google.Cloud.DevTools.Common](https://googleapis.dev/dotnet/Google.Cloud.DevTools.Common/2.1.0) | 2.1.0 | Common Protocol Buffer messages for Google Cloud Developer Tools APIs |
 | [Google.Cloud.DevTools.ContainerAnalysis.V1](https://googleapis.dev/dotnet/Google.Cloud.DevTools.ContainerAnalysis.V1/2.2.0) | 2.2.0 | [Google Container Analysis](https://cloud.google.com/container-registry/docs/container-analysis/) |
 | [Google.Cloud.Diagnostics.AspNetCore](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.AspNetCore/4.2.0) | 4.2.0 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core |

--- a/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2.csproj
+++ b/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.2.0</Version>
+    <Version>2.3.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Debugger API.</Description>
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.DevTools.Common" Version="[2.0.0, 3.0.0)" />
+    <PackageReference Include="Google.Cloud.DevTools.Common" Version="[2.1.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />

--- a/apis/Google.Cloud.Debugger.V2/docs/history.md
+++ b/apis/Google.Cloud.Debugger.V2/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 2.2.1, released 2021-05-26
+
+Re-release 2.2.0. (The release failed, and it's simpler to re-release than to fix up 2.2.0.)
+
 # Version 2.2.0, released 2021-05-25
 
 No API surface changes; just dependency updates.

--- a/apis/Google.Cloud.Debugger.V2/docs/history.md
+++ b/apis/Google.Cloud.Debugger.V2/docs/history.md
@@ -1,8 +1,10 @@
 # Version history
 
-# Version 2.2.1, released 2021-05-26
+# Version 2.3.0, released 2021-05-26
 
-Re-release 2.2.0. (The release failed, and it's simpler to re-release than to fix up 2.2.0.)
+No API surface changes; just dependency updates.
+This release is primarily to account for the 2.2.0 release failing,
+but the DevTools.Common dependency has also been updated. 
 
 # Version 2.2.0, released 2021-05-25
 

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -635,7 +635,7 @@
       "protoPath": "google/devtools/clouddebugger/v2",
       "productName": "Google Cloud Debugger",
       "productUrl": "https://cloud.google.com/debugger/",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Debugger API.",
       "tags": [
@@ -646,7 +646,7 @@
       ],
       "dependencies": {
         "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Google.Cloud.DevTools.Common": "2.0.0",
+        "Google.Cloud.DevTools.Common": "2.1.0",
         "Grpc.Core": "2.36.4"
       }
     },

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -53,7 +53,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Dataproc.V1](Google.Cloud.Dataproc.V1/index.html) | 3.1.0 | [Google Cloud Dataproc](https://cloud.google.com/dataproc/docs/concepts/overview) |
 | [Google.Cloud.Datastore.Admin.V1](Google.Cloud.Datastore.Admin.V1/index.html) | 1.1.0 | Cloud Datastore |
 | [Google.Cloud.Datastore.V1](Google.Cloud.Datastore.V1/index.html) | 3.2.0 | [Google Cloud Datastore](https://cloud.google.com/datastore/docs/concepts/overview) |
-| [Google.Cloud.Debugger.V2](Google.Cloud.Debugger.V2/index.html) | 2.2.0 | [Google Cloud Debugger](https://cloud.google.com/debugger/) |
+| [Google.Cloud.Debugger.V2](Google.Cloud.Debugger.V2/index.html) | 2.3.0 | [Google Cloud Debugger](https://cloud.google.com/debugger/) |
 | [Google.Cloud.DevTools.Common](Google.Cloud.DevTools.Common/index.html) | 2.1.0 | Common Protocol Buffer messages for Google Cloud Developer Tools APIs |
 | [Google.Cloud.DevTools.ContainerAnalysis.V1](Google.Cloud.DevTools.ContainerAnalysis.V1/index.html) | 2.2.0 | [Google Container Analysis](https://cloud.google.com/container-registry/docs/container-analysis/) |
 | [Google.Cloud.Diagnostics.AspNetCore](Google.Cloud.Diagnostics.AspNetCore/index.html) | 4.2.0 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core |


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates. This release is primarily to account for the 2.2.0 release failing, but the DevTools.Common dependency has also been updated.
