### PR TITLE
Release Google.Cloud.PubSub.V1 version 2.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.PolicyTroubleshooter.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.PolicyTroubleshooter.V1/latest) | 1.1.0 | [Policy Troubleshooter](https://cloud.google.com/iam/docs/reference/policytroubleshooter/rest) |
 | [Google.Cloud.PrivateCatalog.V1Beta1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.PrivateCatalog.V1Beta1/latest) | 1.0.0-beta01 | [Cloud Private Catalog](https://cloud.google.com/private-catalog/docs/) |
 | [Google.Cloud.Profiler.V2](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Profiler.V2/latest) | 1.1.0 | [Cloud Profiler](https://cloud.google.com/profiler/) |
-| [Google.Cloud.PubSub.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.PubSub.V1/latest) | 2.5.0 | [Cloud Pub/Sub](https://cloud.google.com/pubsub/) |
+| [Google.Cloud.PubSub.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.PubSub.V1/latest) | 2.6.0 | [Cloud Pub/Sub](https://cloud.google.com/pubsub/) |
 | [Google.Cloud.RecaptchaEnterprise.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.RecaptchaEnterprise.V1/latest) | 1.2.0 | [Google Cloud reCAPTCHA Enterprise (V1 API)](https://cloud.google.com/recaptcha-enterprise/) |
 | [Google.Cloud.RecaptchaEnterprise.V1Beta1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.RecaptchaEnterprise.V1Beta1/latest) | 1.0.0-beta04 | [Google Cloud reCAPTCHA Enterprise (V1Beta1 API)](https://cloud.google.com/recaptcha-enterprise/) |
 | [Google.Cloud.RecommendationEngine.V1Beta1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.RecommendationEngine.V1Beta1/latest) | 1.0.0-beta02 | [Recommendations AI](https://cloud.google.com/recommendations) |

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.5.0</Version>
+    <Version>2.6.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.</Description>
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.PubSub.V1/docs/history.md
+++ b/apis/Google.Cloud.PubSub.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+# Version 2.6.0, released 2021-08-10
+
+- [Commit 61c5c17](https://github.com/googleapis/google-cloud-dotnet/commit/61c5c17): chore: Remove unused fields in PublisherClient
+- [Commit c75f979](https://github.com/googleapis/google-cloud-dotnet/commit/c75f979): Update PubSub ConfigureAwait warning disablement
+- [Commit 5fede56](https://github.com/googleapis/google-cloud-dotnet/commit/5fede56): feat: Add method signature for Subscriber.Pull without the deprecated return_immediately field.
+- [Commit 887ec05](https://github.com/googleapis/google-cloud-dotnet/commit/887ec05): feat: Adding subscription properties to streaming pull response in third party pubsub.proto.
+
 # Version 2.5.0, released 2021-05-26
 
 - [Commit 3717e0d](https://github.com/googleapis/google-cloud-dotnet/commit/3717e0d): Regenerate all APIs with generator change for deprecation

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2001,19 +2001,19 @@
       "protoPath": "google/pubsub/v1",
       "productName": "Cloud Pub/Sub",
       "productUrl": "https://cloud.google.com/pubsub/",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.",
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
         "Google.Cloud.Iam.V1": "2.2.0",
-        "Grpc.Core": "2.36.4"
+        "Grpc.Core": "2.38.1"
       },
       "testDependencies": {
+        "Google.Api.Gax.Testing": "3.4.0",
         "Google.Apis.CloudResourceManager.v1": "1.53.0.2281",
         "System.ValueTuple": "4.5.0",
-        "Google.Api.Gax.Testing": "3.4.0",
         "Xunit.Combinatorial": "1.4.1"
       },
       "tags": [


### PR DESCRIPTION

Changes in this release:

- [Commit 61c5c17](https://github.com/googleapis/google-cloud-dotnet/commit/61c5c17): chore: Remove unused fields in PublisherClient
- [Commit c75f979](https://github.com/googleapis/google-cloud-dotnet/commit/c75f979): Update PubSub ConfigureAwait warning disablement
- [Commit 5fede56](https://github.com/googleapis/google-cloud-dotnet/commit/5fede56): feat: Add method signature for Subscriber.Pull without the deprecated return_immediately field.
- [Commit 887ec05](https://github.com/googleapis/google-cloud-dotnet/commit/887ec05): feat: Adding subscription properties to streaming pull response in third party pubsub.proto.
