### PR TITLE
Release Google.Cloud.AIPlatform.V1 version 1.0.0-beta01

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Each package name links to the documentation for that package.
 | [Google.Area120.Tables.V1Alpha1](https://googleapis.dev/dotnet/Google.Area120.Tables.V1Alpha1/1.0.0-alpha03) | 1.0.0-alpha03 | Google Area 120 Tables |
 | [Google.Cloud.AccessApproval.V1](https://googleapis.dev/dotnet/Google.Cloud.AccessApproval.V1/1.1.0) | 1.1.0 | [Access Approval](https://cloud.google.com/access-approval/docs/) |
 | [Google.Cloud.ApiGateway.V1](https://googleapis.dev/dotnet/Google.Cloud.ApiGateway.V1/1.0.0) | 1.0.0 | [API Gateway](https://cloud.google.com/api-gateway/docs) |
+| [Google.Cloud.AIPlatform.V1](https://googleapis.dev/dotnet/Google.Cloud.AIPlatform.V1/1.0.0-beta01) | 1.0.0-beta01 | [Cloud AI Platform](https://cloud.google.com/ai-platform/docs/) |
 | [Google.Cloud.ApigeeConnect.V1](https://googleapis.dev/dotnet/Google.Cloud.ApigeeConnect.V1/1.0.0-beta01) | 1.0.0-beta01 | [Apigee Connect](https://cloud.google.com/apigee/docs/hybrid/v1.4/apigee-connect) |
 | [Google.Cloud.AppEngine.V1](https://googleapis.dev/dotnet/Google.Cloud.AppEngine.V1/1.1.0) | 1.1.0 | [App Engine Audit Data](https://cloud.google.com/appengine) |
 | [Google.Cloud.ArtifactRegistry.V1Beta2](https://googleapis.dev/dotnet/Google.Cloud.ArtifactRegistry.V1Beta2/1.0.0-beta02) | 1.0.0-beta02 | [Artifact Registry](https://cloud.google.com/artifact-registry) |

--- a/apis/Google.Cloud.AIPlatform.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.AIPlatform.V1/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+  "distribution_name": "Google.Cloud.AIPlatform.V1",
+  "release_level": "beta",
+  "client_documentation": "https://googleapis.dev/dotnet/Google.Cloud.AIPlatform.V1/latest",
+  "library_type": "GAPIC_AUTO"
+}

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta00</Version>
+    <Version>1.0.0-beta01</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AI Platform API, which allows you to train high-quality custom machine learning models with minimal machine learning expertise and effort.</Description>

--- a/apis/Google.Cloud.AIPlatform.V1/docs/history.md
+++ b/apis/Google.Cloud.AIPlatform.V1/docs/history.md
@@ -1,0 +1,5 @@
+# Version history
+
+# Version 1.0.0-beta01, released 2021-06-28
+
+Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -109,7 +109,7 @@
     },
     {
       "id": "Google.Cloud.AIPlatform.V1",
-      "version": "1.0.0-beta00",
+      "version": "1.0.0-beta01",
       "type": "grpc",
       "productName": "Cloud AI Platform",
       "productUrl": "https://cloud.google.com/ai-platform/docs/",

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -25,6 +25,7 @@ Each package name links to the documentation for that package.
 | [Google.Area120.Tables.V1Alpha1](Google.Area120.Tables.V1Alpha1/index.html) | 1.0.0-alpha03 | Google Area 120 Tables |
 | [Google.Cloud.AccessApproval.V1](Google.Cloud.AccessApproval.V1/index.html) | 1.1.0 | [Access Approval](https://cloud.google.com/access-approval/docs/) |
 | [Google.Cloud.ApiGateway.V1](Google.Cloud.ApiGateway.V1/index.html) | 1.0.0 | [API Gateway](https://cloud.google.com/api-gateway/docs) |
+| [Google.Cloud.AIPlatform.V1](Google.Cloud.AIPlatform.V1/index.html) | 1.0.0-beta01 | [Cloud AI Platform](https://cloud.google.com/ai-platform/docs/) |
 | [Google.Cloud.ApigeeConnect.V1](Google.Cloud.ApigeeConnect.V1/index.html) | 1.0.0-beta01 | [Apigee Connect](https://cloud.google.com/apigee/docs/hybrid/v1.4/apigee-connect) |
 | [Google.Cloud.AppEngine.V1](Google.Cloud.AppEngine.V1/index.html) | 1.1.0 | [App Engine Audit Data](https://cloud.google.com/appengine) |
 | [Google.Cloud.ArtifactRegistry.V1Beta2](Google.Cloud.ArtifactRegistry.V1Beta2/index.html) | 1.0.0-beta02 | [Artifact Registry](https://cloud.google.com/artifact-registry) |


### PR DESCRIPTION

Changes in this release:

Initial release.
