### PR TITLE
Start generating canonical links

### DIFF
--- a/docs/builddocs.sh
+++ b/docs/builddocs.sh
@@ -63,8 +63,7 @@ build_api_docs() {
   (! grep --quiet 'Build failed.' errors.txt)
   
   # Add canonical links where appropriate
-  # (Uncomment this when the canonical links are actually published.)
-  # dotnet run --no-build --no-restore -p ../tools/Google.Cloud.Tools.GenerateCanonicalLinks -- $api
+  dotnet run --no-build --no-restore -p ../tools/Google.Cloud.Tools.GenerateCanonicalLinks -- $api
 
   # Special case root: that should end up in the root of the assembled
   # site.


### PR DESCRIPTION
https://cloud.google.com/dotnet/docs/reference is now live, so let's
use it.

(Later we'll convert all GitHub Pages files into redirects, which
will be handy.)