### PR TITLE
Release Google.Cloud.Common version 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Channel.V1](https://googleapis.dev/dotnet/Google.Cloud.Channel.V1/1.2.0) | 1.2.0 | [Cloud Channel](https://cloud.google.com/channel/docs/) |
 | [Google.Cloud.CloudBuild.V1](https://googleapis.dev/dotnet/Google.Cloud.CloudBuild.V1/1.2.0) | 1.2.0 | [Cloud Build](https://cloud.google.com/cloud-build) |
 | [Google.Cloud.CloudDms.V1](https://googleapis.dev/dotnet/Google.Cloud.CloudDms.V1/1.0.0) | 1.0.0 | [Database Migration](https://cloud.google.com/database-migration) |
-| [Google.Cloud.Common](https://googleapis.dev/dotnet/Google.Cloud.Common/1.0.0-beta01) | 1.0.0-beta01 | Common protos for Cloud APIs |
+| [Google.Cloud.Common](https://googleapis.dev/dotnet/Google.Cloud.Common/1.0.0) | 1.0.0 | Common protos for Cloud APIs |
 | [Google.Cloud.Compute.V1](https://googleapis.dev/dotnet/Google.Cloud.Compute.V1/1.0.0-alpha02) | 1.0.0-alpha02 | [Compute Engine](https://cloud.google.com/compute) |
 | [Google.Cloud.Container.V1](https://googleapis.dev/dotnet/Google.Cloud.Container.V1/2.4.0) | 2.4.0 | [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/reference/rest/) |
 | [Google.Cloud.DataCatalog.V1](https://googleapis.dev/dotnet/Google.Cloud.DataCatalog.V1/1.2.0) | 1.2.0 | [Data Catalog](https://cloud.google.com/data-catalog/docs) |

--- a/apis/Google.Cloud.Common/.repo-metadata.json
+++ b/apis/Google.Cloud.Common/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.Common",
-  "release_level": "beta",
+  "release_level": "ga",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Common/latest",
   "library_type": "OTHER"
 }

--- a/apis/Google.Cloud.Common/Google.Cloud.Common/Google.Cloud.Common.csproj
+++ b/apis/Google.Cloud.Common/Google.Cloud.Common/Google.Cloud.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Common protos for Cloud APIs.</Description>

--- a/apis/Google.Cloud.Common/docs/history.md
+++ b/apis/Google.Cloud.Common/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.0.0, released 2021-07-19
+
+No API surface changes; just the GA release.
+
 # Version 1.0.0-beta01, released 2021-06-25
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -528,7 +528,7 @@
     },
     {
       "id": "Google.Cloud.Common",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0",
       "targetFrameworks": "netstandard2.0;net461",
       "type": "other",
       "description": "Common protos for Cloud APIs.",

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -47,7 +47,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Channel.V1](Google.Cloud.Channel.V1/index.html) | 1.2.0 | [Cloud Channel](https://cloud.google.com/channel/docs/) |
 | [Google.Cloud.CloudBuild.V1](Google.Cloud.CloudBuild.V1/index.html) | 1.2.0 | [Cloud Build](https://cloud.google.com/cloud-build) |
 | [Google.Cloud.CloudDms.V1](Google.Cloud.CloudDms.V1/index.html) | 1.0.0 | [Database Migration](https://cloud.google.com/database-migration) |
-| [Google.Cloud.Common](Google.Cloud.Common/index.html) | 1.0.0-beta01 | Common protos for Cloud APIs |
+| [Google.Cloud.Common](Google.Cloud.Common/index.html) | 1.0.0 | Common protos for Cloud APIs |
 | [Google.Cloud.Compute.V1](Google.Cloud.Compute.V1/index.html) | 1.0.0-alpha02 | [Compute Engine](https://cloud.google.com/compute) |
 | [Google.Cloud.Container.V1](Google.Cloud.Container.V1/index.html) | 2.4.0 | [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/reference/rest/) |
 | [Google.Cloud.DataCatalog.V1](Google.Cloud.DataCatalog.V1/index.html) | 1.2.0 | [Data Catalog](https://cloud.google.com/data-catalog/docs) |


### PR DESCRIPTION

Changes in this release:

No API surface changes; just the GA release.
