### PR TITLE
Release Google.Cloud.ResourceManager.V3 version 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Recommender.V1](https://googleapis.dev/dotnet/Google.Cloud.Recommender.V1/2.5.0) | 2.5.0 | [Google Cloud Recommender](https://cloud.google.com/recommender/) |
 | [Google.Cloud.Redis.V1](https://googleapis.dev/dotnet/Google.Cloud.Redis.V1/2.2.0) | 2.2.0 | [Google Cloud Memorystore for Redis (V1 API)](https://cloud.google.com/memorystore/) |
 | [Google.Cloud.Redis.V1Beta1](https://googleapis.dev/dotnet/Google.Cloud.Redis.V1Beta1/2.0.0-beta04) | 2.0.0-beta04 | [Google Cloud Memorystore for Redis (V1Beta1 API)](https://cloud.google.com/memorystore/) |
-| [Google.Cloud.ResourceManager.V3](https://googleapis.dev/dotnet/Google.Cloud.ResourceManager.V3/1.0.0-beta01) | 1.0.0-beta01 | [Cloud Resource Manager](https://cloud.google.com/resource-manager/docs) |
+| [Google.Cloud.ResourceManager.V3](https://googleapis.dev/dotnet/Google.Cloud.ResourceManager.V3/1.0.0) | 1.0.0 | [Cloud Resource Manager](https://cloud.google.com/resource-manager/docs) |
 | [Google.Cloud.ResourceSettings.V1](https://googleapis.dev/dotnet/Google.Cloud.ResourceSettings.V1/1.0.0) | 1.0.0 | [Resource Settings](https://cloud.google.com/resource-settings/docs) |
 | [Google.Cloud.Retail.V2](https://googleapis.dev/dotnet/Google.Cloud.Retail.V2/1.1.0) | 1.1.0 | [Retail](https://cloud.google.com/retail/docs) |
 | [Google.Cloud.Scheduler.V1](https://googleapis.dev/dotnet/Google.Cloud.Scheduler.V1/2.2.0) | 2.2.0 | [Google Cloud Scheduler](https://cloud.google.com/scheduler/) |

--- a/apis/Google.Cloud.ResourceManager.V3/.repo-metadata.json
+++ b/apis/Google.Cloud.ResourceManager.V3/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.ResourceManager.V3",
-  "release_level": "beta",
+  "release_level": "ga",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.ResourceManager.V3/latest",
   "library_type": "GAPIC_AUTO"
 }

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.csproj
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Resource Manager API (v3), which creates, reads, and updates metadata for Google Cloud Platform resource containers.</Description>

--- a/apis/Google.Cloud.ResourceManager.V3/docs/history.md
+++ b/apis/Google.Cloud.ResourceManager.V3/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.0.0, released 2021-07-19
+
+No API changes - just promotion to GA.
+
 # Version 1.0.0-beta01, released 2021-06-28
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2055,7 +2055,7 @@
     },
     {
       "id": "Google.Cloud.ResourceManager.V3",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Cloud Resource Manager",
       "productUrl": "https://cloud.google.com/resource-manager/docs",
@@ -2064,8 +2064,10 @@
         "resources"
       ],
       "dependencies": {
+        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
         "Google.Cloud.Iam.V1": "2.2.0",
-        "Google.LongRunning": "2.2.0"
+        "Google.LongRunning": "2.2.0",
+        "Grpc.Core": "2.38.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/resourcemanager/v3"

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -125,7 +125,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Recommender.V1](Google.Cloud.Recommender.V1/index.html) | 2.5.0 | [Google Cloud Recommender](https://cloud.google.com/recommender/) |
 | [Google.Cloud.Redis.V1](Google.Cloud.Redis.V1/index.html) | 2.2.0 | [Google Cloud Memorystore for Redis (V1 API)](https://cloud.google.com/memorystore/) |
 | [Google.Cloud.Redis.V1Beta1](Google.Cloud.Redis.V1Beta1/index.html) | 2.0.0-beta04 | [Google Cloud Memorystore for Redis (V1Beta1 API)](https://cloud.google.com/memorystore/) |
-| [Google.Cloud.ResourceManager.V3](Google.Cloud.ResourceManager.V3/index.html) | 1.0.0-beta01 | [Cloud Resource Manager](https://cloud.google.com/resource-manager/docs) |
+| [Google.Cloud.ResourceManager.V3](Google.Cloud.ResourceManager.V3/index.html) | 1.0.0 | [Cloud Resource Manager](https://cloud.google.com/resource-manager/docs) |
 | [Google.Cloud.ResourceSettings.V1](Google.Cloud.ResourceSettings.V1/index.html) | 1.0.0 | [Resource Settings](https://cloud.google.com/resource-settings/docs) |
 | [Google.Cloud.Retail.V2](Google.Cloud.Retail.V2/index.html) | 1.1.0 | [Retail](https://cloud.google.com/retail/docs) |
 | [Google.Cloud.Scheduler.V1](Google.Cloud.Scheduler.V1/index.html) | 2.2.0 | [Google Cloud Scheduler](https://cloud.google.com/scheduler/) |


### PR DESCRIPTION

Changes in this release:

No API changes - just promotion to GA.
