### PR TITLE
Release Google.Cloud.Container.V1 version 2.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Common](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Common/latest) | 1.0.0 | Common protos for Cloud APIs |
 | [Google.Cloud.Compute.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Compute.V1/latest) | 1.0.0-beta01 | [Compute Engine](https://cloud.google.com/compute) |
 | [Google.Cloud.ContactCenterInsights.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.ContactCenterInsights.V1/latest) | 1.0.0-beta01 | [Contact Center AI Insights](https://cloud.google.com/contact-center/insights/docs) |
-| [Google.Cloud.Container.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Container.V1/latest) | 2.4.0 | [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/reference/rest/) |
+| [Google.Cloud.Container.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Container.V1/latest) | 2.5.0 | [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/reference/rest/) |
 | [Google.Cloud.DataCatalog.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.DataCatalog.V1/latest) | 1.3.0 | [Data Catalog](https://cloud.google.com/data-catalog/docs) |
 | [Google.Cloud.DataFusion.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.DataFusion.V1/latest) | 1.0.0-beta01 | [Cloud Data Fusion](https://cloud.google.com/data-fusion/docs/) |
 | [Google.Cloud.DataLabeling.V1Beta1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.DataLabeling.V1Beta1/latest) | 1.0.0-beta02 | [Data Labeling](https://cloud.google.com/ai-platform/data-labeling/docs) |

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.4.0</Version>
+    <Version>2.5.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.</Description>
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.38.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Container.V1/docs/history.md
+++ b/apis/Google.Cloud.Container.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 2.5.0, released 2021-08-10
+
+- [Commit 28e502a](https://github.com/googleapis/google-cloud-dotnet/commit/28e502a): feat: allow updating security group on existing clusters
+
 # Version 2.4.0, released 2021-06-22
 
 - [Commit 10470bb](https://github.com/googleapis/google-cloud-dotnet/commit/10470bb): feat: support for NodeAutoprovisioning ImageType

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -597,12 +597,12 @@
       "protoPath": "google/container/v1",
       "productName": "Google Kubernetes Engine",
       "productUrl": "https://cloud.google.com/kubernetes-engine/docs/reference/rest/",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.",
       "dependencies": {
         "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
-        "Grpc.Core": "2.38.0"
+        "Grpc.Core": "2.38.1"
       },
       "tags": [
         "Kubernetes"


### PR DESCRIPTION

Changes in this release:

- [Commit 28e502a](https://github.com/googleapis/google-cloud-dotnet/commit/28e502a): feat: allow updating security group on existing clusters
