### PR TITLE
Release Google.Cloud.Asset.V1 version 2.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.ApigeeConnect.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.ApigeeConnect.V1/latest) | 1.0.0 | [Apigee Connect](https://cloud.google.com/apigee/docs/hybrid/v1.4/apigee-connect) |
 | [Google.Cloud.AppEngine.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.AppEngine.V1/latest) | 1.1.0 | [App Engine Audit Data](https://cloud.google.com/appengine) |
 | [Google.Cloud.ArtifactRegistry.V1Beta2](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.ArtifactRegistry.V1Beta2/latest) | 1.0.0-beta02 | [Artifact Registry](https://cloud.google.com/artifact-registry) |
-| [Google.Cloud.Asset.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Asset.V1/latest) | 2.8.0 | [Google Cloud Asset Inventory](https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview) |
+| [Google.Cloud.Asset.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Asset.V1/latest) | 2.9.0 | [Google Cloud Asset Inventory](https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview) |
 | [Google.Cloud.AssuredWorkloads.V1Beta1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.AssuredWorkloads.V1Beta1/latest) | 1.0.0-beta05 | [Assured Workloads](https://cloud.google.com/assured-workloads/docs) |
 | [Google.Cloud.Audit](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Audit/latest) | 1.0.0-beta02 | [Google Cloud Audit](https://cloud.google.com/logging/docs/audit) |
 | [Google.Cloud.AutoML.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.AutoML.V1/latest) | 2.2.0 | [Google AutoML](https://cloud.google.com/automl/) |

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.csproj
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.8.0</Version>
+    <Version>2.9.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Asset Inventory API (v1).</Description>
@@ -10,14 +10,14 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Google.Cloud.OrgPolicy.V1" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Google.Cloud.OsConfig.V1" Version="[1.3.0, 2.0.0)" />
     <PackageReference Include="Google.Identity.AccessContextManager.Type" Version="[1.1.0, 2.0.0)" />
-    <PackageReference Include="Google.Identity.AccessContextManager.V1" Version="[1.2.0, 2.0.0)" />
+    <PackageReference Include="Google.Identity.AccessContextManager.V1" Version="[1.3.0, 2.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Asset.V1/docs/history.md
+++ b/apis/Google.Cloud.Asset.V1/docs/history.md
@@ -1,5 +1,21 @@
 # Version history
 
+# Version 2.9.0, released 2021-08-10
+
+- [Commit ba29ee0](https://github.com/googleapis/google-cloud-dotnet/commit/ba29ee0):
+  - feat!: Change metadata field for the AnalyzeIamPolicyLongrunning.
+  - feat: Add AnalyzeMove API.
+  - feat: Add read_mask field for SearchAllResourcesRequest
+  - feat: Add VersionedResource/AttachedResource fields for ResourceSearchResult.
+- [Commit bf524b6](https://github.com/googleapis/google-cloud-dotnet/commit/bf524b6): feat: add new searchable fields (memberTypes, roles, project, folders and organization), new request fields (assetTypes and orderBy) and new response fields (assetType, folders and organization) in SearchAllIamPolicies
+
+The metadata field change for AnalyzeIamPolicyLongrunning is
+BACKWARD INCOMPATIBLE. Adding this change expands our ability to
+return richer metadata information for the longrunning operation.
+Due to the small usage of this API, we've contacted all the
+customers to make sure they are not using the metadata field and
+hence won't be broken by this change.
+
 # Version 2.8.0, released 2021-05-27
 
 - [Commit 2722d51](https://github.com/googleapis/google-cloud-dotnet/commit/2722d51):

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -190,18 +190,18 @@
       "protoPath": "google/cloud/asset/v1",
       "productName": "Google Cloud Asset Inventory",
       "productUrl": "https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Asset Inventory API (v1).",
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
         "Google.Cloud.Iam.V1": "2.2.0",
         "Google.Cloud.OrgPolicy.V1": "2.2.0",
         "Google.Cloud.OsConfig.V1": "1.3.0",
         "Google.Identity.AccessContextManager.Type": "1.1.0",
-        "Google.Identity.AccessContextManager.V1": "1.2.0",
+        "Google.Identity.AccessContextManager.V1": "1.3.0",
         "Google.LongRunning": "2.2.0",
-        "Grpc.Core": "2.36.4"
+        "Grpc.Core": "2.38.1"
       },
       "tags": [
         "asset",


### PR DESCRIPTION

Changes in this release:

- [Commit ba29ee0](https://github.com/googleapis/google-cloud-dotnet/commit/ba29ee0):
  - feat!: Change metadata field for the AnalyzeIamPolicyLongrunning.
  - feat: Add AnalyzeMove API.
  - feat: Add read_mask field for SearchAllResourcesRequest
  - feat: Add VersionedResource/AttachedResource fields for ResourceSearchResult.
- [Commit bf524b6](https://github.com/googleapis/google-cloud-dotnet/commit/bf524b6): feat: add new searchable fields (memberTypes, roles, project, folders and organization), new request fields (assetTypes and orderBy) and new response fields (assetType, folders and organization) in SearchAllIamPolicies

The metadata field change for AnalyzeIamPolicyLongrunning is BACKWARD INCOMPATIBLE. Adding this change expands our ability to return richer metadata information for the longrunning operation. Due to the small usage of this API, we've contacted all the customers to make sure they are not using the metadata field and hence won't be broken by this change.
