### PR TITLE
Release Google.Cloud.BinaryAuthorization.V1Beta1 version 1.0.0-beta03

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Billing.Budgets.V1](https://googleapis.dev/dotnet/Google.Cloud.Billing.Budgets.V1/1.1.0) | 1.1.0 | [Cloud Billing Budget (V1 API)](https://cloud.google.com/billing/docs/how-to/budget-api-overview) |
 | [Google.Cloud.Billing.Budgets.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Billing.Budgets.V1Beta1/1.0.0-beta03) | 1.0.0-beta03 | [Cloud Billing Budget (V1Beta1 API)](https://cloud.google.com/billing/docs/how-to/budget-api-overview) |
 | [Google.Cloud.Billing.V1](https://googleapis.dev/dotnet/Google.Cloud.Billing.V1/2.2.0) | 2.2.0 | [Google Cloud Billing](https://cloud.google.com/billing/docs/) |
-| [Google.Cloud.BinaryAuthorization.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.BinaryAuthorization.V1Beta1/1.0.0-beta02) | 1.0.0-beta02 | [Binary Authorization](https://cloud.google.com/binary-authorization/docs/reference/rpc) |
+| [Google.Cloud.BinaryAuthorization.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.BinaryAuthorization.V1Beta1/1.0.0-beta03) | 1.0.0-beta03 | [Binary Authorization](https://cloud.google.com/binary-authorization/docs/reference/rpc) |
 | [Google.Cloud.Channel.V1](https://googleapis.dev/dotnet/Google.Cloud.Channel.V1/1.1.0) | 1.1.0 | [Cloud Channel](https://cloud.google.com/channel/docs/) |
 | [Google.Cloud.CloudBuild.V1](https://googleapis.dev/dotnet/Google.Cloud.CloudBuild.V1/1.1.0) | 1.1.0 | [Cloud Build](https://cloud.google.com/cloud-build) |
 | [Google.Cloud.CloudDms.V1](https://googleapis.dev/dotnet/Google.Cloud.CloudDms.V1/1.0.0) | 1.0.0 | [Database Migration](https://cloud.google.com/database-migration) |

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.csproj
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Binary Authorization API v1beta1, providing policy control for images deployed to Kubernetes Engine clusters.</Description>

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.0.0-beta03, released 2021-06-22
+
+- [Commit 9e5abc8](https://github.com/googleapis/google-cloud-dotnet/commit/9e5abc8): feat: Publish Binary Authorization ContinuousValidationEvent proto. This is used in the new [Continuous Validation](https://cloud.google.com/binary-authorization/docs/overview-cv) feature
+
 # Version 1.0.0-beta02, released 2021-04-29
 
 - [Commit e94047c](https://github.com/googleapis/google-cloud-dotnet/commit/e94047c): docs: Replace "whitelist" with "allowlist" in generated documentation

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -431,7 +431,7 @@
     },
     {
       "id": "Google.Cloud.BinaryAuthorization.V1Beta1",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0-beta03",
       "type": "grpc",
       "productName": "Binary Authorization",
       "productUrl": "https://cloud.google.com/binary-authorization/docs/reference/rpc",

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -42,7 +42,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Billing.Budgets.V1](Google.Cloud.Billing.Budgets.V1/index.html) | 1.1.0 | [Cloud Billing Budget (V1 API)](https://cloud.google.com/billing/docs/how-to/budget-api-overview) |
 | [Google.Cloud.Billing.Budgets.V1Beta1](Google.Cloud.Billing.Budgets.V1Beta1/index.html) | 1.0.0-beta03 | [Cloud Billing Budget (V1Beta1 API)](https://cloud.google.com/billing/docs/how-to/budget-api-overview) |
 | [Google.Cloud.Billing.V1](Google.Cloud.Billing.V1/index.html) | 2.2.0 | [Google Cloud Billing](https://cloud.google.com/billing/docs/) |
-| [Google.Cloud.BinaryAuthorization.V1Beta1](Google.Cloud.BinaryAuthorization.V1Beta1/index.html) | 1.0.0-beta02 | [Binary Authorization](https://cloud.google.com/binary-authorization/docs/reference/rpc) |
+| [Google.Cloud.BinaryAuthorization.V1Beta1](Google.Cloud.BinaryAuthorization.V1Beta1/index.html) | 1.0.0-beta03 | [Binary Authorization](https://cloud.google.com/binary-authorization/docs/reference/rpc) |
 | [Google.Cloud.Channel.V1](Google.Cloud.Channel.V1/index.html) | 1.1.0 | [Cloud Channel](https://cloud.google.com/channel/docs/) |
 | [Google.Cloud.CloudBuild.V1](Google.Cloud.CloudBuild.V1/index.html) | 1.1.0 | [Cloud Build](https://cloud.google.com/cloud-build) |
 | [Google.Cloud.CloudDms.V1](Google.Cloud.CloudDms.V1/index.html) | 1.0.0 | [Database Migration](https://cloud.google.com/database-migration) |


### PR DESCRIPTION

Changes in this release:

- [Commit 9e5abc8](https://github.com/googleapis/google-cloud-dotnet/commit/9e5abc8): feat: Publish Binary Authorization ContinuousValidationEvent proto. This is used in the new [Continuous Validation](https://cloud.google.com/binary-authorization/docs/overview-cv) feature
