### PR TITLE
Release Google.Cloud.AssuredWorkloads.V1Beta1 version 1.0.0-beta05

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.AppEngine.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.AppEngine.V1/latest) | 1.1.0 | [App Engine Audit Data](https://cloud.google.com/appengine) |
 | [Google.Cloud.ArtifactRegistry.V1Beta2](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.ArtifactRegistry.V1Beta2/latest) | 1.0.0-beta02 | [Artifact Registry](https://cloud.google.com/artifact-registry) |
 | [Google.Cloud.Asset.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Asset.V1/latest) | 2.8.0 | [Google Cloud Asset Inventory](https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview) |
-| [Google.Cloud.AssuredWorkloads.V1Beta1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.AssuredWorkloads.V1Beta1/latest) | 1.0.0-beta04 | [Assured Workloads](https://cloud.google.com/assured-workloads/docs) |
+| [Google.Cloud.AssuredWorkloads.V1Beta1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.AssuredWorkloads.V1Beta1/latest) | 1.0.0-beta05 | [Assured Workloads](https://cloud.google.com/assured-workloads/docs) |
 | [Google.Cloud.Audit](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Audit/latest) | 1.0.0-beta02 | [Google Cloud Audit](https://cloud.google.com/logging/docs/audit) |
 | [Google.Cloud.AutoML.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.AutoML.V1/latest) | 2.2.0 | [Google AutoML](https://cloud.google.com/automl/) |
 | [Google.Cloud.BigQuery.Connection.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.BigQuery.Connection.V1/latest) | 1.2.0 | [BigQuery Connection](https://cloud.google.com/bigquery/docs/reference/bigqueryconnection) |

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.csproj
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta04</Version>
+    <Version>1.0.0-beta05</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Assured Workloads API (v1beta1)</Description>
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.0.0-beta05, released 2021-08-10
+
+- [Commit 28a4164](https://github.com/googleapis/google-cloud-dotnet/commit/28a4164): feat: Add EU Regions And Support compliance regime
+
 # Version 1.0.0-beta04, released 2021-04-28
 
 - [Commit 4593a55](https://github.com/googleapis/google-cloud-dotnet/commit/4593a55): feat: add HIPAA and HITRUST compliance regimes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -211,7 +211,7 @@
     },
     {
       "id": "Google.Cloud.AssuredWorkloads.V1Beta1",
-      "version": "1.0.0-beta04",
+      "version": "1.0.0-beta05",
       "type": "grpc",
       "productName": "Assured Workloads",
       "productUrl": "https://cloud.google.com/assured-workloads/docs",
@@ -221,7 +221,7 @@
         "compilance"
       ],
       "dependencies": {
-        "Google.LongRunning": "2.1.0"
+        "Google.LongRunning": "2.2.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/assuredworkloads/v1beta1"


### PR DESCRIPTION

Changes in this release:

- [Commit 28a4164](https://github.com/googleapis/google-cloud-dotnet/commit/28a4164): feat: Add EU Regions And Support compliance regime
