### PR TITLE
Always build Diagnostics.AspNetCore3 if Diagnostics.AspNetCore is beeing built.

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/TestServerHelpers.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/TestServerHelpers.cs
@@ -58,8 +58,8 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
             return host.GetTestServer();
         }
 
-        public static TestServer GetTestServer<TStartup>() where TStartup : class =>
-            GetTestServer(GetHostBuilder<TStartup>());
+        public static TestServer GetTestServer<TStartup>(Action<IWebHostBuilder> configure = null) where TStartup : class =>
+            GetTestServer(GetHostBuilder<TStartup>(configure));
 
         public static IServiceProvider GetServices(TestServer server) => server.Services;
 

--- a/build.sh
+++ b/build.sh
@@ -109,6 +109,26 @@ then
   fi
 fi
 
+# If we are building Google.Cloud.Diagnostics.AspNetCore we also need to build
+# Google.Cloud.Diagnostics.AspNetCore3 since they share code files.
+hasCore=false
+hasCore3=false
+for api in ${apis[*]}
+do
+  if [[ "$api" == "Google.Cloud.Diagnostics.AspNetCore" ]]
+  then
+    hasCore=true
+  elif [[ "$api" == "Google.Cloud.Diagnostics.AspNetCore3" ]]
+  then
+    hasCore3=true
+  fi
+done
+if [[ "$hasCore" == "true" ]] && [[ "$hasCore3" == "false" ]]
+then
+  apis+=("Google.Cloud.Diagnostics.AspNetCore3")
+fi
+
+
 if [[ "$nobuild" == "true" ]]
 then
   echo "APIs that would be built:"
@@ -133,12 +153,6 @@ do
 
   # ServiceDirectory is in apis/ for the sake of autosynth, but doesn't really build.
   if [[ "$api" == "ServiceDirectory" ]]
-  then
-    continue
-  fi
-
-  # Only build ASP.NET support on Windows
-  if [[ "$OS" != "Windows_NT" ]] && [[ "$apidir" == "apis/Google.Cloud.Diagnostics.AspNet" ]]
   then
     continue
   fi


### PR DESCRIPTION
And fix leftover outdated code from #6568.