### PR TITLE
Release Google.Analytics.Admin.V1Alpha version 1.0.0-alpha07

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Each package name links to the documentation for that package.
 
 | Package | Latest version | Description |
 |---------|----------------|-------------|
-| [Google.Analytics.Admin.V1Alpha](https://googleapis.dev/dotnet/Google.Analytics.Admin.V1Alpha/1.0.0-alpha06) | 1.0.0-alpha06 | [Analytics Admin](https://developers.google.com/analytics) |
+| [Google.Analytics.Admin.V1Alpha](https://googleapis.dev/dotnet/Google.Analytics.Admin.V1Alpha/1.0.0-alpha07) | 1.0.0-alpha07 | [Analytics Admin](https://developers.google.com/analytics) |
 | [Google.Analytics.Data.V1Alpha](https://googleapis.dev/dotnet/Google.Analytics.Data.V1Alpha/1.0.0-alpha05) | 1.0.0-alpha05 | [Google Analytics Data (V1Alpha API)](https://developers.google.com/analytics) |
 | [Google.Analytics.Data.V1Beta](https://googleapis.dev/dotnet/Google.Analytics.Data.V1Beta/1.0.0-beta03) | 1.0.0-beta03 | [Google Analytics Data (V1Beta API)](https://developers.google.com/analytics) |
 | [Google.Apps.Script.Type](https://googleapis.dev/dotnet/Google.Apps.Script.Type/1.0.0) | 1.0.0 | Version-agnostic types for Apps Script APIs |
@@ -59,7 +59,6 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Dialogflow.V2](https://googleapis.dev/dotnet/Google.Cloud.Dialogflow.V2/3.2.0) | 3.2.0 | [Google Cloud Dialogflow](https://cloud.google.com/dialogflow-enterprise/) |
 | [Google.Cloud.Dlp.V2](https://googleapis.dev/dotnet/Google.Cloud.Dlp.V2/3.2.0) | 3.2.0 | [Google Cloud Data Loss Prevention](https://cloud.google.com/dlp/) |
 | [Google.Cloud.DocumentAI.V1](https://googleapis.dev/dotnet/Google.Cloud.DocumentAI.V1/1.0.0) | 1.0.0 | [Cloud Document AI (V1 API)](https://cloud.google.com/solutions/document-ai) |
-| [Google.Cloud.DocumentAI.V1Beta2](https://googleapis.dev/dotnet/Google.Cloud.DocumentAI.V1Beta2/1.0.0-beta03) | 1.0.0-beta03 | [Cloud Document AI (V1Beta2 API)](https://cloud.google.com/solutions/document-ai) |
 | [Google.Cloud.DocumentAI.V1Beta3](https://googleapis.dev/dotnet/Google.Cloud.DocumentAI.V1Beta3/1.0.0-beta01) | 1.0.0-beta01 | [Cloud Document AI (V1Beta3 API)](https://cloud.google.com/solutions/document-ai) |
 | [Google.Cloud.Domains.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Domains.V1Beta1/1.0.0-beta02) | 1.0.0-beta02 | [Cloud Domains](https://cloud.google.com/domains/) |
 | [Google.Cloud.ErrorReporting.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.ErrorReporting.V1Beta1/2.0.0-beta04) | 2.0.0-beta04 | [Google Cloud Error Reporting](https://cloud.google.com/error-reporting/) |

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha06</Version>
+    <Version>1.0.0-alpha07</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Analytics Admin API (v1alpha)</Description>

--- a/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
+++ b/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
@@ -1,5 +1,21 @@
 # Version history
 
+# Version 1.0.0-alpha07, released 2021-06-22
+
+- [Commit 1ca49a3](https://github.com/googleapis/google-cloud-dotnet/commit/1ca49a3):
+  - feat: add `GetMeasurementProtocolSecret`, `ListMeasurementProtocolSecrets`, `CreateMeasurementProtocolSecret`, `DeleteMeasurementProtocolSecret`, `UpdateMeasurementProtocolSecret` methods to the API
+  - feat: add `GetGoogleSignalsSettings`, `UpdateGoogleSignalsSettings` methods to the API
+  - feat: add `CreateConversionEvent`, `GetConversionEvent`, `DeleteConversionEvent`, `ListConversionEvents` methods to the API
+  - feat: add `CreateCustomDimension`, `GetCustomDimension`, `UpdateCustomDimension`, `ListCustomDimensions`, `ArchiveCustomDimension` methods to the API
+  - feat: add `CreateCustomMetric`, `GetCustomMetric`, `UpdateCustomMetric`, `ListCustomMetrics`, `ArchiveCustomMetric` methods to the API
+  - feat: add `GoogleSignalsState`, `GoogleSignalsConsent` types
+  - feat: add `GoogleSignalsSettings` type
+  - feat: add `MeasurementProtocolSecret` type
+  - feat: add `ConversionEvent` type
+  - feat: add `CustomDimension` type
+  - feat: add `CustomMetric` type
+  - feat: extend `ChangeHistoryResourceType` enum to support `GOOGLE_SIGNALS_SETTINGS`, `CONVERSION_EVENT`, `MEASUREMENT_PROTOCOL_SECRET`, `CUSTOM_DIMENSION`, `CUSTOM_METRIC` values fix: label `email_address` field of `UserLink` type as immutable fix: label `name` field of `UserLink` type as output only
+
 # Version 1.0.0-alpha06, released 2021-04-28
 
 - [Commit b01d59c](https://github.com/googleapis/google-cloud-dotnet/commit/b01d59c):

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2,7 +2,7 @@
   "apis": [
     {
       "id": "Google.Analytics.Admin.V1Alpha",
-      "version": "1.0.0-alpha06",
+      "version": "1.0.0-alpha07",
       "type": "grpc",
       "productName": "Analytics Admin",
       "productUrl": "https://developers.google.com/analytics",

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -18,7 +18,7 @@ Each package name links to the documentation for that package.
 
 | Package | Latest version | Description |
 |---------|----------------|-------------|
-| [Google.Analytics.Admin.V1Alpha](Google.Analytics.Admin.V1Alpha/index.html) | 1.0.0-alpha06 | [Analytics Admin](https://developers.google.com/analytics) |
+| [Google.Analytics.Admin.V1Alpha](Google.Analytics.Admin.V1Alpha/index.html) | 1.0.0-alpha07 | [Analytics Admin](https://developers.google.com/analytics) |
 | [Google.Analytics.Data.V1Alpha](Google.Analytics.Data.V1Alpha/index.html) | 1.0.0-alpha05 | [Google Analytics Data (V1Alpha API)](https://developers.google.com/analytics) |
 | [Google.Analytics.Data.V1Beta](Google.Analytics.Data.V1Beta/index.html) | 1.0.0-beta03 | [Google Analytics Data (V1Beta API)](https://developers.google.com/analytics) |
 | [Google.Apps.Script.Type](Google.Apps.Script.Type/index.html) | 1.0.0 | Version-agnostic types for Apps Script APIs |
@@ -64,7 +64,6 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Dialogflow.V2](Google.Cloud.Dialogflow.V2/index.html) | 3.2.0 | [Google Cloud Dialogflow](https://cloud.google.com/dialogflow-enterprise/) |
 | [Google.Cloud.Dlp.V2](Google.Cloud.Dlp.V2/index.html) | 3.2.0 | [Google Cloud Data Loss Prevention](https://cloud.google.com/dlp/) |
 | [Google.Cloud.DocumentAI.V1](Google.Cloud.DocumentAI.V1/index.html) | 1.0.0 | [Cloud Document AI (V1 API)](https://cloud.google.com/solutions/document-ai) |
-| [Google.Cloud.DocumentAI.V1Beta2](Google.Cloud.DocumentAI.V1Beta2/index.html) | 1.0.0-beta03 | [Cloud Document AI (V1Beta2 API)](https://cloud.google.com/solutions/document-ai) |
 | [Google.Cloud.DocumentAI.V1Beta3](Google.Cloud.DocumentAI.V1Beta3/index.html) | 1.0.0-beta01 | [Cloud Document AI (V1Beta3 API)](https://cloud.google.com/solutions/document-ai) |
 | [Google.Cloud.Domains.V1Beta1](Google.Cloud.Domains.V1Beta1/index.html) | 1.0.0-beta02 | [Cloud Domains](https://cloud.google.com/domains/) |
 | [Google.Cloud.ErrorReporting.V1Beta1](Google.Cloud.ErrorReporting.V1Beta1/index.html) | 2.0.0-beta04 | [Google Cloud Error Reporting](https://cloud.google.com/error-reporting/) |


### PR DESCRIPTION

Changes in this release:

- [Commit 1ca49a3](https://github.com/googleapis/google-cloud-dotnet/commit/1ca49a3):
  - feat: add `GetMeasurementProtocolSecret`, `ListMeasurementProtocolSecrets`, `CreateMeasurementProtocolSecret`, `DeleteMeasurementProtocolSecret`, `UpdateMeasurementProtocolSecret` methods to the API
  - feat: add `GetGoogleSignalsSettings`, `UpdateGoogleSignalsSettings` methods to the API
  - feat: add `CreateConversionEvent`, `GetConversionEvent`, `DeleteConversionEvent`, `ListConversionEvents` methods to the API
  - feat: add `CreateCustomDimension`, `GetCustomDimension`, `UpdateCustomDimension`, `ListCustomDimensions`, `ArchiveCustomDimension` methods to the API
  - feat: add `CreateCustomMetric`, `GetCustomMetric`, `UpdateCustomMetric`, `ListCustomMetrics`, `ArchiveCustomMetric` methods to the API
  - feat: add `GoogleSignalsState`, `GoogleSignalsConsent` types
  - feat: add `GoogleSignalsSettings` type
  - feat: add `MeasurementProtocolSecret` type
  - feat: add `ConversionEvent` type
  - feat: add `CustomDimension` type
  - feat: add `CustomMetric` type
  - feat: extend `ChangeHistoryResourceType` enum to support `GOOGLE_SIGNALS_SETTINGS`, `CONVERSION_EVENT`, `MEASUREMENT_PROTOCOL_SECRET`, `CUSTOM_DIMENSION`, `CUSTOM_METRIC` values fix: label `email_address` field of `UserLink` type as immutable fix: label `name` field of `UserLink` type as output only
