### PR TITLE
Release Google.Cloud.Datastore.Admin.V1 version 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.DataQnA.V1Alpha](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.DataQnA.V1Alpha/latest) | 1.0.0-alpha02 | [Data QnA](https://cloud.google.com/bigquery/docs/dataqna) |
 | [Google.Cloud.Dataflow.V1Beta3](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Dataflow.V1Beta3/latest) | 1.0.0-beta01 | [Dataflow](https://cloud.google.com/dataflow/docs/) |
 | [Google.Cloud.Dataproc.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Dataproc.V1/latest) | 3.1.0 | [Google Cloud Dataproc](https://cloud.google.com/dataproc/docs/concepts/overview) |
-| [Google.Cloud.Datastore.Admin.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Datastore.Admin.V1/latest) | 1.1.0 | Cloud Datastore |
+| [Google.Cloud.Datastore.Admin.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Datastore.Admin.V1/latest) | 1.2.0 | Cloud Datastore |
 | [Google.Cloud.Datastore.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Datastore.V1/latest) | 3.2.0 | [Google Cloud Datastore](https://cloud.google.com/datastore/docs/concepts/overview) |
 | [Google.Cloud.Datastream.V1Alpha1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Datastream.V1Alpha1/latest) | 1.0.0-beta01 | [DataStream](https://cloud.google.com/datastream/docs) |
 | [Google.Cloud.Debugger.V2](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Debugger.V2/latest) | 2.3.0 | [Google Cloud Debugger](https://cloud.google.com/debugger/) |

--- a/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.csproj
+++ b/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Datastore Admin API. This accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.</Description>
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Datastore.Admin.V1/docs/history.md
+++ b/apis/Google.Cloud.Datastore.Admin.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.2.0, released 2021-08-10
+
+- [Commit c13f1e3](https://github.com/googleapis/google-cloud-dotnet/commit/c13f1e3): feat: Publish message definitions for new Cloud Datastore migration logging steps.
+
 # Version 1.1.0, released 2021-04-29
 
 - [Commit 1313ce6](https://github.com/googleapis/google-cloud-dotnet/commit/1313ce6): feat: Added methods for creating and deleting composite indexes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -712,7 +712,7 @@
     },
     {
       "id": "Google.Cloud.Datastore.Admin.V1",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "type": "grpc",
       "productName": "Cloud Datastore",
       "description": "Recommended Google client library to access the Google Cloud Datastore Admin API. This accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.",
@@ -721,9 +721,9 @@
         "admin"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Google.LongRunning": "2.1.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.LongRunning": "2.2.0",
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/datastore/admin/v1"


### PR DESCRIPTION

Changes in this release:

- [Commit c13f1e3](https://github.com/googleapis/google-cloud-dotnet/commit/c13f1e3): feat: Publish message definitions for new Cloud Datastore migration logging steps.
