### PR TITLE
feat(Spanner): Support comments and statement hints in untyped commands.

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerCommandTextBuilderTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerCommandTextBuilderTests.cs
@@ -77,6 +77,25 @@ namespace Google.Cloud.Spanner.Data.Tests
         [InlineData("\t\nWITH AlbumsView AS (SELECT * FROM Albums) select Title from AlbumsView")]
         [InlineData(" WITH   AlbumsView AS (SELECT * FROM Albums) select Title from AlbumsView")]
         [InlineData("WITH\t\nAlbumsView AS (SELECT * FROM Albums) select Title from AlbumsView")]
+        [InlineData("-- Single line comment\nSELECT * FROM Albums")]
+        [InlineData("# Single line comment\nSELECT * FROM Albums")]
+        [InlineData("/* Multi\nline\ncomment\n */\nSELECT * FROM Albums")]
+        [InlineData("/* Multi\n * line\n * comment\n */\nSELECT * FROM Albums")]
+        [InlineData("@{FORCE_INDEX=_BASE_TABLE} SELECT * FROM Albums")]
+        [InlineData("@{FORCE_INDEX=_BASE_TABLE} \n-- Single line comment\nSELECT * FROM Albums")]
+        [InlineData("@{FORCE_INDEX=_BASE_TABLE} \n# Single line comment\nSELECT * FROM Albums")]
+        [InlineData("@{FORCE_INDEX=_BASE_TABLE} /* Multi\nline\ncomment\n */\nSELECT * FROM Albums")]
+        [InlineData("@{FORCE_INDEX=_BASE_TABLE} /* Multi\n * line\n * comment\n */\nSELECT * FROM Albums")]
+        [InlineData("-- Single line comment\n@{FORCE_INDEX=_BASE_TABLE} \nSELECT * FROM Albums")]
+        [InlineData("# Single line comment\n@{FORCE_INDEX=_BASE_TABLE} \nSELECT * FROM Albums")]
+        [InlineData("/* Multi\nline\ncomment\n */\n@{FORCE_INDEX=_BASE_TABLE} \nSELECT * FROM Albums")]
+        [InlineData("/* Multi\n * line\n * comment\n */\n@{FORCE_INDEX=_BASE_TABLE} \nSELECT * FROM Albums")]
+        [InlineData("-- Single line comment\n@{FORCE_INDEX=_BASE_TABLE, OPTIMIZER_VERSION=1} \n\t \nSELECT * FROM Albums")]
+        [InlineData("-- Single line comment\n@{FORCE_INDEX=_BASE_TABLE, OPTIMIZER_VERSION=1} -- Another single line comment \n\t @{FORCE_INDEX=_BASE_TABLE, OPTIMIZER_VERSION=1} /* Multi\n * line\n * comment\n */\nSELECT * FROM Albums")]
+        [InlineData("-- Single line comment\n@{FORCE_INDEX=_BASE_TABLE, /* Multi\n * line\n * comment\n */ OPTIMIZER_VERSION=1} \n\t \nSELECT * FROM Albums")]
+        [InlineData("-- Single line comment\n@{FORCE_INDEX=_BASE_TABLE, -- Inner single line comment\n OPTIMIZER_VERSION=1} \n\t \nSELECT * FROM Albums")]
+        [InlineData("SELECT/*comment*/ * FROM Albums")]
+        [InlineData("SELECT--comment\n * FROM Albums")]
         public void SelectCommand(string commandText)
         {
             var builder = SpannerCommandTextBuilder.FromCommandText(commandText);
@@ -95,6 +114,10 @@ namespace Google.Cloud.Spanner.Data.Tests
         [InlineData("\t\nINSERT\t\nAlbums\t\n(AlbumId)t\nVALUESt\n(@id)")]
         [InlineData("INSERT  Albums  (AlbumId) VALUES (@id)")]
         [InlineData("INSERT\t\nAlbums\t\n(AlbumId)t\nVALUESt\n(@id)")]
+        [InlineData("-- Single line comment\nINSERT INTO Albums (AlbumId) VALUES (@id)")]
+        [InlineData("# Single line comment\nINSERT INTO Albums (AlbumId) VALUES (@id)")]
+        [InlineData("/* Multi line comment */ INSERT INTO Albums (AlbumId) VALUES (@id)")]
+        [InlineData("@{FORCE_INDEX=_BASE_TABLE} INSERT INTO Albums (AlbumId) VALUES (@id)")]
         public void DmlInsertCommand(string commandText)
         {
             var builder = SpannerCommandTextBuilder.FromCommandText(commandText);
@@ -108,6 +131,10 @@ namespace Google.Cloud.Spanner.Data.Tests
         [InlineData("\t\nUPDATE\t\nAlbumst\nSETt\nTitle=@titlet\nWHEREt\nTRUE")]
         [InlineData("UPDATE  Albums  SET Title=@title WHERE TRUE")]
         [InlineData("UPDATE\t\nAlbums\t\nSETt\nTitle=@titlet\nWHEREt\nTRUE")]
+        [InlineData("-- Single line comment\nUPDATE Albums SET Title=@title WHERE TRUE")]
+        [InlineData("# Single line comment\nUPDATE Albums SET Title=@title WHERE TRUE")]
+        [InlineData("/* Multi line comment */ UPDATE Albums SET Title=@title WHERE TRUE")]
+        [InlineData("@{FORCE_INDEX=_BASE_TABLE} UPDATE Albums SET Title=@title WHERE TRUE")]
         public void DmlUpdateCommand(string commandText)
         {
             var builder = SpannerCommandTextBuilder.FromCommandText(commandText);
@@ -126,6 +153,10 @@ namespace Google.Cloud.Spanner.Data.Tests
         [InlineData("\t\nDELETE\t\nAlbumst\nWHEREt\nTRUE")]
         [InlineData("DELETE  Albums  WHERE TRUE")]
         [InlineData("DELETE\t\nAlbumst\nWHEREt\nTRUE")]
+        [InlineData("-- Single line comment\nDELETE FROM Albums WHERE TRUE")]
+        [InlineData("# Single line comment\nDELETE FROM Albums WHERE TRUE")]
+        [InlineData("/* Multi line comment */ DELETE FROM Albums WHERE TRUE")]
+        [InlineData("@{FORCE_INDEX=_BASE_TABLE} DELETE FROM Albums WHERE TRUE")]
         public void DmlDeleteCommand(string commandText)
         {
             var builder = SpannerCommandTextBuilder.FromCommandText(commandText);
@@ -146,10 +177,23 @@ namespace Google.Cloud.Spanner.Data.Tests
         [InlineData(" ALTER TABLE FOO")]
         [InlineData("ALTER\t\nTABLE\t\nFOO")]
         [InlineData("\t\nALTER\t\nTABLE\t\nFOO")]
+        [InlineData("-- Single line comment\nCREATE TABLE FOO")]
+        [InlineData("# Single line comment\nCREATE TABLE FOO")]
+        [InlineData("/* Multi line comment */ CREATE TABLE FOO")]
         public void DdlCommand(string commandText)
         {
             var builder = SpannerCommandTextBuilder.FromCommandText(commandText);
             Assert.Equal(SpannerCommandType.Ddl, builder.SpannerCommandType);
         }
+
+        [Theory]
+        [InlineData("-- never ending line")]
+        [InlineData("# never ending line")]
+        [InlineData("/* never ending block")]
+        [InlineData("@ never ending hint")]
+        [InlineData("@ never ending hint /* } */")]
+        [InlineData("-- just comments and hints and white spaces\n #comment\n @}       ")]
+        public void InvalidCommand(string commandText) =>
+            Assert.Throws<ArgumentException>(() => SpannerCommandTextBuilder.FromCommandText(commandText));
     }
 }


### PR DESCRIPTION
Alternative to #6848
Closes #6847

My approach here is to do the minimum necessary to be able to determine the command type, which is what we really need. Proper command correctness will be done by the backend. This is in contrast to #6848 which is more about completeness and correctness when it comes to comment and hint parsing. I prefer my approach as I believe is less prone to corner cases and easier to maintain, but I'm happy to go with #6848 if this does not seem enough.

My approach/assumptions:

- I assume the command is well formed. If it's not, the backend (or in some cases us) will fail.
- I'm only removing leading comments and hints, I don't look at what's after the start of the command. The advantage this has is that we don't care about literal strings.
- For a mutation, if it had leading comments or hints, I throw. Neither are supported by the backend and the alternative we have is to silently remove them, which I think will lead to unexpected results for users that attempted to use them, hints in particular.
  - Note that if a "mutation" has comments or hints after the start of the command (also not supported by the backend) it was being and will continue to be recognized as DML, which will fail in the backend.
- This passes the same tests as #6848, and I've added a few more on the SELECT theory to check for alternating comments and hints.

@olavloite there's a TODO there about escaping special characters in comments, I don't know if it's possible and which is the escape character, but that's an easy check anyway.