### PR TITLE
Release Google.Cloud.Compute.V1 version 1.0.0-beta01

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.CloudBuild.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.CloudBuild.V1/latest) | 1.3.0 | [Cloud Build](https://cloud.google.com/cloud-build) |
 | [Google.Cloud.CloudDms.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.CloudDms.V1/latest) | 1.0.0 | [Database Migration](https://cloud.google.com/database-migration) |
 | [Google.Cloud.Common](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Common/latest) | 1.0.0 | Common protos for Cloud APIs |
-| [Google.Cloud.Compute.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Compute.V1/latest) | 1.0.0-alpha02 | [Compute Engine](https://cloud.google.com/compute) |
+| [Google.Cloud.Compute.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Compute.V1/latest) | 1.0.0-beta01 | [Compute Engine](https://cloud.google.com/compute) |
 | [Google.Cloud.Container.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Container.V1/latest) | 2.4.0 | [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/reference/rest/) |
 | [Google.Cloud.DataCatalog.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.DataCatalog.V1/latest) | 1.2.0 | [Data Catalog](https://cloud.google.com/data-catalog/docs) |
 | [Google.Cloud.DataFusion.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.DataFusion.V1/latest) | 1.0.0-beta01 | [Cloud Data Fusion](https://cloud.google.com/data-fusion/docs/) |

--- a/apis/Google.Cloud.Compute.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.Compute.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.Compute.V1",
-  "release_level": "alpha",
+  "release_level": "beta",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Compute.V1/latest",
   "library_type": "GAPIC_AUTO"
 }

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha02</Version>
+    <Version>1.0.0-beta01</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Compute Engine API.</Description>

--- a/apis/Google.Cloud.Compute.V1/docs/history.md
+++ b/apis/Google.Cloud.Compute.V1/docs/history.md
@@ -1,5 +1,19 @@
 # Version history
 
+# Version 1.0.0-beta01, released 2021-08-09
+
+Main changes from 1.0.0-alpha02:
+
+- Automatic pagination is now implemented for all "list" methods. This is a breaking
+  change, as the return type has changed. Any code which was
+  previously looping over responses manually and handling page
+  tokens can be simplified at this point. See https://cloud.google.com/dotnet/docs/reference/help/page-streaming
+  for more details.
+- Failed RPCs will now contain details of the failure, rather than
+  just a status code. Currently this is just the textual
+  representation of the original RPC response; in the future this
+  text may be parsed automatically.
+
 # Version 1.0.0-alpha02, released 2021-06-16
 
 Regenerated with changes from googleapis-discovery, and GAX

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -559,7 +559,7 @@
     },
     {
       "id": "Google.Cloud.Compute.V1",
-      "version": "1.0.0-alpha02",
+      "version": "1.0.0-beta01",
       "type": "regapic",
       "productName": "Compute Engine",
       "productUrl": "https://cloud.google.com/compute",


### PR DESCRIPTION

Changes in this release:

Main changes from 1.0.0-alpha02:

- Automatic pagination is now implemented for all "list" methods. This is a breaking
  change, as the return type has changed. Any code which was
  previously looping over responses manually and handling page
  tokens can be simplified at this point. See https://cloud.google.com/dotnet/docs/reference/help/page-streaming
  for more details.
- Failed RPCs will now contain details of the failure, rather than
  just a status code. Currently this is just the textual
  representation of the original RPC response; in the future this
  text may be parsed automatically.
