### PR TITLE
Release Google.Cloud.Video.Transcoder.V1Beta1 version 1.0.0-beta03

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Translate.V3](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Translate.V3/latest) | 2.2.0 | [Google Cloud Translation (V3 API)](https://cloud.google.com/translate/) |
 | [Google.Cloud.Translation.V2](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Translation.V2/latest) | 2.1.0 | [Google Cloud Translation (V2 API)](https://cloud.google.com/translate/) |
 | [Google.Cloud.Video.Transcoder.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Video.Transcoder.V1/latest) | 1.0.0-beta01 | [Transcoder (V1 API)](https://cloud.google.com/transcoder/docs) |
-| [Google.Cloud.Video.Transcoder.V1Beta1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Video.Transcoder.V1Beta1/latest) | 1.0.0-beta02 | [Transcoder (V1Beta1 API)](https://cloud.google.com/transcoder/docs) |
+| [Google.Cloud.Video.Transcoder.V1Beta1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Video.Transcoder.V1Beta1/latest) | 1.0.0-beta03 | [Transcoder (V1Beta1 API)](https://cloud.google.com/transcoder/docs) |
 | [Google.Cloud.VideoIntelligence.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.VideoIntelligence.V1/latest) | 2.2.0 | [Google Cloud Video Intelligence](https://cloud.google.com/video-intelligence) |
 | [Google.Cloud.Vision.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Vision.V1/latest) | 2.3.0 | [Google Cloud Vision](https://cloud.google.com/vision) |
 | [Google.Cloud.VpcAccess.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.VpcAccess.V1/latest) | 1.0.0 | [Serverless VPC Access](https://cloud.google.com/vpc/docs/) |

--- a/apis/Google.Cloud.Video.Transcoder.V1Beta1/Google.Cloud.Video.Transcoder.V1Beta1/Google.Cloud.Video.Transcoder.V1Beta1.csproj
+++ b/apis/Google.Cloud.Video.Transcoder.V1Beta1/Google.Cloud.Video.Transcoder.V1Beta1/Google.Cloud.Video.Transcoder.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Transcoder API version v1beta1, which converts video files into formats suitable for consumer distribution.</Description>

--- a/apis/Google.Cloud.Video.Transcoder.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.Video.Transcoder.V1Beta1/docs/history.md
@@ -1,5 +1,14 @@
 # Version history
 
+# Version 1.0.0-beta03, released 2021-08-10
+
+- [Commit 972b006](https://github.com/googleapis/google-cloud-dotnet/commit/972b006):
+  - feat: Add video cropping feature
+  - feat: Add video padding feature
+  - feat: Add ttl_after_completion_days field to Job
+  - docs: Update proto documentation
+  - docs: Indicate v1beta1 deprecation
+
 # Version 1.0.0-beta02, released 2021-05-26
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2839,7 +2839,7 @@
     },
     {
       "id": "Google.Cloud.Video.Transcoder.V1Beta1",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0-beta03",
       "type": "grpc",
       "productName": "Transcoder",
       "productUrl": "https://cloud.google.com/transcoder/docs",


### PR DESCRIPTION

Changes in this release:

- [Commit 972b006](https://github.com/googleapis/google-cloud-dotnet/commit/972b006):
  - feat: Add video cropping feature
  - feat: Add video padding feature
  - feat: Add ttl_after_completion_days field to Job
  - docs: Update proto documentation
  - docs: Indicate v1beta1 deprecation
