### PR TITLE
Release Google.Cloud.StorageTransfer.V1 version 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Speech.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Speech.V1/latest) | 2.3.0 | [Google Cloud Speech (V1 API)](https://cloud.google.com/speech) |
 | [Google.Cloud.Speech.V1P1Beta1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Speech.V1P1Beta1/latest) | 2.0.0-beta05 | [Google Cloud Speech (V1P1Beta1 API)](https://cloud.google.com/speech) |
 | [Google.Cloud.Storage.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Storage.V1/latest) | 3.5.0 | [Google Cloud Storage](https://cloud.google.com/storage/) |
-| [Google.Cloud.StorageTransfer.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.StorageTransfer.V1/latest) | 1.0.0-beta01 | [Storage Transfer](https://cloud.google.com/storage-transfer-service) |
+| [Google.Cloud.StorageTransfer.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.StorageTransfer.V1/latest) | 1.0.0 | [Storage Transfer](https://cloud.google.com/storage-transfer-service) |
 | [Google.Cloud.Talent.V4](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Talent.V4/latest) | 1.1.0 | [Google Cloud Talent Solution (V4 API)](https://cloud.google.com/talent-solution/) |
 | [Google.Cloud.Talent.V4Beta1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Talent.V4Beta1/latest) | 2.0.0-beta05 | [Google Cloud Talent Solution (V4Beta1 API)](https://cloud.google.com/talent-solution/) |
 | [Google.Cloud.Tasks.V2](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Tasks.V2/latest) | 2.2.0 | [Google Cloud Tasks (V2 API)](https://cloud.google.com/tasks/) |

--- a/apis/Google.Cloud.StorageTransfer.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.StorageTransfer.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.StorageTransfer.V1",
-  "release_level": "beta",
+  "release_level": "ga",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.StorageTransfer.V1/latest",
   "library_type": "GAPIC_AUTO"
 }

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.csproj
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Transfers data from external data sources to a Google Cloud Storage bucket or between Google Cloud Storage buckets.</Description>

--- a/apis/Google.Cloud.StorageTransfer.V1/docs/history.md
+++ b/apis/Google.Cloud.StorageTransfer.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.0.0, released 2021-08-16
+
+No API surface changes; just dependency updates and promotion to GA.
+
 # Version 1.0.0-beta01, released 2021-07-23
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2610,7 +2610,7 @@
     },
     {
       "id": "Google.Cloud.StorageTransfer.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Storage Transfer",
       "productUrl": "https://cloud.google.com/storage-transfer-service",
@@ -2622,7 +2622,9 @@
         "gcs"
       ],
       "dependencies": {
-        "Google.LongRunning": "2.2.0"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.LongRunning": "2.2.0",
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/storagetransfer/v1"


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates and promotion to GA.
