### PR TITLE
Release Google.Cloud.Speech.V1 version 2.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Spanner.Data](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Spanner.Data/latest) | 3.11.0 | Google ADO.NET Provider for Google Cloud Spanner |
 | [Google.Cloud.Spanner.Common.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Spanner.Common.V1/latest) | 3.11.0 | Common resource names used by all Spanner V1 APIs |
 | [Google.Cloud.Spanner.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Spanner.V1/latest) | 3.11.0 | [Google Cloud Spanner](https://cloud.google.com/spanner/) |
-| [Google.Cloud.Speech.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Speech.V1/latest) | 2.2.0 | [Google Cloud Speech (V1 API)](https://cloud.google.com/speech) |
+| [Google.Cloud.Speech.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Speech.V1/latest) | 2.3.0 | [Google Cloud Speech (V1 API)](https://cloud.google.com/speech) |
 | [Google.Cloud.Speech.V1P1Beta1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Speech.V1P1Beta1/latest) | 2.0.0-beta05 | [Google Cloud Speech (V1P1Beta1 API)](https://cloud.google.com/speech) |
 | [Google.Cloud.Storage.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Storage.V1/latest) | 3.5.0 | [Google Cloud Storage](https://cloud.google.com/storage/) |
 | [Google.Cloud.StorageTransfer.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.StorageTransfer.V1/latest) | 1.0.0-beta01 | [Storage Transfer](https://cloud.google.com/storage-transfer-service) |

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.csproj
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.2.0</Version>
+    <Version>2.3.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Speech API, which performs speech recognition.</Description>
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Speech.V1/docs/history.md
+++ b/apis/Google.Cloud.Speech.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 2.3.0, released 2021-08-10
+
+- [Commit 73a4ba0](https://github.com/googleapis/google-cloud-dotnet/commit/73a4ba0): feat: add total_billed_time response field
+
 # Version 2.2.0, released 2021-05-26
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2557,7 +2557,7 @@
       "protoPath": "google/cloud/speech/v1",
       "productName": "Google Cloud Speech",
       "productUrl": "https://cloud.google.com/speech",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Speech API, which performs speech recognition.",
@@ -2565,9 +2565,9 @@
         "Speech"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
         "Google.LongRunning": "2.2.0",
-        "Grpc.Core": "2.36.4"
+        "Grpc.Core": "2.38.1"
       }
     },
     {


### PR DESCRIPTION

Changes in this release:

- [Commit 73a4ba0](https://github.com/googleapis/google-cloud-dotnet/commit/73a4ba0): feat: add total_billed_time response field
