### PR TITLE
Release Google.Identity.AccessContextManager.V1 version 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Workflows.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Workflows.V1/latest) | 1.0.0 | [Workflows (V1 API)](https://cloud.google.com/workflows/docs/apis) |
 | [Google.Cloud.Workflows.V1Beta](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Workflows.V1Beta/latest) | 1.0.0-beta02 | [Workflows (V1Beta API)](https://cloud.google.com/workflows/docs/apis) |
 | [Google.Identity.AccessContextManager.Type](https://cloud.google.com/dotnet/docs/reference/Google.Identity.AccessContextManager.Type/latest) | 1.1.0 | Version-agnostic types for the Google Identity Access Context Manager API |
-| [Google.Identity.AccessContextManager.V1](https://cloud.google.com/dotnet/docs/reference/Google.Identity.AccessContextManager.V1/latest) | 1.2.0 | Recommended Google client library to access the Identity Access Context Manager API V1 |
+| [Google.Identity.AccessContextManager.V1](https://cloud.google.com/dotnet/docs/reference/Google.Identity.AccessContextManager.V1/latest) | 1.3.0 | Recommended Google client library to access the Identity Access Context Manager API V1 |
 | [Google.LongRunning](https://cloud.google.com/dotnet/docs/reference/Google.LongRunning/latest) | 2.2.0 | Support for the Long-Running Operations API pattern |
 | [Grafeas.V1](https://cloud.google.com/dotnet/docs/reference/Grafeas.V1/latest) | 2.2.0 | [Grafeas](https://grafeas.io/) |
 

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.csproj
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Identity Access Context Manager API V1.</Description>

--- a/apis/Google.Identity.AccessContextManager.V1/docs/history.md
+++ b/apis/Google.Identity.AccessContextManager.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.3.0, released 2021-08-10
+
+- [Commit abd324d](https://github.com/googleapis/google-cloud-dotnet/commit/abd324d): chore: publish Access Context Manager API v1
+
 # Version 1.2.0, released 2021-05-26
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3091,7 +3091,7 @@
       "packageOwner": "google-cloud",
       "generator": "proto",
       "protoPath": "google/identity/accesscontextmanager/v1",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "targetFrameworks": "netstandard2.0;net461",
       "description": "Recommended Google client library to access the Identity Access Context Manager API V1.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

- [Commit abd324d](https://github.com/googleapis/google-cloud-dotnet/commit/abd324d): chore: publish Access Context Manager API v1
