### PR TITLE
Release Google.Cloud.CloudBuild.V1 version 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Billing.V1](https://googleapis.dev/dotnet/Google.Cloud.Billing.V1/2.2.0) | 2.2.0 | [Google Cloud Billing](https://cloud.google.com/billing/docs/) |
 | [Google.Cloud.BinaryAuthorization.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.BinaryAuthorization.V1Beta1/1.0.0-beta03) | 1.0.0-beta03 | [Binary Authorization](https://cloud.google.com/binary-authorization/docs/reference/rpc) |
 | [Google.Cloud.Channel.V1](https://googleapis.dev/dotnet/Google.Cloud.Channel.V1/1.2.0) | 1.2.0 | [Cloud Channel](https://cloud.google.com/channel/docs/) |
-| [Google.Cloud.CloudBuild.V1](https://googleapis.dev/dotnet/Google.Cloud.CloudBuild.V1/1.1.0) | 1.1.0 | [Cloud Build](https://cloud.google.com/cloud-build) |
+| [Google.Cloud.CloudBuild.V1](https://googleapis.dev/dotnet/Google.Cloud.CloudBuild.V1/1.2.0) | 1.2.0 | [Cloud Build](https://cloud.google.com/cloud-build) |
 | [Google.Cloud.CloudDms.V1](https://googleapis.dev/dotnet/Google.Cloud.CloudDms.V1/1.0.0) | 1.0.0 | [Database Migration](https://cloud.google.com/database-migration) |
 | [Google.Cloud.Compute.V1](https://googleapis.dev/dotnet/Google.Cloud.Compute.V1/1.0.0-alpha02) | 1.0.0-alpha02 | [Compute Engine](https://cloud.google.com/compute) |
 | [Google.Cloud.Container.V1](https://googleapis.dev/dotnet/Google.Cloud.Container.V1/2.3.0) | 2.3.0 | [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/reference/rest/) |

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.csproj
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Build API, which creates and manages builds on Google Cloud Platform.</Description>
@@ -11,9 +11,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.CloudBuild.V1/docs/history.md
+++ b/apis/Google.Cloud.CloudBuild.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+# Version 1.2.0, released 2021-06-22
+
+- [Commit 8c80969](https://github.com/googleapis/google-cloud-dotnet/commit/8c80969):
+  - feat: Implementation of Source Manifests
+    - Added message StorageSourceManifest as an option for the Source message
+    - Added StorageSourceManifest field to the SourceProvenance message
+
 # Version 1.1.0, released 2021-04-29
 
 - [Commit f4e1ad2](https://github.com/googleapis/google-cloud-dotnet/commit/f4e1ad2): feat: Add fields for Pub/Sub triggers

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -468,7 +468,7 @@
     },
     {
       "id": "Google.Cloud.CloudBuild.V1",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "type": "grpc",
       "productName": "Cloud Build",
       "productUrl": "https://cloud.google.com/cloud-build",
@@ -478,9 +478,9 @@
         "cloudbuild"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Google.LongRunning": "2.1.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.LongRunning": "2.2.0",
+        "Grpc.Core": "2.38.0"
       },
       "generator": "micro",
       "protoPath": "google/devtools/cloudbuild/v1"

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -44,7 +44,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Billing.V1](Google.Cloud.Billing.V1/index.html) | 2.2.0 | [Google Cloud Billing](https://cloud.google.com/billing/docs/) |
 | [Google.Cloud.BinaryAuthorization.V1Beta1](Google.Cloud.BinaryAuthorization.V1Beta1/index.html) | 1.0.0-beta03 | [Binary Authorization](https://cloud.google.com/binary-authorization/docs/reference/rpc) |
 | [Google.Cloud.Channel.V1](Google.Cloud.Channel.V1/index.html) | 1.2.0 | [Cloud Channel](https://cloud.google.com/channel/docs/) |
-| [Google.Cloud.CloudBuild.V1](Google.Cloud.CloudBuild.V1/index.html) | 1.1.0 | [Cloud Build](https://cloud.google.com/cloud-build) |
+| [Google.Cloud.CloudBuild.V1](Google.Cloud.CloudBuild.V1/index.html) | 1.2.0 | [Cloud Build](https://cloud.google.com/cloud-build) |
 | [Google.Cloud.CloudDms.V1](Google.Cloud.CloudDms.V1/index.html) | 1.0.0 | [Database Migration](https://cloud.google.com/database-migration) |
 | [Google.Cloud.Compute.V1](Google.Cloud.Compute.V1/index.html) | 1.0.0-alpha02 | [Compute Engine](https://cloud.google.com/compute) |
 | [Google.Cloud.Container.V1](Google.Cloud.Container.V1/index.html) | 2.3.0 | [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/reference/rest/) |


### PR DESCRIPTION

Changes in this release:

- [Commit 8c80969](https://github.com/googleapis/google-cloud-dotnet/commit/8c80969):
  - feat: Implementation of Source Manifests
    - Added message StorageSourceManifest as an option for the Source message
    - Added StorageSourceManifest field to the SourceProvenance message
