### PR TITLE
Release Google.Cloud.OsConfig.V1Alpha version 1.0.0-alpha02

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.OrgPolicy.V1](https://googleapis.dev/dotnet/Google.Cloud.OrgPolicy.V1/2.2.0) | 2.2.0 | OrgPolicy API messages |
 | [Google.Cloud.OrgPolicy.V2](https://googleapis.dev/dotnet/Google.Cloud.OrgPolicy.V2/1.0.0) | 1.0.0 | [Organization Policy](https://cloud.google.com/resource-manager/docs/organization-policy/overview) |
 | [Google.Cloud.OsConfig.V1](https://googleapis.dev/dotnet/Google.Cloud.OsConfig.V1/1.3.0) | 1.3.0 | [Google Cloud OS Config (V1 API)](https://cloud.google.com/compute/docs/osconfig/rest) |
-| [Google.Cloud.OsConfig.V1Alpha](https://googleapis.dev/dotnet/Google.Cloud.OsConfig.V1Alpha/1.0.0-alpha01) | 1.0.0-alpha01 | [Google Cloud OS Config (V1Alpha API)](https://cloud.google.com/compute/docs/osconfig/rest) |
+| [Google.Cloud.OsConfig.V1Alpha](https://googleapis.dev/dotnet/Google.Cloud.OsConfig.V1Alpha/1.0.0-alpha02) | 1.0.0-alpha02 | [Google Cloud OS Config (V1Alpha API)](https://cloud.google.com/compute/docs/osconfig/rest) |
 | [Google.Cloud.OsLogin.Common](https://googleapis.dev/dotnet/Google.Cloud.OsLogin.Common/2.2.0) | 2.2.0 | Version-agnostic types for the Google OS Login API |
 | [Google.Cloud.OsLogin.V1](https://googleapis.dev/dotnet/Google.Cloud.OsLogin.V1/2.2.0) | 2.2.0 | [Google Cloud OS Login (V1 API)](https://cloud.google.com/compute/docs/instances/managing-instance-access) |
 | [Google.Cloud.OsLogin.V1Beta](https://googleapis.dev/dotnet/Google.Cloud.OsLogin.V1Beta/2.0.0-beta04) | 2.0.0-beta04 | [Google Cloud OS Login (V1Beta API)](https://cloud.google.com/compute/docs/instances/managing-instance-access) |

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.csproj
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha01</Version>
+    <Version>1.0.0-alpha02</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library for the Cloud OS Config API (v1 alpha). These are OS management tools that can be used for patch management, patch compliance, and configuration management on VM instances.</Description>
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />

--- a/apis/Google.Cloud.OsConfig.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.0.0-alpha02, released 2021-06-22
+
+- [Commit bf2ca0a](https://github.com/googleapis/google-cloud-dotnet/commit/bf2ca0a): feat: OSConfig: add ExecResourceOutput and per step error message.
+
 # Version 1.0.0-alpha01, released 2021-05-12
 
 First (alpha) release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1623,7 +1623,7 @@
     },
     {
       "id": "Google.Cloud.OsConfig.V1Alpha",
-      "version": "1.0.0-alpha01",
+      "version": "1.0.0-alpha02",
       "type": "grpc",
       "productName": "Google Cloud OS Config",
       "productUrl": "https://cloud.google.com/compute/docs/osconfig/rest",
@@ -1636,7 +1636,7 @@
         "Configuration"
       ],
       "dependencies": {
-        "Google.LongRunning": "2.1.0"
+        "Google.LongRunning": "2.2.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/osconfig/v1alpha"

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -102,7 +102,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.OrgPolicy.V1](Google.Cloud.OrgPolicy.V1/index.html) | 2.2.0 | OrgPolicy API messages |
 | [Google.Cloud.OrgPolicy.V2](Google.Cloud.OrgPolicy.V2/index.html) | 1.0.0 | [Organization Policy](https://cloud.google.com/resource-manager/docs/organization-policy/overview) |
 | [Google.Cloud.OsConfig.V1](Google.Cloud.OsConfig.V1/index.html) | 1.3.0 | [Google Cloud OS Config (V1 API)](https://cloud.google.com/compute/docs/osconfig/rest) |
-| [Google.Cloud.OsConfig.V1Alpha](Google.Cloud.OsConfig.V1Alpha/index.html) | 1.0.0-alpha01 | [Google Cloud OS Config (V1Alpha API)](https://cloud.google.com/compute/docs/osconfig/rest) |
+| [Google.Cloud.OsConfig.V1Alpha](Google.Cloud.OsConfig.V1Alpha/index.html) | 1.0.0-alpha02 | [Google Cloud OS Config (V1Alpha API)](https://cloud.google.com/compute/docs/osconfig/rest) |
 | [Google.Cloud.OsLogin.Common](Google.Cloud.OsLogin.Common/index.html) | 2.2.0 | Version-agnostic types for the Google OS Login API |
 | [Google.Cloud.OsLogin.V1](Google.Cloud.OsLogin.V1/index.html) | 2.2.0 | [Google Cloud OS Login (V1 API)](https://cloud.google.com/compute/docs/instances/managing-instance-access) |
 | [Google.Cloud.OsLogin.V1Beta](Google.Cloud.OsLogin.V1Beta/index.html) | 2.0.0-beta04 | [Google Cloud OS Login (V1Beta API)](https://cloud.google.com/compute/docs/instances/managing-instance-access) |


### PR DESCRIPTION

Changes in this release:

- [Commit bf2ca0a](https://github.com/googleapis/google-cloud-dotnet/commit/bf2ca0a): feat: OSConfig: add ExecResourceOutput and per step error message.
