### PR TITLE
Release Google.Cloud.BigQuery.Connection.V1 version 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.AssuredWorkloads.V1Beta1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.AssuredWorkloads.V1Beta1/latest) | 1.0.0-beta05 | [Assured Workloads](https://cloud.google.com/assured-workloads/docs) |
 | [Google.Cloud.Audit](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Audit/latest) | 1.0.0-beta02 | [Google Cloud Audit](https://cloud.google.com/logging/docs/audit) |
 | [Google.Cloud.AutoML.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.AutoML.V1/latest) | 2.2.0 | [Google AutoML](https://cloud.google.com/automl/) |
-| [Google.Cloud.BigQuery.Connection.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.BigQuery.Connection.V1/latest) | 1.2.0 | [BigQuery Connection](https://cloud.google.com/bigquery/docs/reference/bigqueryconnection) |
+| [Google.Cloud.BigQuery.Connection.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.BigQuery.Connection.V1/latest) | 1.3.0 | [BigQuery Connection](https://cloud.google.com/bigquery/docs/reference/bigqueryconnection) |
 | [Google.Cloud.BigQuery.DataTransfer.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.BigQuery.DataTransfer.V1/latest) | 3.1.0 | [Google BigQuery Data Transfer](https://cloud.google.com/bigquery/transfer/) |
 | [Google.Cloud.BigQuery.Reservation.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.BigQuery.Reservation.V1/latest) | 1.2.0 | [BigQuery Reservation](https://cloud.google.com/bigquery/docs/reference/reservations) |
 | [Google.Cloud.BigQuery.V2](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.BigQuery.V2/latest) | 2.3.0 | [Google BigQuery](https://cloud.google.com/bigquery/) |

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery connection API, which allows users to manage BigQuery connections to external data sources.</Description>
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.BigQuery.Connection.V1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.3.0, released 2021-08-10
+
+- [Commit e425177](https://github.com/googleapis/google-cloud-dotnet/commit/e425177): feat: add cloud spanner connection support
+
 # Version 1.2.0, released 2021-05-25
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -264,7 +264,7 @@
     },
     {
       "id": "Google.Cloud.BigQuery.Connection.V1",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "type": "grpc",
       "productName": "BigQuery Connection",
       "productUrl": "https://cloud.google.com/bigquery/docs/reference/bigqueryconnection",
@@ -274,9 +274,9 @@
         "connection"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Google.Cloud.Iam.V1": "2.1.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Cloud.Iam.V1": "2.2.0",
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/cloud/bigquery/connection/v1"


### PR DESCRIPTION

Changes in this release:

- [Commit e425177](https://github.com/googleapis/google-cloud-dotnet/commit/e425177): feat: add cloud spanner connection support
