### PR TITLE
Implement canonical link generation for googleapis.dev

### DIFF
--- a/docs/builddocs.sh
+++ b/docs/builddocs.sh
@@ -61,6 +61,10 @@ build_api_docs() {
   # Note that the devsite build will happen elsewhere.
   $DOCFX build --logLevel Warning --disableGitFeatures output/$api/docfx.json | tee errors.txt | grep -v "Invalid file link"
   (! grep --quiet 'Build failed.' errors.txt)
+  
+  # Add canonical links where appropriate
+  # (Uncomment this when the canonical links are actually published.)
+  # dotnet run --no-build --no-restore -p ../tools/Google.Cloud.Tools.GenerateCanonicalLinks -- $api
 
   # Special case root: that should end up in the root of the assembled
   # site.

--- a/tools/Google.Cloud.Tools.GenerateCanonicalLinks.Tests/CanonicalizerTest.cs
+++ b/tools/Google.Cloud.Tools.GenerateCanonicalLinks.Tests/CanonicalizerTest.cs
@@ -56,6 +56,7 @@ namespace Google.Cloud.Tools.GenerateCanonicalLinks.Tests
         [Theory]
         [InlineData("Google.Area120.Tables.V1Alpha1", "api/Google.Area120.Tables.V1Alpha1.BatchCreateRowsRequest.html")]
         [InlineData("Google.Analytics.Data.V1Alpha", "api/Google.Analytics.Data.V1Alpha.AlphaAnalyticsData.html")]
+        [InlineData("Google.Cloud.Debugger.V2", "api/toc.html")]
         public void GetUrl_NotOnDevsite(string package, string page) =>
             Assert.Null(Canonicalizer.GetUrl(package, page));
     }

--- a/tools/Google.Cloud.Tools.GenerateCanonicalLinks/Canonicalizer.cs
+++ b/tools/Google.Cloud.Tools.GenerateCanonicalLinks/Canonicalizer.cs
@@ -93,6 +93,12 @@ namespace Google.Cloud.Tools.GenerateCanonicalLinks
                 package = packageParts[^2];
             }
 
+            // DevSite doesn't have toc.html files
+            if (page == "api/toc.html")
+            {
+                return null;
+            }
+
             // DevSite URLs don't have an extension
             if (page.EndsWith(".html"))
             {

--- a/toolversions.sh
+++ b/toolversions.sh
@@ -6,7 +6,7 @@
 declare -r REPO_ROOT=$(readlink -f $(dirname ${BASH_SOURCE}))
 declare -r TOOL_PACKAGES=$REPO_ROOT/packages
 
-declare -r DOCFX_VERSION=2.50
+declare -r DOCFX_VERSION=2.57.2
 declare -r DOTCOVER_VERSION=2019.3.4
 declare -r REPORTGENERATOR_VERSION=2.4.5.0
 declare -r PROTOC_VERSION=3.15.8


### PR DESCRIPTION
This is disabled for now, but we'll enable it once docs are public on cloud.google.com