### PR TITLE
feat(spanner): add query_optimizer_statistics_package support

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/QueryOptionsTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/QueryOptionsTests.cs
@@ -38,7 +38,9 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
         {
             using (var connection = _fixture.GetConnection())
             {
-                connection.QueryOptions = QueryOptions.Empty.WithOptimizerVersion("1");
+                connection.QueryOptions = QueryOptions.Empty
+                    .WithOptimizerVersion("1")
+                    .WithOptimizerStatisticsPackage("auto_20191128_14_47_22UTC");
                 var cmd = connection.CreateSelectCommand($"SELECT * FROM {_fixture.TableName} WHERE Key = 'k1'");
                 using (var reader = await cmd.ExecuteReaderAsync())
                 {
@@ -57,7 +59,9 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             using (var connection = _fixture.GetConnection())
             {
                 var cmd = connection.CreateSelectCommand($"SELECT * FROM {_fixture.TableName} WHERE Key = 'k1'");
-                cmd.QueryOptions = QueryOptions.Empty.WithOptimizerVersion("1");
+                cmd.QueryOptions = QueryOptions.Empty
+                    .WithOptimizerVersion("1")
+                    .WithOptimizerStatisticsPackage("auto_20191128_14_47_22UTC");
                 using (var reader = await cmd.ExecuteReaderAsync())
                 {
                     Assert.True(await reader.ReadAsync());

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/QueryOptionsTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/QueryOptionsTests.cs
@@ -26,6 +26,7 @@ namespace Google.Cloud.Spanner.Data.Tests
             var proto = new V1.ExecuteSqlRequest.Types.QueryOptions();
             var queryOptions = QueryOptions.FromProto(proto);
             Assert.Equal("", queryOptions.OptimizerVersion);
+            Assert.Equal("", queryOptions.OptimizerStatisticsPackage);
         }
 
         [Fact]
@@ -33,6 +34,7 @@ namespace Google.Cloud.Spanner.Data.Tests
         {
             var queryOptions = QueryOptions.Empty;
             Assert.Equal("", queryOptions.OptimizerVersion);
+            Assert.Equal("", queryOptions.OptimizerStatisticsPackage);
         }
 
         [Fact]
@@ -40,6 +42,13 @@ namespace Google.Cloud.Spanner.Data.Tests
         {
             var queryOptions = QueryOptions.Empty.WithOptimizerVersion("latest");
             Assert.Equal("latest", queryOptions.OptimizerVersion);
+        }
+
+        [Fact]
+        public void SetAndGetOptimizerStatisticsPackage()
+        {
+            var queryOptions = QueryOptions.Empty.WithOptimizerStatisticsPackage("latest");
+            Assert.Equal("latest", queryOptions.OptimizerStatisticsPackage);
         }
     }
 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/QueryOptions.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/QueryOptions.cs
@@ -26,7 +26,12 @@ namespace Google.Cloud.Spanner.Data
         /// <summary>
         /// The query optimizer version configured in the options.
         /// </summary>
-        public string OptimizerVersion { get => Proto.OptimizerVersion; }
+        public string OptimizerVersion => Proto.OptimizerVersion;
+
+        /// <summary>
+        /// The query optimizer statistics package configured in the options.
+        /// </summary>
+        public string OptimizerStatisticsPackage => Proto.OptimizerStatisticsPackage;
 
         /// <summary>
         /// Clones the options and sets the optimizer version to the given value.
@@ -48,6 +53,29 @@ namespace Google.Cloud.Spanner.Data
         {
            var protoCopy = Proto.Clone();
            protoCopy.OptimizerVersion = optimizerVersion;
+           return new QueryOptions(protoCopy);
+        }
+
+        /// <summary>
+        /// Clones the options and sets the optimizer statistics package to the given value.
+        /// </summary>
+        /// <returns>
+        /// A clone of the options with the updated optimizer statistics package.
+        /// </returns>
+        /// <remarks>
+        /// <para>The parameter allows individual queries to pick different query
+        /// optimizer statistics packages.</para>
+        /// <para>Specifying "latest" as a value instructs Cloud Spanner to use the
+        /// latest supported query optimizer statistics package. If not specified,
+        /// Cloud Spanner uses the optimizer statistics package set at the database
+        /// level options. Any other supported statistics package value overrides
+        /// the default optimizer statistics package for query execution.</para>
+        /// </remarks>
+        /// <param name="optimizerStatisticsPackage">Optimizer statistics package to set.</param>
+        public QueryOptions WithOptimizerStatisticsPackage(string optimizerStatisticsPackage)
+        {
+           var protoCopy = Proto.Clone();
+           protoCopy.OptimizerStatisticsPackage = optimizerStatisticsPackage;
            return new QueryOptions(protoCopy);
         }
 
@@ -83,7 +111,10 @@ namespace Google.Cloud.Spanner.Data
         public V1.ExecuteSqlRequest.Types.QueryOptions ToProto() => Proto.Clone();
 
         /// <inheritdoc />
-        public bool Equals(QueryOptions other) => other is object && OptimizerVersion == other.OptimizerVersion;
+        public bool Equals(QueryOptions other) =>
+            other is object &&
+            OptimizerVersion == other.OptimizerVersion &&
+            OptimizerStatisticsPackage == other.OptimizerStatisticsPackage;
 
         /// <inheritdoc />
         public override bool Equals(object obj) => Equals(obj as QueryOptions);

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.ExecutableCommand.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.ExecutableCommand.cs
@@ -54,6 +54,7 @@ namespace Google.Cloud.Spanner.Data
             }
 
             private const string SpannerOptimizerVersionVariable = "SPANNER_OPTIMIZER_VERSION";
+            private const string SpannerOptimizerStatisticsPackageVariable = "SPANNER_OPTIMIZER_STATISTICS_PACKAGE";
 
             internal SpannerConnection Connection { get; }
             internal SpannerCommandTextBuilder CommandTextBuilder { get; }
@@ -362,7 +363,8 @@ namespace Google.Cloud.Spanner.Data
                 // Query options set through an environment variable have the next highest precedence.
                 var envQueryOptionsProto = new V1.ExecuteSqlRequest.Types.QueryOptions
                 {
-                    OptimizerVersion = Environment.GetEnvironmentVariable(SpannerOptimizerVersionVariable)?.Trim() ?? ""
+                    OptimizerVersion = Environment.GetEnvironmentVariable(SpannerOptimizerVersionVariable)?.Trim() ?? "",
+                    OptimizerStatisticsPackage = Environment.GetEnvironmentVariable(SpannerOptimizerStatisticsPackageVariable)?.Trim() ?? ""
                 };
                 queryOptionsProto.MergeFrom(envQueryOptionsProto);
 


### PR DESCRIPTION
The optimizer statistics package can be set through `QueryOptions`, which can be configured through the following mechanisms.
1. At the `SpannerConnection` level.
1. Through the `SPANNER_OPTIMIZER_STATISTICS_PACKAGE` environment variable.
1. At a query level.
    
If the options are configured through multiple mechanisms then:
1. Options set at an environment variable level will override options configured at the `SpannerConnection` level.
1. Options set at a query-level will override options set at either the `SpannerConnection` or environment variable level.
    
If no options are set, the optimizer statistics package will default to:
1. The package the database is pinned to.
1. If the database is not pinned to a specific package, then the Cloud Spanner backend will use the "latest" version.