### PR TITLE
Release Google.Cloud.CloudDms.V1 version 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.BinaryAuthorization.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.BinaryAuthorization.V1Beta1/1.0.0-beta02) | 1.0.0-beta02 | [Binary Authorization](https://cloud.google.com/binary-authorization/docs/reference/rpc) |
 | [Google.Cloud.Channel.V1](https://googleapis.dev/dotnet/Google.Cloud.Channel.V1/1.1.0) | 1.1.0 | [Cloud Channel](https://cloud.google.com/channel/docs/) |
 | [Google.Cloud.CloudBuild.V1](https://googleapis.dev/dotnet/Google.Cloud.CloudBuild.V1/1.1.0) | 1.1.0 | [Cloud Build](https://cloud.google.com/cloud-build) |
-| [Google.Cloud.CloudDms.V1](https://googleapis.dev/dotnet/Google.Cloud.CloudDms.V1/1.0.0-beta01) | 1.0.0-beta01 | [Database Migration](https://cloud.google.com/database-migration) |
+| [Google.Cloud.CloudDms.V1](https://googleapis.dev/dotnet/Google.Cloud.CloudDms.V1/1.0.0) | 1.0.0 | [Database Migration](https://cloud.google.com/database-migration) |
 | [Google.Cloud.Compute.V1](https://googleapis.dev/dotnet/Google.Cloud.Compute.V1/1.0.0-alpha02) | 1.0.0-alpha02 | [Compute Engine](https://cloud.google.com/compute) |
 | [Google.Cloud.Container.V1](https://googleapis.dev/dotnet/Google.Cloud.Container.V1/2.3.0) | 2.3.0 | [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/reference/rest/) |
 | [Google.Cloud.DataCatalog.V1](https://googleapis.dev/dotnet/Google.Cloud.DataCatalog.V1/1.2.0) | 1.2.0 | [Data Catalog](https://cloud.google.com/data-catalog/docs) |

--- a/apis/Google.Cloud.CloudDms.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.CloudDms.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.CloudDms.V1",
-  "release_level": "beta",
+  "release_level": "ga",
   "client_documentation": "https://googleapis.dev/dotnet/Google.Cloud.CloudDms.V1/latest",
   "library_type": "GAPIC_AUTO"
 }

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.csproj
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Database Migration API, which manages Cloud Database Migration Service resources on Google Cloud Platform.</Description>
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />

--- a/apis/Google.Cloud.CloudDms.V1/docs/history.md
+++ b/apis/Google.Cloud.CloudDms.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+# Version 1.0.0, released 2021-06-16
+
+- [Commit 5be25f6](https://github.com/googleapis/google-cloud-dotnet/commit/5be25f6): docs: update link in comments
+
+Other than the comment change shown above, this is just a dependency
+update and promotion to GA.
+
 # Version 1.0.0-beta01, released 2021-05-11
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -487,7 +487,7 @@
     },
     {
       "id": "Google.Cloud.CloudDms.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Database Migration",
       "productUrl": "https://cloud.google.com/database-migration",
@@ -497,7 +497,9 @@
         "migration"
       ],
       "dependencies": {
-        "Google.LongRunning": "2.1.0"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.LongRunning": "2.2.0",
+        "Grpc.Core": "2.38.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/clouddms/v1"

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -45,7 +45,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.BinaryAuthorization.V1Beta1](Google.Cloud.BinaryAuthorization.V1Beta1/index.html) | 1.0.0-beta02 | [Binary Authorization](https://cloud.google.com/binary-authorization/docs/reference/rpc) |
 | [Google.Cloud.Channel.V1](Google.Cloud.Channel.V1/index.html) | 1.1.0 | [Cloud Channel](https://cloud.google.com/channel/docs/) |
 | [Google.Cloud.CloudBuild.V1](Google.Cloud.CloudBuild.V1/index.html) | 1.1.0 | [Cloud Build](https://cloud.google.com/cloud-build) |
-| [Google.Cloud.CloudDms.V1](Google.Cloud.CloudDms.V1/index.html) | 1.0.0-beta01 | [Database Migration](https://cloud.google.com/database-migration) |
+| [Google.Cloud.CloudDms.V1](Google.Cloud.CloudDms.V1/index.html) | 1.0.0 | [Database Migration](https://cloud.google.com/database-migration) |
 | [Google.Cloud.Compute.V1](Google.Cloud.Compute.V1/index.html) | 1.0.0-alpha02 | [Compute Engine](https://cloud.google.com/compute) |
 | [Google.Cloud.Container.V1](Google.Cloud.Container.V1/index.html) | 2.3.0 | [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/reference/rest/) |
 | [Google.Cloud.DataCatalog.V1](Google.Cloud.DataCatalog.V1/index.html) | 1.2.0 | [Data Catalog](https://cloud.google.com/data-catalog/docs) |


### PR DESCRIPTION

Changes in this release:

- [Commit 5be25f6](https://github.com/googleapis/google-cloud-dotnet/commit/5be25f6): docs: update link in comments

Other than the comment change shown above, this is just a dependency update and promotion to GA.
