### PR TITLE
Release Google.Cloud.Filestore.V1 version 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.ErrorReporting.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.ErrorReporting.V1Beta1/2.0.0-beta04) | 2.0.0-beta04 | [Google Cloud Error Reporting](https://cloud.google.com/error-reporting/) |
 | [Google.Cloud.EssentialContacts.V1](https://googleapis.dev/dotnet/Google.Cloud.EssentialContacts.V1/1.0.0) | 1.0.0 | [Essential Contacts](https://cloud.google.com/resource-manager/docs/reference/essentialcontacts/rest) |
 | [Google.Cloud.Eventarc.V1](https://googleapis.dev/dotnet/Google.Cloud.Eventarc.V1/1.0.0) | 1.0.0 | [Eventarc](https://cloud.google.com/eventarc/docs) |
-| [Google.Cloud.Filestore.V1](https://googleapis.dev/dotnet/Google.Cloud.Filestore.V1/1.0.0-beta01) | 1.0.0-beta01 | Cloud Filestore |
+| [Google.Cloud.Filestore.V1](https://googleapis.dev/dotnet/Google.Cloud.Filestore.V1/1.0.0) | 1.0.0 | Cloud Filestore |
 | [Google.Cloud.Firestore.Admin.V1](https://googleapis.dev/dotnet/Google.Cloud.Firestore.Admin.V1/2.2.0) | 2.2.0 | [Firestore Administration (e.g. index management)](https://firebase.google.com) |
 | [Google.Cloud.Firestore](https://googleapis.dev/dotnet/Google.Cloud.Firestore/2.4.0) | 2.4.0 | [Firestore high-level library](https://firebase.google.com/docs/firestore/) |
 | [Google.Cloud.Firestore.V1](https://googleapis.dev/dotnet/Google.Cloud.Firestore.V1/2.3.0) | 2.3.0 | [Firestore low-level API access](https://firebase.google.com) |

--- a/apis/Google.Cloud.Filestore.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.Filestore.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.Filestore.V1",
-  "release_level": "beta",
+  "release_level": "ga",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Filestore.V1/latest",
   "library_type": "GAPIC_AUTO"
 }

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.csproj
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>The Cloud Filestore API is used for creating and managing cloud file servers.</Description>
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Common" Version="[1.0.0-beta01, 2.0.0)" />
+    <PackageReference Include="Google.Cloud.Common" Version="[1.0.0, 2.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.Filestore.V1/docs/history.md
+++ b/apis/Google.Cloud.Filestore.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.0.0, released 2021-07-19
+
+No API surface changes; just promotion to GA.
+
 # Version 1.0.0-beta01, released 2021-06-25
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1055,14 +1055,16 @@
     },
     {
       "id": "Google.Cloud.Filestore.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Cloud Filestore",
       "description": "The Cloud Filestore API is used for creating and managing cloud file servers.",
       "tags": [],
       "dependencies": {
-        "Google.Cloud.Common": "1.0.0-beta01",
-        "Google.LongRunning": "2.2.0"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Cloud.Common": "1.0.0",
+        "Google.LongRunning": "2.2.0",
+        "Grpc.Core": "2.38.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/filestore/v1"

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -74,7 +74,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.ErrorReporting.V1Beta1](Google.Cloud.ErrorReporting.V1Beta1/index.html) | 2.0.0-beta04 | [Google Cloud Error Reporting](https://cloud.google.com/error-reporting/) |
 | [Google.Cloud.EssentialContacts.V1](Google.Cloud.EssentialContacts.V1/index.html) | 1.0.0 | [Essential Contacts](https://cloud.google.com/resource-manager/docs/reference/essentialcontacts/rest) |
 | [Google.Cloud.Eventarc.V1](Google.Cloud.Eventarc.V1/index.html) | 1.0.0 | [Eventarc](https://cloud.google.com/eventarc/docs) |
-| [Google.Cloud.Filestore.V1](Google.Cloud.Filestore.V1/index.html) | 1.0.0-beta01 | Cloud Filestore |
+| [Google.Cloud.Filestore.V1](Google.Cloud.Filestore.V1/index.html) | 1.0.0 | Cloud Filestore |
 | [Google.Cloud.Firestore.Admin.V1](Google.Cloud.Firestore.Admin.V1/index.html) | 2.2.0 | [Firestore Administration (e.g. index management)](https://firebase.google.com) |
 | [Google.Cloud.Firestore](Google.Cloud.Firestore/index.html) | 2.4.0 | [Firestore high-level library](https://firebase.google.com/docs/firestore/) |
 | [Google.Cloud.Firestore.V1](Google.Cloud.Firestore.V1/index.html) | 2.3.0 | [Firestore low-level API access](https://firebase.google.com) |


### PR DESCRIPTION

Changes in this release:

No API surface changes; just promotion to GA.
