### PR TITLE
Release Google.Cloud.BigQuery.V2 version 2.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.BigQuery.Connection.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.BigQuery.Connection.V1/latest) | 1.2.0 | [BigQuery Connection](https://cloud.google.com/bigquery/docs/reference/bigqueryconnection) |
 | [Google.Cloud.BigQuery.DataTransfer.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.BigQuery.DataTransfer.V1/latest) | 3.1.0 | [Google BigQuery Data Transfer](https://cloud.google.com/bigquery/transfer/) |
 | [Google.Cloud.BigQuery.Reservation.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.BigQuery.Reservation.V1/latest) | 1.2.0 | [BigQuery Reservation](https://cloud.google.com/bigquery/docs/reference/reservations) |
-| [Google.Cloud.BigQuery.V2](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.BigQuery.V2/latest) | 2.2.0 | [Google BigQuery](https://cloud.google.com/bigquery/) |
+| [Google.Cloud.BigQuery.V2](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.BigQuery.V2/latest) | 2.3.0 | [Google BigQuery](https://cloud.google.com/bigquery/) |
 | [Google.Cloud.BigQuery.Storage.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.BigQuery.Storage.V1/latest) | 2.3.0 | [Google BigQuery Storage](https://cloud.google.com/bigquery/docs/reference/storage/) |
 | [Google.Cloud.Bigtable.Admin.V2](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Bigtable.Admin.V2/latest) | 2.4.0 | [Google Cloud Bigtable Administration](https://cloud.google.com/bigtable/) |
 | [Google.Cloud.Bigtable.Common.V2](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Bigtable.Common.V2/latest) | 2.1.0 | Common code used by Bigtable V2 APIs |

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.2.0</Version>
+    <Version>2.3.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery API. It wraps the Google.Apis.Bigquery.v2 client library, making common operations simpler in client code. BigQuery is a data platform for customers to create, manage, share and query data.</Description>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Rest" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Rest" Version="[3.4.0, 4.0.0)" />
     <PackageReference Include="Google.Apis.Bigquery.v2" Version="[1.54.0.2397, 2.0.0.0)" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Rest" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Google.Apis.Bigquery.v2" Version="[1.53.0.2359, 2.0.0.0)" />
+    <PackageReference Include="Google.Apis.Bigquery.v2" Version="[1.54.0.2397, 2.0.0.0)" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.BigQuery.V2/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.V2/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 2.3.0, released 2021-08-10
+
+- [Commit d51544c](https://github.com/googleapis/google-cloud-dotnet/commit/d51544c): In GetOrCreate methods, retry "get" operation if "create" fails due to conflict. Fixes [issue 6902](https://github.com/googleapis/google-cloud-dotnet/issues/6902)
+
 # Version 2.2.0, released 2021-05-05
 
 - [Commit a07ebae](https://github.com/googleapis/google-cloud-dotnet/commit/a07ebae): feat: Model extract jobs.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -326,7 +326,7 @@
       "description": "Recommended Google client library to access the BigQuery API. It wraps the Google.Apis.Bigquery.v2 client library, making common operations simpler in client code. BigQuery is a data platform for customers to create, manage, share and query data.",
       "dependencies": {
         "Google.Api.Gax.Rest": "3.3.0",
-        "Google.Apis.Bigquery.v2": "1.53.0.2359"
+        "Google.Apis.Bigquery.v2": "1.54.0.2397"
       },
       "testDependencies": {
         "Google.Cloud.Storage.V1": "project",

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -321,11 +321,11 @@
       "id": "Google.Cloud.BigQuery.V2",
       "productName": "Google BigQuery",
       "productUrl": "https://cloud.google.com/bigquery/",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "type": "rest",
       "description": "Recommended Google client library to access the BigQuery API. It wraps the Google.Apis.Bigquery.v2 client library, making common operations simpler in client code. BigQuery is a data platform for customers to create, manage, share and query data.",
       "dependencies": {
-        "Google.Api.Gax.Rest": "3.3.0",
+        "Google.Api.Gax.Rest": "3.4.0",
         "Google.Apis.Bigquery.v2": "1.54.0.2397"
       },
       "testDependencies": {


### PR DESCRIPTION

Changes in this release:

- [Commit d51544c](https://github.com/googleapis/google-cloud-dotnet/commit/d51544c): In GetOrCreate methods, retry "get" operation if "create" fails due to conflict. Fixes [issue 6902](https://github.com/googleapis/google-cloud-dotnet/issues/6902)
