### PR TITLE
Release version 4.3.0-beta01 of all diagnostics packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Debugger.V2](https://googleapis.dev/dotnet/Google.Cloud.Debugger.V2/2.3.0) | 2.3.0 | [Google Cloud Debugger](https://cloud.google.com/debugger/) |
 | [Google.Cloud.DevTools.Common](https://googleapis.dev/dotnet/Google.Cloud.DevTools.Common/2.1.0) | 2.1.0 | Common Protocol Buffer messages for Google Cloud Developer Tools APIs |
 | [Google.Cloud.DevTools.ContainerAnalysis.V1](https://googleapis.dev/dotnet/Google.Cloud.DevTools.ContainerAnalysis.V1/2.2.0) | 2.2.0 | [Google Container Analysis](https://cloud.google.com/container-registry/docs/container-analysis/) |
-| [Google.Cloud.Diagnostics.AspNetCore](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.AspNetCore/4.2.0) | 4.2.0 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core |
-| [Google.Cloud.Diagnostics.AspNetCore3](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.AspNetCore3/4.2.0) | 4.2.0 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core 3 |
-| [Google.Cloud.Diagnostics.Common](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.Common/4.2.0) | 4.2.0 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries Common Components |
+| [Google.Cloud.Diagnostics.AspNetCore](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.AspNetCore/4.3.0-beta01) | 4.3.0-beta01 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core |
+| [Google.Cloud.Diagnostics.AspNetCore3](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.AspNetCore3/4.3.0-beta01) | 4.3.0-beta01 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core 3 |
+| [Google.Cloud.Diagnostics.Common](https://googleapis.dev/dotnet/Google.Cloud.Diagnostics.Common/4.3.0-beta01) | 4.3.0-beta01 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries Common Components |
 | [Google.Cloud.Dialogflow.Cx.V3](https://googleapis.dev/dotnet/Google.Cloud.Dialogflow.Cx.V3/1.2.0) | 1.2.0 | [Dialogflow](https://cloud.google.com/dialogflow/cx/docs) |
 | [Google.Cloud.Dialogflow.V2](https://googleapis.dev/dotnet/Google.Cloud.Dialogflow.V2/3.3.0) | 3.3.0 | [Google Cloud Dialogflow](https://cloud.google.com/dialogflow-enterprise/) |
 | [Google.Cloud.Dlp.V2](https://googleapis.dev/dotnet/Google.Cloud.Dlp.V2/3.2.0) | 3.2.0 | [Google Cloud Data Loss Prevention](https://cloud.google.com/dlp/) |

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests.csproj
@@ -12,7 +12,7 @@
     <DebugType Condition="'$(TargetFramework)' == 'netcoreapp2.1'">portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.4.0, 4.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Diagnostics.AspNetCore\Google.Cloud.Diagnostics.AspNetCore.csproj" />
     <ProjectReference Include="..\..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.IntegrationTests\Google.Cloud.Diagnostics.Common.IntegrationTests.csproj" />

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/Google.Cloud.Diagnostics.AspNetCore.Snippets.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/Google.Cloud.Diagnostics.AspNetCore.Snippets.csproj
@@ -13,7 +13,7 @@
     <DebugType Condition="'$(TargetFramework)' == 'netcoreapp2.1'">portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.4.0, 4.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Diagnostics.AspNetCore\Google.Cloud.Diagnostics.AspNetCore.csproj" />
     <ProjectReference Include="..\..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.IntegrationTests\Google.Cloud.Diagnostics.Common.IntegrationTests.csproj" />

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Google.Cloud.Diagnostics.AspNetCore.Tests.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Google.Cloud.Diagnostics.AspNetCore.Tests.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.4.0, 4.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Diagnostics.AspNetCore\Google.Cloud.Diagnostics.AspNetCore.csproj" />
     <ProjectReference Include="..\..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.IntegrationTests\Google.Cloud.Diagnostics.Common.IntegrationTests.csproj" />

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.2.0</Version>
+    <Version>4.3.0-beta01</Version>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core.</Description>
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <ProjectReference Include="..\..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.csproj" />
-    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.1.1" />

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/docs/history.md
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/docs/history.md
@@ -1,5 +1,41 @@
 # Version history
 
+# Version 4.3.0-beta01, released 2021-06-24
+
+- [Commit 60e8cd8](https://github.com/googleapis/google-cloud-dotnet/commit/60e8cd8):
+  - feat: Copies GoogleLogger to Common. This allows easier use of GoogleLogger in non ASP.NET Core applications.
+  - Towards [issue 6367](https://github.com/googleapis/google-cloud-dotnet/issues/6367)
+  - Replicate LoggerOptions in Common, and have AspNetCore\*.LoggerOptions be just a wrapper of Common.LoggerOptions.
+  - Copies ILogEntryLabelProvider to Common and marks the one in AspNetCore* Obsolete.
+  - Makes AspNetCore*.IExternalTraceProvider obsolete. It can now be replaced by Common.ITraceContext.
+- [Commit 32cb606](https://github.com/googleapis/google-cloud-dotnet/commit/32cb606):
+  - feat: Allows per log entry labels.
+  - Closes [issue 5313](https://github.com/googleapis/google-cloud-dotnet/issues/5313)
+  - Closes [issue 5929](https://github.com/googleapis/google-cloud-dotnet/issues/5929)
+- [Commit c8e9a48](https://github.com/googleapis/google-cloud-dotnet/commit/c8e9a48):
+  - refactor: Makes GoogleLoggerScope extendable.
+    Moves GoogleLoggerScope to Diagnostics.Common.
+    In preparation for allowing LogEntry augmentation and making it easier to use Google logging from non ASP.NET Core apps.
+    Towards [issue 5313](https://github.com/googleapis/google-cloud-dotnet/issues/5313), [issue 5360](https://github.com/googleapis/google-cloud-dotnet/issues/5360), [issue 5929](https://github.com/googleapis/google-cloud-dotnet/issues/5929) and [issue 6367](https://github.com/googleapis/google-cloud-dotnet/issues/6367)
+- [Commit 7f5f89e](https://github.com/googleapis/google-cloud-dotnet/commit/7f5f89e):
+  - docs: Change Stackdriver to Google Cloud, and fix some typos, including in test code.
+- [Commit c4c9cd5](https://github.com/googleapis/google-cloud-dotnet/commit/c4c9cd5):
+  - feat: Makes it easier to use tracing from non ASP.NET Core applications
+    Closes [issue 5897](https://github.com/googleapis/google-cloud-dotnet/issues/5897)
+    Towards [issue 6367](https://github.com/googleapis/google-cloud-dotnet/issues/6367)
+- [Commit b35b9ea](https://github.com/googleapis/google-cloud-dotnet/commit/b35b9ea):
+  - feat: Decouples Diagnostics tracing from Google's trace header. Towards [issue 5360](https://github.com/googleapis/google-cloud-dotnet/issues/5360) and [issue 5897](https://github.com/googleapis/google-cloud-dotnet/issues/5897)
+- [Commit 0c00d2c](https://github.com/googleapis/google-cloud-dotnet/commit/0c00d2c):
+  - refactor: Remove unnecesary service provider extension method. There's an equivalent method offered by Microsoft.Extensions.DependencyInjection so we don't need our own.
+- [Commit bb0c7b2](https://github.com/googleapis/google-cloud-dotnet/commit/bb0c7b2):
+  - refactor: Remove unnecesary interface IManagedTracerFactory. It's an internal interface that we don't use anywhere. We can always add it back in if we need it at some point.
+- [Commit 8ef3983](https://github.com/googleapis/google-cloud-dotnet/commit/8ef3983):
+  - fix: X-Cloud-Trace-Context trace mask values should be 0-1. See https://cloud.google.com/trace/docs/setup#force-trace
+
+Note: changing a generic type parameter constraint in
+`LabelProviderExtensions` is notionally a breaking change, but due
+to how it will be used, we don't expect it to actually break any customers.
+
 # Version 4.2.0, released 2020-12-07
 
 No API changes since 4.2.0-beta02; just a stable release of the changes since 4.1.0.

--- a/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.IntegrationTests/Google.Cloud.Diagnostics.AspNetCore3.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.IntegrationTests/Google.Cloud.Diagnostics.AspNetCore3.IntegrationTests.csproj
@@ -11,7 +11,7 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.4.0, 4.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Diagnostics.AspNetCore3\Google.Cloud.Diagnostics.AspNetCore3.csproj" />
     <ProjectReference Include="..\..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.IntegrationTests\Google.Cloud.Diagnostics.Common.IntegrationTests.csproj" />

--- a/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.Snippets/Google.Cloud.Diagnostics.AspNetCore3.Snippets.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.Snippets/Google.Cloud.Diagnostics.AspNetCore3.Snippets.csproj
@@ -11,7 +11,7 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.4.0, 4.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Diagnostics.AspNetCore3\Google.Cloud.Diagnostics.AspNetCore3.csproj" />
     <ProjectReference Include="..\..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.IntegrationTests\Google.Cloud.Diagnostics.Common.IntegrationTests.csproj" />

--- a/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.Tests/Google.Cloud.Diagnostics.AspNetCore3.Tests.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.Tests/Google.Cloud.Diagnostics.AspNetCore3.Tests.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.4.0, 4.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Diagnostics.AspNetCore3\Google.Cloud.Diagnostics.AspNetCore3.csproj" />
     <ProjectReference Include="..\..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.IntegrationTests\Google.Cloud.Diagnostics.Common.IntegrationTests.csproj" />

--- a/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.2.0</Version>
+    <Version>4.3.0-beta01</Version>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core 3.</Description>
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <ProjectReference Include="..\..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.csproj" />
-    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Diagnostics.AspNetCore3/docs/history.md
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore3/docs/history.md
@@ -1,5 +1,43 @@
 # Version history
 
+# Version 4.3.0-beta01, released 2021-06-24
+
+- [Commit 60e8cd8](https://github.com/googleapis/google-cloud-dotnet/commit/60e8cd8):
+  - feat: Copies GoogleLogger to Common.
+  - This allows easier use of GoogleLogger in non ASP.NET Core applications.
+  - Towards [issue 6367](https://github.com/googleapis/google-cloud-dotnet/issues/6367)
+  - Replicate LoggerOptions in Common.
+    - And have AspNetCore*.LoggerOptions be just a wrapper of Common.LoggerOptions.
+  - Copies ILogEntryLabelProvider to Common.
+    - And marks the one in AspNetCore* Obsolete.
+  - Makes AspNetCore*.IExternalTraceProvider obsolete.
+    - It can now be replaced by Common.ITraceContext.
+- [Commit 32cb606](https://github.com/googleapis/google-cloud-dotnet/commit/32cb606):
+  - feat: Allows per log entry labels.
+  - Closes [issue 5313](https://github.com/googleapis/google-cloud-dotnet/issues/5313)
+  - Closes [issue 5929](https://github.com/googleapis/google-cloud-dotnet/issues/5929)
+- [Commit c8e9a48](https://github.com/googleapis/google-cloud-dotnet/commit/c8e9a48):
+  - refactor: Makes GoogleLoggerScope extendable.
+  - Moves GoogleLoggerScope to Diagnostics.Common.
+  - In preparation for allowing LogEntry augmentation and making it easier to use Google logging from non ASP.NET Core apps.
+  - Towards [issue 5313](https://github.com/googleapis/google-cloud-dotnet/issues/5313), [issue 5360](https://github.com/googleapis/google-cloud-dotnet/issues/5360), [issue 5929](https://github.com/googleapis/google-cloud-dotnet/issues/5929) and [issue 6367](https://github.com/googleapis/google-cloud-dotnet/issues/6367)
+- [Commit 7f5f89e](https://github.com/googleapis/google-cloud-dotnet/commit/7f5f89e):
+  - docs: Change Stackdriver to Google Cloud
+  - And fix some typos, including in test code.
+- [Commit c4c9cd5](https://github.com/googleapis/google-cloud-dotnet/commit/c4c9cd5):
+  - feat: Makes it easier to use tracing from non ASP.NET Core applications
+  - Closes [issue 5897](https://github.com/googleapis/google-cloud-dotnet/issues/5897)
+  - Towards [issue 6367](https://github.com/googleapis/google-cloud-dotnet/issues/6367)
+- [Commit b35b9ea](https://github.com/googleapis/google-cloud-dotnet/commit/b35b9ea):
+  - feat: Decouples Diagnostics tracing from Google's trace header
+  - Towards [issue 5360](https://github.com/googleapis/google-cloud-dotnet/issues/5360) and [issue 5897](https://github.com/googleapis/google-cloud-dotnet/issues/5897)
+- [Commit bb0c7b2](https://github.com/googleapis/google-cloud-dotnet/commit/bb0c7b2):
+  - refactor: Remove unnecesary interface IManagedTracerFactory.
+  - It's an internal interface that we don't use anywhere. We can always add it back in if we need it at some point.
+- [Commit 8ef3983](https://github.com/googleapis/google-cloud-dotnet/commit/8ef3983):
+  - fix: X-Cloud-Trace-Context trace mask values should be 0-1.
+  - See https://cloud.google.com/trace/docs/setup#force-trace
+
 # Version 4.2.0, released 2020-12-07
 
 No API changes since 4.0.0-beta01, but this is the first stable release.

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Google.Cloud.Diagnostics.Common.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Google.Cloud.Diagnostics.Common.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.csproj" />
-    <PackageReference Include="Google.Cloud.ErrorReporting.V1Beta1" Version="[2.0.0-beta03, 3.0.0)" />
+    <PackageReference Include="Google.Cloud.ErrorReporting.V1Beta1" Version="[2.0.0-beta04, 3.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Moq" Version="4.12.0" />

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Google.Cloud.Diagnostics.Common.Tests.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Google.Cloud.Diagnostics.Common.Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.csproj" />
-    <PackageReference Include="Google.Cloud.ErrorReporting.V1Beta1" Version="[2.0.0-beta03, 3.0.0)" />
+    <PackageReference Include="Google.Cloud.ErrorReporting.V1Beta1" Version="[2.0.0-beta04, 3.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Moq" Version="4.12.0" />

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.2.0</Version>
+    <Version>4.3.0-beta01</Version>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries Common Components.</Description>
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Logging.V2" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Trace.V1" Version="[2.1.0, 3.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Logging.V2" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Trace.V1" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -720,7 +720,7 @@
     },
     {
       "id": "Google.Cloud.Diagnostics.AspNetCore",
-      "version": "4.2.0",
+      "version": "4.3.0-beta01",
       "type": "other",
       "metadataType": "INTEGRATION",
       "targetFrameworks": "netstandard2.0",
@@ -736,13 +736,13 @@
       ],
       "dependencies": {
         "Google.Cloud.Diagnostics.Common": "project",
-        "Grpc.Core": "2.31.0",
+        "Grpc.Core": "2.38.0",
         "Microsoft.AspNetCore.Hosting.Abstractions": "2.1.1",
         "Microsoft.AspNetCore.Http": "2.1.1",
         "Microsoft.AspNetCore.Http.Extensions": "2.1.1"
       },
       "testDependencies": {
-        "Google.Api.Gax.Testing": "3.2.0",
+        "Google.Api.Gax.Testing": "3.4.0",
         "Google.Cloud.Diagnostics.Common.IntegrationTests": "project",
         "Google.Cloud.Diagnostics.Common.Tests": "project",
         "Microsoft.AspNetCore.Mvc": "2.1.3",
@@ -756,7 +756,7 @@
     },
     {
       "id": "Google.Cloud.Diagnostics.AspNetCore3",
-      "version": "4.2.0",
+      "version": "4.3.0-beta01",
       "type": "other",
       "metadataType": "INTEGRATION",
       "targetFrameworks": "netcoreapp3.1",
@@ -772,10 +772,10 @@
       ],
       "dependencies": {
         "Google.Cloud.Diagnostics.Common": "project",
-        "Grpc.Core": "2.31.0"
+        "Grpc.Core": "2.38.0"
       },
       "testDependencies": {
-        "Google.Api.Gax.Testing": "3.2.0",
+        "Google.Api.Gax.Testing": "3.4.0",
         "Google.Cloud.Diagnostics.Common.IntegrationTests": "project",
         "Google.Cloud.Diagnostics.Common.Tests": "project",
         "Microsoft.AspNetCore.TestHost": "3.1.8"
@@ -783,7 +783,7 @@
     },
     {
       "id": "Google.Cloud.Diagnostics.Common",
-      "version": "4.2.0",
+      "version": "4.3.0-beta01",
       "type": "other",
       "targetFrameworks": "netstandard2.0",
       "testTargetFrameworks": "netcoreapp2.1;netcoreapp3.1;net461",
@@ -797,14 +797,14 @@
         "Diagnostics"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.2.0",
-        "Google.Cloud.Logging.V2": "3.2.0",
-        "Google.Cloud.Trace.V1": "2.1.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Cloud.Logging.V2": "3.3.0",
+        "Google.Cloud.Trace.V1": "2.2.0",
         "Microsoft.Extensions.Http": "2.1.1",
         "System.Diagnostics.StackTrace": "4.3.0"
       },
       "testDependencies": {
-        "Google.Cloud.ErrorReporting.V1Beta1": "2.0.0-beta03"
+        "Google.Cloud.ErrorReporting.V1Beta1": "2.0.0-beta04"
       },
       "noVersionHistory": true
     },

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -58,9 +58,9 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Debugger.V2](Google.Cloud.Debugger.V2/index.html) | 2.3.0 | [Google Cloud Debugger](https://cloud.google.com/debugger/) |
 | [Google.Cloud.DevTools.Common](Google.Cloud.DevTools.Common/index.html) | 2.1.0 | Common Protocol Buffer messages for Google Cloud Developer Tools APIs |
 | [Google.Cloud.DevTools.ContainerAnalysis.V1](Google.Cloud.DevTools.ContainerAnalysis.V1/index.html) | 2.2.0 | [Google Container Analysis](https://cloud.google.com/container-registry/docs/container-analysis/) |
-| [Google.Cloud.Diagnostics.AspNetCore](Google.Cloud.Diagnostics.AspNetCore/index.html) | 4.2.0 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core |
-| [Google.Cloud.Diagnostics.AspNetCore3](Google.Cloud.Diagnostics.AspNetCore3/index.html) | 4.2.0 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core 3 |
-| [Google.Cloud.Diagnostics.Common](Google.Cloud.Diagnostics.Common/index.html) | 4.2.0 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries Common Components |
+| [Google.Cloud.Diagnostics.AspNetCore](Google.Cloud.Diagnostics.AspNetCore/index.html) | 4.3.0-beta01 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core |
+| [Google.Cloud.Diagnostics.AspNetCore3](Google.Cloud.Diagnostics.AspNetCore3/index.html) | 4.3.0-beta01 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core 3 |
+| [Google.Cloud.Diagnostics.Common](Google.Cloud.Diagnostics.Common/index.html) | 4.3.0-beta01 | Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries Common Components |
 | [Google.Cloud.Dialogflow.Cx.V3](Google.Cloud.Dialogflow.Cx.V3/index.html) | 1.2.0 | [Dialogflow](https://cloud.google.com/dialogflow/cx/docs) |
 | [Google.Cloud.Dialogflow.V2](Google.Cloud.Dialogflow.V2/index.html) | 3.3.0 | [Google Cloud Dialogflow](https://cloud.google.com/dialogflow-enterprise/) |
 | [Google.Cloud.Dlp.V2](Google.Cloud.Dlp.V2/index.html) | 3.2.0 | [Google Cloud Data Loss Prevention](https://cloud.google.com/dlp/) |


### PR DESCRIPTION

Changes in Google.Cloud.Diagnostics.AspNetCore version 4.3.0-beta01:

- [Commit 60e8cd8](https://github.com/googleapis/google-cloud-dotnet/commit/60e8cd8):
  - feat: Copies GoogleLogger to Common. This allows easier use of GoogleLogger in non ASP.NET Core applications.
  - Towards [issue 6367](https://github.com/googleapis/google-cloud-dotnet/issues/6367)
  - Replicate LoggerOptions in Common, and have AspNetCore\*.LoggerOptions be just a wrapper of Common.LoggerOptions.
  - Copies ILogEntryLabelProvider to Common and marks the one in AspNetCore* Obsolete.
  - Makes AspNetCore*.IExternalTraceProvider obsolete. It can now be replaced by Common.ITraceContext.
- [Commit 32cb606](https://github.com/googleapis/google-cloud-dotnet/commit/32cb606):
  - feat: Allows per log entry labels.
  - Closes [issue 5313](https://github.com/googleapis/google-cloud-dotnet/issues/5313)
  - Closes [issue 5929](https://github.com/googleapis/google-cloud-dotnet/issues/5929)
- [Commit c8e9a48](https://github.com/googleapis/google-cloud-dotnet/commit/c8e9a48):
  - refactor: Makes GoogleLoggerScope extendable.
    Moves GoogleLoggerScope to Diagnostics.Common.
    In preparation for allowing LogEntry augmentation and making it easier to use Google logging from non ASP.NET Core apps.
    Towards [issue 5313](https://github.com/googleapis/google-cloud-dotnet/issues/5313), [issue 5360](https://github.com/googleapis/google-cloud-dotnet/issues/5360), [issue 5929](https://github.com/googleapis/google-cloud-dotnet/issues/5929) and [issue 6367](https://github.com/googleapis/google-cloud-dotnet/issues/6367)
- [Commit 7f5f89e](https://github.com/googleapis/google-cloud-dotnet/commit/7f5f89e):
  - docs: Change Stackdriver to Google Cloud, and fix some typos, including in test code.
- [Commit c4c9cd5](https://github.com/googleapis/google-cloud-dotnet/commit/c4c9cd5):
  - feat: Makes it easier to use tracing from non ASP.NET Core applications
    Closes [issue 5897](https://github.com/googleapis/google-cloud-dotnet/issues/5897)
    Towards [issue 6367](https://github.com/googleapis/google-cloud-dotnet/issues/6367)
- [Commit b35b9ea](https://github.com/googleapis/google-cloud-dotnet/commit/b35b9ea):
  - feat: Decouples Diagnostics tracing from Google's trace header. Towards [issue 5360](https://github.com/googleapis/google-cloud-dotnet/issues/5360) and [issue 5897](https://github.com/googleapis/google-cloud-dotnet/issues/5897)
- [Commit 0c00d2c](https://github.com/googleapis/google-cloud-dotnet/commit/0c00d2c):
  - refactor: Remove unnecesary service provider extension method. There's an equivalent method offered by Microsoft.Extensions.DependencyInjection so we don't need our own.
- [Commit bb0c7b2](https://github.com/googleapis/google-cloud-dotnet/commit/bb0c7b2):
  - refactor: Remove unnecesary interface IManagedTracerFactory. It's an internal interface that we don't use anywhere. We can always add it back in if we need it at some point.
- [Commit 8ef3983](https://github.com/googleapis/google-cloud-dotnet/commit/8ef3983):
  - fix: X-Cloud-Trace-Context trace mask values should be 0-1. See https://cloud.google.com/trace/docs/setup#force-trace

Note: changing a generic type parameter constraint in `LabelProviderExtensions` is notionally a breaking change, but due to how it will be used, we don't expect it to actually break any customers.

Changes in Google.Cloud.Diagnostics.AspNetCore3 version 4.3.0-beta01:

- [Commit 60e8cd8](https://github.com/googleapis/google-cloud-dotnet/commit/60e8cd8):
  - feat: Copies GoogleLogger to Common.
  - This allows easier use of GoogleLogger in non ASP.NET Core applications.
  - Towards [issue 6367](https://github.com/googleapis/google-cloud-dotnet/issues/6367)
  - Replicate LoggerOptions in Common.
    - And have AspNetCore*.LoggerOptions be just a wrapper of Common.LoggerOptions.
  - Copies ILogEntryLabelProvider to Common.
    - And marks the one in AspNetCore* Obsolete.
  - Makes AspNetCore*.IExternalTraceProvider obsolete.
    - It can now be replaced by Common.ITraceContext.
- [Commit 32cb606](https://github.com/googleapis/google-cloud-dotnet/commit/32cb606):
  - feat: Allows per log entry labels.
  - Closes [issue 5313](https://github.com/googleapis/google-cloud-dotnet/issues/5313)
  - Closes [issue 5929](https://github.com/googleapis/google-cloud-dotnet/issues/5929)
- [Commit c8e9a48](https://github.com/googleapis/google-cloud-dotnet/commit/c8e9a48):
  - refactor: Makes GoogleLoggerScope extendable.
  - Moves GoogleLoggerScope to Diagnostics.Common.
  - In preparation for allowing LogEntry augmentation and making it easier to use Google logging from non ASP.NET Core apps.
  - Towards [issue 5313](https://github.com/googleapis/google-cloud-dotnet/issues/5313), [issue 5360](https://github.com/googleapis/google-cloud-dotnet/issues/5360), [issue 5929](https://github.com/googleapis/google-cloud-dotnet/issues/5929) and [issue 6367](https://github.com/googleapis/google-cloud-dotnet/issues/6367)
- [Commit 7f5f89e](https://github.com/googleapis/google-cloud-dotnet/commit/7f5f89e):
  - docs: Change Stackdriver to Google Cloud
  - And fix some typos, including in test code.
- [Commit c4c9cd5](https://github.com/googleapis/google-cloud-dotnet/commit/c4c9cd5):
  - feat: Makes it easier to use tracing from non ASP.NET Core applications
  - Closes [issue 5897](https://github.com/googleapis/google-cloud-dotnet/issues/5897)
  - Towards [issue 6367](https://github.com/googleapis/google-cloud-dotnet/issues/6367)
- [Commit b35b9ea](https://github.com/googleapis/google-cloud-dotnet/commit/b35b9ea):
  - feat: Decouples Diagnostics tracing from Google's trace header
  - Towards [issue 5360](https://github.com/googleapis/google-cloud-dotnet/issues/5360) and [issue 5897](https://github.com/googleapis/google-cloud-dotnet/issues/5897)
- [Commit bb0c7b2](https://github.com/googleapis/google-cloud-dotnet/commit/bb0c7b2):
  - refactor: Remove unnecesary interface IManagedTracerFactory.
  - It's an internal interface that we don't use anywhere. We can always add it back in if we need it at some point.
- [Commit 8ef3983](https://github.com/googleapis/google-cloud-dotnet/commit/8ef3983):
  - fix: X-Cloud-Trace-Context trace mask values should be 0-1.
  - See https://cloud.google.com/trace/docs/setup#force-trace

Packages in this release:
- Release Google.Cloud.Diagnostics.AspNetCore version 4.3.0-beta01
- Release Google.Cloud.Diagnostics.AspNetCore3 version 4.3.0-beta01
- Release Google.Cloud.Diagnostics.Common version 4.3.0-beta01
