### PR TITLE
Release Google.Cloud.DocumentAI.V1 version 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Dialogflow.Cx.V3](https://googleapis.dev/dotnet/Google.Cloud.Dialogflow.Cx.V3/1.1.0) | 1.1.0 | [Dialogflow](https://cloud.google.com/dialogflow/cx/docs) |
 | [Google.Cloud.Dialogflow.V2](https://googleapis.dev/dotnet/Google.Cloud.Dialogflow.V2/3.2.0) | 3.2.0 | [Google Cloud Dialogflow](https://cloud.google.com/dialogflow-enterprise/) |
 | [Google.Cloud.Dlp.V2](https://googleapis.dev/dotnet/Google.Cloud.Dlp.V2/3.2.0) | 3.2.0 | [Google Cloud Data Loss Prevention](https://cloud.google.com/dlp/) |
-| [Google.Cloud.DocumentAI.V1](https://googleapis.dev/dotnet/Google.Cloud.DocumentAI.V1/1.0.0-beta02) | 1.0.0-beta02 | [Cloud Document AI (V1 API)](https://cloud.google.com/solutions/document-ai) |
+| [Google.Cloud.DocumentAI.V1](https://googleapis.dev/dotnet/Google.Cloud.DocumentAI.V1/1.0.0) | 1.0.0 | [Cloud Document AI (V1 API)](https://cloud.google.com/solutions/document-ai) |
 | [Google.Cloud.DocumentAI.V1Beta2](https://googleapis.dev/dotnet/Google.Cloud.DocumentAI.V1Beta2/1.0.0-beta03) | 1.0.0-beta03 | [Cloud Document AI (V1Beta2 API)](https://cloud.google.com/solutions/document-ai) |
 | [Google.Cloud.Domains.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Domains.V1Beta1/1.0.0-beta02) | 1.0.0-beta02 | [Cloud Domains](https://cloud.google.com/domains/) |
 | [Google.Cloud.ErrorReporting.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.ErrorReporting.V1Beta1/2.0.0-beta04) | 2.0.0-beta04 | [Google Cloud Error Reporting](https://cloud.google.com/error-reporting/) |

--- a/apis/Google.Cloud.DocumentAI.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.DocumentAI.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.DocumentAI.V1",
-  "release_level": "beta",
+  "release_level": "ga",
   "client_documentation": "https://googleapis.dev/dotnet/Google.Cloud.DocumentAI.V1/latest",
   "library_type": "GAPIC_AUTO"
 }

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.csproj
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Document AI API (v1), which is a service to parse structured information from unstructured or semi-structured documents using state-of-the-art Google AI such as natural language, computer vision, translation, and AutoML.</Description>
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />

--- a/apis/Google.Cloud.DocumentAI.V1/docs/history.md
+++ b/apis/Google.Cloud.DocumentAI.V1/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+# Version 1.0.0, released 2021-06-08
+
+- [Commit 7e77c2a](https://github.com/googleapis/google-cloud-dotnet/commit/7e77c2a): feat: Move CommonOperationMetadata into a separate proto file for potential reuse.
+- [Commit a5723b7](https://github.com/googleapis/google-cloud-dotnet/commit/a5723b7): feat: Use non-regionalized default host name for documentai.googleapis.com
+
 # Version 1.0.0-beta02, released 2021-04-29
 
 - [Commit 64c687d](https://github.com/googleapis/google-cloud-dotnet/commit/64c687d): feat: add confidence field to the PageAnchor.PageRef in document.proto.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -840,7 +840,7 @@
     },
     {
       "id": "Google.Cloud.DocumentAI.V1",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Cloud Document AI",
       "productUrl": "https://cloud.google.com/solutions/document-ai",
@@ -854,7 +854,9 @@
         "automl"
       ],
       "dependencies": {
-        "Google.LongRunning": "2.1.0"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Google.LongRunning": "2.2.0",
+        "Grpc.Core": "2.36.4"
       },
       "generator": "micro",
       "protoPath": "google/cloud/documentai/v1"

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -62,7 +62,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Dialogflow.Cx.V3](Google.Cloud.Dialogflow.Cx.V3/index.html) | 1.1.0 | [Dialogflow](https://cloud.google.com/dialogflow/cx/docs) |
 | [Google.Cloud.Dialogflow.V2](Google.Cloud.Dialogflow.V2/index.html) | 3.2.0 | [Google Cloud Dialogflow](https://cloud.google.com/dialogflow-enterprise/) |
 | [Google.Cloud.Dlp.V2](Google.Cloud.Dlp.V2/index.html) | 3.2.0 | [Google Cloud Data Loss Prevention](https://cloud.google.com/dlp/) |
-| [Google.Cloud.DocumentAI.V1](Google.Cloud.DocumentAI.V1/index.html) | 1.0.0-beta02 | [Cloud Document AI (V1 API)](https://cloud.google.com/solutions/document-ai) |
+| [Google.Cloud.DocumentAI.V1](Google.Cloud.DocumentAI.V1/index.html) | 1.0.0 | [Cloud Document AI (V1 API)](https://cloud.google.com/solutions/document-ai) |
 | [Google.Cloud.DocumentAI.V1Beta2](Google.Cloud.DocumentAI.V1Beta2/index.html) | 1.0.0-beta03 | [Cloud Document AI (V1Beta2 API)](https://cloud.google.com/solutions/document-ai) |
 | [Google.Cloud.Domains.V1Beta1](Google.Cloud.Domains.V1Beta1/index.html) | 1.0.0-beta02 | [Cloud Domains](https://cloud.google.com/domains/) |
 | [Google.Cloud.ErrorReporting.V1Beta1](Google.Cloud.ErrorReporting.V1Beta1/index.html) | 2.0.0-beta04 | [Google Cloud Error Reporting](https://cloud.google.com/error-reporting/) |


### PR DESCRIPTION

Changes in this release:

- [Commit 7e77c2a](https://github.com/googleapis/google-cloud-dotnet/commit/7e77c2a): feat: Move CommonOperationMetadata into a separate proto file for potential reuse.
- [Commit a5723b7](https://github.com/googleapis/google-cloud-dotnet/commit/a5723b7): feat: Use non-regionalized default host name for documentai.googleapis.com
