### PR TITLE
Release Spanner libraries version 3.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,11 +132,11 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.ServiceManagement.V1](https://googleapis.dev/dotnet/Google.Cloud.ServiceManagement.V1/1.2.0) | 1.2.0 | [Service Management](https://cloud.google.com/service-infrastructure/docs/service-management/reference/rpc) |
 | [Google.Cloud.ServiceUsage.V1](https://googleapis.dev/dotnet/Google.Cloud.ServiceUsage.V1/1.0.0) | 1.0.0 | [Service Usage](https://cloud.google.com/service-usage/docs/) |
 | [Google.Cloud.Shell.V1](https://googleapis.dev/dotnet/Google.Cloud.Shell.V1/1.0.0) | 1.0.0 | [Cloud Shell](https://cloud.google.com/shell/) |
-| [Google.Cloud.Spanner.Admin.Database.V1](https://googleapis.dev/dotnet/Google.Cloud.Spanner.Admin.Database.V1/3.9.0) | 3.9.0 | [Google Cloud Spanner Database Administration](https://cloud.google.com/spanner/) |
-| [Google.Cloud.Spanner.Admin.Instance.V1](https://googleapis.dev/dotnet/Google.Cloud.Spanner.Admin.Instance.V1/3.9.0) | 3.9.0 | [Google Cloud Spanner Instance Administration](https://cloud.google.com/spanner/) |
-| [Google.Cloud.Spanner.Data](https://googleapis.dev/dotnet/Google.Cloud.Spanner.Data/3.9.0) | 3.9.0 | Google ADO.NET Provider for Google Cloud Spanner |
-| [Google.Cloud.Spanner.Common.V1](https://googleapis.dev/dotnet/Google.Cloud.Spanner.Common.V1/3.9.0) | 3.9.0 | Common resource names used by all Spanner V1 APIs |
-| [Google.Cloud.Spanner.V1](https://googleapis.dev/dotnet/Google.Cloud.Spanner.V1/3.9.0) | 3.9.0 | [Google Cloud Spanner](https://cloud.google.com/spanner/) |
+| [Google.Cloud.Spanner.Admin.Database.V1](https://googleapis.dev/dotnet/Google.Cloud.Spanner.Admin.Database.V1/3.10.0) | 3.10.0 | [Google Cloud Spanner Database Administration](https://cloud.google.com/spanner/) |
+| [Google.Cloud.Spanner.Admin.Instance.V1](https://googleapis.dev/dotnet/Google.Cloud.Spanner.Admin.Instance.V1/3.10.0) | 3.10.0 | [Google Cloud Spanner Instance Administration](https://cloud.google.com/spanner/) |
+| [Google.Cloud.Spanner.Data](https://googleapis.dev/dotnet/Google.Cloud.Spanner.Data/3.10.0) | 3.10.0 | Google ADO.NET Provider for Google Cloud Spanner |
+| [Google.Cloud.Spanner.Common.V1](https://googleapis.dev/dotnet/Google.Cloud.Spanner.Common.V1/3.10.0) | 3.10.0 | Common resource names used by all Spanner V1 APIs |
+| [Google.Cloud.Spanner.V1](https://googleapis.dev/dotnet/Google.Cloud.Spanner.V1/3.10.0) | 3.10.0 | [Google Cloud Spanner](https://cloud.google.com/spanner/) |
 | [Google.Cloud.Speech.V1](https://googleapis.dev/dotnet/Google.Cloud.Speech.V1/2.2.0) | 2.2.0 | [Google Cloud Speech (V1 API)](https://cloud.google.com/speech) |
 | [Google.Cloud.Speech.V1P1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Speech.V1P1Beta1/2.0.0-beta04) | 2.0.0-beta04 | [Google Cloud Speech (V1P1Beta1 API)](https://cloud.google.com/speech) |
 | [Google.Cloud.Storage.V1](https://googleapis.dev/dotnet/Google.Cloud.Storage.V1/3.5.0) | 3.5.0 | [Google Cloud Storage](https://cloud.google.com/storage/) |

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.csproj
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.9.0</Version>
+    <Version>3.10.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Spanner Database Admin API.</Description>
@@ -11,11 +11,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.2.0, 3.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1.csproj" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.csproj
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.9.0</Version>
+    <Version>3.10.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Spanner Instance Admin API.</Description>
@@ -11,11 +11,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.2.0, 3.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1.csproj" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1.csproj
+++ b/apis/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.9.0</Version>
+    <Version>3.10.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Common resource names used by all Spanner V1 APIs</Description>
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax" Version="[3.4.0, 4.0.0)" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/Google.Cloud.Spanner.Data.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/Google.Cloud.Spanner.Data.IntegrationTests.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CoreCompat.EnterpriseLibrary.TransientFaultHandling" Version="6.0.1304-r3" />
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.4.0, 4.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Spanner.Data\Google.Cloud.Spanner.Data.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/Google.Cloud.Spanner.Data.Snippets.csproj
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/Google.Cloud.Spanner.Data.Snippets.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CoreCompat.EnterpriseLibrary.TransientFaultHandling" Version="6.0.1304-r3" />
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.4.0, 4.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Spanner.Data\Google.Cloud.Spanner.Data.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/Google.Cloud.Spanner.Data.Tests.csproj
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/Google.Cloud.Spanner.Data.Tests.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CoreCompat.EnterpriseLibrary.TransientFaultHandling" Version="6.0.1304-r3" />
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.4.0, 4.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Spanner.Data\Google.Cloud.Spanner.Data.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.csproj
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.9.0</Version>
+    <Version>3.10.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google ADO.NET Provider for Google Cloud Spanner.</Description>
@@ -11,11 +11,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.Spanner.Admin.Database.V1\Google.Cloud.Spanner.Admin.Database.V1\Google.Cloud.Spanner.Admin.Database.V1.csproj" />
     <ProjectReference Include="..\..\Google.Cloud.Spanner.Admin.Instance.V1\Google.Cloud.Spanner.Admin.Instance.V1\Google.Cloud.Spanner.Admin.Instance.V1.csproj" />
     <ProjectReference Include="..\..\Google.Cloud.Spanner.V1\Google.Cloud.Spanner.V1\Google.Cloud.Spanner.V1.csproj" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Grpc.Gcp" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />

--- a/apis/Google.Cloud.Spanner.Data/docs/history.md
+++ b/apis/Google.Cloud.Spanner.Data/docs/history.md
@@ -1,8 +1,13 @@
 # Version history
 
+# Version 3.10.0, released 2021-06-28
+
+- [Commit 10c86e0](https://github.com/googleapis/google-cloud-dotnet/commit/10c86e0): feat: add JSON type (currently only in the low-level API)
+- [Commit 41094ed](https://github.com/googleapis/google-cloud-dotnet/commit/41094ed): feat: add processing_units to Instance resource
+
 # Version 3.9.0, released 2021-06-09
 
-- [Commit 0fb438e](https://github.com/googleapis/google-cloud-dotnet/commit/0fb438e): feat(spanner): add `query_optimizer_statistics_package` support (see below)
+- [Commit 0fb438e](https://github.com/googleapis/google-cloud-dotnet/commit/0fb438e): feat: add `query_optimizer_statistics_package` support (see below)
 
 The optimizer statistics package can be set through `QueryOptions`, which can be configured through the following mechanisms:
 

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.csproj
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.9.0</Version>
+    <Version>3.10.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Low-level Google client library to access the Google Cloud Spanner API. The ADO.NET provider (Google.Cloud.Spanner.Data) which depends on this package is generally preferred for Spanner access.</Description>
@@ -11,9 +11,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1.csproj" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2272,7 +2272,7 @@
       "testTargetFrameworks": "netcoreapp2.0;net461",
       "productName": "Google Cloud Spanner Database Administration",
       "productUrl": "https://cloud.google.com/spanner/",
-      "version": "3.9.0",
+      "version": "3.10.0",
       "commonResourcesConfig": "apis/Google.Cloud.Spanner.Common.V1/CommonResourcesConfig.json",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Spanner Database Admin API.",
@@ -2280,11 +2280,11 @@
         "Spanner"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
         "Google.Cloud.Iam.V1": "2.2.0",
         "Google.Cloud.Spanner.Common.V1": "project",
         "Google.LongRunning": "2.2.0",
-        "Grpc.Core": "2.36.4"
+        "Grpc.Core": "2.38.0"
       },
       "noVersionHistory": true
     },
@@ -2296,7 +2296,7 @@
       "testTargetFrameworks": "netcoreapp2.0;net461",
       "productName": "Google Cloud Spanner Instance Administration",
       "productUrl": "https://cloud.google.com/spanner/",
-      "version": "3.9.0",
+      "version": "3.10.0",
       "commonResourcesConfig": "apis/Google.Cloud.Spanner.Common.V1/CommonResourcesConfig.json",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Spanner Instance Admin API.",
@@ -2304,11 +2304,11 @@
         "Spanner"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
         "Google.Cloud.Iam.V1": "2.2.0",
         "Google.Cloud.Spanner.Common.V1": "project",
         "Google.LongRunning": "2.2.0",
-        "Grpc.Core": "2.36.4"
+        "Grpc.Core": "2.38.0"
       },
       "noVersionHistory": true
     },
@@ -2316,7 +2316,7 @@
       "id": "Google.Cloud.Spanner.Data",
       "targetFrameworks": "netstandard2.0;net461",
       "testTargetFrameworks": "netcoreapp2.1;net461",
-      "version": "3.9.0",
+      "version": "3.10.0",
       "type": "other",
       "metadataType": "INTEGRATION",
       "description": "Google ADO.NET Provider for Google Cloud Spanner.",
@@ -2325,30 +2325,30 @@
         "ADO"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
         "Google.Cloud.Spanner.Admin.Database.V1": "project",
         "Google.Cloud.Spanner.Admin.Instance.V1": "project",
         "Google.Cloud.Spanner.V1": "project",
-        "Grpc.Core": "2.36.4",
+        "Grpc.Core": "2.38.0",
         "Grpc.Gcp": "2.0.0"
       },
       "testDependencies": {
         "CoreCompat.EnterpriseLibrary.TransientFaultHandling": "6.0.1304-r3",
-        "Google.Api.Gax.Grpc.Testing": "3.3.0",
-        "Google.Api.Gax.Testing": "3.3.0"
+        "Google.Api.Gax.Grpc.Testing": "3.4.0",
+        "Google.Api.Gax.Testing": "3.4.0"
       }
     },
     {
       "id": "Google.Cloud.Spanner.Common.V1",
       "type": "other",
       "targetFrameworks": "netstandard2.0;net461",
-      "version": "3.9.0",
+      "version": "3.10.0",
       "description": "Common resource names used by all Spanner V1 APIs",
       "tags": [
         "Spanner"
       ],
       "dependencies": {
-        "Google.Api.Gax": "3.3.0"
+        "Google.Api.Gax": "3.4.0"
       },
       "noVersionHistory": true
     },
@@ -2360,7 +2360,7 @@
       "testTargetFrameworks": "netcoreapp2.0;net461",
       "productName": "Google Cloud Spanner",
       "productUrl": "https://cloud.google.com/spanner/",
-      "version": "3.9.0",
+      "version": "3.10.0",
       "commonResourcesConfig": "apis/Google.Cloud.Spanner.Common.V1/CommonResourcesConfig.json",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
@@ -2369,9 +2369,9 @@
         "Spanner"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
         "Google.Cloud.Spanner.Common.V1": "project",
-        "Grpc.Core": "2.36.4"
+        "Grpc.Core": "2.38.0"
       },
       "noVersionHistory": true
     },

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -137,11 +137,11 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.ServiceManagement.V1](Google.Cloud.ServiceManagement.V1/index.html) | 1.2.0 | [Service Management](https://cloud.google.com/service-infrastructure/docs/service-management/reference/rpc) |
 | [Google.Cloud.ServiceUsage.V1](Google.Cloud.ServiceUsage.V1/index.html) | 1.0.0 | [Service Usage](https://cloud.google.com/service-usage/docs/) |
 | [Google.Cloud.Shell.V1](Google.Cloud.Shell.V1/index.html) | 1.0.0 | [Cloud Shell](https://cloud.google.com/shell/) |
-| [Google.Cloud.Spanner.Admin.Database.V1](Google.Cloud.Spanner.Admin.Database.V1/index.html) | 3.9.0 | [Google Cloud Spanner Database Administration](https://cloud.google.com/spanner/) |
-| [Google.Cloud.Spanner.Admin.Instance.V1](Google.Cloud.Spanner.Admin.Instance.V1/index.html) | 3.9.0 | [Google Cloud Spanner Instance Administration](https://cloud.google.com/spanner/) |
-| [Google.Cloud.Spanner.Data](Google.Cloud.Spanner.Data/index.html) | 3.9.0 | Google ADO.NET Provider for Google Cloud Spanner |
-| [Google.Cloud.Spanner.Common.V1](Google.Cloud.Spanner.Common.V1/index.html) | 3.9.0 | Common resource names used by all Spanner V1 APIs |
-| [Google.Cloud.Spanner.V1](Google.Cloud.Spanner.V1/index.html) | 3.9.0 | [Google Cloud Spanner](https://cloud.google.com/spanner/) |
+| [Google.Cloud.Spanner.Admin.Database.V1](Google.Cloud.Spanner.Admin.Database.V1/index.html) | 3.10.0 | [Google Cloud Spanner Database Administration](https://cloud.google.com/spanner/) |
+| [Google.Cloud.Spanner.Admin.Instance.V1](Google.Cloud.Spanner.Admin.Instance.V1/index.html) | 3.10.0 | [Google Cloud Spanner Instance Administration](https://cloud.google.com/spanner/) |
+| [Google.Cloud.Spanner.Data](Google.Cloud.Spanner.Data/index.html) | 3.10.0 | Google ADO.NET Provider for Google Cloud Spanner |
+| [Google.Cloud.Spanner.Common.V1](Google.Cloud.Spanner.Common.V1/index.html) | 3.10.0 | Common resource names used by all Spanner V1 APIs |
+| [Google.Cloud.Spanner.V1](Google.Cloud.Spanner.V1/index.html) | 3.10.0 | [Google Cloud Spanner](https://cloud.google.com/spanner/) |
 | [Google.Cloud.Speech.V1](Google.Cloud.Speech.V1/index.html) | 2.2.0 | [Google Cloud Speech (V1 API)](https://cloud.google.com/speech) |
 | [Google.Cloud.Speech.V1P1Beta1](Google.Cloud.Speech.V1P1Beta1/index.html) | 2.0.0-beta04 | [Google Cloud Speech (V1P1Beta1 API)](https://cloud.google.com/speech) |
 | [Google.Cloud.Storage.V1](Google.Cloud.Storage.V1/index.html) | 3.5.0 | [Google Cloud Storage](https://cloud.google.com/storage/) |


### PR DESCRIPTION

Changes in Google.Cloud.Spanner.Data version 3.10.0:

- [Commit 10c86e0](https://github.com/googleapis/google-cloud-dotnet/commit/10c86e0): feat: add JSON type (currently only in the low-level API)
- [Commit 41094ed](https://github.com/googleapis/google-cloud-dotnet/commit/41094ed): feat: add processing_units to Instance resource

Packages in this release:
- Release Google.Cloud.Spanner.Admin.Database.V1 version 3.10.0
- Release Google.Cloud.Spanner.Admin.Instance.V1 version 3.10.0
- Release Google.Cloud.Spanner.Common.V1 version 3.10.0
- Release Google.Cloud.Spanner.Data version 3.10.0
- Release Google.Cloud.Spanner.V1 version 3.10.0
