### PR TITLE
chore: Fix the analyzer

### DIFF
--- a/tools/Google.Cloud.AnalyzersTesting/Google.Cloud.AnalyzersTesting.csproj
+++ b/tools/Google.Cloud.AnalyzersTesting/Google.Cloud.AnalyzersTesting.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFrameworks>netstandard1.5</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyOriginatorKeyFile>../GoogleApiTools.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>

--- a/tools/Google.Cloud.Tools.Analyzers/Google.Cloud.Tools.Analyzers.csproj
+++ b/tools/Google.Cloud.Tools.Analyzers/Google.Cloud.Tools.Analyzers.csproj
@@ -2,9 +2,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Version>1.0.0</Version>
-    <TargetFrameworks>netstandard1.3</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard1.3|AnyCPU'">
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <NoWarn>$(NoWarn);RS2008</NoWarn>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/tools/Google.Cloud.Tools.Analyzers/InternalOptionalParametersRequiredAnalyzer.cs
+++ b/tools/Google.Cloud.Tools.Analyzers/InternalOptionalParametersRequiredAnalyzer.cs
@@ -57,10 +57,13 @@ namespace Google.Cloud.Tools.Analyzers
             var invocation = (IInvocationOperation)context.Operation;
             if (invocation.Syntax is InvocationExpressionSyntax invocationExpression &&
                 invocation.TargetMethod?.IsExternallyVisible() == true &&
-                context.Compilation.Assembly == invocation.TargetMethod.ContainingAssembly &&
+                SymbolEqualityComparer.Default.Equals(context.Compilation.Assembly, invocation.TargetMethod.ContainingAssembly) &&
                 invocation.Arguments.Any(ShouldAnalyzeArgument))
             {
+#pragma warning disable RS1030 // Not entirely sure how to avoid this, but it does seem to work...
                 var semanticModel = context.Compilation.GetSemanticModel(context.Operation.Syntax.SyntaxTree);
+#pragma warning restore RS1030
+
                 var usableVariables = GetUsableVariables(context.Operation.Syntax, semanticModel);
 
                 foreach (var arg in invocation.Arguments)

--- a/tools/Google.Cloud.Tools.Analyzers/PublicDependencyForbiddenAnalyzer.cs
+++ b/tools/Google.Cloud.Tools.Analyzers/PublicDependencyForbiddenAnalyzer.cs
@@ -169,7 +169,9 @@ namespace Google.Cloud.Tools.Analyzers
                 return;
             }
 
-            var checkedTypes = new Dictionary<ITypeSymbol, TypeCheckResult>();
+#pragma warning disable RS1024 // We're providing an appropriate symbol equality comparer, so all comparisons should be fine.
+            var checkedTypes = new Dictionary<ITypeSymbol, TypeCheckResult>(SymbolEqualityComparer.Default);
+#pragma warning restore RS1024
             var result = CheckType(type, checkedTypes);
             if (!result.IsTypeForbidden)
             {


### PR DESCRIPTION
Renovate didn't take the target framework into account when proposing changes :(

This commit updates everything and fixes a couple of Roslyn
warnings; it disables one warning suggesting a release tracker (we
don't release this as a package) and another which would take
significant extra work to fix and doesn't seem to be causing a
problem.