### PR TITLE
Fix links between APIs

### DIFF
--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/docs/index.md
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/docs/index.md
@@ -5,8 +5,13 @@
 {{version}}
 
 Support for automatic error reporting can be found in the
-[`Google.Cloud.Diagnostics.AspNet`](../Google.Cloud.Diagnostics.AspNet/index.html)
-NuGet package.
+[`Google.Cloud.Diagnostics.AspNetCore`](../../Google.Cloud.Diagnostics.AspNetCore/latest)
+and
+[`Google.Cloud.Diagnostics.AspNetCore3`](../../Google.Cloud.Diagnostics.AspNetCore3/latest)
+NuGet packages.
+
+Those packages are generally preferred over using the Error
+Reporting API directly.
 
 {{installation}}
 
@@ -18,27 +23,7 @@ NuGet package.
 
 {{client-construction}}
 
-# Sample code
-
-## Automatic Error Reporting for ASP.NET
-
-Using [`Google.Cloud.Diagnostics.AspNet`'s ExceptionLogger or ExceptionFilter](../Google.Cloud.Diagnostics.AspNet/index.html)
-uncaught exceptions in ASP.NET applications can be automatically reported to the Stackdriver Error Reporting API.
-
-In ASP.NET MVC:
-
-[!code-cs[](../Google.Cloud.Diagnostics.AspNet/obj/snippets/Google.Cloud.Diagnostics.AspNet.AspNet.txt#RegisterExceptionLoggerMvc)]
-
-In Web API:
-
-[!code-cs[](../Google.Cloud.Diagnostics.AspNet/obj/snippets/Google.Cloud.Diagnostics.AspNet.AspNet.txt#RegisterExceptionLoggerWebApi)]
-
-## Automatic Error Reporting for ASP.NET Core
-
-Using [`Google.Cloud.Diagnostics.AspNetCore`'s Exception Logger Middleware](../Google.Cloud.Diagnostics.AspNetCore/index.html)
-uncaught exceptions in ASP.NET Core applications can be automatically reported to the Stackdriver Error Reporting API.
-
-[!code-cs[](../Google.Cloud.Diagnostics.AspNetCore/obj/snippets/Google.Cloud.Diagnostics.AspNetCore.ErrorReporting.txt#ReportUnhandledExceptions)]
+# Sample code using the Error Reporting API directly
 
 ## Report an error
 

--- a/apis/Google.Cloud.Language.V1/docs/index.md
+++ b/apis/Google.Cloud.Language.V1/docs/index.md
@@ -4,9 +4,6 @@
 
 {{version}}
 
-If you're looking for the experimental features, you can find them
-in [this separate package](../Google.Cloud.Language.V1.Experimental/index.html).
-
 {{installation}}
 
 {{auth}}

--- a/apis/Google.Cloud.Logging.V2/docs/index.md
+++ b/apis/Google.Cloud.Logging.V2/docs/index.md
@@ -4,8 +4,8 @@
 
 {{version}}
 
-- Integration with [log4net](https://logging.apache.org/log4net/) is provided by the [Google.Cloud.Logging.Log4Net](../Google.Cloud.Logging.Log4Net/index.html) package.
-- Integration with [NLog](https://nlog-project.org/) is provided by the [Google.Cloud.Logging.NLog](../Google.Cloud.Logging.NLog/index.html) package.
+- Integration with [log4net](https://logging.apache.org/log4net/) is provided by the [Google.Cloud.Logging.Log4Net](../../Google.Cloud.Logging.Log4Net/latest) package.
+- Integration with [NLog](https://nlog-project.org/) is provided by the [Google.Cloud.Logging.NLog](../../Google.Cloud.Logging.NLog/latest) package.
 
 {{installation}}
 

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/docs/index.md
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/docs/index.md
@@ -2,7 +2,7 @@
 
 {{description}}
 
-For non-administrative Spanner usage, the [Spanner ADO.NET provider](../Google.Cloud.Spanner.Data/) is recommended.
+For non-administrative Spanner usage, the [Spanner ADO.NET provider](../../Google.Cloud.Spanner.Data/latest) is recommended.
 
 {{installation}}
 

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/docs/index.md
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/docs/index.md
@@ -2,7 +2,7 @@
 
 {{description}}
 
-For non-administrative Spanner usage, the [Spanner ADO.NET provider](../Google.Cloud.Spanner.Data/) is recommended.
+For non-administrative Spanner usage, the [Spanner ADO.NET provider](../../Google.Cloud.Spanner.Data/latest) is recommended.
 
 {{installation}}
 

--- a/apis/Google.Cloud.Spanner.Data/docs/index.md
+++ b/apis/Google.Cloud.Spanner.Data/docs/index.md
@@ -5,7 +5,7 @@ package for regular Cloud Spanner database access from .NET.
 
 {{version}}
 
-The [Google.Cloud.Spanner.Admin.Instance.V1](../Google.Cloud.Spanner.Admin.Instance.V1/) package
+The [Google.Cloud.Spanner.Admin.Instance.V1](../../Google.Cloud.Spanner.Admin.Instance.V1/latest) package
 should be used for Cloud Spanner instance administration, such as creating or deleting instances.
 
 {{installation}}

--- a/apis/Google.Cloud.Spanner.V1/docs/index.md
+++ b/apis/Google.Cloud.Spanner.V1/docs/index.md
@@ -2,7 +2,7 @@
 
 The `Google.Cloud.Spanner.V1` package provides low-level access to the Google Cloud Spanner API.
 This is not recommended for most scenarios. Where possible, use the
-[Spanner ADO.NET provider](../../Google.Cloud.Spanner.Data/) instead. (That in turn depends on this package,
+[Spanner ADO.NET provider](../../Google.Cloud.Spanner.Data/latest) instead. (That in turn depends on this package,
 but provides a much more user-friendly API, and takes care of a lot of resource management automatically.)
 
 {{installation}}

--- a/uploaddocs.sh
+++ b/uploaddocs.sh
@@ -34,7 +34,6 @@ do
 
     # We need to perform a few fix-ups of the docfx generated site for googleapis.dev:
     # - Remove the "All APIs" link, as that page isn't included on googleapis.dev
-    # - Fix up links from one API to another (e.g. from Google.Cloud.Spanner.Data to Google.Cloud.Spanner.V1)
     # - Add an xrefmap baseUrl
 
     if grep -q "All APIs" toc.html
@@ -45,15 +44,6 @@ do
       echo "No 'All APIs' link to remove"
     fi
     
-    # We assume all non-reference html files are just in the root directory
-    # Regex is nasty due to all the escaping, but we're basically capturing
-    # href="../{foo}/"
-    # and replacing it with
-    # href="../{foo}/latest/
-    # It's slightly annoying to use latest, but otherwise we need
-    # to know the precise API version we're depending on.
-    sed -ie 's/href="\.\.\/\([^\//]*\)\//href="\.\.\/\1\/latest\//g' *.html
-
     if ! head xrefmap.yml | grep -q baseUrl
     then
       sed -i "1s/^/baseUrl: https:\/\/googleapis.dev\/dotnet\/$pkg\/$version\/\n/" xrefmap.yml


### PR DESCRIPTION
We no longer need to worry about the difference between GitHub pages and googleapis.dev, as we don't publish to GitHub pages any more. But currently the links are broken on cloud.google.com.

In some cases (e.g. Language and Error Reporting) the links have been removed as they're out of date.