### PR TITLE
Release Google.Cloud.Iap.V1 version 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Iam.Admin.V1](https://googleapis.dev/dotnet/Google.Cloud.Iam.Admin.V1/1.0.0) | 1.0.0 | [Identity and Access Management (IAM)](https://cloud.google.com/iam/docs) |
 | [Google.Cloud.Iam.Credentials.V1](https://googleapis.dev/dotnet/Google.Cloud.Iam.Credentials.V1/1.1.0) | 1.1.0 | [IAM Service Account Credentials](https://cloud.google.com/iam/docs/reference/credentials/rest) |
 | [Google.Cloud.Iam.V1](https://googleapis.dev/dotnet/Google.Cloud.Iam.V1/2.2.0) | 2.2.0 | [Google Cloud Identity and Access Management (IAM)](https://cloud.google.com/iam/) |
-| [Google.Cloud.Iap.V1](https://googleapis.dev/dotnet/Google.Cloud.Iap.V1/1.0.0-beta01) | 1.0.0-beta01 | [Cloud Identity-Aware Proxy](https://cloud.google.com/iap/docs/) |
+| [Google.Cloud.Iap.V1](https://googleapis.dev/dotnet/Google.Cloud.Iap.V1/1.0.0) | 1.0.0 | [Cloud Identity-Aware Proxy](https://cloud.google.com/iap/docs/) |
 | [Google.Cloud.Iot.V1](https://googleapis.dev/dotnet/Google.Cloud.Iot.V1/1.1.0) | 1.1.0 | [Cloud IoT](https://cloud.google.com/iot/docs/reference/cloudiot/rest) |
 | [Google.Cloud.Kms.V1](https://googleapis.dev/dotnet/Google.Cloud.Kms.V1/2.3.0) | 2.3.0 | [Google Cloud Key Management Service](https://cloud.google.com/kms/) |
 | [Google.Cloud.Language.V1](https://googleapis.dev/dotnet/Google.Cloud.Language.V1/2.2.0) | 2.2.0 | [Google Cloud Natural Language](https://cloud.google.com/natural-language) |

--- a/apis/Google.Cloud.Iap.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.Iap.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.Iap.V1",
-  "release_level": "beta",
+  "release_level": "ga",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Iap.V1/latest",
   "library_type": "GAPIC_AUTO"
 }

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.csproj
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud IAP API, which controls access to cloud applications running on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Iap.V1/docs/history.md
+++ b/apis/Google.Cloud.Iap.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.0.0, released 2021-07-19
+
+No API surface changes; just promotion to GA.
+
 # Version 1.0.0-beta01, released 2021-06-29
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1317,7 +1317,7 @@
     },
     {
       "id": "Google.Cloud.Iap.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Cloud Identity-Aware Proxy",
       "productUrl": "https://cloud.google.com/iap/docs/",
@@ -1328,7 +1328,9 @@
         "access"
       ],
       "dependencies": {
-        "Google.Cloud.Iam.V1": "2.2.0"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Cloud.Iam.V1": "2.2.0",
+        "Grpc.Core": "2.38.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/iap/v1"

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -87,7 +87,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Iam.Admin.V1](Google.Cloud.Iam.Admin.V1/index.html) | 1.0.0 | [Identity and Access Management (IAM)](https://cloud.google.com/iam/docs) |
 | [Google.Cloud.Iam.Credentials.V1](Google.Cloud.Iam.Credentials.V1/index.html) | 1.1.0 | [IAM Service Account Credentials](https://cloud.google.com/iam/docs/reference/credentials/rest) |
 | [Google.Cloud.Iam.V1](Google.Cloud.Iam.V1/index.html) | 2.2.0 | [Google Cloud Identity and Access Management (IAM)](https://cloud.google.com/iam/) |
-| [Google.Cloud.Iap.V1](Google.Cloud.Iap.V1/index.html) | 1.0.0-beta01 | [Cloud Identity-Aware Proxy](https://cloud.google.com/iap/docs/) |
+| [Google.Cloud.Iap.V1](Google.Cloud.Iap.V1/index.html) | 1.0.0 | [Cloud Identity-Aware Proxy](https://cloud.google.com/iap/docs/) |
 | [Google.Cloud.Iot.V1](Google.Cloud.Iot.V1/index.html) | 1.1.0 | [Cloud IoT](https://cloud.google.com/iot/docs/reference/cloudiot/rest) |
 | [Google.Cloud.Kms.V1](Google.Cloud.Kms.V1/index.html) | 2.3.0 | [Google Cloud Key Management Service](https://cloud.google.com/kms/) |
 | [Google.Cloud.Language.V1](Google.Cloud.Language.V1/index.html) | 2.2.0 | [Google Cloud Natural Language](https://cloud.google.com/natural-language) |


### PR DESCRIPTION

Changes in this release:

No API surface changes; just promotion to GA.
