### PR TITLE
Prototype of library changes for self-signed JWTs

### DIFF
--- a/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1/CloudShellServiceClient.g.cs
+++ b/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1/CloudShellServiceClient.g.cs
@@ -212,6 +212,12 @@ namespace Google.Cloud.Shell.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<CloudShellServiceClient> task);
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public CloudShellServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = CloudShellServiceClient.UseJwtAccessWithScopes;
+        }
+
         /// <summary>Builds the resulting client.</summary>
         public override CloudShellServiceClient Build()
         {
@@ -287,7 +293,19 @@ namespace Google.Cloud.Shell.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="CloudShellServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.csproj
+++ b/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.csproj
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/SpeechClient.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/SpeechClient.cs
@@ -1,0 +1,25 @@
+﻿// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Google.Cloud.Speech.V1
+{
+    public partial class SpeechClient
+    {
+        // Speech doesn't support self-signed JWTs, so force normal OAuth2.
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes)
+        {
+            useJwtAccessWithScopes = false;
+        }
+    }
+}

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/SpeechClient.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/SpeechClient.g.cs
@@ -130,6 +130,12 @@ namespace Google.Cloud.Speech.V1
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<SpeechClient> task);
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public SpeechClientBuilder()
+        {
+            UseJwtAccessWithScopes = SpeechClient.UseJwtAccessWithScopes;
+        }
+
         /// <summary>Builds the resulting client.</summary>
         public override SpeechClient Build()
         {
@@ -198,7 +204,19 @@ namespace Google.Cloud.Speech.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="SpeechClient"/> using the default credentials, endpoint and settings. To

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2435,9 +2435,9 @@
         "shell"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.LongRunning": "2.2.0",
-        "Grpc.Core": "2.36.4"
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/cloud/shell/v1"
@@ -2565,7 +2565,7 @@
         "Speech"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.LongRunning": "2.2.0",
         "Grpc.Core": "2.38.1"
       }


### PR DESCRIPTION
This assumes:

- ChannelPool has a constructor with an additional Boolean parameter
- ClientBuilderBase has a protected Boolean property of UseJwtAccessWithScopes

The generated classes for both Speech and Shell have been modified
in the same way (indicating what we'd need to do in the generator).

Additionally, a manual partial class in SpeechClient shows what we'd
need to do in order to disable self-signed JWTs for a specific API.
(I'm assuming we *don't* have this information in the generator. If
we ever *do* know it in the generator, we can just generate the
right thing and remove the partial method.)