### PR TITLE
Release Google.Cloud.ApigeeConnect.V1 version 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.AccessApproval.V1](https://googleapis.dev/dotnet/Google.Cloud.AccessApproval.V1/1.1.0) | 1.1.0 | [Access Approval](https://cloud.google.com/access-approval/docs/) |
 | [Google.Cloud.ApiGateway.V1](https://googleapis.dev/dotnet/Google.Cloud.ApiGateway.V1/1.0.0) | 1.0.0 | [API Gateway](https://cloud.google.com/api-gateway/docs) |
 | [Google.Cloud.AIPlatform.V1](https://googleapis.dev/dotnet/Google.Cloud.AIPlatform.V1/1.0.0-beta01) | 1.0.0-beta01 | [Cloud AI Platform](https://cloud.google.com/ai-platform/docs/) |
-| [Google.Cloud.ApigeeConnect.V1](https://googleapis.dev/dotnet/Google.Cloud.ApigeeConnect.V1/1.0.0-beta01) | 1.0.0-beta01 | [Apigee Connect](https://cloud.google.com/apigee/docs/hybrid/v1.4/apigee-connect) |
+| [Google.Cloud.ApigeeConnect.V1](https://googleapis.dev/dotnet/Google.Cloud.ApigeeConnect.V1/1.0.0) | 1.0.0 | [Apigee Connect](https://cloud.google.com/apigee/docs/hybrid/v1.4/apigee-connect) |
 | [Google.Cloud.AppEngine.V1](https://googleapis.dev/dotnet/Google.Cloud.AppEngine.V1/1.1.0) | 1.1.0 | [App Engine Audit Data](https://cloud.google.com/appengine) |
 | [Google.Cloud.ArtifactRegistry.V1Beta2](https://googleapis.dev/dotnet/Google.Cloud.ArtifactRegistry.V1Beta2/1.0.0-beta02) | 1.0.0-beta02 | [Artifact Registry](https://cloud.google.com/artifact-registry) |
 | [Google.Cloud.Asset.V1](https://googleapis.dev/dotnet/Google.Cloud.Asset.V1/2.8.0) | 2.8.0 | [Google Cloud Asset Inventory](https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview) |

--- a/apis/Google.Cloud.ApigeeConnect.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.ApigeeConnect.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.ApigeeConnect.V1",
-  "release_level": "beta",
+  "release_level": "ga",
   "client_documentation": "https://googleapis.dev/dotnet/Google.Cloud.ApigeeConnect.V1/latest",
   "library_type": "GAPIC_AUTO"
 }

--- a/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1.csproj
+++ b/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Apigee Connect API which allows the Apigee hybrid management plane to connect securely to the MART service in the runtime plane.</Description>

--- a/apis/Google.Cloud.ApigeeConnect.V1/docs/history.md
+++ b/apis/Google.Cloud.ApigeeConnect.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.0.0, released 2021-06-28
+
+No API surface changes; just dependency updates and promotion to GA.
+
 # Version 1.0.0-beta01, released 2021-06-09
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -128,7 +128,7 @@
     },
     {
       "id": "Google.Cloud.ApigeeConnect.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Apigee Connect",
       "productUrl": "https://cloud.google.com/apigee/docs/hybrid/v1.4/apigee-connect",
@@ -138,7 +138,10 @@
         "mart",
         "hybrid"
       ],
-      "dependencies": {},
+      "dependencies": {
+        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Grpc.Core": "2.38.0"
+      },
       "generator": "micro",
       "protoPath": "google/cloud/apigeeconnect/v1"
     },

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -26,7 +26,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.AccessApproval.V1](Google.Cloud.AccessApproval.V1/index.html) | 1.1.0 | [Access Approval](https://cloud.google.com/access-approval/docs/) |
 | [Google.Cloud.ApiGateway.V1](Google.Cloud.ApiGateway.V1/index.html) | 1.0.0 | [API Gateway](https://cloud.google.com/api-gateway/docs) |
 | [Google.Cloud.AIPlatform.V1](Google.Cloud.AIPlatform.V1/index.html) | 1.0.0-beta01 | [Cloud AI Platform](https://cloud.google.com/ai-platform/docs/) |
-| [Google.Cloud.ApigeeConnect.V1](Google.Cloud.ApigeeConnect.V1/index.html) | 1.0.0-beta01 | [Apigee Connect](https://cloud.google.com/apigee/docs/hybrid/v1.4/apigee-connect) |
+| [Google.Cloud.ApigeeConnect.V1](Google.Cloud.ApigeeConnect.V1/index.html) | 1.0.0 | [Apigee Connect](https://cloud.google.com/apigee/docs/hybrid/v1.4/apigee-connect) |
 | [Google.Cloud.AppEngine.V1](Google.Cloud.AppEngine.V1/index.html) | 1.1.0 | [App Engine Audit Data](https://cloud.google.com/appengine) |
 | [Google.Cloud.ArtifactRegistry.V1Beta2](Google.Cloud.ArtifactRegistry.V1Beta2/index.html) | 1.0.0-beta02 | [Artifact Registry](https://cloud.google.com/artifact-registry) |
 | [Google.Cloud.Asset.V1](Google.Cloud.Asset.V1/index.html) | 2.8.0 | [Google Cloud Asset Inventory](https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview) |


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates and promotion to GA.
