### PR TITLE
Release Google.Cloud.Retail.V2 version 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Redis.V1Beta1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Redis.V1Beta1/latest) | 2.0.0-beta04 | [Google Cloud Memorystore for Redis (V1Beta1 API)](https://cloud.google.com/memorystore/) |
 | [Google.Cloud.ResourceManager.V3](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.ResourceManager.V3/latest) | 1.0.0 | [Cloud Resource Manager](https://cloud.google.com/resource-manager/docs) |
 | [Google.Cloud.ResourceSettings.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.ResourceSettings.V1/latest) | 1.1.0 | [Resource Settings](https://cloud.google.com/resource-settings/docs) |
-| [Google.Cloud.Retail.V2](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Retail.V2/latest) | 1.1.0 | [Retail](https://cloud.google.com/retail/docs) |
+| [Google.Cloud.Retail.V2](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Retail.V2/latest) | 1.2.0 | [Retail](https://cloud.google.com/retail/docs) |
 | [Google.Cloud.Scheduler.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Scheduler.V1/latest) | 2.2.0 | [Google Cloud Scheduler](https://cloud.google.com/scheduler/) |
 | [Google.Cloud.SecretManager.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.SecretManager.V1/latest) | 1.6.0 | [Secret Manager (V1 API)](https://cloud.google.com/secret-manager) |
 | [Google.Cloud.SecretManager.V1Beta1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.SecretManager.V1Beta1/latest) | 2.0.0-beta04 | [Secret Manager (V1Beta1 API)](https://cloud.google.com/secret-manager) |

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.csproj
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Cloud Retail service enables customers to build end-to-end personalized recommendation systems without requiring a high level of expertise in machine learning, recommendation system, or Google Cloud.</Description>
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Retail.V2/docs/history.md
+++ b/apis/Google.Cloud.Retail.V2/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+# Version 1.2.0, released 2021-08-10
+
+- [Commit 130477c](https://github.com/googleapis/google-cloud-dotnet/commit/130477c): docs(retail): Quote several literal expressions for better rendering
+- [Commit e5f12af](https://github.com/googleapis/google-cloud-dotnet/commit/e5f12af): docs: Remove HTML tags from Cloud Retail API library docs
+- [Commit 30871b2](https://github.com/googleapis/google-cloud-dotnet/commit/30871b2): docs: remove remaining private links
+- [Commit 360c029](https://github.com/googleapis/google-cloud-dotnet/commit/360c029): feat: Add restricted Retail Search features for Retail API v2.
+
 # Version 1.1.0, released 2021-04-29
 
 - [Commit 91fa8df](https://github.com/googleapis/google-cloud-dotnet/commit/91fa8df): docs: Put resource paths in code spans and use absolute URLs

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2160,7 +2160,7 @@
     },
     {
       "id": "Google.Cloud.Retail.V2",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "type": "grpc",
       "productName": "Retail",
       "productUrl": "https://cloud.google.com/retail/docs",
@@ -2169,9 +2169,9 @@
         "retail"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Google.LongRunning": "2.1.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.LongRunning": "2.2.0",
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/cloud/retail/v2"


### PR DESCRIPTION

Changes in this release:

- [Commit 130477c](https://github.com/googleapis/google-cloud-dotnet/commit/130477c): docs(retail): Quote several literal expressions for better rendering
- [Commit e5f12af](https://github.com/googleapis/google-cloud-dotnet/commit/e5f12af): docs: Remove HTML tags from Cloud Retail API library docs
- [Commit 30871b2](https://github.com/googleapis/google-cloud-dotnet/commit/30871b2): docs: remove remaining private links
- [Commit 360c029](https://github.com/googleapis/google-cloud-dotnet/commit/360c029): feat: Add restricted Retail Search features for Retail API v2.
