### PR TITLE
Release Google.Cloud.SecretManager.V1 version 1.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.ResourceSettings.V1](https://googleapis.dev/dotnet/Google.Cloud.ResourceSettings.V1/1.0.0-beta01) | 1.0.0-beta01 | [Resource Settings](https://cloud.google.com/resource-settings/docs) |
 | [Google.Cloud.Retail.V2](https://googleapis.dev/dotnet/Google.Cloud.Retail.V2/1.1.0) | 1.1.0 | [Retail](https://cloud.google.com/retail/docs) |
 | [Google.Cloud.Scheduler.V1](https://googleapis.dev/dotnet/Google.Cloud.Scheduler.V1/2.2.0) | 2.2.0 | [Google Cloud Scheduler](https://cloud.google.com/scheduler/) |
-| [Google.Cloud.SecretManager.V1](https://googleapis.dev/dotnet/Google.Cloud.SecretManager.V1/1.4.0) | 1.4.0 | [Secret Manager (V1 API)](https://cloud.google.com/secret-manager) |
+| [Google.Cloud.SecretManager.V1](https://googleapis.dev/dotnet/Google.Cloud.SecretManager.V1/1.5.0) | 1.5.0 | [Secret Manager (V1 API)](https://cloud.google.com/secret-manager) |
 | [Google.Cloud.SecretManager.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.SecretManager.V1Beta1/2.0.0-beta04) | 2.0.0-beta04 | [Secret Manager (V1Beta1 API)](https://cloud.google.com/secret-manager) |
 | [Google.Cloud.Security.PrivateCA.V1](https://googleapis.dev/dotnet/Google.Cloud.Security.PrivateCA.V1/1.0.0-beta01) | 1.0.0-beta01 | [Certificate Authority (V1 API)](https://cloud.google.com/certificate-authority-service/) |
 | [Google.Cloud.Security.PrivateCA.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Security.PrivateCA.V1Beta1/1.0.0-beta02) | 1.0.0-beta02 | [Certificate Authority (V1Beta1 API)](https://cloud.google.com/certificate-authority-service/) |

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.csproj
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.4.0</Version>
+    <Version>1.5.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Secret Manager API.</Description>
@@ -11,9 +11,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.SecretManager.V1/docs/history.md
+++ b/apis/Google.Cloud.SecretManager.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.5.0, released 2021-06-22
+
+- [Commit fbd2e65](https://github.com/googleapis/google-cloud-dotnet/commit/fbd2e65): - feat: Etags - users can now use etags for optimistic concurrency control when modifying Secret or SecretVersion.
+
 # Version 1.4.0, released 2021-05-05
 
 - [Commit 5e2fe40](https://github.com/googleapis/google-cloud-dotnet/commit/5e2fe40): feat: Rotation for Secrets

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1964,13 +1964,13 @@
       "protoPath": "google/cloud/secretmanager/v1",
       "productName": "Secret Manager",
       "productUrl": "https://cloud.google.com/secret-manager",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Secret Manager API.",
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Google.Cloud.Iam.V1": "2.1.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Cloud.Iam.V1": "2.2.0",
+        "Grpc.Core": "2.38.0"
       },
       "tags": [
         "secret",

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -120,7 +120,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.ResourceSettings.V1](Google.Cloud.ResourceSettings.V1/index.html) | 1.0.0-beta01 | [Resource Settings](https://cloud.google.com/resource-settings/docs) |
 | [Google.Cloud.Retail.V2](Google.Cloud.Retail.V2/index.html) | 1.1.0 | [Retail](https://cloud.google.com/retail/docs) |
 | [Google.Cloud.Scheduler.V1](Google.Cloud.Scheduler.V1/index.html) | 2.2.0 | [Google Cloud Scheduler](https://cloud.google.com/scheduler/) |
-| [Google.Cloud.SecretManager.V1](Google.Cloud.SecretManager.V1/index.html) | 1.4.0 | [Secret Manager (V1 API)](https://cloud.google.com/secret-manager) |
+| [Google.Cloud.SecretManager.V1](Google.Cloud.SecretManager.V1/index.html) | 1.5.0 | [Secret Manager (V1 API)](https://cloud.google.com/secret-manager) |
 | [Google.Cloud.SecretManager.V1Beta1](Google.Cloud.SecretManager.V1Beta1/index.html) | 2.0.0-beta04 | [Secret Manager (V1Beta1 API)](https://cloud.google.com/secret-manager) |
 | [Google.Cloud.Security.PrivateCA.V1](Google.Cloud.Security.PrivateCA.V1/index.html) | 1.0.0-beta01 | [Certificate Authority (V1 API)](https://cloud.google.com/certificate-authority-service/) |
 | [Google.Cloud.Security.PrivateCA.V1Beta1](Google.Cloud.Security.PrivateCA.V1Beta1/index.html) | 1.0.0-beta02 | [Certificate Authority (V1Beta1 API)](https://cloud.google.com/certificate-authority-service/) |


### PR DESCRIPTION

Changes in this release:

- [Commit fbd2e65](https://github.com/googleapis/google-cloud-dotnet/commit/fbd2e65): - feat: Etags - users can now use etags for optimistic concurrency control when modifying Secret or SecretVersion.
