### PR TITLE
In GetOrCreate, retry "get" operation if "create" fails due to conflict

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/RoutineTests.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/RoutineTests.cs
@@ -13,8 +13,11 @@
 // limitations under the License.
 
 using Google.Apis.Bigquery.v2.Data;
+using System;
+using System.Collections.Concurrent;
 using System.Linq;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -36,13 +39,7 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             var client = BigQueryClient.Create(_fixture.ProjectId);
             string datasetId = _fixture.DatasetId;
             var routineId = _fixture.CreateRoutineId();
-            Routine routine = new Routine
-            {
-                DefinitionBody = "SELECT 1;",
-                Description = "test routine",
-            };
-            routine.SetRoutineLanguage(RoutineLanguage.Sql);
-            routine.SetRoutineType(RoutineType.StoredProcedure);
+            var routine = CreateTestRoutineInMemory();
 
             var created = client.CreateRoutine(datasetId, routineId, routine);
             var fetched = client.GetRoutine(datasetId, routineId);
@@ -56,13 +53,7 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             var client = BigQueryClient.Create(_fixture.ProjectId);
             string datasetId = _fixture.DatasetId;
             var routineId = _fixture.CreateRoutineId();
-            Routine routine = new Routine
-            {
-                DefinitionBody = "SELECT 1;",
-                Description = "test routine",
-            };
-            routine.SetRoutineLanguage(RoutineLanguage.Sql);
-            routine.SetRoutineType(RoutineType.StoredProcedure);
+            var routine = CreateTestRoutineInMemory();
 
             var created = await client.CreateRoutineAsync(datasetId, routineId, routine);
             var fetched = client.GetRoutine(datasetId, routineId);
@@ -96,6 +87,74 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             var fetched = await client.GetRoutineAsync(datasetId, routineId);
 
             Assert.Equal(routineId, fetched.Reference.RoutineId);
+        }
+
+        /// <summary>
+        /// Calls GetOrCreateRoutine with multiple concurrent requests. We create 5 threads all trying
+        /// to GetOrCreate the same dataset at the same time, to check that
+        /// "get (not found) -> create (conflict) -> get (ok)" works appropriately.
+        /// We use 5 threads as that's the quota limit for updates to a single dataset's metadata within 10
+        /// seconds. We can't actually tell for sure whether any of the calls went through all three RPCs,
+        /// but the test does fail without the final "get".
+        /// 
+        /// We could potentially detect the create request failing due to lack of quota and perform
+        /// a second "get", but the quota check happens early - leading to "not found" errors while the dataset
+        /// is being created. Rather than get into polling intervals etc, we just let it fail in that case;
+        /// users will need to write higher-level retry if they're in that very niche situation.
+        /// 
+        /// (Threads are used rather than tasks to ensure that the requests really are pretty much "all at
+        /// the same time"; we don't want the normal slow task warm-up to skew this, although they're used
+        /// in the async test for convenience.)
+        /// </summary>
+        [Fact]
+        public void GetOrCreate_HighContention()
+        {
+            var client = BigQueryClient.Create(_fixture.ProjectId);
+            var datasetId = _fixture.CreateDatasetId();
+            client.CreateDataset(datasetId);
+            var routineId = _fixture.CreateRoutineId();
+            var routine = CreateTestRoutineInMemory();
+
+            int successes = 0;
+            ConcurrentBag<Exception> exceptions = new ConcurrentBag<Exception>();
+            var threads = Enumerable.Range(0, 5).Select(_ => new Thread(() =>
+            {
+                try
+                {
+                    client.GetOrCreateRoutine(datasetId, routineId, routine);
+                    Interlocked.Increment(ref successes);
+                }
+                catch (Exception ex)
+                {
+                    exceptions.Add(ex);
+                }
+            })).ToList();
+
+            // Start all the threads at roughly the same time
+            threads.ForEach(t => t.Start());
+
+            // ... and wait for them all to finish
+            threads.ForEach(t => t.Join(5000));
+
+            Assert.Empty(exceptions);
+            // If any threads timed out, we won't have enough successes.
+            Assert.Equal(threads.Count, successes);
+        }
+
+        /// <summary>
+        /// See <see cref="GetOrCreate_HighContention"/> for commentary on the test.
+        /// </summary>
+        [Fact]
+        public async Task GetOrCreateAsync_HighContention()
+        {
+            var client = BigQueryClient.Create(_fixture.ProjectId);
+            var datasetId = _fixture.CreateDatasetId();
+            await client.CreateDatasetAsync(datasetId);
+            var routineId = _fixture.CreateRoutineId();
+            var routine = CreateTestRoutineInMemory();
+
+            var tasks = Enumerable.Range(0, 5).Select(_ => client.GetOrCreateRoutineAsync(datasetId, routineId, routine)).ToList();
+            await Task.WhenAll(tasks);
         }
 
         [Fact]
@@ -217,6 +276,18 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             
             var exception = Assert.Throws<GoogleApiException>(() => original.Update());
             Assert.Equal(HttpStatusCode.PreconditionFailed, exception.HttpStatusCode);
+        }
+
+        private static Routine CreateTestRoutineInMemory()
+        {
+            Routine routine = new Routine
+            {
+                DefinitionBody = "SELECT 1;",
+                Description = "test routine",
+            };
+            routine.SetRoutineLanguage(RoutineLanguage.Sql);
+            routine.SetRoutineType(RoutineType.StoredProcedure);
+            return routine;
         }
     }
 }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.DatasetCrud.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.DatasetCrud.cs
@@ -105,7 +105,14 @@ namespace Google.Cloud.BigQuery.V2
             }
             catch (GoogleApiException ex) when (ex.HttpStatusCode == HttpStatusCode.NotFound)
             {
-                return CreateDataset(datasetReference, resource, createOptions);
+                try
+                {
+                    return CreateDataset(datasetReference, resource, createOptions);
+                }
+                catch (GoogleApiException ex2) when (ex2.HttpStatusCode == HttpStatusCode.Conflict)
+                {
+                    return GetDataset(datasetReference, getOptions);
+                }
             }
         }
 
@@ -123,7 +130,14 @@ namespace Google.Cloud.BigQuery.V2
             }
             catch (GoogleApiException ex) when (ex.HttpStatusCode == HttpStatusCode.NotFound)
             {
-                return await CreateDatasetAsync(datasetReference, resource, createOptions, cancellationToken).ConfigureAwait(false); ;
+                try
+                {
+                    return await CreateDatasetAsync(datasetReference, resource, createOptions, cancellationToken).ConfigureAwait(false);
+                }
+                catch (GoogleApiException ex2) when (ex2.HttpStatusCode == HttpStatusCode.Conflict)
+                {
+                    return await GetDatasetAsync(datasetReference, getOptions, cancellationToken).ConfigureAwait(false);
+                }
             }
         }
 

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.RoutineCrud.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.RoutineCrud.cs
@@ -107,7 +107,14 @@ namespace Google.Cloud.BigQuery.V2
             }
             catch (GoogleApiException ex) when (ex.HttpStatusCode == HttpStatusCode.NotFound)
             {
-                return CreateRoutine(routineReference, resource, createOptions);
+                try
+                {
+                    return CreateRoutine(routineReference, resource, createOptions);
+                }
+                catch (GoogleApiException ex2) when (ex2.HttpStatusCode == HttpStatusCode.Conflict)
+                {
+                    return GetRoutine(routineReference, getOptions);
+                }
             }
         }
 
@@ -122,7 +129,14 @@ namespace Google.Cloud.BigQuery.V2
             }
             catch (GoogleApiException ex) when (ex.HttpStatusCode == HttpStatusCode.NotFound)
             {
-                return await CreateRoutineAsync(routineReference, resource, createOptions, cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    return await CreateRoutineAsync(routineReference, resource, createOptions, cancellationToken).ConfigureAwait(false);
+                }
+                catch (GoogleApiException ex2) when (ex2.HttpStatusCode == HttpStatusCode.Conflict)
+                {
+                    return await GetRoutineAsync(routineReference, getOptions, cancellationToken).ConfigureAwait(false);
+                }
             }
         }
 

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.TableCrud.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.TableCrud.cs
@@ -148,7 +148,14 @@ namespace Google.Cloud.BigQuery.V2
             }
             catch (GoogleApiException ex) when (ex.HttpStatusCode == HttpStatusCode.NotFound)
             {
-                return CreateTable(tableReference, resource, createOptions);
+                try
+                {
+                    return CreateTable(tableReference, resource, createOptions);
+                }
+                catch (GoogleApiException ex2) when (ex2.HttpStatusCode == HttpStatusCode.Conflict)
+                {
+                    return GetTable(tableReference, getOptions);
+                }
             }
         }
 
@@ -164,7 +171,14 @@ namespace Google.Cloud.BigQuery.V2
             }
             catch (GoogleApiException ex) when (ex.HttpStatusCode == HttpStatusCode.NotFound)
             {
-                return await CreateTableAsync(tableReference, resource, createOptions, cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    return await CreateTableAsync(tableReference, resource, createOptions, cancellationToken).ConfigureAwait(false);
+                }
+                catch (GoogleApiException ex2) when (ex2.HttpStatusCode == HttpStatusCode.Conflict)
+                {
+                    return await GetTableAsync(tableReference, getOptions, cancellationToken).ConfigureAwait(false);
+                }
             }
         }
 


### PR DESCRIPTION
This addresses the situation where multiple calls to GetOrCreate(Dataset,Table,Routine) are executing at once - if the "get" operation returns "not found" for all of them, they'll then all proceed to "create" but only one will succeed. The others can just "get" the result of the successful one.

This does *not* address the situation where there are so many concurrent requests that quota fails. That's trickier to work around within the library code, and should be rarer.

Fixes #6902