### PR TITLE
Release Google.Cloud.Audit version 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.ArtifactRegistry.V1Beta2](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.ArtifactRegistry.V1Beta2/latest) | 1.0.0-beta02 | [Artifact Registry](https://cloud.google.com/artifact-registry) |
 | [Google.Cloud.Asset.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Asset.V1/latest) | 2.9.0 | [Google Cloud Asset Inventory](https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview) |
 | [Google.Cloud.AssuredWorkloads.V1Beta1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.AssuredWorkloads.V1Beta1/latest) | 1.0.0-beta05 | [Assured Workloads](https://cloud.google.com/assured-workloads/docs) |
-| [Google.Cloud.Audit](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Audit/latest) | 1.0.0-beta02 | [Google Cloud Audit](https://cloud.google.com/logging/docs/audit) |
+| [Google.Cloud.Audit](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Audit/latest) | 1.0.0 | [Google Cloud Audit](https://cloud.google.com/logging/docs/audit) |
 | [Google.Cloud.AutoML.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.AutoML.V1/latest) | 2.2.0 | [Google AutoML](https://cloud.google.com/automl/) |
 | [Google.Cloud.BigQuery.Connection.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.BigQuery.Connection.V1/latest) | 1.3.0 | [BigQuery Connection](https://cloud.google.com/bigquery/docs/reference/bigqueryconnection) |
 | [Google.Cloud.BigQuery.DataTransfer.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.BigQuery.DataTransfer.V1/latest) | 3.1.0 | [Google BigQuery Data Transfer](https://cloud.google.com/bigquery/transfer/) |

--- a/apis/Google.Cloud.Audit/.repo-metadata.json
+++ b/apis/Google.Cloud.Audit/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.Audit",
-  "release_level": "beta",
+  "release_level": "ga",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Audit/latest",
   "library_type": "OTHER"
 }

--- a/apis/Google.Cloud.Audit/Google.Cloud.Audit/Google.Cloud.Audit.csproj
+++ b/apis/Google.Cloud.Audit/Google.Cloud.Audit/Google.Cloud.Audit.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Protobuf messages for Google Cloud audit logs.</Description>

--- a/apis/Google.Cloud.Audit/docs/history.md
+++ b/apis/Google.Cloud.Audit/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.0.0, released 2021-08-16
+
+No API surface changes; just promotion to GA.
+
 # Version 1.0.0-beta02, released 2021-07-28
 
 No code changes; just fixing the docs that broke the 1.0.0-beta01 release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -228,7 +228,7 @@
     },
     {
       "id": "Google.Cloud.Audit",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0",
       "targetFrameworks": "netstandard2.0;net461",
       "productName": "Google Cloud Audit",
       "productUrl": "https://cloud.google.com/logging/docs/audit",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just promotion to GA.
