### PR TITLE
Release Google.Cloud.SecretManager.V1 version 1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.ResourceSettings.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.ResourceSettings.V1/latest) | 1.0.0 | [Resource Settings](https://cloud.google.com/resource-settings/docs) |
 | [Google.Cloud.Retail.V2](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Retail.V2/latest) | 1.1.0 | [Retail](https://cloud.google.com/retail/docs) |
 | [Google.Cloud.Scheduler.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Scheduler.V1/latest) | 2.2.0 | [Google Cloud Scheduler](https://cloud.google.com/scheduler/) |
-| [Google.Cloud.SecretManager.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.SecretManager.V1/latest) | 1.5.0 | [Secret Manager (V1 API)](https://cloud.google.com/secret-manager) |
+| [Google.Cloud.SecretManager.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.SecretManager.V1/latest) | 1.6.0 | [Secret Manager (V1 API)](https://cloud.google.com/secret-manager) |
 | [Google.Cloud.SecretManager.V1Beta1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.SecretManager.V1Beta1/latest) | 2.0.0-beta04 | [Secret Manager (V1Beta1 API)](https://cloud.google.com/secret-manager) |
 | [Google.Cloud.Security.PrivateCA.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Security.PrivateCA.V1/latest) | 2.0.0 | [Certificate Authority (V1 API)](https://cloud.google.com/certificate-authority-service/) |
 | [Google.Cloud.Security.PrivateCA.V1Beta1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Security.PrivateCA.V1Beta1/latest) | 1.0.0-beta02 | [Certificate Authority (V1Beta1 API)](https://cloud.google.com/certificate-authority-service/) |

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.csproj
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.5.0</Version>
+    <Version>1.6.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Secret Manager API.</Description>
@@ -12,7 +12,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.38.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.SecretManager.V1/docs/history.md
+++ b/apis/Google.Cloud.SecretManager.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+# Version 1.6.0, released 2021-08-10
+
+- [Commit 9bd536a](https://github.com/googleapis/google-cloud-dotnet/commit/9bd536a): feat: In Secret Manager, users can now use filter to customize the output of ListSecrets/ListSecretVersions calls
+- [Commit edf114d](https://github.com/googleapis/google-cloud-dotnet/commit/edf114d):
+  - feat: Tune Secret Manager auto retry parameters
+  - UNKNOWN removed from retryable errors per AIP-194. Added RESOURCE_EXHAUSTED with adjusted parameters for better performance with spikes of AccessSecretVersion requests at or near quota limits.
+
 # Version 1.5.0, released 2021-06-22
 
 - [Commit fbd2e65](https://github.com/googleapis/google-cloud-dotnet/commit/fbd2e65): - feat: Etags - users can now use etags for optimistic concurrency control when modifying Secret or SecretVersion.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2200,13 +2200,13 @@
       "protoPath": "google/cloud/secretmanager/v1",
       "productName": "Secret Manager",
       "productUrl": "https://cloud.google.com/secret-manager",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Secret Manager API.",
       "dependencies": {
         "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
         "Google.Cloud.Iam.V1": "2.2.0",
-        "Grpc.Core": "2.38.0"
+        "Grpc.Core": "2.38.1"
       },
       "tags": [
         "secret",


### PR DESCRIPTION

Changes in this release:

- [Commit 9bd536a](https://github.com/googleapis/google-cloud-dotnet/commit/9bd536a): feat: In Secret Manager, users can now use filter to customize the output of ListSecrets/ListSecretVersions calls
- [Commit edf114d](https://github.com/googleapis/google-cloud-dotnet/commit/edf114d):
  - feat: Tune Secret Manager auto retry parameters
  - UNKNOWN removed from retryable errors per AIP-194. Added RESOURCE_EXHAUSTED with adjusted parameters for better performance with spikes of AccessSecretVersion requests at or near quota limits.
