### PR TITLE
Release Google.Cloud.DataCatalog.V1 version 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Compute.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Compute.V1/latest) | 1.0.0-beta01 | [Compute Engine](https://cloud.google.com/compute) |
 | [Google.Cloud.ContactCenterInsights.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.ContactCenterInsights.V1/latest) | 1.0.0-beta01 | [Contact Center AI Insights](https://cloud.google.com/contact-center/insights/docs) |
 | [Google.Cloud.Container.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Container.V1/latest) | 2.4.0 | [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/reference/rest/) |
-| [Google.Cloud.DataCatalog.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.DataCatalog.V1/latest) | 1.2.0 | [Data Catalog](https://cloud.google.com/data-catalog/docs) |
+| [Google.Cloud.DataCatalog.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.DataCatalog.V1/latest) | 1.3.0 | [Data Catalog](https://cloud.google.com/data-catalog/docs) |
 | [Google.Cloud.DataFusion.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.DataFusion.V1/latest) | 1.0.0-beta01 | [Cloud Data Fusion](https://cloud.google.com/data-fusion/docs/) |
 | [Google.Cloud.DataLabeling.V1Beta1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.DataLabeling.V1Beta1/latest) | 1.0.0-beta02 | [Data Labeling](https://cloud.google.com/ai-platform/data-labeling/docs) |
 | [Google.Cloud.DataQnA.V1Alpha](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.DataQnA.V1Alpha/latest) | 1.0.0-alpha02 | [Data QnA](https://cloud.google.com/bigquery/docs/dataqna) |

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.csproj
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Data Catalog API. Data Catalog is a fully managed and highly scalable data discovery and metadata management service.</Description>
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.DataCatalog.V1/docs/history.md
+++ b/apis/Google.Cloud.DataCatalog.V1/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+# Version 1.3.0, released 2021-08-10
+
+- [Commit 2fc3992](https://github.com/googleapis/google-cloud-dotnet/commit/2fc3992):
+  - feat: Added support for BigQuery connections entries
+  - feat: Added support for BigQuery routines entries
+  - feat: Added usage_signal field
+  - feat: Added labels field
+  - feat: Added ReplaceTaxonomy in Policy Tag Manager Serialization API
+  - feat: Added support for public tag templates
+  - feat: Added support for rich text tags
+  - docs: Documentation improvements
+
 # Version 1.2.0, released 2021-05-05
 
 - [Commit 29c9961](https://github.com/googleapis/google-cloud-dotnet/commit/29c9961): docs: reformat comments in PolicyTagManager definition

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -614,7 +614,7 @@
       "protoPath": "google/cloud/datacatalog/v1",
       "productName": "Data Catalog",
       "productUrl": "https://cloud.google.com/data-catalog/docs",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Data Catalog API. Data Catalog is a fully managed and highly scalable data discovery and metadata management service.",
       "tags": [
@@ -622,9 +622,9 @@
         "metadata"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Google.Cloud.Iam.V1": "2.1.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Cloud.Iam.V1": "2.2.0",
+        "Grpc.Core": "2.38.1"
       }
     },
     {


### PR DESCRIPTION

Changes in this release:

- [Commit 2fc3992](https://github.com/googleapis/google-cloud-dotnet/commit/2fc3992):
  - feat: Added support for BigQuery connections entries
  - feat: Added support for BigQuery routines entries
  - feat: Added usage_signal field
  - feat: Added labels field
  - feat: Added ReplaceTaxonomy in Policy Tag Manager Serialization API
  - feat: Added support for public tag templates
  - feat: Added support for rich text tags
  - docs: Documentation improvements
