### PR TITLE
Don't run the diff action if the PR has been merged

### DIFF
--- a/.github/workflows/diff-pr.yml
+++ b/.github/workflows/diff-pr.yml
@@ -7,6 +7,9 @@ on:
 jobs:
 
   diff:
+    # Don't run if a label has changed post-merge
+    if: github.event.pull_request.merged == false
+
     runs-on: ubuntu-latest
     env:
       DOTNET_NOLOGO: true


### PR DESCRIPTION
(This wasn't a problem until we started running the action on label
changes.)

Fixes #6777