### PR TITLE
Include googleapis for REGAPIC

### DIFF
--- a/apis/Google.Cloud.Compute.V1/synth.metadata
+++ b/apis/Google.Cloud.Compute.V1/synth.metadata
@@ -6,6 +6,13 @@
         "remote": "https://github.com/googleapis/googleapis-discovery.git",
         "sha": "4f5d0604132e93e63330e65e2e6648c75012780c"
       }
+    },
+    {
+      "git": {
+        "name": "googleapis",
+        "remote": "https://github.com/googleapis/googleapis.git",
+        "sha": "ac5d0130755d21daf6296f9f910200b334ee7b23"
+      }
     }
   ]
 }

--- a/generateapis.sh
+++ b/generateapis.sh
@@ -391,21 +391,43 @@ generate_api() {
 
   # Record the commit in synth.metadata, using either googleapis or googleapis-discovery
   # depending on the generator.
-  REPO_TO_HASH=$([ "$GENERATOR" == "regapic" ] && echo "$GOOGLEAPIS_DISCOVERY" || echo "$GOOGLEAPIS")
-  REMOTE_NAME=$(basename $REPO_TO_HASH)
-  cat > $PACKAGE_DIR/synth.metadata <<END
+  if [[ "$GENERATOR" == "regapic" ]]
+  then
+    cat > $PACKAGE_DIR/synth.metadata <<END
 {
   "sources": [
     {
       "git": {
-        "name": "$REMOTE_NAME",
-        "remote": "https://github.com/googleapis/$REMOTE_NAME.git",
-        "sha": "$(git -C $REPO_TO_HASH rev-parse HEAD)"
+        "name": "googleapis-discovery",
+        "remote": "https://github.com/googleapis/googleapis-discovery.git",
+        "sha": "$(git -C $GOOGLEAPIS_DISCOVERY rev-parse HEAD)"
+      }
+    },
+    {
+      "git": {
+        "name": "googleapis",
+        "remote": "https://github.com/googleapis/googleapis.git",
+        "sha": "$(git -C $GOOGLEAPIS rev-parse HEAD)"
       }
     }
   ]
 }
 END
+  else
+    cat > $PACKAGE_DIR/synth.metadata <<END
+{
+  "sources": [
+    {
+      "git": {
+        "name": "googleapis",
+        "remote": "https://github.com/googleapis/googleapis.git",
+        "sha": "$(git -C $GOOGLEAPIS rev-parse HEAD)"
+      }
+    }
+  ]
+}
+END
+  fi
 }
 
 


### PR DESCRIPTION
We still need the "core" protos that are in googleapis, so let's
declare that dependency. This may confuse autosynth in the future,
but we'll cross that bridge when we come to it.