### PR TITLE
Release Google.Cloud.ServiceUsage.V1 version 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.ServiceDirectory.V1](https://googleapis.dev/dotnet/Google.Cloud.ServiceDirectory.V1/1.1.0) | 1.1.0 | [Service Directory (V1 API)](https://cloud.google.com/service-directory/) |
 | [Google.Cloud.ServiceDirectory.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.ServiceDirectory.V1Beta1/1.0.0-beta04) | 1.0.0-beta04 | [Service Directory (V1Beta1 API)](https://cloud.google.com/service-directory/) |
 | [Google.Cloud.ServiceManagement.V1](https://googleapis.dev/dotnet/Google.Cloud.ServiceManagement.V1/1.1.0) | 1.1.0 | [Service Management](https://cloud.google.com/service-infrastructure/docs/service-management/reference/rpc) |
-| [Google.Cloud.ServiceUsage.V1](https://googleapis.dev/dotnet/Google.Cloud.ServiceUsage.V1/1.0.0-beta01) | 1.0.0-beta01 | [Service Usage](https://cloud.google.com/service-usage/docs/) |
+| [Google.Cloud.ServiceUsage.V1](https://googleapis.dev/dotnet/Google.Cloud.ServiceUsage.V1/1.0.0) | 1.0.0 | [Service Usage](https://cloud.google.com/service-usage/docs/) |
 | [Google.Cloud.Shell.V1](https://googleapis.dev/dotnet/Google.Cloud.Shell.V1/1.0.0) | 1.0.0 | [Cloud Shell](https://cloud.google.com/shell/) |
 | [Google.Cloud.Spanner.Admin.Database.V1](https://googleapis.dev/dotnet/Google.Cloud.Spanner.Admin.Database.V1/3.9.0) | 3.9.0 | [Google Cloud Spanner Database Administration](https://cloud.google.com/spanner/) |
 | [Google.Cloud.Spanner.Admin.Instance.V1](https://googleapis.dev/dotnet/Google.Cloud.Spanner.Admin.Instance.V1/3.9.0) | 3.9.0 | [Google Cloud Spanner Instance Administration](https://cloud.google.com/spanner/) |

--- a/apis/Google.Cloud.ServiceUsage.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.ServiceUsage.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.ServiceUsage.V1",
-  "release_level": "beta",
+  "release_level": "ga",
   "client_documentation": "https://googleapis.dev/dotnet/Google.Cloud.ServiceUsage.V1/latest",
   "library_type": "GAPIC_AUTO"
 }

--- a/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1.csproj
+++ b/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Service Usage API, which enables services that service consumers want to use on Google Cloud Platform, lists the available or enabled services, or disables services that service consumers no longer use.</Description>

--- a/apis/Google.Cloud.ServiceUsage.V1/docs/history.md
+++ b/apis/Google.Cloud.ServiceUsage.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.0.0, released 2021-06-22
+
+No API surface changes; just dependency updates and promotion to GA.
+
 # Version 1.0.0-beta01, released 2021-05-20
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2169,7 +2169,7 @@
     },
     {
       "id": "Google.Cloud.ServiceUsage.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Service Usage",
       "productUrl": "https://cloud.google.com/service-usage/docs/",
@@ -2179,7 +2179,9 @@
         "apis"
       ],
       "dependencies": {
-        "Google.LongRunning": "2.2.0"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.LongRunning": "2.2.0",
+        "Grpc.Core": "2.38.0"
       },
       "generator": "micro",
       "protoPath": "google/api/serviceusage/v1"

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -131,7 +131,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.ServiceDirectory.V1](Google.Cloud.ServiceDirectory.V1/index.html) | 1.1.0 | [Service Directory (V1 API)](https://cloud.google.com/service-directory/) |
 | [Google.Cloud.ServiceDirectory.V1Beta1](Google.Cloud.ServiceDirectory.V1Beta1/index.html) | 1.0.0-beta04 | [Service Directory (V1Beta1 API)](https://cloud.google.com/service-directory/) |
 | [Google.Cloud.ServiceManagement.V1](Google.Cloud.ServiceManagement.V1/index.html) | 1.1.0 | [Service Management](https://cloud.google.com/service-infrastructure/docs/service-management/reference/rpc) |
-| [Google.Cloud.ServiceUsage.V1](Google.Cloud.ServiceUsage.V1/index.html) | 1.0.0-beta01 | [Service Usage](https://cloud.google.com/service-usage/docs/) |
+| [Google.Cloud.ServiceUsage.V1](Google.Cloud.ServiceUsage.V1/index.html) | 1.0.0 | [Service Usage](https://cloud.google.com/service-usage/docs/) |
 | [Google.Cloud.Shell.V1](Google.Cloud.Shell.V1/index.html) | 1.0.0 | [Cloud Shell](https://cloud.google.com/shell/) |
 | [Google.Cloud.Spanner.Admin.Database.V1](Google.Cloud.Spanner.Admin.Database.V1/index.html) | 3.9.0 | [Google Cloud Spanner Database Administration](https://cloud.google.com/spanner/) |
 | [Google.Cloud.Spanner.Admin.Instance.V1](Google.Cloud.Spanner.Admin.Instance.V1/index.html) | 3.9.0 | [Google Cloud Spanner Instance Administration](https://cloud.google.com/spanner/) |


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates and promotion to GA.
