### PR TITLE
Stop using labeled/unlabeled as a trigger for diff-pr

### DIFF
--- a/.github/workflows/diff-pr.yml
+++ b/.github/workflows/diff-pr.yml
@@ -2,7 +2,7 @@ name: Detect differences (PR only)
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened]
 
 jobs:
 


### PR DESCRIPTION
This doesn't play nicely with the CLA bot.

After applying the label, we'll just need to manually run the diff
job again. We could potentially trigger it with an issue comment,
but that looks at least mildly tricky.