### PR TITLE
Release Google.Cloud.Security.PrivateCA.V1 version 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Scheduler.V1](https://googleapis.dev/dotnet/Google.Cloud.Scheduler.V1/2.2.0) | 2.2.0 | [Google Cloud Scheduler](https://cloud.google.com/scheduler/) |
 | [Google.Cloud.SecretManager.V1](https://googleapis.dev/dotnet/Google.Cloud.SecretManager.V1/1.5.0) | 1.5.0 | [Secret Manager (V1 API)](https://cloud.google.com/secret-manager) |
 | [Google.Cloud.SecretManager.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.SecretManager.V1Beta1/2.0.0-beta04) | 2.0.0-beta04 | [Secret Manager (V1Beta1 API)](https://cloud.google.com/secret-manager) |
-| [Google.Cloud.Security.PrivateCA.V1](https://googleapis.dev/dotnet/Google.Cloud.Security.PrivateCA.V1/1.0.0) | 1.0.0 | [Certificate Authority (V1 API)](https://cloud.google.com/certificate-authority-service/) |
+| [Google.Cloud.Security.PrivateCA.V1](https://googleapis.dev/dotnet/Google.Cloud.Security.PrivateCA.V1/2.0.0) | 2.0.0 | [Certificate Authority (V1 API)](https://cloud.google.com/certificate-authority-service/) |
 | [Google.Cloud.Security.PrivateCA.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Security.PrivateCA.V1Beta1/1.0.0-beta02) | 1.0.0-beta02 | [Certificate Authority (V1Beta1 API)](https://cloud.google.com/certificate-authority-service/) |
 | [Google.Cloud.SecurityCenter.Settings.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.SecurityCenter.Settings.V1Beta1/1.0.0-beta03) | 1.0.0-beta03 | [Google Cloud Security Command Center Settings](https://cloud.google.com/security-command-center/) |
 | [Google.Cloud.SecurityCenter.V1](https://googleapis.dev/dotnet/Google.Cloud.SecurityCenter.V1/2.4.0) | 2.4.0 | [Google Cloud Security Command Center (V1 API)](https://cloud.google.com/security-command-center/) |

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.csproj
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>2.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Certificate Authority Service API version v1. The Certificate Authority Service API is a highly-available, scalable service that enables you to simplify and automate the management of private certificate authorities (CAs) while staying in control of your private keys.</Description>

--- a/apis/Google.Cloud.Security.PrivateCA.V1/docs/history.md
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+# Version 2.0.0, released 2021-07-16
+
+- [Commit f09fdff](https://github.com/googleapis/google-cloud-dotnet/commit/f09fdff): fix!: mark some bools as optional, correct response type of DeleteCaPool
+
+This is a new major version as the change in response type for
+`DeleteCaPool` is a breaking change. Customers using the 1.x libraries
+are encouraged to upgrade, as attempting to obtain the result of the
+operation created by the `DeleteCaPool` RPC will throw an exception
+at execution time.
+
 # Version 1.0.0, released 2021-06-28
 
 No API surface changes; just dependency updates and promotion to GA.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2161,7 +2161,7 @@
     },
     {
       "id": "Google.Cloud.Security.PrivateCA.V1",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "type": "grpc",
       "productName": "Certificate Authority",
       "productUrl": "https://cloud.google.com/certificate-authority-service/",

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -131,7 +131,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Scheduler.V1](Google.Cloud.Scheduler.V1/index.html) | 2.2.0 | [Google Cloud Scheduler](https://cloud.google.com/scheduler/) |
 | [Google.Cloud.SecretManager.V1](Google.Cloud.SecretManager.V1/index.html) | 1.5.0 | [Secret Manager (V1 API)](https://cloud.google.com/secret-manager) |
 | [Google.Cloud.SecretManager.V1Beta1](Google.Cloud.SecretManager.V1Beta1/index.html) | 2.0.0-beta04 | [Secret Manager (V1Beta1 API)](https://cloud.google.com/secret-manager) |
-| [Google.Cloud.Security.PrivateCA.V1](Google.Cloud.Security.PrivateCA.V1/index.html) | 1.0.0 | [Certificate Authority (V1 API)](https://cloud.google.com/certificate-authority-service/) |
+| [Google.Cloud.Security.PrivateCA.V1](Google.Cloud.Security.PrivateCA.V1/index.html) | 2.0.0 | [Certificate Authority (V1 API)](https://cloud.google.com/certificate-authority-service/) |
 | [Google.Cloud.Security.PrivateCA.V1Beta1](Google.Cloud.Security.PrivateCA.V1Beta1/index.html) | 1.0.0-beta02 | [Certificate Authority (V1Beta1 API)](https://cloud.google.com/certificate-authority-service/) |
 | [Google.Cloud.SecurityCenter.Settings.V1Beta1](Google.Cloud.SecurityCenter.Settings.V1Beta1/index.html) | 1.0.0-beta03 | [Google Cloud Security Command Center Settings](https://cloud.google.com/security-command-center/) |
 | [Google.Cloud.SecurityCenter.V1](Google.Cloud.SecurityCenter.V1/index.html) | 2.4.0 | [Google Cloud Security Command Center (V1 API)](https://cloud.google.com/security-command-center/) |


### PR DESCRIPTION

Changes in this release:

- [Commit f09fdff](https://github.com/googleapis/google-cloud-dotnet/commit/f09fdff): fix!: mark some bools as optional, correct response type of DeleteCaPool

This is a new major version as the change in response type for `DeleteCaPool` is a breaking change. Customers using the 1.x libraries are encouraged to upgrade, as attempting to obtain the result of the operation created by the `DeleteCaPool` RPC will throw an exception at execution time.
