### PR TITLE
Return no canonical link for API-specific packages beginning with Google.Apis

### DIFF
--- a/tools/Google.Cloud.Tools.GenerateCanonicalLinks.Tests/CanonicalizerTest.cs
+++ b/tools/Google.Cloud.Tools.GenerateCanonicalLinks.Tests/CanonicalizerTest.cs
@@ -57,6 +57,8 @@ namespace Google.Cloud.Tools.GenerateCanonicalLinks.Tests
         [InlineData("Google.Area120.Tables.V1Alpha1", "api/Google.Area120.Tables.V1Alpha1.BatchCreateRowsRequest.html")]
         [InlineData("Google.Analytics.Data.V1Alpha", "api/Google.Analytics.Data.V1Alpha.AlphaAnalyticsData.html")]
         [InlineData("Google.Cloud.Debugger.V2", "api/toc.html")]
+        [InlineData("Google.Apis.Storage.v1", "api/Google.Apis.Storage.v1.html")]
+        [InlineData("Google.Apis.AdSense.v1_4", "api/Google.Apis.AdSense.v1_4.AccountsResource.html")]
         public void GetUrl_NotOnDevsite(string package, string page) =>
             Assert.Null(Canonicalizer.GetUrl(package, page));
     }

--- a/tools/Google.Cloud.Tools.GenerateCanonicalLinks/Canonicalizer.cs
+++ b/tools/Google.Cloud.Tools.GenerateCanonicalLinks/Canonicalizer.cs
@@ -43,11 +43,12 @@ namespace Google.Cloud.Tools.GenerateCanonicalLinks
             { ("Grpc", "Grpc.Core") },
             { ("Google.Protobuf", "Google.Protobuf") },
             { ("Google.Api.Gax", "Google.Api.Gax") },
-            // Google.Apis and Google.Apis.Core contain some types in the Google namespace and some in
+            // Google.Apis, Google.Apis.Auth and Google.Apis.Core contain some types in the Google namespace and some in
             // the Google.Apis namespace, then some sub-namespaces. We want to be able to distinguish between
             // those and things like Google.Apis.Storage.V1.
             { ("Google.ApplicationContext", "Google.Apis") },
             { ("Google.GoogleApiException", "Google.Apis") },
+            { ("Google.Apis.Auth", "Google.Apis") },
             { ("Google.Apis.Discovery", "Google.Apis") },
             { ("Google.Apis.Download", "Google.Apis") },
             { ("Google.Apis.ETagAction", "Google.Apis") },
@@ -60,7 +61,6 @@ namespace Google.Cloud.Tools.GenerateCanonicalLinks
             { ("Google.Apis.Upload", "Google.Apis") },
             { ("Google.Apis.Testing", "Google.Apis") },
             { ("Google.Apis.Util", "Google.Apis") },
-            { ("Google.Apis", "Google.Apis") },
             { ("Google.Cloud.Diagnostics.Common", "Google.Cloud.Diagnostics.Common") },
             { ("Google.Cloud.OsLogin.Common", "Google.Cloud.OsLogin.Common") },
             { ("Google.Cloud.DevTools.Source", "Google.Cloud.DevTools.Common") },
@@ -109,6 +109,14 @@ namespace Google.Cloud.Tools.GenerateCanonicalLinks
             page = page.Split('/').Last();
 
             package = MaybeAdjustPackage(package, page);
+
+            // DevSite doesn't have REST-based libraries from https://github.com/googleapis/google-api-dotnet-client
+            // other than Google.Apis, Google.Apis.Core and Google.Apis.Auth, all of which are mapped
+            // to Google.Apis as the package (as that's the DevSite "bundle of packages").
+            if (package.StartsWith("Google.Apis") && package != "Google.Apis")
+            {
+                return null;
+            }
 
             return ApiMetadata.IsCloudPackage(package) || DevSiteSupportPackages.Contains(package)
                 ? $"{CloudSitePrefix}{package}/latest/{page}"


### PR DESCRIPTION
The non-API-specific packages (Google.Apis, Google.Apis.Core, Google.Apis.Auth) *are* still canonicalized appropriately.

Fixes #6687.