### PR TITLE
Release Google.Cloud.NetworkManagement.V1 version 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Metastore.V1Beta](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Metastore.V1Beta/latest) | 1.0.0-beta01 | [Dataproc Metastore (V1Beta API)](https://cloud.google.com/dataproc-metastore/docs) |
 | [Google.Cloud.Monitoring.V3](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Monitoring.V3/latest) | 2.3.0 | [Google Cloud Monitoring](https://cloud.google.com/monitoring/api/v3/) |
 | [Google.Cloud.NetworkConnectivity.V1Alpha1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.NetworkConnectivity.V1Alpha1/latest) | 1.0.0-alpha02 | [Network Connectivity](https://cloud.google.com/network-connectivity/docs/apis) |
-| [Google.Cloud.NetworkManagement.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.NetworkManagement.V1/latest) | 1.0.0-beta01 | [Network Management](https://cloud.google.com/network-intelligence-center/docs/) |
+| [Google.Cloud.NetworkManagement.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.NetworkManagement.V1/latest) | 1.0.0 | [Network Management](https://cloud.google.com/network-intelligence-center/docs/) |
 | [Google.Cloud.Notebooks.V1Beta1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Notebooks.V1Beta1/latest) | 1.0.0-beta03 | [AI Platform Notebooks](https://cloud.google.com/ai-platform-notebooks) |
 | [Google.Cloud.OrgPolicy.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.OrgPolicy.V1/latest) | 2.2.0 | OrgPolicy API messages |
 | [Google.Cloud.OrgPolicy.V2](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.OrgPolicy.V2/latest) | 1.0.0 | [Organization Policy](https://cloud.google.com/resource-manager/docs/organization-policy/overview) |

--- a/apis/Google.Cloud.NetworkManagement.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.NetworkManagement.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.NetworkManagement.V1",
-  "release_level": "beta",
+  "release_level": "ga",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.NetworkManagement.V1/latest",
   "library_type": "GAPIC_AUTO"
 }

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.csproj
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Network Management API, which provides a collection of network performance monitoring and diagnostic capabilities.</Description>

--- a/apis/Google.Cloud.NetworkManagement.V1/docs/history.md
+++ b/apis/Google.Cloud.NetworkManagement.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.0.0, released 2021-08-05
+
+No API surface changes; just promotion to GA.
+
 # Version 1.0.0-beta01, released 2021-07-05
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1707,7 +1707,7 @@
     },
     {
       "id": "Google.Cloud.NetworkManagement.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Network Management",
       "productUrl": "https://cloud.google.com/network-intelligence-center/docs/",
@@ -1721,7 +1721,9 @@
         "diagnostics"
       ],
       "dependencies": {
-        "Google.LongRunning": "2.2.0"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.LongRunning": "2.2.0",
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/cloud/networkmanagement/v1"


### PR DESCRIPTION

Changes in this release:

No API surface changes; just promotion to GA.
