### PR TITLE
Release Google.Cloud.CloudBuild.V1 version 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Billing.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Billing.V1/latest) | 2.2.0 | [Google Cloud Billing](https://cloud.google.com/billing/docs/) |
 | [Google.Cloud.BinaryAuthorization.V1Beta1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.BinaryAuthorization.V1Beta1/latest) | 1.0.0-beta03 | [Binary Authorization](https://cloud.google.com/binary-authorization/docs/reference/rpc) |
 | [Google.Cloud.Channel.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Channel.V1/latest) | 1.2.0 | [Cloud Channel](https://cloud.google.com/channel/docs/) |
-| [Google.Cloud.CloudBuild.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.CloudBuild.V1/latest) | 1.2.0 | [Cloud Build](https://cloud.google.com/cloud-build) |
+| [Google.Cloud.CloudBuild.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.CloudBuild.V1/latest) | 1.3.0 | [Cloud Build](https://cloud.google.com/cloud-build) |
 | [Google.Cloud.CloudDms.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.CloudDms.V1/latest) | 1.0.0 | [Database Migration](https://cloud.google.com/database-migration) |
 | [Google.Cloud.Common](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Common/latest) | 1.0.0 | Common protos for Cloud APIs |
 | [Google.Cloud.Compute.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Compute.V1/latest) | 1.0.0-alpha02 | [Compute Engine](https://cloud.google.com/compute) |

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.csproj
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Build API, which creates and manages builds on Google Cloud Platform.</Description>
@@ -12,7 +12,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.38.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.CloudBuild.V1/docs/history.md
+++ b/apis/Google.Cloud.CloudBuild.V1/docs/history.md
@@ -1,5 +1,18 @@
 # Version history
 
+# Version 1.3.0, released 2021-07-29
+
+- [Commit 0ded664](https://github.com/googleapis/google-cloud-dotnet/commit/0ded664): docs: Add a new build phase `SETUPBUILD` for timing information
+- [Commit cf7e645](https://github.com/googleapis/google-cloud-dotnet/commit/cf7e645): feat: Implementation of Build Failure Info
+- [Commit ae27ce0](https://github.com/googleapis/google-cloud-dotnet/commit/ae27ce0): feat!: add a WorkerPools API
+- [Commit 48b5b1d](https://github.com/googleapis/google-cloud-dotnet/commit/48b5b1d): Synchronize new proto/yaml changes.
+
+Note that the new WorkerPools API is a technically-breaking change,
+as there was a previous, similar API in earlier releases. However,
+as that API wasn't implemented on the back-end, we're not bumping
+the major version: we don't expect customers were actually referring
+to the old messages in their code.
+
 # Version 1.2.0, released 2021-06-22
 
 - [Commit 8c80969](https://github.com/googleapis/google-cloud-dotnet/commit/8c80969):

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -507,7 +507,7 @@
     },
     {
       "id": "Google.Cloud.CloudBuild.V1",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "type": "grpc",
       "productName": "Cloud Build",
       "productUrl": "https://cloud.google.com/cloud-build",
@@ -519,7 +519,7 @@
       "dependencies": {
         "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
         "Google.LongRunning": "2.2.0",
-        "Grpc.Core": "2.38.0"
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/devtools/cloudbuild/v1"


### PR DESCRIPTION

Changes in this release:

- [Commit 0ded664](https://github.com/googleapis/google-cloud-dotnet/commit/0ded664): docs: Add a new build phase `SETUPBUILD` for timing information
- [Commit cf7e645](https://github.com/googleapis/google-cloud-dotnet/commit/cf7e645): feat: Implementation of Build Failure Info
- [Commit ae27ce0](https://github.com/googleapis/google-cloud-dotnet/commit/ae27ce0): feat!: add a WorkerPools API
- [Commit 48b5b1d](https://github.com/googleapis/google-cloud-dotnet/commit/48b5b1d): Synchronize new proto/yaml changes.

Note that the new WorkerPools API is a technically-breaking change, as there was a previous, similar API in earlier releases. However, as that API wasn't implemented on the back-end, we're not bumping the major version: we don't expect customers were actually referring to the old messages in their code.
