### PR TITLE
Release Google.Cloud.ResourceSettings.V1 version 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Redis.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Redis.V1/latest) | 2.2.0 | [Google Cloud Memorystore for Redis (V1 API)](https://cloud.google.com/memorystore/) |
 | [Google.Cloud.Redis.V1Beta1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Redis.V1Beta1/latest) | 2.0.0-beta04 | [Google Cloud Memorystore for Redis (V1Beta1 API)](https://cloud.google.com/memorystore/) |
 | [Google.Cloud.ResourceManager.V3](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.ResourceManager.V3/latest) | 1.0.0 | [Cloud Resource Manager](https://cloud.google.com/resource-manager/docs) |
-| [Google.Cloud.ResourceSettings.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.ResourceSettings.V1/latest) | 1.0.0 | [Resource Settings](https://cloud.google.com/resource-settings/docs) |
+| [Google.Cloud.ResourceSettings.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.ResourceSettings.V1/latest) | 1.1.0 | [Resource Settings](https://cloud.google.com/resource-settings/docs) |
 | [Google.Cloud.Retail.V2](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Retail.V2/latest) | 1.1.0 | [Retail](https://cloud.google.com/retail/docs) |
 | [Google.Cloud.Scheduler.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Scheduler.V1/latest) | 2.2.0 | [Google Cloud Scheduler](https://cloud.google.com/scheduler/) |
 | [Google.Cloud.SecretManager.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.SecretManager.V1/latest) | 1.5.0 | [Secret Manager (V1 API)](https://cloud.google.com/secret-manager) |

--- a/apis/Google.Cloud.ResourceSettings.V1/Google.Cloud.ResourceSettings.V1/Google.Cloud.ResourceSettings.V1.csproj
+++ b/apis/Google.Cloud.ResourceSettings.V1/Google.Cloud.ResourceSettings.V1/Google.Cloud.ResourceSettings.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Resource Settings API, which allows users to control and modify the behavior of their GCP resources (e.g., VM, firewall, Project, etc.) across the Cloud Resource Hierarchy.</Description>
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.38.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.ResourceSettings.V1/docs/history.md
+++ b/apis/Google.Cloud.ResourceSettings.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.1.0, released 2021-08-10
+
+- [Commit 4d6b7e8](https://github.com/googleapis/google-cloud-dotnet/commit/4d6b7e8): feat:Publish Cloud ResourceSettings v1 API
+
 # Version 1.0.0, released 2021-06-28
 
 No API surface changes; just dependency updates and promotion to GA.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2142,7 +2142,7 @@
     },
     {
       "id": "Google.Cloud.ResourceSettings.V1",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "grpc",
       "productName": "Resource Settings",
       "productUrl": "https://cloud.google.com/resource-settings/docs",
@@ -2153,7 +2153,7 @@
       ],
       "dependencies": {
         "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
-        "Grpc.Core": "2.38.0"
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/cloud/resourcesettings/v1"


### PR DESCRIPTION

Changes in this release:

- [Commit 4d6b7e8](https://github.com/googleapis/google-cloud-dotnet/commit/4d6b7e8): feat:Publish Cloud ResourceSettings v1 API
