### PR TITLE
feat(spanner): support comments and statement hints in untyped commands

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerCommandTextBuilderTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerCommandTextBuilderTests.cs
@@ -230,9 +230,9 @@ namespace Google.Cloud.Spanner.Data.Tests
         [InlineData("SELECT * FROM Foo@{FORCE_INDEX=`INDEX FOR SELECT`}", "SELECT * FROM Foo@{FORCE_INDEX=`INDEX FOR SELECT`}")]
         [InlineData("@{OPTIMIZER_VERSION=1 SELECT 1", "@{OPTIMIZER_VERSION=1 SELECT 1")]
         [InlineData("{OPTIMIZER_VERSION=1} SELECT 1", "{OPTIMIZER_VERSION=1} SELECT 1")]
-        public void RemoveStatementHintAndComments(string sql, string sqlWithoutHintsAndComments)
+        public void RemoveStatementHints(string sql, string sqlWithoutHints)
         {
-            Assert.Equal(sqlWithoutHintsAndComments, SpannerCommandTextBuilder.RemoveCommentsAndStatementHint(sql));
+            Assert.Equal(sqlWithoutHints, SpannerCommandTextBuilder.RemoveCommentsAndStatementHints(sql));
         }
     }
 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerCommandTextBuilderTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerCommandTextBuilderTests.cs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace Google.Cloud.Spanner.Data.Tests
@@ -77,6 +79,20 @@ namespace Google.Cloud.Spanner.Data.Tests
         [InlineData("\t\nWITH AlbumsView AS (SELECT * FROM Albums) select Title from AlbumsView")]
         [InlineData(" WITH   AlbumsView AS (SELECT * FROM Albums) select Title from AlbumsView")]
         [InlineData("WITH\t\nAlbumsView AS (SELECT * FROM Albums) select Title from AlbumsView")]
+        [InlineData("-- Single line comment\nSELECT * FROM Albums")]
+        [InlineData("# Single line comment\nSELECT * FROM Albums")]
+        [InlineData("/* Multi\nline\ncomment\n */\nSELECT * FROM Albums")]
+        [InlineData("/* Multi\n * line\n * comment\n */\nSELECT * FROM Albums")]
+        [InlineData("@{FORCE_INDEX=_BASE_TABLE} SELECT * FROM Albums")]
+        [InlineData("@{FORCE_INDEX=_BASE_TABLE} \n-- Single line comment\nSELECT * FROM Albums")]
+        [InlineData("@{FORCE_INDEX=_BASE_TABLE} \n# Single line comment\nSELECT * FROM Albums")]
+        [InlineData("@{FORCE_INDEX=_BASE_TABLE} /* Multi\nline\ncomment\n */\nSELECT * FROM Albums")]
+        [InlineData("@{FORCE_INDEX=_BASE_TABLE} /* Multi\n * line\n * comment\n */\nSELECT * FROM Albums")]
+        [InlineData("-- Single line comment\n@{FORCE_INDEX=_BASE_TABLE} \nSELECT * FROM Albums")]
+        [InlineData("# Single line comment\n@{FORCE_INDEX=_BASE_TABLE} \nSELECT * FROM Albums")]
+        [InlineData("/* Multi\nline\ncomment\n */\n@{FORCE_INDEX=_BASE_TABLE} \nSELECT * FROM Albums")]
+        [InlineData("/* Multi\n * line\n * comment\n */\n@{FORCE_INDEX=_BASE_TABLE} \nSELECT * FROM Albums")]
+        [InlineData("-- Single line comment\n@{FORCE_INDEX=_BASE_TABLE, OPTIMIZER_VERSION=1} \n\t \nSELECT * FROM Albums")]
         public void SelectCommand(string commandText)
         {
             var builder = SpannerCommandTextBuilder.FromCommandText(commandText);
@@ -95,6 +111,10 @@ namespace Google.Cloud.Spanner.Data.Tests
         [InlineData("\t\nINSERT\t\nAlbums\t\n(AlbumId)t\nVALUESt\n(@id)")]
         [InlineData("INSERT  Albums  (AlbumId) VALUES (@id)")]
         [InlineData("INSERT\t\nAlbums\t\n(AlbumId)t\nVALUESt\n(@id)")]
+        [InlineData("-- Single line comment\nINSERT INTO Albums (AlbumId) VALUES (@id)")]
+        [InlineData("# Single line comment\nINSERT INTO Albums (AlbumId) VALUES (@id)")]
+        [InlineData("/* Multi line comment */ INSERT INTO Albums (AlbumId) VALUES (@id)")]
+        [InlineData("@{FORCE_INDEX=_BASE_TABLE} INSERT INTO Albums (AlbumId) VALUES (@id)")]
         public void DmlInsertCommand(string commandText)
         {
             var builder = SpannerCommandTextBuilder.FromCommandText(commandText);
@@ -108,6 +128,10 @@ namespace Google.Cloud.Spanner.Data.Tests
         [InlineData("\t\nUPDATE\t\nAlbumst\nSETt\nTitle=@titlet\nWHEREt\nTRUE")]
         [InlineData("UPDATE  Albums  SET Title=@title WHERE TRUE")]
         [InlineData("UPDATE\t\nAlbums\t\nSETt\nTitle=@titlet\nWHEREt\nTRUE")]
+        [InlineData("-- Single line comment\nUPDATE Albums SET Title=@title WHERE TRUE")]
+        [InlineData("# Single line comment\nUPDATE Albums SET Title=@title WHERE TRUE")]
+        [InlineData("/* Multi line comment */ UPDATE Albums SET Title=@title WHERE TRUE")]
+        [InlineData("@{FORCE_INDEX=_BASE_TABLE} UPDATE Albums SET Title=@title WHERE TRUE")]
         public void DmlUpdateCommand(string commandText)
         {
             var builder = SpannerCommandTextBuilder.FromCommandText(commandText);
@@ -126,6 +150,10 @@ namespace Google.Cloud.Spanner.Data.Tests
         [InlineData("\t\nDELETE\t\nAlbumst\nWHEREt\nTRUE")]
         [InlineData("DELETE  Albums  WHERE TRUE")]
         [InlineData("DELETE\t\nAlbumst\nWHEREt\nTRUE")]
+        [InlineData("-- Single line comment\nDELETE FROM Albums WHERE TRUE")]
+        [InlineData("# Single line comment\nDELETE FROM Albums WHERE TRUE")]
+        [InlineData("/* Multi line comment */ DELETE FROM Albums WHERE TRUE")]
+        [InlineData("@{FORCE_INDEX=_BASE_TABLE} DELETE FROM Albums WHERE TRUE")]
         public void DmlDeleteCommand(string commandText)
         {
             var builder = SpannerCommandTextBuilder.FromCommandText(commandText);
@@ -146,10 +174,60 @@ namespace Google.Cloud.Spanner.Data.Tests
         [InlineData(" ALTER TABLE FOO")]
         [InlineData("ALTER\t\nTABLE\t\nFOO")]
         [InlineData("\t\nALTER\t\nTABLE\t\nFOO")]
+        [InlineData("-- Single line comment\nCREATE TABLE FOO")]
+        [InlineData("# Single line comment\nCREATE TABLE FOO")]
+        [InlineData("/* Multi line comment */ CREATE TABLE FOO")]
         public void DdlCommand(string commandText)
         {
             var builder = SpannerCommandTextBuilder.FromCommandText(commandText);
             Assert.Equal(SpannerCommandType.Ddl, builder.SpannerCommandType);
+        }
+
+        [Theory]
+        [InlineData("", "")]
+        [InlineData("SELECT 1", "SELECT 1")]
+        [InlineData("-- Single line comment\nSELECT 1", "\nSELECT 1")]
+        [InlineData("# Single line comment\nSELECT 1", "\nSELECT 1")]
+        [InlineData("/* Multi line comment on one line */SELECT 1", "SELECT 1")]
+        [InlineData("/* Multi\nline\ncomment\n */SELECT 1", "SELECT 1")]
+        [InlineData("SELECT 1 --Single line comment", "SELECT 1 ")]
+        [InlineData("SELECT 1 # Single line comment", "SELECT 1 ")]
+        [InlineData("SELECT 1 /* Multi line comment on one line */", "SELECT 1 ")]
+        [InlineData("SELECT 1 /* Multi\nline\ncomment\n */", "SELECT 1 ")]
+        [InlineData("SELECT '-- Not a comment'", "SELECT '-- Not a comment'")]
+        [InlineData("SELECT '''-- Not a comment\n'''", "SELECT '''-- Not a comment\n'''")]
+        [InlineData("SELECT '# Not a comment'", "SELECT '# Not a comment'")]
+        [InlineData("SELECT '''# Not a comment\n'''", "SELECT '''# Not a comment\n'''")]
+        [InlineData("SELECT '/* Not a comment */'", "SELECT '/* Not a comment */'")]
+        [InlineData("SELECT '''/* Not a comment\n */'''", "SELECT '''/* Not a comment\n */'''")]
+        [InlineData("SELECT \"-- Not a comment\"", "SELECT \"-- Not a comment\"")]
+        [InlineData("SELECT \"\"\"-- Not a comment\n\"\"\"", "SELECT \"\"\"-- Not a comment\n\"\"\"")]
+        [InlineData("SELECT \"# Not a comment\"", "SELECT \"# Not a comment\"")]
+        [InlineData("SELECT \"\"\"# Not a comment\n\"\"\"", "SELECT \"\"\"# Not a comment\n\"\"\"")]
+        [InlineData("SELECT \"/* Not a comment */\"", "SELECT \"/* Not a comment */\"")]
+        [InlineData("SELECT \"\"\"/* Not a comment\n */\"\"\"", "SELECT \"\"\"/* Not a comment\n */\"\"\"")]
+        [InlineData("SELECT * FROM `-- Not a comment`", "SELECT * FROM `-- Not a comment`")]
+        [InlineData("SELECT * FROM ```-- Not a comment\n```", "SELECT * FROM ```-- Not a comment\n```")]
+        [InlineData("SELECT * FROM `# Not a comment`", "SELECT * FROM `# Not a comment`")]
+        [InlineData("SELECT * FROM ```# Not a comment\n```", "SELECT * FROM ```# Not a comment\n```")]
+        [InlineData("SELECT * FROM `/* Not a comment */`", "SELECT * FROM `/* Not a comment */`")]
+        [InlineData("SELECT * FROM ```/* Not a comment\n */```", "SELECT * FROM ```/* Not a comment\n */```")]
+        public void RemoveComments(string sql, string sqlWithoutComments)
+        {
+            Assert.Equal(sqlWithoutComments, SpannerCommandTextBuilder.RemoveComments(sql));
+        }
+
+        [Theory]
+        [InlineData("", "")]
+        [InlineData("SELECT 1", "SELECT 1")]
+        [InlineData("@{FORCE_INDEX=_BASE_TABLE} SELECT 1", " SELECT 1")]
+        [InlineData("@{FORCE_INDEX=_BASE_TABLE}\nSELECT 1", "\nSELECT 1")]
+        [InlineData("@{FORCE_INDEX=_BASE_TABLE}\tSELECT 1", "\tSELECT 1")]
+        [InlineData("@{FORCE_INDEX=_BASE_TABLE}SELECT 1", "SELECT 1")]
+        [InlineData("@{FORCE_INDEX=_BASE_TABLE, OPTIMIZER_VERSION=2} SELECT 1", " SELECT 1")]
+        public void RemoveStatementHintAndComments(string sql, string sqlWithoutHintsAndComments)
+        {
+            Assert.Equal(sqlWithoutHintsAndComments, SpannerCommandTextBuilder.RemoveCommentsAndStatementHint(sql));
         }
     }
 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerCommandTextBuilderTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerCommandTextBuilderTests.cs
@@ -225,6 +225,9 @@ namespace Google.Cloud.Spanner.Data.Tests
         [InlineData("@{FORCE_INDEX=_BASE_TABLE}\tSELECT 1", "\tSELECT 1")]
         [InlineData("@{FORCE_INDEX=_BASE_TABLE}SELECT 1", "SELECT 1")]
         [InlineData("@{FORCE_INDEX=_BASE_TABLE, OPTIMIZER_VERSION=2} SELECT 1", " SELECT 1")]
+        [InlineData("SELECT '@{OPTIMIZER_VERSION=1}'", "SELECT '@{OPTIMIZER_VERSION=1}'")]
+        [InlineData("SELECT '@{OPTIMIZER_VERSION=1} SELECT 1'", "SELECT '@{OPTIMIZER_VERSION=1} SELECT 1'")]
+        [InlineData("SELECT * FROM Foo@{FORCE_INDEX=`INDEX FOR SELECT`}", "SELECT * FROM Foo@{FORCE_INDEX=`INDEX FOR SELECT`}")]
         public void RemoveStatementHintAndComments(string sql, string sqlWithoutHintsAndComments)
         {
             Assert.Equal(sqlWithoutHintsAndComments, SpannerCommandTextBuilder.RemoveCommentsAndStatementHint(sql));

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerCommandTextBuilderTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerCommandTextBuilderTests.cs
@@ -220,14 +220,16 @@ namespace Google.Cloud.Spanner.Data.Tests
         [Theory]
         [InlineData("", "")]
         [InlineData("SELECT 1", "SELECT 1")]
-        [InlineData("@{FORCE_INDEX=_BASE_TABLE} SELECT 1", " SELECT 1")]
-        [InlineData("@{FORCE_INDEX=_BASE_TABLE}\nSELECT 1", "\nSELECT 1")]
-        [InlineData("@{FORCE_INDEX=_BASE_TABLE}\tSELECT 1", "\tSELECT 1")]
+        [InlineData("@{FORCE_INDEX=_BASE_TABLE} SELECT 1", "SELECT 1")]
+        [InlineData("@{FORCE_INDEX=_BASE_TABLE}\nSELECT 1", "SELECT 1")]
+        [InlineData("@{FORCE_INDEX=_BASE_TABLE}\tSELECT 1", "SELECT 1")]
         [InlineData("@{FORCE_INDEX=_BASE_TABLE}SELECT 1", "SELECT 1")]
-        [InlineData("@{FORCE_INDEX=_BASE_TABLE, OPTIMIZER_VERSION=2} SELECT 1", " SELECT 1")]
+        [InlineData("@{FORCE_INDEX=_BASE_TABLE, OPTIMIZER_VERSION=2} SELECT 1", "SELECT 1")]
         [InlineData("SELECT '@{OPTIMIZER_VERSION=1}'", "SELECT '@{OPTIMIZER_VERSION=1}'")]
         [InlineData("SELECT '@{OPTIMIZER_VERSION=1} SELECT 1'", "SELECT '@{OPTIMIZER_VERSION=1} SELECT 1'")]
         [InlineData("SELECT * FROM Foo@{FORCE_INDEX=`INDEX FOR SELECT`}", "SELECT * FROM Foo@{FORCE_INDEX=`INDEX FOR SELECT`}")]
+        [InlineData("@{OPTIMIZER_VERSION=1 SELECT 1", "@{OPTIMIZER_VERSION=1 SELECT 1")]
+        [InlineData("{OPTIMIZER_VERSION=1} SELECT 1", "{OPTIMIZER_VERSION=1} SELECT 1")]
         public void RemoveStatementHintAndComments(string sql, string sqlWithoutHintsAndComments)
         {
             Assert.Equal(sqlWithoutHintsAndComments, SpannerCommandTextBuilder.RemoveCommentsAndStatementHint(sql));

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommandTextBuilder.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommandTextBuilder.cs
@@ -221,7 +221,7 @@ namespace Google.Cloud.Spanner.Data
         {
             GaxPreconditions.CheckNotNullOrEmpty(commandText, nameof(commandText));
             commandText = commandText.Trim();
-            var trimmedCommandText = RemoveCommentsAndStatementHint(commandText);
+            var trimmedCommandText = RemoveCommentsAndStatementHints(commandText);
             // Split(new char[0]) splits the string using all whitespace characters.
             var commandSections = trimmedCommandText.Split((char[]) null, StringSplitOptions.RemoveEmptyEntries);
             if (commandSections.Length < 2)
@@ -426,7 +426,7 @@ namespace Google.Cloud.Spanner.Data
         /// </summary>
         /// <param name="sql">The sql statement to strip for comments and statement hints</param>
         /// <returns>The sql statement without comments, statement hints, and leading and trailing spaces</returns>
-        internal static string RemoveCommentsAndStatementHint(string sql)
+        internal static string RemoveCommentsAndStatementHints(string sql)
         {
             GaxPreconditions.CheckNotNull(sql, nameof(sql));
             // First remove all comments from the statement and trim it.


### PR DESCRIPTION
SpannerCommandTextBuilder will try to determine the type of command based on the first word of the command text if no type is specified. This works well as long as the command text does not contain any comments or statement hints at the beginning of the command text.
This change adds a simple parser that will remove any comments and statement hints before checking the type of command. The command that is stripped of comments and hints is only used for determining the type of command. The original command will be passed on to Cloud Spanner.

Fixes #6847