### PR TITLE
Release Google.Analytics.Data.V1Beta version 1.0.0-beta04

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Each package name links to the documentation for that package.
 |---------|----------------|-------------|
 | [Google.Analytics.Admin.V1Alpha](https://googleapis.dev/dotnet/Google.Analytics.Admin.V1Alpha/1.0.0-alpha07) | 1.0.0-alpha07 | [Analytics Admin](https://developers.google.com/analytics) |
 | [Google.Analytics.Data.V1Alpha](https://googleapis.dev/dotnet/Google.Analytics.Data.V1Alpha/1.0.0-alpha05) | 1.0.0-alpha05 | [Google Analytics Data (V1Alpha API)](https://developers.google.com/analytics) |
-| [Google.Analytics.Data.V1Beta](https://googleapis.dev/dotnet/Google.Analytics.Data.V1Beta/1.0.0-beta03) | 1.0.0-beta03 | [Google Analytics Data (V1Beta API)](https://developers.google.com/analytics) |
+| [Google.Analytics.Data.V1Beta](https://googleapis.dev/dotnet/Google.Analytics.Data.V1Beta/1.0.0-beta04) | 1.0.0-beta04 | [Google Analytics Data (V1Beta API)](https://developers.google.com/analytics) |
 | [Google.Apps.Script.Type](https://googleapis.dev/dotnet/Google.Apps.Script.Type/1.0.0) | 1.0.0 | Version-agnostic types for Apps Script APIs |
 | [Google.Area120.Tables.V1Alpha1](https://googleapis.dev/dotnet/Google.Area120.Tables.V1Alpha1/1.0.0-alpha03) | 1.0.0-alpha03 | Google Area 120 Tables |
 | [Google.Cloud.AccessApproval.V1](https://googleapis.dev/dotnet/Google.Cloud.AccessApproval.V1/1.1.0) | 1.1.0 | [Access Approval](https://cloud.google.com/access-approval/docs/) |

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.csproj
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta03</Version>
+    <Version>1.0.0-beta04</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Analytics Data API (v1beta)</Description>

--- a/apis/Google.Analytics.Data.V1Beta/docs/history.md
+++ b/apis/Google.Analytics.Data.V1Beta/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.0.0-beta04, released 2021-07-26
+
+- [Commit 5d64452](https://github.com/googleapis/google-cloud-dotnet/commit/5d64452): feat: add `minute_ranges` field to `RunRealtimeReportRequest` object which can be used to specify the time range (in minutes) for realtime report queries docs: document the increase from 8 to 9 of the number of allowed dimensions in a report query
+
 # Version 1.0.0-beta03, released 2021-04-28
 
 - [Commit 391b953](https://github.com/googleapis/google-cloud-dotnet/commit/391b953):

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -30,7 +30,7 @@
     },
     {
       "id": "Google.Analytics.Data.V1Beta",
-      "version": "1.0.0-beta03",
+      "version": "1.0.0-beta04",
       "type": "grpc",
       "productName": "Google Analytics Data",
       "productUrl": "https://developers.google.com/analytics",


### PR DESCRIPTION

Changes in this release:

- [Commit 5d64452](https://github.com/googleapis/google-cloud-dotnet/commit/5d64452): feat: add `minute_ranges` field to `RunRealtimeReportRequest` object which can be used to specify the time range (in minutes) for realtime report queries docs: document the increase from 8 to 9 of the number of allowed dimensions in a report query
