### PR TITLE
Tool to rewrite GitHub pages to redirects

### DIFF
--- a/docs/Google.Cloud.DocTools.sln
+++ b/docs/Google.Cloud.DocTools.sln
@@ -35,7 +35,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Tools.Generate
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Tools.CanonicalLinkFunction", "..\tools\Google.Cloud.Tools.CanonicalLinkFunction\Google.Cloud.Tools.CanonicalLinkFunction.csproj", "{C42A623C-F5C8-43A4-9842-F8D8D6206626}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Tools.GenerateCanonicalLinks.Tests", "..\tools\Google.Cloud.Tools.GenerateCanonicalLinks.Tests\Google.Cloud.Tools.GenerateCanonicalLinks.Tests.csproj", "{17CF0C6A-F06E-4FB7-988B-97E6A36571D6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Tools.GenerateCanonicalLinks.Tests", "..\tools\Google.Cloud.Tools.GenerateCanonicalLinks.Tests\Google.Cloud.Tools.GenerateCanonicalLinks.Tests.csproj", "{17CF0C6A-F06E-4FB7-988B-97E6A36571D6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Tools.RewriteGitHubPages", "..\tools\Google.Cloud.Tools.RewriteGitHubPages\Google.Cloud.Tools.RewriteGitHubPages.csproj", "{E940BD9B-4DF8-4700-87B8-CB6FA2EBE6E6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -251,6 +253,18 @@ Global
 		{17CF0C6A-F06E-4FB7-988B-97E6A36571D6}.Release|x64.Build.0 = Release|Any CPU
 		{17CF0C6A-F06E-4FB7-988B-97E6A36571D6}.Release|x86.ActiveCfg = Release|Any CPU
 		{17CF0C6A-F06E-4FB7-988B-97E6A36571D6}.Release|x86.Build.0 = Release|Any CPU
+		{E940BD9B-4DF8-4700-87B8-CB6FA2EBE6E6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E940BD9B-4DF8-4700-87B8-CB6FA2EBE6E6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E940BD9B-4DF8-4700-87B8-CB6FA2EBE6E6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E940BD9B-4DF8-4700-87B8-CB6FA2EBE6E6}.Debug|x64.Build.0 = Debug|Any CPU
+		{E940BD9B-4DF8-4700-87B8-CB6FA2EBE6E6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E940BD9B-4DF8-4700-87B8-CB6FA2EBE6E6}.Debug|x86.Build.0 = Debug|Any CPU
+		{E940BD9B-4DF8-4700-87B8-CB6FA2EBE6E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E940BD9B-4DF8-4700-87B8-CB6FA2EBE6E6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E940BD9B-4DF8-4700-87B8-CB6FA2EBE6E6}.Release|x64.ActiveCfg = Release|Any CPU
+		{E940BD9B-4DF8-4700-87B8-CB6FA2EBE6E6}.Release|x64.Build.0 = Release|Any CPU
+		{E940BD9B-4DF8-4700-87B8-CB6FA2EBE6E6}.Release|x86.ActiveCfg = Release|Any CPU
+		{E940BD9B-4DF8-4700-87B8-CB6FA2EBE6E6}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/tools/Google.Cloud.Tools.RewriteGitHubPages/Google.Cloud.Tools.RewriteGitHubPages.csproj
+++ b/tools/Google.Cloud.Tools.RewriteGitHubPages/Google.Cloud.Tools.RewriteGitHubPages.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Google.Cloud.Tools.Common\Google.Cloud.Tools.Common.csproj" />
+    <ProjectReference Include="..\Google.Cloud.Tools.GenerateCanonicalLinks\Google.Cloud.Tools.GenerateCanonicalLinks.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tools/Google.Cloud.Tools.RewriteGitHubPages/Program.cs
+++ b/tools/Google.Cloud.Tools.RewriteGitHubPages/Program.cs
@@ -1,0 +1,127 @@
+﻿// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Tools.Common;
+using Google.Cloud.Tools.GenerateCanonicalLinks;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Google.Cloud.Tools.RewriteGitHubPages
+{
+    class Program
+    {
+        private static Dictionary<string, string> HardCodedEntries = new Dictionary<string, string>
+        {
+            { "index.html", "https://cloud.google.com/dotnet/docs/reference" },
+            { "docs/index.html", "https://cloud.google.com/dotnet/docs/reference" },
+            { "docs/toc.html", "https://cloud.google.com/dotnet/docs/reference/help/getting-started" },
+            { "docs/major-version.html", "https://cloud.google.com/dotnet/docs/reference" },
+            { "docs/faq.html", "https://cloud.google.com/dotnet/docs/reference/help/troubleshooting" },
+        };
+
+        private static void Main(string[] args)
+        {
+            if (args.Length != 1)
+            {
+                Console.WriteLine("Argument: <gh-pages directory>");
+                return;
+            }
+
+            string root = args[0];
+
+            var pages = Directory.EnumerateFiles(root, "*.html", new EnumerationOptions { RecurseSubdirectories = true });
+            foreach (var page in pages)
+            {
+                var relative = Path.GetRelativePath(root, page);
+                var uri = GenerateRedirectUri(relative);
+                var content = GenerateRedirectPage(uri);
+                File.WriteAllText(page, content);
+            }
+        }
+
+        private static string GenerateRedirectUri(string relative)
+        {
+            relative = relative.Replace('\\', '/');
+            var bits = relative.Split('/');
+            if (HardCodedEntries.TryGetValue(relative, out var uri))
+            {
+                return uri;
+            }
+            if (bits.Length < 3 || bits.Length > 4 || bits[0] != "docs")
+            {
+                throw new Exception($"Don't know how to handle {relative}");
+            }
+
+            string api = bits[1];
+            // Hard-code this... it's delisted anyway, but it breaks the link canonicalizer.
+            if (api == "Google.Cloud.EntityFrameworkCore.Spanner")
+            {
+                return "https://cloud.google.com/dotnet/docs/reference";
+            }
+
+            string apiRelative = string.Join("/", bits.Skip(2));
+
+            // If we have a canonical link, use it
+            var canonical = Canonicalizer.GetUrl(api, apiRelative);
+            if (canonical is string)
+            {
+                return canonical;
+            }
+
+            if (ApiMetadata.IsCloudPackage(api))
+            {
+                // Top-level TOC => getting started
+                if (apiRelative == "toc.html")
+                {
+                    return $"https://cloud.google.com/dotnet/docs/reference/{api}/latest";
+                }
+                // API-level TOC => all types
+                if (apiRelative == "api/toc.html")
+                {
+                    return $"https://cloud.google.com/dotnet/docs/reference/{api}/latest/{api}";
+                }
+
+                // No canonical link, and not a TOC, so we're probably in something like the Storage REST API... fall through.
+            }
+
+            string baseUri = $"https://googleapis.dev/dotnet/{api}/latest";
+
+            // Top-level TOC => index
+            if (apiRelative == "toc.html")
+            {
+                return $"{baseUri}/";
+            }
+            // API-level TOC => all types
+            if (apiRelative == "api/toc.html")
+            {
+                return $"{baseUri}/api/{api}.html";
+            }
+
+            return $"{baseUri}/{apiRelative}";
+        }
+
+        private static string GenerateRedirectPage(string uri) => $@"
+<html>
+  <head>
+    <meta http-equiv=""refresh"" content=""0; URL='{uri}'"" />
+  </head>
+  <body>
+    <h1>Page moved</h1>
+    <p>If your browser does not redirect you automatically, please visit <a href=""{uri}"">{uri}</a>.</p>
+  <body>
+</html>";
+    }
+}

--- a/tools/Google.Cloud.Tools.RewriteGitHubPages/Program.cs
+++ b/tools/Google.Cloud.Tools.RewriteGitHubPages/Program.cs
@@ -30,6 +30,19 @@ namespace Google.Cloud.Tools.RewriteGitHubPages
             { "docs/toc.html", "https://cloud.google.com/dotnet/docs/reference/help/getting-started" },
             { "docs/major-version.html", "https://cloud.google.com/dotnet/docs/reference" },
             { "docs/faq.html", "https://cloud.google.com/dotnet/docs/reference/help/troubleshooting" },
+
+            // Map the guides as best we can
+            { "docs/guides/api-layers.html", "https://cloud.google.com/dotnet/docs/reference/help/api-layers" },
+            { "docs/guides/cleanup.html", "https://cloud.google.com/dotnet/docs/reference/help/cleanup" },
+            { "docs/guides/gax-dependencies.html", "https://cloud.google.com/dotnet/docs/reference/help/getting-started" },
+            { "docs/guides/platforms.html", "https://cloud.google.com/dotnet/docs/reference/help/platforms" },
+            { "docs/guides/versioning.html", "https://cloud.google.com/dotnet/docs/reference/help/versioning" },
+            { "docs/guides/breaking-gax.html", "https://cloud.google.com/dotnet/docs/reference/help/getting-started" },
+            { "docs/guides/package-names.html", "https://cloud.google.com/dotnet/docs/reference/help/package-names" },
+            { "docs/guides/resource-names.html", "https://cloud.google.com/dotnet/docs/reference/help/resource-names" },
+            { "docs/guides/call-settings.html", "https://cloud.google.com/dotnet/docs/reference/help/call-settings" },
+            { "docs/guides/page-streaming.html", "https://cloud.google.com/dotnet/docs/reference/help/page-streaming" },
+            { "docs/guides/toc.html", "https://cloud.google.com/dotnet/docs/reference/help/getting-started" },
         };
 
         private static void Main(string[] args)


### PR DESCRIPTION
This will be removed in a subsequent PR, but it's good to have in
the history. (Aside from anything else, we don't depend on the
content of the pages, so if we want to change what the redirect page
looks like, we can do that and just rerun the tool.)