### PR TITLE
Release Google.Cloud.Shell.V1 version 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.ServiceDirectory.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.ServiceDirectory.V1Beta1/1.0.0-beta04) | 1.0.0-beta04 | [Service Directory (V1Beta1 API)](https://cloud.google.com/service-directory/) |
 | [Google.Cloud.ServiceManagement.V1](https://googleapis.dev/dotnet/Google.Cloud.ServiceManagement.V1/1.1.0) | 1.1.0 | [Service Management](https://cloud.google.com/service-infrastructure/docs/service-management/reference/rpc) |
 | [Google.Cloud.ServiceUsage.V1](https://googleapis.dev/dotnet/Google.Cloud.ServiceUsage.V1/1.0.0-beta01) | 1.0.0-beta01 | [Service Usage](https://cloud.google.com/service-usage/docs/) |
-| [Google.Cloud.Shell.V1](https://googleapis.dev/dotnet/Google.Cloud.Shell.V1/1.0.0-beta01) | 1.0.0-beta01 | [Cloud Shell](https://cloud.google.com/shell/) |
+| [Google.Cloud.Shell.V1](https://googleapis.dev/dotnet/Google.Cloud.Shell.V1/1.0.0) | 1.0.0 | [Cloud Shell](https://cloud.google.com/shell/) |
 | [Google.Cloud.Spanner.Admin.Database.V1](https://googleapis.dev/dotnet/Google.Cloud.Spanner.Admin.Database.V1/3.8.0) | 3.8.0 | [Google Cloud Spanner Database Administration](https://cloud.google.com/spanner/) |
 | [Google.Cloud.Spanner.Admin.Instance.V1](https://googleapis.dev/dotnet/Google.Cloud.Spanner.Admin.Instance.V1/3.8.0) | 3.8.0 | [Google Cloud Spanner Instance Administration](https://cloud.google.com/spanner/) |
 | [Google.Cloud.Spanner.Data](https://googleapis.dev/dotnet/Google.Cloud.Spanner.Data/3.8.0) | 3.8.0 | Google ADO.NET Provider for Google Cloud Spanner |

--- a/apis/Google.Cloud.Shell.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.Shell.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.Shell.V1",
-  "release_level": "beta",
+  "release_level": "ga",
   "client_documentation": "https://googleapis.dev/dotnet/Google.Cloud.Shell.V1/latest",
   "library_type": "GAPIC_AUTO"
 }

--- a/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.csproj
+++ b/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Cloud Shell API, which allows users to start, configure, and connect to interactive shell sessions running in the cloud.</Description>
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />

--- a/apis/Google.Cloud.Shell.V1/docs/history.md
+++ b/apis/Google.Cloud.Shell.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.0.0, released 2021-06-08
+
+No API surface changes; just promotion to GA.
+
 # Version 1.0.0-beta01, released 2021-05-17
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2132,7 +2132,7 @@
     },
     {
       "id": "Google.Cloud.Shell.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Cloud Shell",
       "productUrl": "https://cloud.google.com/shell/",
@@ -2141,7 +2141,9 @@
         "shell"
       ],
       "dependencies": {
-        "Google.LongRunning": "2.1.0"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Google.LongRunning": "2.2.0",
+        "Grpc.Core": "2.36.4"
       },
       "generator": "micro",
       "protoPath": "google/cloud/shell/v1"

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -129,7 +129,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.ServiceDirectory.V1Beta1](Google.Cloud.ServiceDirectory.V1Beta1/index.html) | 1.0.0-beta04 | [Service Directory (V1Beta1 API)](https://cloud.google.com/service-directory/) |
 | [Google.Cloud.ServiceManagement.V1](Google.Cloud.ServiceManagement.V1/index.html) | 1.1.0 | [Service Management](https://cloud.google.com/service-infrastructure/docs/service-management/reference/rpc) |
 | [Google.Cloud.ServiceUsage.V1](Google.Cloud.ServiceUsage.V1/index.html) | 1.0.0-beta01 | [Service Usage](https://cloud.google.com/service-usage/docs/) |
-| [Google.Cloud.Shell.V1](Google.Cloud.Shell.V1/index.html) | 1.0.0-beta01 | [Cloud Shell](https://cloud.google.com/shell/) |
+| [Google.Cloud.Shell.V1](Google.Cloud.Shell.V1/index.html) | 1.0.0 | [Cloud Shell](https://cloud.google.com/shell/) |
 | [Google.Cloud.Spanner.Admin.Database.V1](Google.Cloud.Spanner.Admin.Database.V1/index.html) | 3.8.0 | [Google Cloud Spanner Database Administration](https://cloud.google.com/spanner/) |
 | [Google.Cloud.Spanner.Admin.Instance.V1](Google.Cloud.Spanner.Admin.Instance.V1/index.html) | 3.8.0 | [Google Cloud Spanner Instance Administration](https://cloud.google.com/spanner/) |
 | [Google.Cloud.Spanner.Data](Google.Cloud.Spanner.Data/index.html) | 3.8.0 | Google ADO.NET Provider for Google Cloud Spanner |


### PR DESCRIPTION

Changes in this release:

No API surface changes; just promotion to GA.
