### PR TITLE
Release Google.Cloud.Tpu.V1 version 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Tasks.V2Beta3](https://googleapis.dev/dotnet/Google.Cloud.Tasks.V2Beta3/2.0.0-beta05) | 2.0.0-beta05 | [Google Cloud Tasks (V2Beta3 API)](https://cloud.google.com/tasks/) |
 | [Google.Cloud.TextToSpeech.V1](https://googleapis.dev/dotnet/Google.Cloud.TextToSpeech.V1/2.2.0) | 2.2.0 | [Google Cloud Text-to-Speech (V1 API)](https://cloud.google.com/text-to-speech) |
 | [Google.Cloud.TextToSpeech.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.TextToSpeech.V1Beta1/1.0.0-beta01) | 1.0.0-beta01 | [Google Cloud Text-to-Speech (V1Beta1 API)](https://cloud.google.com/text-to-speech) |
-| [Google.Cloud.Tpu.V1](https://googleapis.dev/dotnet/Google.Cloud.Tpu.V1/1.0.0-beta01) | 1.0.0-beta01 | [Cloud TPU](https://cloud.google.com/tpu/) |
+| [Google.Cloud.Tpu.V1](https://googleapis.dev/dotnet/Google.Cloud.Tpu.V1/1.0.0) | 1.0.0 | [Cloud TPU](https://cloud.google.com/tpu/) |
 | [Google.Cloud.Trace.V1](https://googleapis.dev/dotnet/Google.Cloud.Trace.V1/2.2.0) | 2.2.0 | [Google Cloud Trace (V1 API)](https://cloud.google.com/trace/) |
 | [Google.Cloud.Trace.V2](https://googleapis.dev/dotnet/Google.Cloud.Trace.V2/2.2.0) | 2.2.0 | [Google Cloud Trace (V2 API)](https://cloud.google.com/trace/) |
 | [Google.Cloud.Translate.V3](https://googleapis.dev/dotnet/Google.Cloud.Translate.V3/2.2.0) | 2.2.0 | [Google Cloud Translation (V3 API)](https://cloud.google.com/translate/) |

--- a/apis/Google.Cloud.Tpu.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.Tpu.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.Tpu.V1",
-  "release_level": "beta",
+  "release_level": "ga",
   "client_documentation": "https://googleapis.dev/dotnet/Google.Cloud.Tpu.V1/latest",
   "library_type": "GAPIC_AUTO"
 }

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.csproj
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud TPU API, which provides customers with access to Google TPU technology.</Description>

--- a/apis/Google.Cloud.Tpu.V1/docs/history.md
+++ b/apis/Google.Cloud.Tpu.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.0.0, released 2021-06-22
+
+No API surface changes; just dependency updates and promotion to GA.
+
 # Version 1.0.0-beta01, released 2021-05-27
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2477,7 +2477,7 @@
     },
     {
       "id": "Google.Cloud.Tpu.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Cloud TPU",
       "productUrl": "https://cloud.google.com/tpu/",
@@ -2486,7 +2486,9 @@
         "tpu"
       ],
       "dependencies": {
-        "Google.LongRunning": "2.2.0"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.LongRunning": "2.2.0",
+        "Grpc.Core": "2.38.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/tpu/v1"

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -147,7 +147,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Tasks.V2Beta3](Google.Cloud.Tasks.V2Beta3/index.html) | 2.0.0-beta05 | [Google Cloud Tasks (V2Beta3 API)](https://cloud.google.com/tasks/) |
 | [Google.Cloud.TextToSpeech.V1](Google.Cloud.TextToSpeech.V1/index.html) | 2.2.0 | [Google Cloud Text-to-Speech (V1 API)](https://cloud.google.com/text-to-speech) |
 | [Google.Cloud.TextToSpeech.V1Beta1](Google.Cloud.TextToSpeech.V1Beta1/index.html) | 1.0.0-beta01 | [Google Cloud Text-to-Speech (V1Beta1 API)](https://cloud.google.com/text-to-speech) |
-| [Google.Cloud.Tpu.V1](Google.Cloud.Tpu.V1/index.html) | 1.0.0-beta01 | [Cloud TPU](https://cloud.google.com/tpu/) |
+| [Google.Cloud.Tpu.V1](Google.Cloud.Tpu.V1/index.html) | 1.0.0 | [Cloud TPU](https://cloud.google.com/tpu/) |
 | [Google.Cloud.Trace.V1](Google.Cloud.Trace.V1/index.html) | 2.2.0 | [Google Cloud Trace (V1 API)](https://cloud.google.com/trace/) |
 | [Google.Cloud.Trace.V2](Google.Cloud.Trace.V2/index.html) | 2.2.0 | [Google Cloud Trace (V2 API)](https://cloud.google.com/trace/) |
 | [Google.Cloud.Translate.V3](Google.Cloud.Translate.V3/index.html) | 2.2.0 | [Google Cloud Translation (V3 API)](https://cloud.google.com/translate/) |


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates and promotion to GA.
