### PR TITLE
Update and regenerate all APIs to use self-signed JWTs

### DIFF
--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/AnalyticsAdminServiceClient.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/AnalyticsAdminServiceClient.g.cs
@@ -1086,6 +1086,12 @@ namespace Google.Analytics.Admin.V1Alpha
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public AnalyticsAdminServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public AnalyticsAdminServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = AnalyticsAdminServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref AnalyticsAdminServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<AnalyticsAdminServiceClient> task);
@@ -1165,7 +1171,19 @@ namespace Google.Analytics.Admin.V1Alpha
             "https://www.googleapis.com/auth/analytics.readonly",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="AnalyticsAdminServiceClient"/> using the default credentials, endpoint

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Analytics.Admin.V1Alpha/synth.metadata
+++ b/apis/Google.Analytics.Admin.V1Alpha/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "c3bf1b727510ffc0e2020affff906fbc649cd563"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Analytics.Data.V1Alpha/Google.Analytics.Data.V1Alpha/AlphaAnalyticsDataClient.g.cs
+++ b/apis/Google.Analytics.Data.V1Alpha/Google.Analytics.Data.V1Alpha/AlphaAnalyticsDataClient.g.cs
@@ -148,6 +148,12 @@ namespace Google.Analytics.Data.V1Alpha
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public AlphaAnalyticsDataSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public AlphaAnalyticsDataClientBuilder()
+        {
+            UseJwtAccessWithScopes = AlphaAnalyticsDataClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref AlphaAnalyticsDataClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<AlphaAnalyticsDataClient> task);
@@ -223,7 +229,19 @@ namespace Google.Analytics.Data.V1Alpha
             "https://www.googleapis.com/auth/analytics.readonly",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="AlphaAnalyticsDataClient"/> using the default credentials, endpoint and

--- a/apis/Google.Analytics.Data.V1Alpha/Google.Analytics.Data.V1Alpha/Google.Analytics.Data.V1Alpha.csproj
+++ b/apis/Google.Analytics.Data.V1Alpha/Google.Analytics.Data.V1Alpha/Google.Analytics.Data.V1Alpha.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Analytics.Data.V1Alpha/synth.metadata
+++ b/apis/Google.Analytics.Data.V1Alpha/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta/BetaAnalyticsDataClient.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta/BetaAnalyticsDataClient.g.cs
@@ -144,6 +144,12 @@ namespace Google.Analytics.Data.V1Beta
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public BetaAnalyticsDataSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public BetaAnalyticsDataClientBuilder()
+        {
+            UseJwtAccessWithScopes = BetaAnalyticsDataClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref BetaAnalyticsDataClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<BetaAnalyticsDataClient> task);
@@ -219,7 +225,19 @@ namespace Google.Analytics.Data.V1Beta
             "https://www.googleapis.com/auth/analytics.readonly",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="BetaAnalyticsDataClient"/> using the default credentials, endpoint and

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.csproj
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Analytics.Data.V1Beta/synth.metadata
+++ b/apis/Google.Analytics.Data.V1Beta/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "41b50a384825d584fe202b0ce47dff73e04b29fc"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Apps.Script.Type/synth.metadata
+++ b/apis/Google.Apps.Script.Type/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "d606bb4a7852604e4045948d6340e73cb0d1d70b"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.csproj
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1/TablesServiceClient.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1/TablesServiceClient.g.cs
@@ -220,6 +220,12 @@ namespace Google.Area120.Tables.V1Alpha1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public TablesServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public TablesServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = TablesServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref TablesServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<TablesServiceClient> task);
@@ -314,7 +320,19 @@ namespace Google.Area120.Tables.V1Alpha1
             "https://www.googleapis.com/auth/tables",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="TablesServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Area120.Tables.V1Alpha1/synth.metadata
+++ b/apis/Google.Area120.Tables.V1Alpha1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/DatasetServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/DatasetServiceClient.g.cs
@@ -272,6 +272,12 @@ namespace Google.Cloud.AIPlatform.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public DatasetServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public DatasetServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = DatasetServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref DatasetServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<DatasetServiceClient> task);
@@ -345,7 +351,19 @@ namespace Google.Cloud.AIPlatform.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="DatasetServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/EndpointServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/EndpointServiceClient.g.cs
@@ -233,6 +233,12 @@ namespace Google.Cloud.AIPlatform.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public EndpointServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public EndpointServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = EndpointServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref EndpointServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<EndpointServiceClient> task);
@@ -306,7 +312,19 @@ namespace Google.Cloud.AIPlatform.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="EndpointServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.AutoML.V1" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Google.Cloud.DataLabeling.V1Beta1" Version="[1.0.0-beta02, 2.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/JobServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/JobServiceClient.g.cs
@@ -406,6 +406,12 @@ namespace Google.Cloud.AIPlatform.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public JobServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public JobServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = JobServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref JobServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<JobServiceClient> task);
@@ -479,7 +485,19 @@ namespace Google.Cloud.AIPlatform.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="JobServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/MigrationServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/MigrationServiceClient.g.cs
@@ -112,6 +112,12 @@ namespace Google.Cloud.AIPlatform.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public MigrationServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public MigrationServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = MigrationServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref MigrationServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<MigrationServiceClient> task);
@@ -186,7 +192,19 @@ namespace Google.Cloud.AIPlatform.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="MigrationServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ModelServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ModelServiceClient.g.cs
@@ -254,6 +254,12 @@ namespace Google.Cloud.AIPlatform.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ModelServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ModelServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = ModelServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ModelServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ModelServiceClient> task);
@@ -327,7 +333,19 @@ namespace Google.Cloud.AIPlatform.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ModelServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/PipelineServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/PipelineServiceClient.g.cs
@@ -238,6 +238,12 @@ namespace Google.Cloud.AIPlatform.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public PipelineServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public PipelineServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = PipelineServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref PipelineServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<PipelineServiceClient> task);
@@ -313,7 +319,19 @@ namespace Google.Cloud.AIPlatform.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="PipelineServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/PredictionServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/PredictionServiceClient.g.cs
@@ -76,6 +76,12 @@ namespace Google.Cloud.AIPlatform.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public PredictionServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public PredictionServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = PredictionServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref PredictionServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<PredictionServiceClient> task);
@@ -149,7 +155,19 @@ namespace Google.Cloud.AIPlatform.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="PredictionServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/SpecialistPoolServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/SpecialistPoolServiceClient.g.cs
@@ -195,6 +195,12 @@ namespace Google.Cloud.AIPlatform.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public SpecialistPoolServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public SpecialistPoolServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = SpecialistPoolServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref SpecialistPoolServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<SpecialistPoolServiceClient> task);
@@ -273,7 +279,19 @@ namespace Google.Cloud.AIPlatform.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="SpecialistPoolServiceClient"/> using the default credentials, endpoint

--- a/apis/Google.Cloud.AIPlatform.V1/synth.metadata
+++ b/apis/Google.Cloud.AIPlatform.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "22e280d15b4e9c7b7c6374f7d29fb63e542a4750"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1/AccessApprovalServiceClient.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1/AccessApprovalServiceClient.g.cs
@@ -173,6 +173,12 @@ namespace Google.Cloud.AccessApproval.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public AccessApprovalServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public AccessApprovalServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = AccessApprovalServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref AccessApprovalServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<AccessApprovalServiceClient> task);
@@ -278,7 +284,19 @@ namespace Google.Cloud.AccessApproval.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="AccessApprovalServiceClient"/> using the default credentials, endpoint

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.csproj
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.AccessApproval.V1/synth.metadata
+++ b/apis/Google.Cloud.AccessApproval.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1/ApiGatewayServiceClient.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1/ApiGatewayServiceClient.g.cs
@@ -459,6 +459,12 @@ namespace Google.Cloud.ApiGateway.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ApiGatewayServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ApiGatewayServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = ApiGatewayServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ApiGatewayServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ApiGatewayServiceClient> task);
@@ -532,7 +538,19 @@ namespace Google.Cloud.ApiGateway.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ApiGatewayServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.csproj
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.ApiGateway.V1/synth.metadata
+++ b/apis/Google.Cloud.ApiGateway.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1/ConnectionServiceClient.g.cs
+++ b/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1/ConnectionServiceClient.g.cs
@@ -79,6 +79,12 @@ namespace Google.Cloud.ApigeeConnect.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ConnectionServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ConnectionServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = ConnectionServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ConnectionServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ConnectionServiceClient> task);
@@ -152,7 +158,19 @@ namespace Google.Cloud.ApigeeConnect.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ConnectionServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1.csproj
+++ b/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.38.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1/TetherClient.g.cs
+++ b/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1/TetherClient.g.cs
@@ -82,6 +82,12 @@ namespace Google.Cloud.ApigeeConnect.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public TetherSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public TetherClientBuilder()
+        {
+            UseJwtAccessWithScopes = TetherClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref TetherClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<TetherClient> task);
@@ -157,7 +163,19 @@ namespace Google.Cloud.ApigeeConnect.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="TetherClient"/> using the default credentials, endpoint and settings. To

--- a/apis/Google.Cloud.ApigeeConnect.V1/synth.metadata
+++ b/apis/Google.Cloud.ApigeeConnect.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "c76dbc16bd0194f17ca2225e2704e7cf2be9ea54"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/ApplicationsClient.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/ApplicationsClient.g.cs
@@ -171,6 +171,12 @@ namespace Google.Cloud.AppEngine.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ApplicationsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ApplicationsClientBuilder()
+        {
+            UseJwtAccessWithScopes = ApplicationsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ApplicationsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ApplicationsClient> task);
@@ -248,7 +254,19 @@ namespace Google.Cloud.AppEngine.V1
             "https://www.googleapis.com/auth/cloud-platform.read-only",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ApplicationsClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/AuthorizedCertificatesClient.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/AuthorizedCertificatesClient.g.cs
@@ -136,6 +136,12 @@ namespace Google.Cloud.AppEngine.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public AuthorizedCertificatesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public AuthorizedCertificatesClientBuilder()
+        {
+            UseJwtAccessWithScopes = AuthorizedCertificatesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref AuthorizedCertificatesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<AuthorizedCertificatesClient> task);
@@ -214,7 +220,19 @@ namespace Google.Cloud.AppEngine.V1
             "https://www.googleapis.com/auth/cloud-platform.read-only",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="AuthorizedCertificatesClient"/> using the default credentials, endpoint

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/AuthorizedDomainsClient.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/AuthorizedDomainsClient.g.cs
@@ -77,6 +77,12 @@ namespace Google.Cloud.AppEngine.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public AuthorizedDomainsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public AuthorizedDomainsClientBuilder()
+        {
+            UseJwtAccessWithScopes = AuthorizedDomainsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref AuthorizedDomainsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<AuthorizedDomainsClient> task);
@@ -156,7 +162,19 @@ namespace Google.Cloud.AppEngine.V1
             "https://www.googleapis.com/auth/cloud-platform.read-only",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="AuthorizedDomainsClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/DomainMappingsClient.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/DomainMappingsClient.g.cs
@@ -187,6 +187,12 @@ namespace Google.Cloud.AppEngine.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public DomainMappingsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public DomainMappingsClientBuilder()
+        {
+            UseJwtAccessWithScopes = DomainMappingsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref DomainMappingsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<DomainMappingsClient> task);
@@ -264,7 +270,19 @@ namespace Google.Cloud.AppEngine.V1
             "https://www.googleapis.com/auth/cloud-platform.read-only",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="DomainMappingsClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/FirewallClient.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/FirewallClient.g.cs
@@ -141,6 +141,12 @@ namespace Google.Cloud.AppEngine.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public FirewallSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public FirewallClientBuilder()
+        {
+            UseJwtAccessWithScopes = FirewallClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref FirewallClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<FirewallClient> task);
@@ -227,7 +233,19 @@ namespace Google.Cloud.AppEngine.V1
             "https://www.googleapis.com/auth/cloud-platform.read-only",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="FirewallClient"/> using the default credentials, endpoint and settings. 

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.csproj
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/InstancesClient.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/InstancesClient.g.cs
@@ -154,6 +154,12 @@ namespace Google.Cloud.AppEngine.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public InstancesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public InstancesClientBuilder()
+        {
+            UseJwtAccessWithScopes = InstancesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref InstancesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<InstancesClient> task);
@@ -231,7 +237,19 @@ namespace Google.Cloud.AppEngine.V1
             "https://www.googleapis.com/auth/cloud-platform.read-only",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="InstancesClient"/> using the default credentials, endpoint and settings.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/ServicesClient.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/ServicesClient.g.cs
@@ -154,6 +154,12 @@ namespace Google.Cloud.AppEngine.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ServicesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ServicesClientBuilder()
+        {
+            UseJwtAccessWithScopes = ServicesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ServicesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ServicesClient> task);
@@ -231,7 +237,19 @@ namespace Google.Cloud.AppEngine.V1
             "https://www.googleapis.com/auth/cloud-platform.read-only",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ServicesClient"/> using the default credentials, endpoint and settings. 

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/VersionsClient.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/VersionsClient.g.cs
@@ -186,6 +186,12 @@ namespace Google.Cloud.AppEngine.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public VersionsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public VersionsClientBuilder()
+        {
+            UseJwtAccessWithScopes = VersionsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref VersionsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<VersionsClient> task);
@@ -263,7 +269,19 @@ namespace Google.Cloud.AppEngine.V1
             "https://www.googleapis.com/auth/cloud-platform.read-only",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="VersionsClient"/> using the default credentials, endpoint and settings. 

--- a/apis/Google.Cloud.AppEngine.V1/synth.metadata
+++ b/apis/Google.Cloud.AppEngine.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2/ArtifactRegistryClient.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2/ArtifactRegistryClient.g.cs
@@ -460,6 +460,12 @@ namespace Google.Cloud.ArtifactRegistry.V1Beta2
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ArtifactRegistrySettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ArtifactRegistryClientBuilder()
+        {
+            UseJwtAccessWithScopes = ArtifactRegistryClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ArtifactRegistryClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ArtifactRegistryClient> task);
@@ -547,7 +553,19 @@ namespace Google.Cloud.ArtifactRegistry.V1Beta2
             "https://www.googleapis.com/auth/cloud-platform.read-only",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ArtifactRegistryClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.csproj
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.1.0, 3.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/synth.metadata
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/AssetServiceClient.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/AssetServiceClient.g.cs
@@ -297,6 +297,12 @@ namespace Google.Cloud.Asset.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public AssetServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public AssetServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = AssetServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref AssetServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<AssetServiceClient> task);
@@ -370,7 +376,19 @@ namespace Google.Cloud.Asset.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="AssetServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.csproj
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Google.Cloud.OrgPolicy.V1" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Google.Cloud.OsConfig.V1" Version="[1.3.0, 2.0.0)" />

--- a/apis/Google.Cloud.Asset.V1/synth.metadata
+++ b/apis/Google.Cloud.Asset.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "b9e69f850f1c8b8c247078d90b92abdcb6aabffc"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1/AssuredWorkloadsServiceClient.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1/AssuredWorkloadsServiceClient.g.cs
@@ -164,6 +164,12 @@ namespace Google.Cloud.AssuredWorkloads.V1Beta1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public AssuredWorkloadsServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public AssuredWorkloadsServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = AssuredWorkloadsServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref AssuredWorkloadsServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<AssuredWorkloadsServiceClient> task);
@@ -237,7 +243,19 @@ namespace Google.Cloud.AssuredWorkloads.V1Beta1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="AssuredWorkloadsServiceClient"/> using the default credentials, endpoint

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.csproj
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "fa5dd8d9ccb7f0da1168481372b3994be70fccc1"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Audit/synth.metadata
+++ b/apis/Google.Cloud.Audit/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "6919bc1030d57680e76ef319013bc8e68c1fb7ce"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/AutoMlClient.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/AutoMlClient.g.cs
@@ -497,6 +497,12 @@ namespace Google.Cloud.AutoML.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public AutoMlSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public AutoMlClientBuilder()
+        {
+            UseJwtAccessWithScopes = AutoMlClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref AutoMlClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<AutoMlClient> task);
@@ -582,7 +588,19 @@ namespace Google.Cloud.AutoML.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="AutoMlClient"/> using the default credentials, endpoint and settings. To

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.csproj
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/PredictionServiceClient.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/PredictionServiceClient.g.cs
@@ -108,6 +108,12 @@ namespace Google.Cloud.AutoML.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public PredictionServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public PredictionServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = PredictionServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref PredictionServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<PredictionServiceClient> task);
@@ -184,7 +190,19 @@ namespace Google.Cloud.AutoML.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="PredictionServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.AutoML.V1/synth.metadata
+++ b/apis/Google.Cloud.AutoML.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1/ConnectionServiceClient.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1/ConnectionServiceClient.g.cs
@@ -180,6 +180,12 @@ namespace Google.Cloud.BigQuery.Connection.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ConnectionServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ConnectionServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = ConnectionServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ConnectionServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ConnectionServiceClient> task);
@@ -255,7 +261,19 @@ namespace Google.Cloud.BigQuery.Connection.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ConnectionServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.BigQuery.Connection.V1/synth.metadata
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "eba54922f4dd1a7e25ee44e0769a3af2ae2d2c0d"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/DataTransferServiceClient.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/DataTransferServiceClient.g.cs
@@ -287,6 +287,12 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public DataTransferServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public DataTransferServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = DataTransferServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref DataTransferServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<DataTransferServiceClient> task);
@@ -363,7 +369,19 @@ namespace Google.Cloud.BigQuery.DataTransfer.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="DataTransferServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/synth.metadata
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1/ReservationServiceClient.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1/ReservationServiceClient.g.cs
@@ -355,6 +355,12 @@ namespace Google.Cloud.BigQuery.Reservation.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ReservationServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ReservationServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = ReservationServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ReservationServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ReservationServiceClient> task);
@@ -444,7 +450,19 @@ namespace Google.Cloud.BigQuery.Reservation.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ReservationServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/synth.metadata
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/BigQueryReadClient.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/BigQueryReadClient.g.cs
@@ -102,6 +102,12 @@ namespace Google.Cloud.BigQuery.Storage.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public BigQueryReadSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public BigQueryReadClientBuilder()
+        {
+            UseJwtAccessWithScopes = BigQueryReadClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref BigQueryReadClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<BigQueryReadClient> task);
@@ -181,7 +187,19 @@ namespace Google.Cloud.BigQuery.Storage.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="BigQueryReadClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.38.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.BigQuery.Storage.V1/synth.metadata
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "23efea9fc7bedfe53b24295ed84b5f873606edcb"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Rest" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Rest" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.Apis.Bigquery.v2" Version="[1.54.0.2397, 2.0.0.0)" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.Snippets/Google.Cloud.Bigtable.Admin.V2.Snippets.csproj
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.Snippets/Google.Cloud.Bigtable.Admin.V2.Snippets.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[3.5.0, 4.0.0)" />
     <ProjectReference Include="..\Google.Cloud.Bigtable.Admin.V2\Google.Cloud.Bigtable.Admin.V2.csproj" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.Tests/Google.Cloud.Bigtable.Admin.V2.Tests.csproj
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.Tests/Google.Cloud.Bigtable.Admin.V2.Tests.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[3.5.0, 4.0.0)" />
     <ProjectReference Include="..\Google.Cloud.Bigtable.Admin.V2\Google.Cloud.Bigtable.Admin.V2.csproj" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/BigtableInstanceAdminClient.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/BigtableInstanceAdminClient.g.cs
@@ -456,6 +456,12 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public BigtableInstanceAdminSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public BigtableInstanceAdminClientBuilder()
+        {
+            UseJwtAccessWithScopes = BigtableInstanceAdminClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref BigtableInstanceAdminClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<BigtableInstanceAdminClient> task);
@@ -543,7 +549,19 @@ namespace Google.Cloud.Bigtable.Admin.V2
             "https://www.googleapis.com/auth/cloud-platform.read-only",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="BigtableInstanceAdminClient"/> using the default credentials, endpoint

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/BigtableTableAdminClient.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/BigtableTableAdminClient.g.cs
@@ -463,6 +463,12 @@ namespace Google.Cloud.Bigtable.Admin.V2
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public BigtableTableAdminSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public BigtableTableAdminClientBuilder()
+        {
+            UseJwtAccessWithScopes = BigtableTableAdminClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref BigtableTableAdminClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<BigtableTableAdminClient> task);
@@ -550,7 +556,19 @@ namespace Google.Cloud.Bigtable.Admin.V2
             "https://www.googleapis.com/auth/cloud-platform.read-only",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="BigtableTableAdminClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.csproj
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.csproj
@@ -10,11 +10,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Bigtable.Common.V2" Version="[2.0.0, 3.0.0)" />
-    <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Bigtable.Common.V2" Version="[2.1.0, 3.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Bigtable.Admin.V2/synth.metadata
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "43d201c7deb4639441d0cbb1c734f1e974b566eb"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Bigtable.Common.V2/Google.Cloud.Bigtable.Common.V2/Google.Cloud.Bigtable.Common.V2.csproj
+++ b/apis/Google.Cloud.Bigtable.Common.V2/Google.Cloud.Bigtable.Common.V2/Google.Cloud.Bigtable.Common.V2.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Google.Protobuf" Version="[3.15.8, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Google.Protobuf" Version="[3.17.3, 4.0.0)" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Bigtable.V2/BigtableServiceApiClient.sed
+++ b/apis/Google.Cloud.Bigtable.V2/BigtableServiceApiClient.sed
@@ -1,14 +1,8 @@
 # Sed commands to use Google.Gax.Grpc.Gcp in
 # BigtableServiceApiClient.g.cs
 
-# Add a using directive
-s/using gaxgrpc = .*/&\nusing gaxgrpcgcp = Google.Api.Gax.Grpc.Gcp;/
-
 # Replace uses of the gRPC generated client, which is still BigtableClient
 s/BigtableServiceApi.BigtableServiceApiClient/Bigtable.BigtableClient/g
-
-# Replace the channel pool declaration with a call invoker pool declaration
-s/gaxgrpc::ChannelPool ChannelPool.*/gaxgrpcgcp::GcpCallInvokerPool CallInvokerPool { get; } = new gaxgrpcgcp::GcpCallInvokerPool(DefaultScopes);/
 
 # Replace channel acquisition with callInvoker acquision
 s/grpccore::Channel channel = ChannelPool\.GetChannel\(endpoint \?\? DefaultEndpoint\)/grpccore::CallInvoker callInvoker = CallInvokerPool.GetCallInvoker(endpoint ?? DefaultEndpoint, settings.CreateChannelOptions())/

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GenerateClient/Program.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GenerateClient/Program.cs
@@ -101,8 +101,6 @@ namespace Google.Cloud.Bigtable.V2.GenerateClient
 
         private static async Task<int> Main(string[] args)
         {
-            FixClientBuilder();
-
             // TODO: Figure out why `dotnet run` from generateapis.sh is sending 6 args instead of 3 as in: arg1 arg2 arg3 arg1 arg2 arg3
             if (args.Length < 3)
             {
@@ -275,17 +273,6 @@ namespace Google.Cloud.Bigtable.V2.GenerateClient
                 return 4;
             }
             return 0;
-        }
-
-        /// <summary>
-        /// Remove the parts of the generated BigtableServiceApiClientBuilder that are provided manual by partial classes.
-        /// </summary>
-        private static void FixClientBuilder()
-        {
-            var layout = DirectoryLayout.ForApi("Google.Cloud.Bigtable.V2");
-            SourceFile.Load(Path.Combine(layout.SourceDirectory, "Google.Cloud.Bigtable.V2", "BigtableServiceApiClient.g.cs"))
-                .RemoveMethod("BigtableServiceApiClientBuilder", "GetChannelPool")
-                .Save();
         }
 
         /// <summary>

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.IntegrationTests/Google.Cloud.Bigtable.V2.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.IntegrationTests/Google.Cloud.Bigtable.V2.IntegrationTests.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[3.5.0, 4.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.Bigtable.Admin.V2\Google.Cloud.Bigtable.Admin.V2\Google.Cloud.Bigtable.Admin.V2.csproj" />
     <ProjectReference Include="..\Google.Cloud.Bigtable.V2\Google.Cloud.Bigtable.V2.csproj" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Snippets/Google.Cloud.Bigtable.V2.Snippets.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Snippets/Google.Cloud.Bigtable.V2.Snippets.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[3.5.0, 4.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.Bigtable.Admin.V2\Google.Cloud.Bigtable.Admin.V2\Google.Cloud.Bigtable.Admin.V2.csproj" />
     <ProjectReference Include="..\Google.Cloud.Bigtable.V2\Google.Cloud.Bigtable.V2.csproj" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/Google.Cloud.Bigtable.V2.Tests.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/Google.Cloud.Bigtable.V2.Tests.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[3.5.0, 4.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.Bigtable.Admin.V2\Google.Cloud.Bigtable.Admin.V2\Google.Cloud.Bigtable.Admin.V2.csproj" />
     <ProjectReference Include="..\Google.Cloud.Bigtable.V2\Google.Cloud.Bigtable.V2.csproj" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableClient.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableClient.cs
@@ -16,7 +16,6 @@
 
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using gaxgrpcgcp = Google.Api.Gax.Grpc.Gcp;
 using gaxgrpccore = Google.Api.Gax.Grpc.GrpcCore;
 using gcbcv = Google.Cloud.Bigtable.Common.V2;
 using proto = Google.Protobuf;

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableClientBuilder.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableClientBuilder.cs
@@ -30,6 +30,12 @@ namespace Google.Cloud.Bigtable.V2
         /// </summary>
         public BigtableServiceApiSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public BigtableClientBuilder()
+        {
+            UseJwtAccessWithScopes = BigtableServiceApiClient.UseJwtAccessWithScopes;
+        }
+
         /// <inheritdoc/>
         public override BigtableClient Build()
         {

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableServiceApiClient.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableServiceApiClient.g.cs
@@ -16,7 +16,6 @@
 
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
-using gaxgrpcgcp = Google.Api.Gax.Grpc.Gcp;
 using gaxgrpccore = Google.Api.Gax.Grpc.GrpcCore;
 using gcbcv = Google.Cloud.Bigtable.Common.V2;
 using proto = Google.Protobuf;
@@ -187,6 +186,9 @@ namespace Google.Cloud.Bigtable.V2
         /// </summary>
         protected override scg::IReadOnlyList<string> GetDefaultScopes() => BigtableServiceApiClient.DefaultScopes;
 
+        /// <summary>Returns the channel pool to use when no other options are specified.</summary>
+        protected override gaxgrpc::ChannelPool GetChannelPool() => BigtableServiceApiClient.ChannelPool;
+
         /// <summary>Returns the default <see cref="gaxgrpc::GrpcAdapter"/>to use if not otherwise specified.</summary>
         protected override gaxgrpc::GrpcAdapter DefaultGrpcAdapter => gaxgrpccore::GrpcCoreAdapter.Instance;
     }
@@ -225,7 +227,7 @@ namespace Google.Cloud.Bigtable.V2
             "https://www.googleapis.com/auth/cloud-platform.read-only",
         });
 
-        internal static gaxgrpcgcp::GcpCallInvokerPool CallInvokerPool { get; } = new gaxgrpcgcp::GcpCallInvokerPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
 
         internal static bool UseJwtAccessWithScopes
         {

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableServiceApiClient.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableServiceApiClient.g.cs
@@ -139,6 +139,12 @@ namespace Google.Cloud.Bigtable.V2
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public BigtableServiceApiSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public BigtableServiceApiClientBuilder()
+        {
+            UseJwtAccessWithScopes = BigtableServiceApiClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref BigtableServiceApiClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<BigtableServiceApiClient> task);
@@ -220,6 +226,18 @@ namespace Google.Cloud.Bigtable.V2
         });
 
         internal static gaxgrpcgcp::GcpCallInvokerPool CallInvokerPool { get; } = new gaxgrpcgcp::GcpCallInvokerPool(DefaultScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="BigtableServiceApiClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableServiceApiClientPartial.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableServiceApiClientPartial.cs
@@ -177,13 +177,6 @@ namespace Google.Cloud.Bigtable.V2
 
     public sealed partial class BigtableServiceApiClientBuilder : ClientBuilderBase<BigtableServiceApiClient>
     {
-        /// <summary>
-        /// Creates a new instance with no settings.
-        /// </summary>
-        public BigtableServiceApiClientBuilder()
-        {
-        }
-
         internal BigtableServiceApiClientBuilder(BigtableClientBuilder builder)
         {
             Settings = builder.Settings;
@@ -234,17 +227,19 @@ namespace Google.Cloud.Bigtable.V2
             }
         }
 
-        /// <inheritdoc />
-        protected override bool CanUseChannelPool => false;
+        // Note: GetChannelPool() will still be called by base.CanUseChannelPool,
+        // so we do *have* a regular channel pool, but it's never asked to create any channels.
 
         /// <inheritdoc />
-        protected override ChannelPool GetChannelPool() => throw new NotImplementedException();
+        protected override bool CanUseChannelPool => false;
 
         private GcpCallInvokerPool CallInvokerPool => BigtableServiceApiClient.CallInvokerPool;
     }
 
     public partial class BigtableServiceApiClient
     {
+        internal static GcpCallInvokerPool CallInvokerPool { get; } = new GcpCallInvokerPool(DefaultScopes, UseJwtAccessWithScopes);
+
         /// <summary>
         /// Gets the value which specifies routing for replication.
         /// If null or empty, the "default" application profile will be used by the server.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.Gcp" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Bigtable.Common.V2" Version="[2.0.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Gcp" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Bigtable.Common.V2" Version="[2.1.0, 3.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Bigtable.V2/synth.metadata
+++ b/apis/Google.Cloud.Bigtable.V2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1/BudgetServiceClient.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1/BudgetServiceClient.g.cs
@@ -142,6 +142,12 @@ namespace Google.Cloud.Billing.Budgets.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public BudgetServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public BudgetServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = BudgetServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref BudgetServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<BudgetServiceClient> task);
@@ -218,7 +224,19 @@ namespace Google.Cloud.Billing.Budgets.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="BudgetServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.csproj
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Billing.Budgets.V1/synth.metadata
+++ b/apis/Google.Cloud.Billing.Budgets.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "dd6ba75f1ef4175d3f34028e2c60aaa04a0e1b65"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1/BudgetServiceClient.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1/BudgetServiceClient.g.cs
@@ -141,6 +141,12 @@ namespace Google.Cloud.Billing.Budgets.V1Beta1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public BudgetServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public BudgetServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = BudgetServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref BudgetServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<BudgetServiceClient> task);
@@ -217,7 +223,19 @@ namespace Google.Cloud.Billing.Budgets.V1Beta1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="BudgetServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1.csproj
+++ b/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.Billing.Budgets.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.Billing.Budgets.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "24f0828e943c3bf73ecc971ea4b7fbfed6d7824d"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/CloudBillingClient.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/CloudBillingClient.g.cs
@@ -222,6 +222,12 @@ namespace Google.Cloud.Billing.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public CloudBillingSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public CloudBillingClientBuilder()
+        {
+            UseJwtAccessWithScopes = CloudBillingClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref CloudBillingClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<CloudBillingClient> task);
@@ -295,7 +301,19 @@ namespace Google.Cloud.Billing.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="CloudBillingClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/CloudCatalogClient.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/CloudCatalogClient.g.cs
@@ -88,6 +88,12 @@ namespace Google.Cloud.Billing.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public CloudCatalogSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public CloudCatalogClientBuilder()
+        {
+            UseJwtAccessWithScopes = CloudCatalogClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref CloudCatalogClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<CloudCatalogClient> task);
@@ -163,7 +169,19 @@ namespace Google.Cloud.Billing.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="CloudCatalogClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.csproj
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Billing.V1/synth.metadata
+++ b/apis/Google.Cloud.Billing.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1/BinauthzManagementServiceV1Beta1Client.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1/BinauthzManagementServiceV1Beta1Client.g.cs
@@ -183,6 +183,12 @@ namespace Google.Cloud.BinaryAuthorization.V1Beta1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public BinauthzManagementServiceV1Beta1Settings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public BinauthzManagementServiceV1Beta1ClientBuilder()
+        {
+            UseJwtAccessWithScopes = BinauthzManagementServiceV1Beta1Client.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref BinauthzManagementServiceV1Beta1Client client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<BinauthzManagementServiceV1Beta1Client> task);
@@ -263,7 +269,19 @@ namespace Google.Cloud.BinaryAuthorization.V1Beta1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="BinauthzManagementServiceV1Beta1Client"/> using the default credentials,

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.csproj
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "c03bfe0cdadaa62342a98617e2888da9a9ccd757"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/CloudChannelServiceClient.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/CloudChannelServiceClient.g.cs
@@ -807,6 +807,12 @@ namespace Google.Cloud.Channel.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public CloudChannelServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public CloudChannelServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = CloudChannelServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref CloudChannelServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<CloudChannelServiceClient> task);
@@ -898,7 +904,19 @@ namespace Google.Cloud.Channel.V1
             "https://www.googleapis.com/auth/apps.order",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="CloudChannelServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.csproj
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.38.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Channel.V1/synth.metadata
+++ b/apis/Google.Cloud.Channel.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "97d42c651f42bc3173b39ac8a9f97ea1d6b1196c"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1/CloudBuildClient.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1/CloudBuildClient.g.cs
@@ -453,6 +453,12 @@ namespace Google.Cloud.CloudBuild.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public CloudBuildSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public CloudBuildClientBuilder()
+        {
+            UseJwtAccessWithScopes = CloudBuildClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref CloudBuildClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<CloudBuildClient> task);
@@ -533,7 +539,19 @@ namespace Google.Cloud.CloudBuild.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="CloudBuildClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.csproj
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.CloudBuild.V1/synth.metadata
+++ b/apis/Google.Cloud.CloudBuild.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7fec72948d74c8b25c837e9acb7f3e357c902ad1"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1/DataMigrationServiceClient.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1/DataMigrationServiceClient.g.cs
@@ -532,6 +532,12 @@ namespace Google.Cloud.CloudDms.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public DataMigrationServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public DataMigrationServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = DataMigrationServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref DataMigrationServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<DataMigrationServiceClient> task);
@@ -605,7 +611,19 @@ namespace Google.Cloud.CloudDms.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="DataMigrationServiceClient"/> using the default credentials, endpoint

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.csproj
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.38.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.CloudDms.V1/synth.metadata
+++ b/apis/Google.Cloud.CloudDms.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "c670b27290cd26a80d700f94236d7f8764078390"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Common/synth.metadata
+++ b/apis/Google.Cloud.Common/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "478169f2acb0e0c28d9ee2ccee95071d710052bb"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/AcceleratorTypesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/AcceleratorTypesClient.g.cs
@@ -102,6 +102,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public AcceleratorTypesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public AcceleratorTypesClientBuilder()
+        {
+            UseJwtAccessWithScopes = AcceleratorTypesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref AcceleratorTypesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<AcceleratorTypesClient> task);
@@ -181,7 +187,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="AcceleratorTypesClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/AddressesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/AddressesClient.g.cs
@@ -127,6 +127,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public AddressesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public AddressesClientBuilder()
+        {
+            UseJwtAccessWithScopes = AddressesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref AddressesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<AddressesClient> task);
@@ -202,7 +208,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="AddressesClient"/> using the default credentials, endpoint and settings.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/AutoscalersClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/AutoscalersClient.g.cs
@@ -153,6 +153,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public AutoscalersSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public AutoscalersClientBuilder()
+        {
+            UseJwtAccessWithScopes = AutoscalersClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref AutoscalersClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<AutoscalersClient> task);
@@ -228,7 +234,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="AutoscalersClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/BackendBucketsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/BackendBucketsClient.g.cs
@@ -167,6 +167,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public BackendBucketsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public BackendBucketsClientBuilder()
+        {
+            UseJwtAccessWithScopes = BackendBucketsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref BackendBucketsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<BackendBucketsClient> task);
@@ -242,7 +248,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="BackendBucketsClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/BackendServicesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/BackendServicesClient.g.cs
@@ -206,6 +206,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public BackendServicesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public BackendServicesClientBuilder()
+        {
+            UseJwtAccessWithScopes = BackendServicesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref BackendServicesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<BackendServicesClient> task);
@@ -281,7 +287,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="BackendServicesClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/DiskTypesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/DiskTypesClient.g.cs
@@ -101,6 +101,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public DiskTypesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public DiskTypesClientBuilder()
+        {
+            UseJwtAccessWithScopes = DiskTypesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref DiskTypesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<DiskTypesClient> task);
@@ -178,7 +184,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="DiskTypesClient"/> using the default credentials, endpoint and settings.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/DisksClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/DisksClient.g.cs
@@ -231,6 +231,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public DisksSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public DisksClientBuilder()
+        {
+            UseJwtAccessWithScopes = DisksClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref DisksClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<DisksClient> task);
@@ -305,7 +311,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="DisksClient"/> using the default credentials, endpoint and settings. To

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ExternalVpnGatewaysClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ExternalVpnGatewaysClient.g.cs
@@ -142,6 +142,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ExternalVpnGatewaysSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ExternalVpnGatewaysClientBuilder()
+        {
+            UseJwtAccessWithScopes = ExternalVpnGatewaysClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ExternalVpnGatewaysClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ExternalVpnGatewaysClient> task);
@@ -217,7 +223,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ExternalVpnGatewaysClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/FirewallPoliciesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/FirewallPoliciesClient.g.cs
@@ -297,6 +297,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public FirewallPoliciesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public FirewallPoliciesClientBuilder()
+        {
+            UseJwtAccessWithScopes = FirewallPoliciesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref FirewallPoliciesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<FirewallPoliciesClient> task);
@@ -372,7 +378,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="FirewallPoliciesClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/FirewallsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/FirewallsClient.g.cs
@@ -140,6 +140,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public FirewallsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public FirewallsClientBuilder()
+        {
+            UseJwtAccessWithScopes = FirewallsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref FirewallsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<FirewallsClient> task);
@@ -215,7 +221,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="FirewallsClient"/> using the default credentials, endpoint and settings.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ForwardingRulesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ForwardingRulesClient.g.cs
@@ -167,6 +167,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ForwardingRulesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ForwardingRulesClientBuilder()
+        {
+            UseJwtAccessWithScopes = ForwardingRulesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ForwardingRulesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ForwardingRulesClient> task);
@@ -242,7 +248,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ForwardingRulesClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/GlobalAddressesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/GlobalAddressesClient.g.cs
@@ -114,6 +114,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public GlobalAddressesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public GlobalAddressesClientBuilder()
+        {
+            UseJwtAccessWithScopes = GlobalAddressesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref GlobalAddressesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<GlobalAddressesClient> task);
@@ -189,7 +195,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="GlobalAddressesClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/GlobalForwardingRulesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/GlobalForwardingRulesClient.g.cs
@@ -155,6 +155,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public GlobalForwardingRulesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public GlobalForwardingRulesClientBuilder()
+        {
+            UseJwtAccessWithScopes = GlobalForwardingRulesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref GlobalForwardingRulesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<GlobalForwardingRulesClient> task);
@@ -230,7 +236,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="GlobalForwardingRulesClient"/> using the default credentials, endpoint

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/GlobalNetworkEndpointGroupsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/GlobalNetworkEndpointGroupsClient.g.cs
@@ -159,6 +159,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public GlobalNetworkEndpointGroupsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public GlobalNetworkEndpointGroupsClientBuilder()
+        {
+            UseJwtAccessWithScopes = GlobalNetworkEndpointGroupsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref GlobalNetworkEndpointGroupsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<GlobalNetworkEndpointGroupsClient> task);
@@ -234,7 +240,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="GlobalNetworkEndpointGroupsClient"/> using the default credentials,

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/GlobalOperationsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/GlobalOperationsClient.g.cs
@@ -128,6 +128,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public GlobalOperationsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public GlobalOperationsClientBuilder()
+        {
+            UseJwtAccessWithScopes = GlobalOperationsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref GlobalOperationsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<GlobalOperationsClient> task);
@@ -203,7 +209,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="GlobalOperationsClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/GlobalOrganizationOperationsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/GlobalOrganizationOperationsClient.g.cs
@@ -103,6 +103,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public GlobalOrganizationOperationsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public GlobalOrganizationOperationsClientBuilder()
+        {
+            UseJwtAccessWithScopes = GlobalOrganizationOperationsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref GlobalOrganizationOperationsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<GlobalOrganizationOperationsClient> task);
@@ -178,7 +184,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="GlobalOrganizationOperationsClient"/> using the default credentials,

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/GlobalPublicDelegatedPrefixesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/GlobalPublicDelegatedPrefixesClient.g.cs
@@ -132,6 +132,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public GlobalPublicDelegatedPrefixesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public GlobalPublicDelegatedPrefixesClientBuilder()
+        {
+            UseJwtAccessWithScopes = GlobalPublicDelegatedPrefixesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref GlobalPublicDelegatedPrefixesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<GlobalPublicDelegatedPrefixesClient> task);
@@ -208,7 +214,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="GlobalPublicDelegatedPrefixesClient"/> using the default credentials,

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[3.6.0-beta01, 4.0.0)" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[3.5.0-beta01, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/HealthChecksClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/HealthChecksClient.g.cs
@@ -153,6 +153,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public HealthChecksSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public HealthChecksClientBuilder()
+        {
+            UseJwtAccessWithScopes = HealthChecksClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref HealthChecksClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<HealthChecksClient> task);
@@ -228,7 +234,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="HealthChecksClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ImagesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ImagesClient.g.cs
@@ -205,6 +205,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ImagesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ImagesClientBuilder()
+        {
+            UseJwtAccessWithScopes = ImagesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ImagesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ImagesClient> task);
@@ -279,7 +285,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ImagesClient"/> using the default credentials, endpoint and settings. To

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InstanceGroupManagersClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InstanceGroupManagersClient.g.cs
@@ -338,6 +338,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public InstanceGroupManagersSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public InstanceGroupManagersClientBuilder()
+        {
+            UseJwtAccessWithScopes = InstanceGroupManagersClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref InstanceGroupManagersClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<InstanceGroupManagersClient> task);
@@ -413,7 +419,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="InstanceGroupManagersClient"/> using the default credentials, endpoint

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InstanceGroupsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InstanceGroupsClient.g.cs
@@ -180,6 +180,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public InstanceGroupsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public InstanceGroupsClientBuilder()
+        {
+            UseJwtAccessWithScopes = InstanceGroupsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref InstanceGroupsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<InstanceGroupsClient> task);
@@ -255,7 +261,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="InstanceGroupsClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InstanceTemplatesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InstanceTemplatesClient.g.cs
@@ -155,6 +155,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public InstanceTemplatesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public InstanceTemplatesClientBuilder()
+        {
+            UseJwtAccessWithScopes = InstanceTemplatesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref InstanceTemplatesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<InstanceTemplatesClient> task);
@@ -230,7 +236,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="InstanceTemplatesClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InstancesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InstancesClient.g.cs
@@ -611,6 +611,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public InstancesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public InstancesClientBuilder()
+        {
+            UseJwtAccessWithScopes = InstancesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref InstancesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<InstancesClient> task);
@@ -686,7 +692,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="InstancesClient"/> using the default credentials, endpoint and settings.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InterconnectAttachmentsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InterconnectAttachmentsClient.g.cs
@@ -144,6 +144,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public InterconnectAttachmentsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public InterconnectAttachmentsClientBuilder()
+        {
+            UseJwtAccessWithScopes = InterconnectAttachmentsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref InterconnectAttachmentsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<InterconnectAttachmentsClient> task);
@@ -219,7 +225,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="InterconnectAttachmentsClient"/> using the default credentials, endpoint

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InterconnectLocationsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InterconnectLocationsClient.g.cs
@@ -91,6 +91,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public InterconnectLocationsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public InterconnectLocationsClientBuilder()
+        {
+            UseJwtAccessWithScopes = InterconnectLocationsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref InterconnectLocationsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<InterconnectLocationsClient> task);
@@ -168,7 +174,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="InterconnectLocationsClient"/> using the default credentials, endpoint

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InterconnectsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InterconnectsClient.g.cs
@@ -141,6 +141,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public InterconnectsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public InterconnectsClientBuilder()
+        {
+            UseJwtAccessWithScopes = InterconnectsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref InterconnectsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<InterconnectsClient> task);
@@ -216,7 +222,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="InterconnectsClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/LicenseCodesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/LicenseCodesClient.g.cs
@@ -87,6 +87,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public LicenseCodesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public LicenseCodesClientBuilder()
+        {
+            UseJwtAccessWithScopes = LicenseCodesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref LicenseCodesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<LicenseCodesClient> task);
@@ -164,7 +170,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="LicenseCodesClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/LicensesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/LicensesClient.g.cs
@@ -153,6 +153,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public LicensesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public LicensesClientBuilder()
+        {
+            UseJwtAccessWithScopes = LicensesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref LicensesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<LicensesClient> task);
@@ -228,7 +234,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="LicensesClient"/> using the default credentials, endpoint and settings. 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/MachineTypesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/MachineTypesClient.g.cs
@@ -101,6 +101,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public MachineTypesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public MachineTypesClientBuilder()
+        {
+            UseJwtAccessWithScopes = MachineTypesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref MachineTypesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<MachineTypesClient> task);
@@ -178,7 +184,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="MachineTypesClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NetworkEndpointGroupsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NetworkEndpointGroupsClient.g.cs
@@ -187,6 +187,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public NetworkEndpointGroupsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public NetworkEndpointGroupsClientBuilder()
+        {
+            UseJwtAccessWithScopes = NetworkEndpointGroupsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref NetworkEndpointGroupsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<NetworkEndpointGroupsClient> task);
@@ -262,7 +268,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="NetworkEndpointGroupsClient"/> using the default credentials, endpoint

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NetworksClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NetworksClient.g.cs
@@ -205,6 +205,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public NetworksSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public NetworksClientBuilder()
+        {
+            UseJwtAccessWithScopes = NetworksClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref NetworksClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<NetworksClient> task);
@@ -280,7 +286,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="NetworksClient"/> using the default credentials, endpoint and settings. 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NodeGroupsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NodeGroupsClient.g.cs
@@ -231,6 +231,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public NodeGroupsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public NodeGroupsClientBuilder()
+        {
+            UseJwtAccessWithScopes = NodeGroupsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref NodeGroupsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<NodeGroupsClient> task);
@@ -306,7 +312,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="NodeGroupsClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NodeTemplatesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NodeTemplatesClient.g.cs
@@ -167,6 +167,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public NodeTemplatesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public NodeTemplatesClientBuilder()
+        {
+            UseJwtAccessWithScopes = NodeTemplatesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref NodeTemplatesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<NodeTemplatesClient> task);
@@ -242,7 +248,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="NodeTemplatesClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NodeTypesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NodeTypesClient.g.cs
@@ -101,6 +101,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public NodeTypesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public NodeTypesClientBuilder()
+        {
+            UseJwtAccessWithScopes = NodeTypesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref NodeTypesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<NodeTypesClient> task);
@@ -178,7 +184,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="NodeTypesClient"/> using the default credentials, endpoint and settings.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/PacketMirroringsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/PacketMirroringsClient.g.cs
@@ -154,6 +154,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public PacketMirroringsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public PacketMirroringsClientBuilder()
+        {
+            UseJwtAccessWithScopes = PacketMirroringsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref PacketMirroringsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<PacketMirroringsClient> task);
@@ -229,7 +235,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="PacketMirroringsClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ProjectsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ProjectsClient.g.cs
@@ -231,6 +231,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ProjectsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ProjectsClientBuilder()
+        {
+            UseJwtAccessWithScopes = ProjectsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ProjectsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ProjectsClient> task);
@@ -306,7 +312,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ProjectsClient"/> using the default credentials, endpoint and settings. 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/PublicAdvertisedPrefixesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/PublicAdvertisedPrefixesClient.g.cs
@@ -130,6 +130,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public PublicAdvertisedPrefixesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public PublicAdvertisedPrefixesClientBuilder()
+        {
+            UseJwtAccessWithScopes = PublicAdvertisedPrefixesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref PublicAdvertisedPrefixesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<PublicAdvertisedPrefixesClient> task);
@@ -205,7 +211,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="PublicAdvertisedPrefixesClient"/> using the default credentials,

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/PublicDelegatedPrefixesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/PublicDelegatedPrefixesClient.g.cs
@@ -144,6 +144,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public PublicDelegatedPrefixesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public PublicDelegatedPrefixesClientBuilder()
+        {
+            UseJwtAccessWithScopes = PublicDelegatedPrefixesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref PublicDelegatedPrefixesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<PublicDelegatedPrefixesClient> task);
@@ -219,7 +225,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="PublicDelegatedPrefixesClient"/> using the default credentials, endpoint

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionAutoscalersClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionAutoscalersClient.g.cs
@@ -141,6 +141,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public RegionAutoscalersSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public RegionAutoscalersClientBuilder()
+        {
+            UseJwtAccessWithScopes = RegionAutoscalersClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref RegionAutoscalersClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<RegionAutoscalersClient> task);
@@ -216,7 +222,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="RegionAutoscalersClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionBackendServicesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionBackendServicesClient.g.cs
@@ -155,6 +155,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public RegionBackendServicesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public RegionBackendServicesClientBuilder()
+        {
+            UseJwtAccessWithScopes = RegionBackendServicesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref RegionBackendServicesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<RegionBackendServicesClient> task);
@@ -230,7 +236,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="RegionBackendServicesClient"/> using the default credentials, endpoint

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionCommitmentsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionCommitmentsClient.g.cs
@@ -115,6 +115,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public RegionCommitmentsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public RegionCommitmentsClientBuilder()
+        {
+            UseJwtAccessWithScopes = RegionCommitmentsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref RegionCommitmentsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<RegionCommitmentsClient> task);
@@ -190,7 +196,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="RegionCommitmentsClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionDiskTypesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionDiskTypesClient.g.cs
@@ -89,6 +89,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public RegionDiskTypesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public RegionDiskTypesClientBuilder()
+        {
+            UseJwtAccessWithScopes = RegionDiskTypesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref RegionDiskTypesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<RegionDiskTypesClient> task);
@@ -166,7 +172,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="RegionDiskTypesClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionDisksClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionDisksClient.g.cs
@@ -217,6 +217,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public RegionDisksSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public RegionDisksClientBuilder()
+        {
+            UseJwtAccessWithScopes = RegionDisksClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref RegionDisksClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<RegionDisksClient> task);
@@ -292,7 +298,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="RegionDisksClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionHealthCheckServicesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionHealthCheckServicesClient.g.cs
@@ -130,6 +130,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public RegionHealthCheckServicesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public RegionHealthCheckServicesClientBuilder()
+        {
+            UseJwtAccessWithScopes = RegionHealthCheckServicesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref RegionHealthCheckServicesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<RegionHealthCheckServicesClient> task);
@@ -205,7 +211,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="RegionHealthCheckServicesClient"/> using the default credentials,

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionHealthChecksClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionHealthChecksClient.g.cs
@@ -140,6 +140,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public RegionHealthChecksSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public RegionHealthChecksClientBuilder()
+        {
+            UseJwtAccessWithScopes = RegionHealthChecksClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref RegionHealthChecksClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<RegionHealthChecksClient> task);
@@ -215,7 +221,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="RegionHealthChecksClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionInstanceGroupManagersClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionInstanceGroupManagersClient.g.cs
@@ -325,6 +325,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public RegionInstanceGroupManagersSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public RegionInstanceGroupManagersClientBuilder()
+        {
+            UseJwtAccessWithScopes = RegionInstanceGroupManagersClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref RegionInstanceGroupManagersClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<RegionInstanceGroupManagersClient> task);
@@ -400,7 +406,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="RegionInstanceGroupManagersClient"/> using the default credentials,

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionInstanceGroupsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionInstanceGroupsClient.g.cs
@@ -115,6 +115,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public RegionInstanceGroupsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public RegionInstanceGroupsClientBuilder()
+        {
+            UseJwtAccessWithScopes = RegionInstanceGroupsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref RegionInstanceGroupsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<RegionInstanceGroupsClient> task);
@@ -190,7 +196,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="RegionInstanceGroupsClient"/> using the default credentials, endpoint

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionInstancesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionInstancesClient.g.cs
@@ -75,6 +75,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public RegionInstancesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public RegionInstancesClientBuilder()
+        {
+            UseJwtAccessWithScopes = RegionInstancesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref RegionInstancesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<RegionInstancesClient> task);
@@ -150,7 +156,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="RegionInstancesClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionNetworkEndpointGroupsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionNetworkEndpointGroupsClient.g.cs
@@ -116,6 +116,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public RegionNetworkEndpointGroupsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public RegionNetworkEndpointGroupsClientBuilder()
+        {
+            UseJwtAccessWithScopes = RegionNetworkEndpointGroupsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref RegionNetworkEndpointGroupsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<RegionNetworkEndpointGroupsClient> task);
@@ -191,7 +197,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="RegionNetworkEndpointGroupsClient"/> using the default credentials,

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionNotificationEndpointsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionNotificationEndpointsClient.g.cs
@@ -117,6 +117,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public RegionNotificationEndpointsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public RegionNotificationEndpointsClientBuilder()
+        {
+            UseJwtAccessWithScopes = RegionNotificationEndpointsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref RegionNotificationEndpointsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<RegionNotificationEndpointsClient> task);
@@ -192,7 +198,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="RegionNotificationEndpointsClient"/> using the default credentials,

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionOperationsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionOperationsClient.g.cs
@@ -114,6 +114,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public RegionOperationsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public RegionOperationsClientBuilder()
+        {
+            UseJwtAccessWithScopes = RegionOperationsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref RegionOperationsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<RegionOperationsClient> task);
@@ -189,7 +195,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="RegionOperationsClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionSslCertificatesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionSslCertificatesClient.g.cs
@@ -117,6 +117,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public RegionSslCertificatesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public RegionSslCertificatesClientBuilder()
+        {
+            UseJwtAccessWithScopes = RegionSslCertificatesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref RegionSslCertificatesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<RegionSslCertificatesClient> task);
@@ -192,7 +198,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="RegionSslCertificatesClient"/> using the default credentials, endpoint

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionTargetHttpProxiesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionTargetHttpProxiesClient.g.cs
@@ -130,6 +130,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public RegionTargetHttpProxiesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public RegionTargetHttpProxiesClientBuilder()
+        {
+            UseJwtAccessWithScopes = RegionTargetHttpProxiesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref RegionTargetHttpProxiesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<RegionTargetHttpProxiesClient> task);
@@ -205,7 +211,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="RegionTargetHttpProxiesClient"/> using the default credentials, endpoint

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionTargetHttpsProxiesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionTargetHttpsProxiesClient.g.cs
@@ -144,6 +144,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public RegionTargetHttpsProxiesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public RegionTargetHttpsProxiesClientBuilder()
+        {
+            UseJwtAccessWithScopes = RegionTargetHttpsProxiesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref RegionTargetHttpsProxiesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<RegionTargetHttpsProxiesClient> task);
@@ -219,7 +225,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="RegionTargetHttpsProxiesClient"/> using the default credentials,

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionUrlMapsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionUrlMapsClient.g.cs
@@ -154,6 +154,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public RegionUrlMapsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public RegionUrlMapsClientBuilder()
+        {
+            UseJwtAccessWithScopes = RegionUrlMapsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref RegionUrlMapsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<RegionUrlMapsClient> task);
@@ -229,7 +235,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="RegionUrlMapsClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionsClient.g.cs
@@ -88,6 +88,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public RegionsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public RegionsClientBuilder()
+        {
+            UseJwtAccessWithScopes = RegionsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref RegionsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<RegionsClient> task);
@@ -164,7 +170,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="RegionsClient"/> using the default credentials, endpoint and settings. 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ReservationsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ReservationsClient.g.cs
@@ -179,6 +179,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ReservationsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ReservationsClientBuilder()
+        {
+            UseJwtAccessWithScopes = ReservationsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ReservationsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ReservationsClient> task);
@@ -254,7 +260,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ReservationsClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ResourcePoliciesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ResourcePoliciesClient.g.cs
@@ -167,6 +167,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ResourcePoliciesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ResourcePoliciesClientBuilder()
+        {
+            UseJwtAccessWithScopes = ResourcePoliciesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ResourcePoliciesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ResourcePoliciesClient> task);
@@ -242,7 +248,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ResourcePoliciesClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RoutersClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RoutersClient.g.cs
@@ -192,6 +192,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public RoutersSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public RoutersClientBuilder()
+        {
+            UseJwtAccessWithScopes = RoutersClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref RoutersClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<RoutersClient> task);
@@ -266,7 +272,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="RoutersClient"/> using the default credentials, endpoint and settings. 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RoutesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RoutesClient.g.cs
@@ -114,6 +114,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public RoutesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public RoutesClientBuilder()
+        {
+            UseJwtAccessWithScopes = RoutesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref RoutesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<RoutesClient> task);
@@ -188,7 +194,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="RoutesClient"/> using the default credentials, endpoint and settings. To

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/SecurityPoliciesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/SecurityPoliciesClient.g.cs
@@ -194,6 +194,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public SecurityPoliciesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public SecurityPoliciesClientBuilder()
+        {
+            UseJwtAccessWithScopes = SecurityPoliciesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref SecurityPoliciesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<SecurityPoliciesClient> task);
@@ -269,7 +275,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="SecurityPoliciesClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/SnapshotsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/SnapshotsClient.g.cs
@@ -153,6 +153,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public SnapshotsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public SnapshotsClientBuilder()
+        {
+            UseJwtAccessWithScopes = SnapshotsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref SnapshotsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<SnapshotsClient> task);
@@ -228,7 +234,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="SnapshotsClient"/> using the default credentials, endpoint and settings.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/SslCertificatesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/SslCertificatesClient.g.cs
@@ -128,6 +128,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public SslCertificatesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public SslCertificatesClientBuilder()
+        {
+            UseJwtAccessWithScopes = SslCertificatesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref SslCertificatesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<SslCertificatesClient> task);
@@ -203,7 +209,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="SslCertificatesClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/SslPoliciesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/SslPoliciesClient.g.cs
@@ -140,6 +140,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public SslPoliciesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public SslPoliciesClientBuilder()
+        {
+            UseJwtAccessWithScopes = SslPoliciesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref SslPoliciesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<SslPoliciesClient> task);
@@ -215,7 +221,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="SslPoliciesClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/SubnetworksClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/SubnetworksClient.g.cs
@@ -219,6 +219,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public SubnetworksSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public SubnetworksClientBuilder()
+        {
+            UseJwtAccessWithScopes = SubnetworksClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref SubnetworksClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<SubnetworksClient> task);
@@ -294,7 +300,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="SubnetworksClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetGrpcProxiesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetGrpcProxiesClient.g.cs
@@ -128,6 +128,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public TargetGrpcProxiesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public TargetGrpcProxiesClientBuilder()
+        {
+            UseJwtAccessWithScopes = TargetGrpcProxiesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref TargetGrpcProxiesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<TargetGrpcProxiesClient> task);
@@ -203,7 +209,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="TargetGrpcProxiesClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetHttpProxiesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetHttpProxiesClient.g.cs
@@ -154,6 +154,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public TargetHttpProxiesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public TargetHttpProxiesClientBuilder()
+        {
+            UseJwtAccessWithScopes = TargetHttpProxiesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref TargetHttpProxiesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<TargetHttpProxiesClient> task);
@@ -229,7 +235,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="TargetHttpProxiesClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetHttpsProxiesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetHttpsProxiesClient.g.cs
@@ -194,6 +194,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public TargetHttpsProxiesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public TargetHttpsProxiesClientBuilder()
+        {
+            UseJwtAccessWithScopes = TargetHttpsProxiesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref TargetHttpsProxiesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<TargetHttpsProxiesClient> task);
@@ -269,7 +275,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="TargetHttpsProxiesClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetInstancesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetInstancesClient.g.cs
@@ -128,6 +128,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public TargetInstancesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public TargetInstancesClientBuilder()
+        {
+            UseJwtAccessWithScopes = TargetInstancesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref TargetInstancesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<TargetInstancesClient> task);
@@ -203,7 +209,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="TargetInstancesClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetPoolsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetPoolsClient.g.cs
@@ -205,6 +205,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public TargetPoolsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public TargetPoolsClientBuilder()
+        {
+            UseJwtAccessWithScopes = TargetPoolsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref TargetPoolsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<TargetPoolsClient> task);
@@ -280,7 +286,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="TargetPoolsClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetSslProxiesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetSslProxiesClient.g.cs
@@ -167,6 +167,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public TargetSslProxiesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public TargetSslProxiesClientBuilder()
+        {
+            UseJwtAccessWithScopes = TargetSslProxiesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref TargetSslProxiesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<TargetSslProxiesClient> task);
@@ -242,7 +248,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="TargetSslProxiesClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetTcpProxiesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetTcpProxiesClient.g.cs
@@ -141,6 +141,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public TargetTcpProxiesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public TargetTcpProxiesClientBuilder()
+        {
+            UseJwtAccessWithScopes = TargetTcpProxiesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref TargetTcpProxiesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<TargetTcpProxiesClient> task);
@@ -216,7 +222,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="TargetTcpProxiesClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetVpnGatewaysClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetVpnGatewaysClient.g.cs
@@ -128,6 +128,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public TargetVpnGatewaysSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public TargetVpnGatewaysClientBuilder()
+        {
+            UseJwtAccessWithScopes = TargetVpnGatewaysClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref TargetVpnGatewaysClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<TargetVpnGatewaysClient> task);
@@ -203,7 +209,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="TargetVpnGatewaysClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/UrlMapsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/UrlMapsClient.g.cs
@@ -179,6 +179,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public UrlMapsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public UrlMapsClientBuilder()
+        {
+            UseJwtAccessWithScopes = UrlMapsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref UrlMapsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<UrlMapsClient> task);
@@ -253,7 +259,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="UrlMapsClient"/> using the default credentials, endpoint and settings. 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/VpnGatewaysClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/VpnGatewaysClient.g.cs
@@ -166,6 +166,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public VpnGatewaysSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public VpnGatewaysClientBuilder()
+        {
+            UseJwtAccessWithScopes = VpnGatewaysClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref VpnGatewaysClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<VpnGatewaysClient> task);
@@ -241,7 +247,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="VpnGatewaysClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/VpnTunnelsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/VpnTunnelsClient.g.cs
@@ -127,6 +127,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public VpnTunnelsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public VpnTunnelsClientBuilder()
+        {
+            UseJwtAccessWithScopes = VpnTunnelsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref VpnTunnelsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<VpnTunnelsClient> task);
@@ -202,7 +208,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="VpnTunnelsClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ZoneOperationsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ZoneOperationsClient.g.cs
@@ -114,6 +114,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ZoneOperationsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ZoneOperationsClientBuilder()
+        {
+            UseJwtAccessWithScopes = ZoneOperationsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ZoneOperationsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ZoneOperationsClient> task);
@@ -189,7 +195,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ZoneOperationsClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ZonesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ZonesClient.g.cs
@@ -88,6 +88,12 @@ namespace Google.Cloud.Compute.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ZonesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ZonesClientBuilder()
+        {
+            UseJwtAccessWithScopes = ZonesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ZonesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ZonesClient> task);
@@ -164,7 +170,19 @@ namespace Google.Cloud.Compute.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ZonesClient"/> using the default credentials, endpoint and settings. To

--- a/apis/Google.Cloud.Compute.V1/synth.metadata
+++ b/apis/Google.Cloud.Compute.V1/synth.metadata
@@ -4,14 +4,14 @@
       "git": {
         "name": "googleapis-discovery",
         "remote": "https://github.com/googleapis/googleapis-discovery.git",
-        "sha": "c5bb8d324832f638d86bc1348fb45fb3d9c1fb30"
+        "sha": "e693b037c832027854353dd6e1408284bd2eace3"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "ac5d0130755d21daf6296f9f910200b334ee7b23"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1/ContactCenterInsightsClient.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1/ContactCenterInsightsClient.g.cs
@@ -651,6 +651,12 @@ namespace Google.Cloud.ContactCenterInsights.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ContactCenterInsightsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ContactCenterInsightsClientBuilder()
+        {
+            UseJwtAccessWithScopes = ContactCenterInsightsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ContactCenterInsightsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ContactCenterInsightsClient> task);
@@ -724,7 +730,19 @@ namespace Google.Cloud.ContactCenterInsights.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ContactCenterInsightsClient"/> using the default credentials, endpoint

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.csproj
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.ContactCenterInsights.V1/synth.metadata
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "e932524ec49b16571834457aef007406075c3a56"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/ClusterManagerClient.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/ClusterManagerClient.g.cs
@@ -511,6 +511,12 @@ namespace Google.Cloud.Container.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ClusterManagerSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ClusterManagerClientBuilder()
+        {
+            UseJwtAccessWithScopes = ClusterManagerClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ClusterManagerClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ClusterManagerClient> task);
@@ -584,7 +590,19 @@ namespace Google.Cloud.Container.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ClusterManagerClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.Container.V1/synth.metadata
+++ b/apis/Google.Cloud.Container.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "e2b7a98e29cabf5d7ee3c359939d8028bb1cca49"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/DataCatalogClient.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/DataCatalogClient.g.cs
@@ -454,6 +454,12 @@ namespace Google.Cloud.DataCatalog.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public DataCatalogSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public DataCatalogClientBuilder()
+        {
+            UseJwtAccessWithScopes = DataCatalogClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref DataCatalogClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<DataCatalogClient> task);
@@ -528,7 +534,19 @@ namespace Google.Cloud.DataCatalog.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="DataCatalogClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.csproj
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/PolicyTagManagerClient.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/PolicyTagManagerClient.g.cs
@@ -235,6 +235,12 @@ namespace Google.Cloud.DataCatalog.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public PolicyTagManagerSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public PolicyTagManagerClientBuilder()
+        {
+            UseJwtAccessWithScopes = PolicyTagManagerClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref PolicyTagManagerClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<PolicyTagManagerClient> task);
@@ -313,7 +319,19 @@ namespace Google.Cloud.DataCatalog.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="PolicyTagManagerClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/PolicyTagManagerSerializationClient.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/PolicyTagManagerSerializationClient.g.cs
@@ -106,6 +106,12 @@ namespace Google.Cloud.DataCatalog.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public PolicyTagManagerSerializationSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public PolicyTagManagerSerializationClientBuilder()
+        {
+            UseJwtAccessWithScopes = PolicyTagManagerSerializationClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref PolicyTagManagerSerializationClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<PolicyTagManagerSerializationClient> task);
@@ -183,7 +189,19 @@ namespace Google.Cloud.DataCatalog.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="PolicyTagManagerSerializationClient"/> using the default credentials,

--- a/apis/Google.Cloud.DataCatalog.V1/synth.metadata
+++ b/apis/Google.Cloud.DataCatalog.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "5b1f7cf1d2e2f8ab028a7090d0981fc774028906"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1/DataFusionClient.g.cs
+++ b/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1/DataFusionClient.g.cs
@@ -231,6 +231,12 @@ namespace Google.Cloud.DataFusion.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public DataFusionSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public DataFusionClientBuilder()
+        {
+            UseJwtAccessWithScopes = DataFusionClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref DataFusionClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<DataFusionClient> task);
@@ -306,7 +312,19 @@ namespace Google.Cloud.DataFusion.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="DataFusionClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.csproj
+++ b/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.DataFusion.V1/synth.metadata
+++ b/apis/Google.Cloud.DataFusion.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "2e6b987a6f6e65c33ddefe0f2278dbbd38b46a91"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.DataLabeling.V1Beta1/Google.Cloud.DataLabeling.V1Beta1/DataLabelingServiceClient.g.cs
+++ b/apis/Google.Cloud.DataLabeling.V1Beta1/Google.Cloud.DataLabeling.V1Beta1/DataLabelingServiceClient.g.cs
@@ -704,6 +704,12 @@ namespace Google.Cloud.DataLabeling.V1Beta1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public DataLabelingServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public DataLabelingServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = DataLabelingServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref DataLabelingServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<DataLabelingServiceClient> task);
@@ -777,7 +783,19 @@ namespace Google.Cloud.DataLabeling.V1Beta1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="DataLabelingServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.DataLabeling.V1Beta1/Google.Cloud.DataLabeling.V1Beta1/Google.Cloud.DataLabeling.V1Beta1.csproj
+++ b/apis/Google.Cloud.DataLabeling.V1Beta1/Google.Cloud.DataLabeling.V1Beta1/Google.Cloud.DataLabeling.V1Beta1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.DataLabeling.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.DataLabeling.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.DataQnA.V1Alpha/Google.Cloud.DataQnA.V1Alpha/AutoSuggestionServiceClient.g.cs
+++ b/apis/Google.Cloud.DataQnA.V1Alpha/Google.Cloud.DataQnA.V1Alpha/AutoSuggestionServiceClient.g.cs
@@ -78,6 +78,12 @@ namespace Google.Cloud.DataQnA.V1Alpha
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public AutoSuggestionServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public AutoSuggestionServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = AutoSuggestionServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref AutoSuggestionServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<AutoSuggestionServiceClient> task);
@@ -216,7 +222,19 @@ namespace Google.Cloud.DataQnA.V1Alpha
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="AutoSuggestionServiceClient"/> using the default credentials, endpoint

--- a/apis/Google.Cloud.DataQnA.V1Alpha/Google.Cloud.DataQnA.V1Alpha/Google.Cloud.DataQnA.V1Alpha.csproj
+++ b/apis/Google.Cloud.DataQnA.V1Alpha/Google.Cloud.DataQnA.V1Alpha/Google.Cloud.DataQnA.V1Alpha.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.DataQnA.V1Alpha/Google.Cloud.DataQnA.V1Alpha/QuestionServiceClient.g.cs
+++ b/apis/Google.Cloud.DataQnA.V1Alpha/Google.Cloud.DataQnA.V1Alpha/QuestionServiceClient.g.cs
@@ -135,6 +135,12 @@ namespace Google.Cloud.DataQnA.V1Alpha
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public QuestionServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public QuestionServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = QuestionServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref QuestionServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<QuestionServiceClient> task);
@@ -222,7 +228,19 @@ namespace Google.Cloud.DataQnA.V1Alpha
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="QuestionServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.DataQnA.V1Alpha/synth.metadata
+++ b/apis/Google.Cloud.DataQnA.V1Alpha/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3/FlexTemplatesServiceClient.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3/FlexTemplatesServiceClient.g.cs
@@ -76,6 +76,12 @@ namespace Google.Cloud.Dataflow.V1Beta3
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public FlexTemplatesServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public FlexTemplatesServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = FlexTemplatesServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref FlexTemplatesServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<FlexTemplatesServiceClient> task);
@@ -155,7 +161,19 @@ namespace Google.Cloud.Dataflow.V1Beta3
             "https://www.googleapis.com/auth/userinfo.email",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="FlexTemplatesServiceClient"/> using the default credentials, endpoint

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.csproj
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3/JobsV1Beta3Client.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3/JobsV1Beta3Client.g.cs
@@ -153,6 +153,12 @@ namespace Google.Cloud.Dataflow.V1Beta3
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public JobsV1Beta3Settings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public JobsV1Beta3ClientBuilder()
+        {
+            UseJwtAccessWithScopes = JobsV1Beta3Client.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref JobsV1Beta3Client client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<JobsV1Beta3Client> task);
@@ -233,7 +239,19 @@ namespace Google.Cloud.Dataflow.V1Beta3
             "https://www.googleapis.com/auth/userinfo.email",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="JobsV1Beta3Client"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3/MessagesV1Beta3Client.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3/MessagesV1Beta3Client.g.cs
@@ -76,6 +76,12 @@ namespace Google.Cloud.Dataflow.V1Beta3
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public MessagesV1Beta3Settings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public MessagesV1Beta3ClientBuilder()
+        {
+            UseJwtAccessWithScopes = MessagesV1Beta3Client.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref MessagesV1Beta3Client client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<MessagesV1Beta3Client> task);
@@ -156,7 +162,19 @@ namespace Google.Cloud.Dataflow.V1Beta3
             "https://www.googleapis.com/auth/userinfo.email",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="MessagesV1Beta3Client"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3/MetricsV1Beta3Client.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3/MetricsV1Beta3Client.g.cs
@@ -104,6 +104,12 @@ namespace Google.Cloud.Dataflow.V1Beta3
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public MetricsV1Beta3Settings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public MetricsV1Beta3ClientBuilder()
+        {
+            UseJwtAccessWithScopes = MetricsV1Beta3Client.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref MetricsV1Beta3Client client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<MetricsV1Beta3Client> task);
@@ -184,7 +190,19 @@ namespace Google.Cloud.Dataflow.V1Beta3
             "https://www.googleapis.com/auth/userinfo.email",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="MetricsV1Beta3Client"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3/SnapshotsV1Beta3Client.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3/SnapshotsV1Beta3Client.g.cs
@@ -101,6 +101,12 @@ namespace Google.Cloud.Dataflow.V1Beta3
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public SnapshotsV1Beta3Settings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public SnapshotsV1Beta3ClientBuilder()
+        {
+            UseJwtAccessWithScopes = SnapshotsV1Beta3Client.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref SnapshotsV1Beta3Client client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<SnapshotsV1Beta3Client> task);
@@ -180,7 +186,19 @@ namespace Google.Cloud.Dataflow.V1Beta3
             "https://www.googleapis.com/auth/userinfo.email",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="SnapshotsV1Beta3Client"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3/TemplatesServiceClient.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3/TemplatesServiceClient.g.cs
@@ -102,6 +102,12 @@ namespace Google.Cloud.Dataflow.V1Beta3
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public TemplatesServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public TemplatesServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = TemplatesServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref TemplatesServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<TemplatesServiceClient> task);
@@ -181,7 +187,19 @@ namespace Google.Cloud.Dataflow.V1Beta3
             "https://www.googleapis.com/auth/userinfo.email",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="TemplatesServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Dataflow.V1Beta3/synth.metadata
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "aeb62a6c03c825f3d6defab8a82fd6dbbe70d9af"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/AutoscalingPolicyServiceClient.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/AutoscalingPolicyServiceClient.g.cs
@@ -146,6 +146,12 @@ namespace Google.Cloud.Dataproc.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public AutoscalingPolicyServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public AutoscalingPolicyServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = AutoscalingPolicyServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref AutoscalingPolicyServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<AutoscalingPolicyServiceClient> task);
@@ -220,7 +226,19 @@ namespace Google.Cloud.Dataproc.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="AutoscalingPolicyServiceClient"/> using the default credentials,

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/ClusterControllerClient.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/ClusterControllerClient.g.cs
@@ -301,6 +301,12 @@ namespace Google.Cloud.Dataproc.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ClusterControllerSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ClusterControllerClientBuilder()
+        {
+            UseJwtAccessWithScopes = ClusterControllerClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ClusterControllerClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ClusterControllerClient> task);
@@ -375,7 +381,19 @@ namespace Google.Cloud.Dataproc.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ClusterControllerClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.csproj
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/JobControllerClient.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/JobControllerClient.g.cs
@@ -196,6 +196,12 @@ namespace Google.Cloud.Dataproc.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public JobControllerSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public JobControllerClientBuilder()
+        {
+            UseJwtAccessWithScopes = JobControllerClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref JobControllerClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<JobControllerClient> task);
@@ -269,7 +275,19 @@ namespace Google.Cloud.Dataproc.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="JobControllerClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/WorkflowTemplateServiceClient.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/WorkflowTemplateServiceClient.g.cs
@@ -226,6 +226,12 @@ namespace Google.Cloud.Dataproc.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public WorkflowTemplateServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public WorkflowTemplateServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = WorkflowTemplateServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref WorkflowTemplateServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<WorkflowTemplateServiceClient> task);
@@ -300,7 +306,19 @@ namespace Google.Cloud.Dataproc.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="WorkflowTemplateServiceClient"/> using the default credentials, endpoint

--- a/apis/Google.Cloud.Dataproc.V1/synth.metadata
+++ b/apis/Google.Cloud.Dataproc.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "439f098cb730af18c8ae4e65971ea3badf45138a"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1/DatastoreAdminClient.g.cs
+++ b/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1/DatastoreAdminClient.g.cs
@@ -225,6 +225,12 @@ namespace Google.Cloud.Datastore.Admin.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public DatastoreAdminSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public DatastoreAdminClientBuilder()
+        {
+            UseJwtAccessWithScopes = DatastoreAdminClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref DatastoreAdminClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<DatastoreAdminClient> task);
@@ -360,7 +366,19 @@ namespace Google.Cloud.Datastore.Admin.V1
             "https://www.googleapis.com/auth/datastore",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="DatastoreAdminClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.csproj
+++ b/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.Datastore.Admin.V1/synth.metadata
+++ b/apis/Google.Cloud.Datastore.Admin.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "e96a2e6ad25a20c70599fbea27ef89c78303d065"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/Google.Cloud.Datastore.V1.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/Google.Cloud.Datastore.V1.IntegrationTests.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[3.5.0, 4.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Datastore.V1\Google.Cloud.Datastore.V1.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/Google.Cloud.Datastore.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/Google.Cloud.Datastore.V1.Snippets.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[3.5.0, 4.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Datastore.V1\Google.Cloud.Datastore.V1.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Tests/Google.Cloud.Datastore.V1.Tests.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Tests/Google.Cloud.Datastore.V1.Tests.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[3.5.0, 4.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Datastore.V1\Google.Cloud.Datastore.V1.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreClient.g.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreClient.g.cs
@@ -162,6 +162,12 @@ namespace Google.Cloud.Datastore.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public DatastoreSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public DatastoreClientBuilder()
+        {
+            UseJwtAccessWithScopes = DatastoreClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref DatastoreClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<DatastoreClient> task);
@@ -242,7 +248,19 @@ namespace Google.Cloud.Datastore.V1
             "https://www.googleapis.com/auth/datastore",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="DatastoreClient"/> using the default credentials, endpoint and settings.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreClientBuilder.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreClientBuilder.cs
@@ -19,13 +19,6 @@ namespace Google.Cloud.Datastore.V1
     // Support for DatastoreDbBuilder.
     public sealed partial class DatastoreClientBuilder : ClientBuilderBase<DatastoreClient>
     {
-        /// <summary>
-        /// Creates a new instance with no settings.
-        /// </summary>
-        public DatastoreClientBuilder()
-        {
-        }
-
         internal DatastoreClientBuilder(DatastoreDbBuilder builder)
         {
             Settings = builder.Settings;

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <PackageReference Include="System.Linq.Async" Version="4.0.0" />

--- a/apis/Google.Cloud.Datastore.V1/synth.metadata
+++ b/apis/Google.Cloud.Datastore.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1/DatastreamClient.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1/DatastreamClient.g.cs
@@ -581,6 +581,12 @@ namespace Google.Cloud.Datastream.V1Alpha1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public DatastreamSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public DatastreamClientBuilder()
+        {
+            UseJwtAccessWithScopes = DatastreamClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref DatastreamClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<DatastreamClient> task);
@@ -654,7 +660,19 @@ namespace Google.Cloud.Datastream.V1Alpha1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="DatastreamClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.csproj
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.Datastream.V1Alpha1/synth.metadata
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "0c62f63ad7ca987f1c22f524d6378cff29da8a33"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2/Controller2Client.g.cs
+++ b/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2/Controller2Client.g.cs
@@ -106,6 +106,12 @@ namespace Google.Cloud.Debugger.V2
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public Controller2Settings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public Controller2ClientBuilder()
+        {
+            UseJwtAccessWithScopes = Controller2Client.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref Controller2Client client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<Controller2Client> task);
@@ -200,7 +206,19 @@ namespace Google.Cloud.Debugger.V2
             "https://www.googleapis.com/auth/cloud_debugger",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="Controller2Client"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2/Debugger2Client.g.cs
+++ b/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2/Debugger2Client.g.cs
@@ -139,6 +139,12 @@ namespace Google.Cloud.Debugger.V2
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public Debugger2Settings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public Debugger2ClientBuilder()
+        {
+            UseJwtAccessWithScopes = Debugger2Client.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref Debugger2Client client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<Debugger2Client> task);
@@ -225,7 +231,19 @@ namespace Google.Cloud.Debugger.V2
             "https://www.googleapis.com/auth/cloud_debugger",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="Debugger2Client"/> using the default credentials, endpoint and settings.

--- a/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2.csproj
+++ b/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.DevTools.Common" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Debugger.V2/synth.metadata
+++ b/apis/Google.Cloud.Debugger.V2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1/ContainerAnalysisClient.g.cs
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1/ContainerAnalysisClient.g.cs
@@ -118,6 +118,12 @@ namespace Google.Cloud.DevTools.ContainerAnalysis.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ContainerAnalysisSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ContainerAnalysisClientBuilder()
+        {
+            UseJwtAccessWithScopes = ContainerAnalysisClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ContainerAnalysisClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ContainerAnalysisClient> task);
@@ -203,7 +209,19 @@ namespace Google.Cloud.DevTools.ContainerAnalysis.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ContainerAnalysisClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.csproj
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.1.0, 3.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.2.0, 3.0.0)" />
     <ProjectReference Include="..\..\Grafeas.V1\Grafeas.V1\Grafeas.V1.csproj" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/synth.metadata
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "4c3702d8c6bd5d69b16b0b21f861faefb04d4f9e"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests.csproj
@@ -12,7 +12,7 @@
     <DebugType Condition="'$(TargetFramework)' == 'netcoreapp2.1'">portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.5.0, 4.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Diagnostics.AspNetCore\Google.Cloud.Diagnostics.AspNetCore.csproj" />
     <ProjectReference Include="..\..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.IntegrationTests\Google.Cloud.Diagnostics.Common.IntegrationTests.csproj" />

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/Google.Cloud.Diagnostics.AspNetCore.Snippets.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/Google.Cloud.Diagnostics.AspNetCore.Snippets.csproj
@@ -13,7 +13,7 @@
     <DebugType Condition="'$(TargetFramework)' == 'netcoreapp2.1'">portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.5.0, 4.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Diagnostics.AspNetCore\Google.Cloud.Diagnostics.AspNetCore.csproj" />
     <ProjectReference Include="..\..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.IntegrationTests\Google.Cloud.Diagnostics.Common.IntegrationTests.csproj" />

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Google.Cloud.Diagnostics.AspNetCore.Tests.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Tests/Google.Cloud.Diagnostics.AspNetCore.Tests.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.5.0, 4.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Diagnostics.AspNetCore\Google.Cloud.Diagnostics.AspNetCore.csproj" />
     <ProjectReference Include="..\..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.IntegrationTests\Google.Cloud.Diagnostics.Common.IntegrationTests.csproj" />

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <ProjectReference Include="..\..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.csproj" />
-    <PackageReference Include="Grpc.Core" Version="[2.38.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.1.1" />

--- a/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.IntegrationTests/Google.Cloud.Diagnostics.AspNetCore3.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.IntegrationTests/Google.Cloud.Diagnostics.AspNetCore3.IntegrationTests.csproj
@@ -11,7 +11,7 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.5.0, 4.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Diagnostics.AspNetCore3\Google.Cloud.Diagnostics.AspNetCore3.csproj" />
     <ProjectReference Include="..\..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.IntegrationTests\Google.Cloud.Diagnostics.Common.IntegrationTests.csproj" />

--- a/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.Snippets/Google.Cloud.Diagnostics.AspNetCore3.Snippets.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.Snippets/Google.Cloud.Diagnostics.AspNetCore3.Snippets.csproj
@@ -11,7 +11,7 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.5.0, 4.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Diagnostics.AspNetCore3\Google.Cloud.Diagnostics.AspNetCore3.csproj" />
     <ProjectReference Include="..\..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.IntegrationTests\Google.Cloud.Diagnostics.Common.IntegrationTests.csproj" />

--- a/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.Tests/Google.Cloud.Diagnostics.AspNetCore3.Tests.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.Tests/Google.Cloud.Diagnostics.AspNetCore3.Tests.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.5.0, 4.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Diagnostics.AspNetCore3\Google.Cloud.Diagnostics.AspNetCore3.csproj" />
     <ProjectReference Include="..\..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.IntegrationTests\Google.Cloud.Diagnostics.Common.IntegrationTests.csproj" />

--- a/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <ProjectReference Include="..\..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.csproj" />
-    <PackageReference Include="Grpc.Core" Version="[2.38.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Logging.V2" Version="[3.3.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Trace.V1" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/AgentsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/AgentsClient.g.cs
@@ -247,6 +247,12 @@ namespace Google.Cloud.Dialogflow.Cx.V3
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public AgentsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public AgentsClientBuilder()
+        {
+            UseJwtAccessWithScopes = AgentsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref AgentsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<AgentsClient> task);
@@ -322,7 +328,19 @@ namespace Google.Cloud.Dialogflow.Cx.V3
             "https://www.googleapis.com/auth/dialogflow",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="AgentsClient"/> using the default credentials, endpoint and settings. To

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/EntityTypesClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/EntityTypesClient.g.cs
@@ -143,6 +143,12 @@ namespace Google.Cloud.Dialogflow.Cx.V3
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public EntityTypesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public EntityTypesClientBuilder()
+        {
+            UseJwtAccessWithScopes = EntityTypesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref EntityTypesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<EntityTypesClient> task);
@@ -218,7 +224,19 @@ namespace Google.Cloud.Dialogflow.Cx.V3
             "https://www.googleapis.com/auth/dialogflow",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="EntityTypesClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/EnvironmentsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/EnvironmentsClient.g.cs
@@ -251,6 +251,12 @@ namespace Google.Cloud.Dialogflow.Cx.V3
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public EnvironmentsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public EnvironmentsClientBuilder()
+        {
+            UseJwtAccessWithScopes = EnvironmentsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref EnvironmentsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<EnvironmentsClient> task);
@@ -326,7 +332,19 @@ namespace Google.Cloud.Dialogflow.Cx.V3
             "https://www.googleapis.com/auth/dialogflow",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="EnvironmentsClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/ExperimentsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/ExperimentsClient.g.cs
@@ -175,6 +175,12 @@ namespace Google.Cloud.Dialogflow.Cx.V3
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ExperimentsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ExperimentsClientBuilder()
+        {
+            UseJwtAccessWithScopes = ExperimentsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ExperimentsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ExperimentsClient> task);
@@ -250,7 +256,19 @@ namespace Google.Cloud.Dialogflow.Cx.V3
             "https://www.googleapis.com/auth/dialogflow",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ExperimentsClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/FlowsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/FlowsClient.g.cs
@@ -281,6 +281,12 @@ namespace Google.Cloud.Dialogflow.Cx.V3
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public FlowsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public FlowsClientBuilder()
+        {
+            UseJwtAccessWithScopes = FlowsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref FlowsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<FlowsClient> task);
@@ -356,7 +362,19 @@ namespace Google.Cloud.Dialogflow.Cx.V3
             "https://www.googleapis.com/auth/dialogflow",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="FlowsClient"/> using the default credentials, endpoint and settings. To

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.csproj
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/IntentsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/IntentsClient.g.cs
@@ -143,6 +143,12 @@ namespace Google.Cloud.Dialogflow.Cx.V3
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public IntentsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public IntentsClientBuilder()
+        {
+            UseJwtAccessWithScopes = IntentsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref IntentsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<IntentsClient> task);
@@ -218,7 +224,19 @@ namespace Google.Cloud.Dialogflow.Cx.V3
             "https://www.googleapis.com/auth/dialogflow",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="IntentsClient"/> using the default credentials, endpoint and settings. 

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/PagesClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/PagesClient.g.cs
@@ -143,6 +143,12 @@ namespace Google.Cloud.Dialogflow.Cx.V3
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public PagesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public PagesClientBuilder()
+        {
+            UseJwtAccessWithScopes = PagesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref PagesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<PagesClient> task);
@@ -218,7 +224,19 @@ namespace Google.Cloud.Dialogflow.Cx.V3
             "https://www.googleapis.com/auth/dialogflow",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="PagesClient"/> using the default credentials, endpoint and settings. To

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/SecuritySettingsServiceClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/SecuritySettingsServiceClient.g.cs
@@ -152,6 +152,12 @@ namespace Google.Cloud.Dialogflow.Cx.V3
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public SecuritySettingsServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public SecuritySettingsServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = SecuritySettingsServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref SecuritySettingsServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<SecuritySettingsServiceClient> task);
@@ -227,7 +233,19 @@ namespace Google.Cloud.Dialogflow.Cx.V3
             "https://www.googleapis.com/auth/dialogflow",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="SecuritySettingsServiceClient"/> using the default credentials, endpoint

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/SessionEntityTypesClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/SessionEntityTypesClient.g.cs
@@ -149,6 +149,12 @@ namespace Google.Cloud.Dialogflow.Cx.V3
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public SessionEntityTypesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public SessionEntityTypesClientBuilder()
+        {
+            UseJwtAccessWithScopes = SessionEntityTypesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref SessionEntityTypesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<SessionEntityTypesClient> task);
@@ -224,7 +230,19 @@ namespace Google.Cloud.Dialogflow.Cx.V3
             "https://www.googleapis.com/auth/dialogflow",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="SessionEntityTypesClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/SessionsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/SessionsClient.g.cs
@@ -130,6 +130,12 @@ namespace Google.Cloud.Dialogflow.Cx.V3
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public SessionsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public SessionsClientBuilder()
+        {
+            UseJwtAccessWithScopes = SessionsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref SessionsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<SessionsClient> task);
@@ -207,7 +213,19 @@ namespace Google.Cloud.Dialogflow.Cx.V3
             "https://www.googleapis.com/auth/dialogflow",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="SessionsClient"/> using the default credentials, endpoint and settings. 

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/TestCasesClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/TestCasesClient.g.cs
@@ -332,6 +332,12 @@ namespace Google.Cloud.Dialogflow.Cx.V3
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public TestCasesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public TestCasesClientBuilder()
+        {
+            UseJwtAccessWithScopes = TestCasesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref TestCasesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<TestCasesClient> task);
@@ -408,7 +414,19 @@ namespace Google.Cloud.Dialogflow.Cx.V3
             "https://www.googleapis.com/auth/dialogflow",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="TestCasesClient"/> using the default credentials, endpoint and settings.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/TransitionRouteGroupsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/TransitionRouteGroupsClient.g.cs
@@ -151,6 +151,12 @@ namespace Google.Cloud.Dialogflow.Cx.V3
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public TransitionRouteGroupsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public TransitionRouteGroupsClientBuilder()
+        {
+            UseJwtAccessWithScopes = TransitionRouteGroupsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref TransitionRouteGroupsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<TransitionRouteGroupsClient> task);
@@ -226,7 +232,19 @@ namespace Google.Cloud.Dialogflow.Cx.V3
             "https://www.googleapis.com/auth/dialogflow",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="TransitionRouteGroupsClient"/> using the default credentials, endpoint

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/VersionsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/VersionsClient.g.cs
@@ -198,6 +198,12 @@ namespace Google.Cloud.Dialogflow.Cx.V3
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public VersionsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public VersionsClientBuilder()
+        {
+            UseJwtAccessWithScopes = VersionsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref VersionsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<VersionsClient> task);
@@ -273,7 +279,19 @@ namespace Google.Cloud.Dialogflow.Cx.V3
             "https://www.googleapis.com/auth/dialogflow",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="VersionsClient"/> using the default credentials, endpoint and settings. 

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/WebhooksClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/WebhooksClient.g.cs
@@ -143,6 +143,12 @@ namespace Google.Cloud.Dialogflow.Cx.V3
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public WebhooksSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public WebhooksClientBuilder()
+        {
+            UseJwtAccessWithScopes = WebhooksClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref WebhooksClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<WebhooksClient> task);
@@ -218,7 +224,19 @@ namespace Google.Cloud.Dialogflow.Cx.V3
             "https://www.googleapis.com/auth/dialogflow",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="WebhooksClient"/> using the default credentials, endpoint and settings. 

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/synth.metadata
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "626df528c5ae8839254f28b1f8daa1bac75be3a4"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/AgentsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/AgentsClient.g.cs
@@ -285,6 +285,12 @@ namespace Google.Cloud.Dialogflow.V2
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public AgentsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public AgentsClientBuilder()
+        {
+            UseJwtAccessWithScopes = AgentsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref AgentsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<AgentsClient> task);
@@ -360,7 +366,19 @@ namespace Google.Cloud.Dialogflow.V2
             "https://www.googleapis.com/auth/dialogflow",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="AgentsClient"/> using the default credentials, endpoint and settings. To

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/AnswerRecordsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/AnswerRecordsClient.g.cs
@@ -97,6 +97,12 @@ namespace Google.Cloud.Dialogflow.V2
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public AnswerRecordsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public AnswerRecordsClientBuilder()
+        {
+            UseJwtAccessWithScopes = AnswerRecordsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref AnswerRecordsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<AnswerRecordsClient> task);
@@ -172,7 +178,19 @@ namespace Google.Cloud.Dialogflow.V2
             "https://www.googleapis.com/auth/dialogflow",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="AnswerRecordsClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ContextsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ContextsClient.g.cs
@@ -159,6 +159,12 @@ namespace Google.Cloud.Dialogflow.V2
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ContextsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ContextsClientBuilder()
+        {
+            UseJwtAccessWithScopes = ContextsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ContextsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ContextsClient> task);
@@ -234,7 +240,19 @@ namespace Google.Cloud.Dialogflow.V2
             "https://www.googleapis.com/auth/dialogflow",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ContextsClient"/> using the default credentials, endpoint and settings. 

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ConversationProfilesClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ConversationProfilesClient.g.cs
@@ -150,6 +150,12 @@ namespace Google.Cloud.Dialogflow.V2
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ConversationProfilesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ConversationProfilesClientBuilder()
+        {
+            UseJwtAccessWithScopes = ConversationProfilesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ConversationProfilesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ConversationProfilesClient> task);
@@ -225,7 +231,19 @@ namespace Google.Cloud.Dialogflow.V2
             "https://www.googleapis.com/auth/dialogflow",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ConversationProfilesClient"/> using the default credentials, endpoint

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ConversationsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ConversationsClient.g.cs
@@ -144,6 +144,12 @@ namespace Google.Cloud.Dialogflow.V2
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ConversationsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ConversationsClientBuilder()
+        {
+            UseJwtAccessWithScopes = ConversationsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ConversationsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ConversationsClient> task);
@@ -219,7 +225,19 @@ namespace Google.Cloud.Dialogflow.V2
             "https://www.googleapis.com/auth/dialogflow",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ConversationsClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/DocumentsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/DocumentsClient.g.cs
@@ -236,6 +236,12 @@ namespace Google.Cloud.Dialogflow.V2
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public DocumentsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public DocumentsClientBuilder()
+        {
+            UseJwtAccessWithScopes = DocumentsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref DocumentsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<DocumentsClient> task);
@@ -311,7 +317,19 @@ namespace Google.Cloud.Dialogflow.V2
             "https://www.googleapis.com/auth/dialogflow",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="DocumentsClient"/> using the default credentials, endpoint and settings.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/EntityTypesClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/EntityTypesClient.g.cs
@@ -319,6 +319,12 @@ namespace Google.Cloud.Dialogflow.V2
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public EntityTypesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public EntityTypesClientBuilder()
+        {
+            UseJwtAccessWithScopes = EntityTypesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref EntityTypesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<EntityTypesClient> task);
@@ -394,7 +400,19 @@ namespace Google.Cloud.Dialogflow.V2
             "https://www.googleapis.com/auth/dialogflow",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="EntityTypesClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/EnvironmentsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/EnvironmentsClient.g.cs
@@ -159,6 +159,12 @@ namespace Google.Cloud.Dialogflow.V2
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public EnvironmentsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public EnvironmentsClientBuilder()
+        {
+            UseJwtAccessWithScopes = EnvironmentsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref EnvironmentsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<EnvironmentsClient> task);
@@ -234,7 +240,19 @@ namespace Google.Cloud.Dialogflow.V2
             "https://www.googleapis.com/auth/dialogflow",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="EnvironmentsClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/FulfillmentsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/FulfillmentsClient.g.cs
@@ -94,6 +94,12 @@ namespace Google.Cloud.Dialogflow.V2
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public FulfillmentsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public FulfillmentsClientBuilder()
+        {
+            UseJwtAccessWithScopes = FulfillmentsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref FulfillmentsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<FulfillmentsClient> task);
@@ -169,7 +175,19 @@ namespace Google.Cloud.Dialogflow.V2
             "https://www.googleapis.com/auth/dialogflow",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="FulfillmentsClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.csproj
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/IntentsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/IntentsClient.g.cs
@@ -214,6 +214,12 @@ namespace Google.Cloud.Dialogflow.V2
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public IntentsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public IntentsClientBuilder()
+        {
+            UseJwtAccessWithScopes = IntentsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref IntentsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<IntentsClient> task);
@@ -289,7 +295,19 @@ namespace Google.Cloud.Dialogflow.V2
             "https://www.googleapis.com/auth/dialogflow",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="IntentsClient"/> using the default credentials, endpoint and settings. 

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/KnowledgeBasesClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/KnowledgeBasesClient.g.cs
@@ -145,6 +145,12 @@ namespace Google.Cloud.Dialogflow.V2
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public KnowledgeBasesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public KnowledgeBasesClientBuilder()
+        {
+            UseJwtAccessWithScopes = KnowledgeBasesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref KnowledgeBasesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<KnowledgeBasesClient> task);
@@ -220,7 +226,19 @@ namespace Google.Cloud.Dialogflow.V2
             "https://www.googleapis.com/auth/dialogflow",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="KnowledgeBasesClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ParticipantsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ParticipantsClient.g.cs
@@ -175,6 +175,12 @@ namespace Google.Cloud.Dialogflow.V2
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ParticipantsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ParticipantsClientBuilder()
+        {
+            UseJwtAccessWithScopes = ParticipantsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ParticipantsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ParticipantsClient> task);
@@ -250,7 +256,19 @@ namespace Google.Cloud.Dialogflow.V2
             "https://www.googleapis.com/auth/dialogflow",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ParticipantsClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/SessionEntityTypesClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/SessionEntityTypesClient.g.cs
@@ -149,6 +149,12 @@ namespace Google.Cloud.Dialogflow.V2
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public SessionEntityTypesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public SessionEntityTypesClientBuilder()
+        {
+            UseJwtAccessWithScopes = SessionEntityTypesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref SessionEntityTypesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<SessionEntityTypesClient> task);
@@ -224,7 +230,19 @@ namespace Google.Cloud.Dialogflow.V2
             "https://www.googleapis.com/auth/dialogflow",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="SessionEntityTypesClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/SessionsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/SessionsClient.g.cs
@@ -98,6 +98,12 @@ namespace Google.Cloud.Dialogflow.V2
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public SessionsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public SessionsClientBuilder()
+        {
+            UseJwtAccessWithScopes = SessionsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref SessionsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<SessionsClient> task);
@@ -176,7 +182,19 @@ namespace Google.Cloud.Dialogflow.V2
             "https://www.googleapis.com/auth/dialogflow",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="SessionsClient"/> using the default credentials, endpoint and settings. 

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/VersionsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/VersionsClient.g.cs
@@ -143,6 +143,12 @@ namespace Google.Cloud.Dialogflow.V2
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public VersionsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public VersionsClientBuilder()
+        {
+            UseJwtAccessWithScopes = VersionsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref VersionsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<VersionsClient> task);
@@ -218,7 +224,19 @@ namespace Google.Cloud.Dialogflow.V2
             "https://www.googleapis.com/auth/dialogflow",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="VersionsClient"/> using the default credentials, endpoint and settings. 

--- a/apis/Google.Cloud.Dialogflow.V2/synth.metadata
+++ b/apis/Google.Cloud.Dialogflow.V2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "4c984f3be8e1bd85eb8fe78a2911a83b9785a7ea"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/DlpServiceClient.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/DlpServiceClient.g.cs
@@ -566,6 +566,12 @@ namespace Google.Cloud.Dlp.V2
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public DlpServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public DlpServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = DlpServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref DlpServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<DlpServiceClient> task);
@@ -646,7 +652,19 @@ namespace Google.Cloud.Dlp.V2
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="DlpServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.csproj
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Dlp.V2/synth.metadata
+++ b/apis/Google.Cloud.Dlp.V2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/DocumentProcessorServiceClient.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/DocumentProcessorServiceClient.g.cs
@@ -154,6 +154,12 @@ namespace Google.Cloud.DocumentAI.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public DocumentProcessorServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public DocumentProcessorServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = DocumentProcessorServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref DocumentProcessorServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<DocumentProcessorServiceClient> task);
@@ -230,7 +236,19 @@ namespace Google.Cloud.DocumentAI.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="DocumentProcessorServiceClient"/> using the default credentials,

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.csproj
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.38.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.DocumentAI.V1/synth.metadata
+++ b/apis/Google.Cloud.DocumentAI.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "87fc4d48c705e307a2427fcaf8f4f799ac3b8ca8"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/DocumentProcessorServiceClient.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/DocumentProcessorServiceClient.g.cs
@@ -298,6 +298,12 @@ namespace Google.Cloud.DocumentAI.V1Beta3
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public DocumentProcessorServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public DocumentProcessorServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = DocumentProcessorServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref DocumentProcessorServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<DocumentProcessorServiceClient> task);
@@ -374,7 +380,19 @@ namespace Google.Cloud.DocumentAI.V1Beta3
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="DocumentProcessorServiceClient"/> using the default credentials,

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.csproj
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/synth.metadata
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "30c4de82221d513b3b125b679fea55067f1a5324"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1/DomainsClient.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1/DomainsClient.g.cs
@@ -368,6 +368,12 @@ namespace Google.Cloud.Domains.V1Beta1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public DomainsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public DomainsClientBuilder()
+        {
+            UseJwtAccessWithScopes = DomainsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref DomainsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<DomainsClient> task);
@@ -440,7 +446,19 @@ namespace Google.Cloud.Domains.V1Beta1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="DomainsClient"/> using the default credentials, endpoint and settings. 

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.csproj
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.Domains.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.Domains.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ErrorGroupServiceClient.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ErrorGroupServiceClient.g.cs
@@ -94,6 +94,12 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ErrorGroupServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ErrorGroupServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = ErrorGroupServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ErrorGroupServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ErrorGroupServiceClient> task);
@@ -167,7 +173,19 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ErrorGroupServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ErrorStatsServiceClient.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ErrorStatsServiceClient.g.cs
@@ -112,6 +112,12 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ErrorStatsServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ErrorStatsServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = ErrorStatsServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ErrorStatsServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ErrorStatsServiceClient> task);
@@ -186,7 +192,19 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ErrorStatsServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.csproj
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ReportErrorsServiceClient.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ReportErrorsServiceClient.g.cs
@@ -77,6 +77,12 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ReportErrorsServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ReportErrorsServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = ReportErrorsServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ReportErrorsServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ReportErrorsServiceClient> task);
@@ -150,7 +156,19 @@ namespace Google.Cloud.ErrorReporting.V1Beta1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ReportErrorsServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1/EssentialContactsServiceClient.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1/EssentialContactsServiceClient.g.cs
@@ -170,6 +170,12 @@ namespace Google.Cloud.EssentialContacts.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public EssentialContactsServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public EssentialContactsServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = EssentialContactsServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref EssentialContactsServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<EssentialContactsServiceClient> task);
@@ -243,7 +249,19 @@ namespace Google.Cloud.EssentialContacts.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="EssentialContactsServiceClient"/> using the default credentials,

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.csproj
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.EssentialContacts.V1/synth.metadata
+++ b/apis/Google.Cloud.EssentialContacts.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "5efeb79eed444f14cf2cf89516dbf9ece86a4a0c"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1/EventarcClient.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1/EventarcClient.g.cs
@@ -187,6 +187,12 @@ namespace Google.Cloud.Eventarc.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public EventarcSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public EventarcClientBuilder()
+        {
+            UseJwtAccessWithScopes = EventarcClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref EventarcClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<EventarcClient> task);
@@ -261,7 +267,19 @@ namespace Google.Cloud.Eventarc.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="EventarcClient"/> using the default credentials, endpoint and settings. 

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.csproj
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.38.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Eventarc.V1/synth.metadata
+++ b/apis/Google.Cloud.Eventarc.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "30c4de82221d513b3b125b679fea55067f1a5324"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1/CloudFilestoreManagerClient.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1/CloudFilestoreManagerClient.g.cs
@@ -361,6 +361,12 @@ namespace Google.Cloud.Filestore.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public CloudFilestoreManagerSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public CloudFilestoreManagerClientBuilder()
+        {
+            UseJwtAccessWithScopes = CloudFilestoreManagerClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref CloudFilestoreManagerClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<CloudFilestoreManagerClient> task);
@@ -452,7 +458,19 @@ namespace Google.Cloud.Filestore.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="CloudFilestoreManagerClient"/> using the default credentials, endpoint

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.csproj
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Common" Version="[1.0.0, 2.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.38.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Filestore.V1/synth.metadata
+++ b/apis/Google.Cloud.Filestore.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "b4967c737377d073125a2758c81357ceb100778f"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/FirestoreAdminClient.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/FirestoreAdminClient.g.cs
@@ -273,6 +273,12 @@ namespace Google.Cloud.Firestore.Admin.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public FirestoreAdminSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public FirestoreAdminClientBuilder()
+        {
+            UseJwtAccessWithScopes = FirestoreAdminClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref FirestoreAdminClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<FirestoreAdminClient> task);
@@ -349,7 +355,19 @@ namespace Google.Cloud.Firestore.Admin.V1
             "https://www.googleapis.com/auth/datastore",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="FirestoreAdminClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.csproj
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Firestore.Admin.V1/synth.metadata
+++ b/apis/Google.Cloud.Firestore.Admin.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/FirestoreClient.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/FirestoreClient.g.cs
@@ -293,6 +293,12 @@ namespace Google.Cloud.Firestore.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public FirestoreSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public FirestoreClientBuilder()
+        {
+            UseJwtAccessWithScopes = FirestoreClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref FirestoreClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<FirestoreClient> task);
@@ -375,7 +381,19 @@ namespace Google.Cloud.Firestore.V1
             "https://www.googleapis.com/auth/datastore",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="FirestoreClient"/> using the default credentials, endpoint and settings.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/FirestoreClientPartial.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/FirestoreClientPartial.cs
@@ -145,14 +145,7 @@ namespace Google.Cloud.Firestore.V1
 
     // Support for FirestoreDbBuilder.
     public sealed partial class FirestoreClientBuilder : ClientBuilderBase<FirestoreClient>
-    {
-        /// <summary>
-        /// Creates a new instance with no settings.
-        /// </summary>
-        public FirestoreClientBuilder()
-        {
-        }
-        
+    {       
         /// <summary>
         /// Creates a <see cref="FirestoreClientBuilder"/> by copying common settings from another builder.
         /// This method is intended for use in Google.Cloud.Firestore with FirestoreDbBuilder. It will

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.csproj
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Firestore.V1/synth.metadata
+++ b/apis/Google.Cloud.Firestore.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "299383230f69e9f2272adda8e0d93c4fdf231deb"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/Google.Cloud.Firestore.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/Google.Cloud.Firestore.IntegrationTests.csproj
@@ -7,11 +7,11 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.5.0, 4.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Firestore\Google.Cloud.Firestore.csproj" />
-    <PackageReference Include="Grpc.Core.Testing" Version="[2.36.4, 3.0.0)" />
+    <PackageReference Include="Grpc.Core.Testing" Version="[2.38.1, 3.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <PackageReference Include="Moq" Version="4.16.1" />

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/Google.Cloud.Firestore.Snippets.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/Google.Cloud.Firestore.Snippets.csproj
@@ -7,11 +7,11 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.5.0, 4.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Firestore\Google.Cloud.Firestore.csproj" />
-    <PackageReference Include="Grpc.Core.Testing" Version="[2.36.4, 3.0.0)" />
+    <PackageReference Include="Grpc.Core.Testing" Version="[2.38.1, 3.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <PackageReference Include="Moq" Version="4.16.1" />

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Google.Cloud.Firestore.Tests.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Google.Cloud.Firestore.Tests.csproj
@@ -7,11 +7,11 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.5.0, 4.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Firestore\Google.Cloud.Firestore.csproj" />
-    <PackageReference Include="Grpc.Core.Testing" Version="[2.36.4, 3.0.0)" />
+    <PackageReference Include="Grpc.Core.Testing" Version="[2.38.1, 3.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <PackageReference Include="Moq" Version="4.16.1" />

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Google.Cloud.Firestore.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Google.Cloud.Firestore.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <ProjectReference Include="..\..\Google.Cloud.Firestore.V1\Google.Cloud.Firestore.V1\Google.Cloud.Firestore.V1.csproj" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1/CloudFunctionsServiceClient.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1/CloudFunctionsServiceClient.g.cs
@@ -287,6 +287,12 @@ namespace Google.Cloud.Functions.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public CloudFunctionsServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public CloudFunctionsServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = CloudFunctionsServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref CloudFunctionsServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<CloudFunctionsServiceClient> task);
@@ -360,7 +366,19 @@ namespace Google.Cloud.Functions.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="CloudFunctionsServiceClient"/> using the default credentials, endpoint

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.csproj
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Functions.V1/synth.metadata
+++ b/apis/Google.Cloud.Functions.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "909c3adecc663893b2eaecd3c2f9b2528a2c6bea"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1/GSuiteAddOnsClient.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1/GSuiteAddOnsClient.g.cs
@@ -199,6 +199,12 @@ namespace Google.Cloud.GSuiteAddOns.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public GSuiteAddOnsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public GSuiteAddOnsClientBuilder()
+        {
+            UseJwtAccessWithScopes = GSuiteAddOnsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref GSuiteAddOnsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<GSuiteAddOnsClient> task);
@@ -299,7 +305,19 @@ namespace Google.Cloud.GSuiteAddOns.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="GSuiteAddOnsClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.csproj
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <ProjectReference Include="..\..\Google.Apps.Script.Type\Google.Apps.Script.Type\Google.Apps.Script.Type.csproj" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.GSuiteAddOns.V1/synth.metadata
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Gaming.V1/Google.Cloud.Gaming.V1/GameServerClustersServiceClient.g.cs
+++ b/apis/Google.Cloud.Gaming.V1/Google.Cloud.Gaming.V1/GameServerClustersServiceClient.g.cs
@@ -251,6 +251,12 @@ namespace Google.Cloud.Gaming.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public GameServerClustersServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public GameServerClustersServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = GameServerClustersServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref GameServerClustersServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<GameServerClustersServiceClient> task);
@@ -325,7 +331,19 @@ namespace Google.Cloud.Gaming.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="GameServerClustersServiceClient"/> using the default credentials,

--- a/apis/Google.Cloud.Gaming.V1/Google.Cloud.Gaming.V1/GameServerConfigsServiceClient.g.cs
+++ b/apis/Google.Cloud.Gaming.V1/Google.Cloud.Gaming.V1/GameServerConfigsServiceClient.g.cs
@@ -167,6 +167,12 @@ namespace Google.Cloud.Gaming.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public GameServerConfigsServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public GameServerConfigsServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = GameServerConfigsServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref GameServerConfigsServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<GameServerConfigsServiceClient> task);
@@ -240,7 +246,19 @@ namespace Google.Cloud.Gaming.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="GameServerConfigsServiceClient"/> using the default credentials,

--- a/apis/Google.Cloud.Gaming.V1/Google.Cloud.Gaming.V1/GameServerDeploymentsServiceClient.g.cs
+++ b/apis/Google.Cloud.Gaming.V1/Google.Cloud.Gaming.V1/GameServerDeploymentsServiceClient.g.cs
@@ -289,6 +289,12 @@ namespace Google.Cloud.Gaming.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public GameServerDeploymentsServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public GameServerDeploymentsServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = GameServerDeploymentsServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref GameServerDeploymentsServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<GameServerDeploymentsServiceClient> task);
@@ -363,7 +369,19 @@ namespace Google.Cloud.Gaming.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="GameServerDeploymentsServiceClient"/> using the default credentials,

--- a/apis/Google.Cloud.Gaming.V1/Google.Cloud.Gaming.V1/Google.Cloud.Gaming.V1.csproj
+++ b/apis/Google.Cloud.Gaming.V1/Google.Cloud.Gaming.V1/Google.Cloud.Gaming.V1.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Gaming.V1/Google.Cloud.Gaming.V1/RealmsServiceClient.g.cs
+++ b/apis/Google.Cloud.Gaming.V1/Google.Cloud.Gaming.V1/RealmsServiceClient.g.cs
@@ -210,6 +210,12 @@ namespace Google.Cloud.Gaming.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public RealmsServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public RealmsServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = RealmsServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref RealmsServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<RealmsServiceClient> task);
@@ -284,7 +290,19 @@ namespace Google.Cloud.Gaming.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="RealmsServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Gaming.V1/synth.metadata
+++ b/apis/Google.Cloud.Gaming.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/GameServerClustersServiceClient.g.cs
+++ b/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/GameServerClustersServiceClient.g.cs
@@ -251,6 +251,12 @@ namespace Google.Cloud.Gaming.V1Beta
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public GameServerClustersServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public GameServerClustersServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = GameServerClustersServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref GameServerClustersServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<GameServerClustersServiceClient> task);
@@ -325,7 +331,19 @@ namespace Google.Cloud.Gaming.V1Beta
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="GameServerClustersServiceClient"/> using the default credentials,

--- a/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/GameServerConfigsServiceClient.g.cs
+++ b/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/GameServerConfigsServiceClient.g.cs
@@ -167,6 +167,12 @@ namespace Google.Cloud.Gaming.V1Beta
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public GameServerConfigsServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public GameServerConfigsServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = GameServerConfigsServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref GameServerConfigsServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<GameServerConfigsServiceClient> task);
@@ -240,7 +246,19 @@ namespace Google.Cloud.Gaming.V1Beta
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="GameServerConfigsServiceClient"/> using the default credentials,

--- a/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/GameServerDeploymentsServiceClient.g.cs
+++ b/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/GameServerDeploymentsServiceClient.g.cs
@@ -289,6 +289,12 @@ namespace Google.Cloud.Gaming.V1Beta
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public GameServerDeploymentsServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public GameServerDeploymentsServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = GameServerDeploymentsServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref GameServerDeploymentsServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<GameServerDeploymentsServiceClient> task);
@@ -363,7 +369,19 @@ namespace Google.Cloud.Gaming.V1Beta
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="GameServerDeploymentsServiceClient"/> using the default credentials,

--- a/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta.csproj
+++ b/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/RealmsServiceClient.g.cs
+++ b/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/RealmsServiceClient.g.cs
@@ -210,6 +210,12 @@ namespace Google.Cloud.Gaming.V1Beta
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public RealmsServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public RealmsServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = RealmsServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref RealmsServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<RealmsServiceClient> task);
@@ -284,7 +290,19 @@ namespace Google.Cloud.Gaming.V1Beta
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="RealmsServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Gaming.V1Beta/synth.metadata
+++ b/apis/Google.Cloud.Gaming.V1Beta/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "001f72d55eba0da1f651dc252084eb7522fbe19d"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.GkeConnect.Gateway.V1Beta1/Google.Cloud.GkeConnect.Gateway.V1Beta1/GatewayServiceClient.g.cs
+++ b/apis/Google.Cloud.GkeConnect.Gateway.V1Beta1/Google.Cloud.GkeConnect.Gateway.V1Beta1/GatewayServiceClient.g.cs
@@ -128,6 +128,12 @@ namespace Google.Cloud.GkeConnect.Gateway.V1Beta1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public GatewayServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public GatewayServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = GatewayServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref GatewayServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<GatewayServiceClient> task);
@@ -205,7 +211,19 @@ namespace Google.Cloud.GkeConnect.Gateway.V1Beta1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="GatewayServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.GkeConnect.Gateway.V1Beta1/Google.Cloud.GkeConnect.Gateway.V1Beta1/Google.Cloud.GkeConnect.Gateway.V1Beta1.csproj
+++ b/apis/Google.Cloud.GkeConnect.Gateway.V1Beta1/Google.Cloud.GkeConnect.Gateway.V1Beta1/Google.Cloud.GkeConnect.Gateway.V1Beta1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.GkeConnect.Gateway.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.GkeConnect.Gateway.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "0bcee5c673ecd59ffae84e8104aaa68c68e7e43a"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1/GkeHubClient.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1/GkeHubClient.g.cs
@@ -355,6 +355,12 @@ namespace Google.Cloud.GkeHub.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public GkeHubSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public GkeHubClientBuilder()
+        {
+            UseJwtAccessWithScopes = GkeHubClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref GkeHubClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<GkeHubClient> task);
@@ -440,7 +446,19 @@ namespace Google.Cloud.GkeHub.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="GkeHubClient"/> using the default credentials, endpoint and settings. To

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.csproj
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.GkeHub.V1/synth.metadata
+++ b/apis/Google.Cloud.GkeHub.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "e8d2996cc44d20d430413f60e88c45fdccc20e4c"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1/GkeHubMembershipServiceClient.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1/GkeHubMembershipServiceClient.g.cs
@@ -260,6 +260,12 @@ namespace Google.Cloud.GkeHub.V1Beta1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public GkeHubMembershipServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public GkeHubMembershipServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = GkeHubMembershipServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref GkeHubMembershipServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<GkeHubMembershipServiceClient> task);
@@ -334,7 +340,19 @@ namespace Google.Cloud.GkeHub.V1Beta1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="GkeHubMembershipServiceClient"/> using the default credentials, endpoint

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.csproj
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.GkeHub.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.csproj
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.38.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1/IAMClient.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1/IAMClient.g.cs
@@ -464,6 +464,12 @@ namespace Google.Cloud.Iam.Admin.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public IAMSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public IAMClientBuilder()
+        {
+            UseJwtAccessWithScopes = IAMClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref IAMClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<IAMClient> task);
@@ -554,7 +560,19 @@ namespace Google.Cloud.Iam.Admin.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="IAMClient"/> using the default credentials, endpoint and settings. To

--- a/apis/Google.Cloud.Iam.Admin.V1/synth.metadata
+++ b/apis/Google.Cloud.Iam.Admin.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "46f4f7054fc945d7af9474fe5d70e623c46d0dd5"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.csproj
+++ b/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1/IAMCredentialsClient.g.cs
+++ b/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1/IAMCredentialsClient.g.cs
@@ -128,6 +128,12 @@ namespace Google.Cloud.Iam.Credentials.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public IAMCredentialsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public IAMCredentialsClientBuilder()
+        {
+            UseJwtAccessWithScopes = IAMCredentialsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref IAMCredentialsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<IAMCredentialsClient> task);
@@ -209,7 +215,19 @@ namespace Google.Cloud.Iam.Credentials.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="IAMCredentialsClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Iam.Credentials.V1/synth.metadata
+++ b/apis/Google.Cloud.Iam.Credentials.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.csproj
+++ b/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Iam.V1/synth.metadata
+++ b/apis/Google.Cloud.Iam.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.csproj
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.38.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1/IdentityAwareProxyAdminServiceClient.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1/IdentityAwareProxyAdminServiceClient.g.cs
@@ -135,6 +135,12 @@ namespace Google.Cloud.Iap.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public IdentityAwareProxyAdminServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public IdentityAwareProxyAdminServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = IdentityAwareProxyAdminServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref IdentityAwareProxyAdminServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<IdentityAwareProxyAdminServiceClient> task);
@@ -209,7 +215,19 @@ namespace Google.Cloud.Iap.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="IdentityAwareProxyAdminServiceClient"/> using the default credentials,

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1/IdentityAwareProxyOAuthServiceClient.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1/IdentityAwareProxyOAuthServiceClient.g.cs
@@ -178,6 +178,12 @@ namespace Google.Cloud.Iap.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public IdentityAwareProxyOAuthServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public IdentityAwareProxyOAuthServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = IdentityAwareProxyOAuthServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref IdentityAwareProxyOAuthServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<IdentityAwareProxyOAuthServiceClient> task);
@@ -254,7 +260,19 @@ namespace Google.Cloud.Iap.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="IdentityAwareProxyOAuthServiceClient"/> using the default credentials,

--- a/apis/Google.Cloud.Iap.V1/synth.metadata
+++ b/apis/Google.Cloud.Iap.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "b6b4b89cae9b4734b7810c65a4fa69b5e9083cdc"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Iot.V1/Google.Cloud.Iot.V1/DeviceManagerClient.g.cs
+++ b/apis/Google.Cloud.Iot.V1/Google.Cloud.Iot.V1/DeviceManagerClient.g.cs
@@ -346,6 +346,12 @@ namespace Google.Cloud.Iot.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public DeviceManagerSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public DeviceManagerClientBuilder()
+        {
+            UseJwtAccessWithScopes = DeviceManagerClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref DeviceManagerClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<DeviceManagerClient> task);
@@ -421,7 +427,19 @@ namespace Google.Cloud.Iot.V1
             "https://www.googleapis.com/auth/cloudiot",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="DeviceManagerClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Iot.V1/Google.Cloud.Iot.V1/Google.Cloud.Iot.V1.csproj
+++ b/apis/Google.Cloud.Iot.V1/Google.Cloud.Iot.V1/Google.Cloud.Iot.V1.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Iot.V1/synth.metadata
+++ b/apis/Google.Cloud.Iot.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.csproj
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/KeyManagementServiceClient.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/KeyManagementServiceClient.g.cs
@@ -479,6 +479,12 @@ namespace Google.Cloud.Kms.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public KeyManagementServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public KeyManagementServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = KeyManagementServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref KeyManagementServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<KeyManagementServiceClient> task);
@@ -565,7 +571,19 @@ namespace Google.Cloud.Kms.V1
             "https://www.googleapis.com/auth/cloudkms",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="KeyManagementServiceClient"/> using the default credentials, endpoint

--- a/apis/Google.Cloud.Kms.V1/synth.metadata
+++ b/apis/Google.Cloud.Kms.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "2efb6951f151116fb7b5766fb4e377db465d49e9"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/Google.Cloud.Language.V1.csproj
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/Google.Cloud.Language.V1.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/LanguageServiceClient.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/LanguageServiceClient.g.cs
@@ -159,6 +159,12 @@ namespace Google.Cloud.Language.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public LanguageServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public LanguageServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = LanguageServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref LanguageServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<LanguageServiceClient> task);
@@ -235,7 +241,19 @@ namespace Google.Cloud.Language.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="LanguageServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Language.V1/synth.metadata
+++ b/apis/Google.Cloud.Language.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.LifeSciences.V2Beta/Google.Cloud.LifeSciences.V2Beta/Google.Cloud.LifeSciences.V2Beta.csproj
+++ b/apis/Google.Cloud.LifeSciences.V2Beta/Google.Cloud.LifeSciences.V2Beta/Google.Cloud.LifeSciences.V2Beta.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.LifeSciences.V2Beta/Google.Cloud.LifeSciences.V2Beta/WorkflowsServiceV2BetaClient.g.cs
+++ b/apis/Google.Cloud.LifeSciences.V2Beta/Google.Cloud.LifeSciences.V2Beta/WorkflowsServiceV2BetaClient.g.cs
@@ -97,6 +97,12 @@ namespace Google.Cloud.LifeSciences.V2Beta
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public WorkflowsServiceV2BetaSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public WorkflowsServiceV2BetaClientBuilder()
+        {
+            UseJwtAccessWithScopes = WorkflowsServiceV2BetaClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref WorkflowsServiceV2BetaClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<WorkflowsServiceV2BetaClient> task);
@@ -171,7 +177,19 @@ namespace Google.Cloud.LifeSciences.V2Beta
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="WorkflowsServiceV2BetaClient"/> using the default credentials, endpoint

--- a/apis/Google.Cloud.LifeSciences.V2Beta/synth.metadata
+++ b/apis/Google.Cloud.LifeSciences.V2Beta/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "0778b6c49e4a568d7e7c36241efb4bd06f893ea8"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.IntegrationTests/Google.Cloud.Logging.Log4Net.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.IntegrationTests/Google.Cloud.Logging.Log4Net.IntegrationTests.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.5.0, 4.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Logging.Log4Net\Google.Cloud.Logging.Log4Net.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />

--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Snippets/Google.Cloud.Logging.Log4Net.Snippets.csproj
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Snippets/Google.Cloud.Logging.Log4Net.Snippets.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.5.0, 4.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Logging.Log4Net\Google.Cloud.Logging.Log4Net.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />

--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Tests/Google.Cloud.Logging.Log4Net.Tests.csproj
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Tests/Google.Cloud.Logging.Log4Net.Tests.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.5.0, 4.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Logging.Log4Net\Google.Cloud.Logging.Log4Net.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />

--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.csproj
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.DevTools.Common" Version="[2.1.0, 3.0.0)" />
     <PackageReference Include="Google.Cloud.Logging.V2" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <PackageReference Include="log4net" Version="2.0.12" />

--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.IntegrationTests/Google.Cloud.Logging.NLog.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.IntegrationTests/Google.Cloud.Logging.NLog.IntegrationTests.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.5.0, 4.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Logging.NLog\Google.Cloud.Logging.NLog.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />

--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.Snippets/Google.Cloud.Logging.NLog.Snippets.csproj
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.Snippets/Google.Cloud.Logging.NLog.Snippets.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.5.0, 4.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Logging.NLog\Google.Cloud.Logging.NLog.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />

--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.Tests/Google.Cloud.Logging.NLog.Tests.csproj
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.Tests/Google.Cloud.Logging.NLog.Tests.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.5.0, 4.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Logging.NLog\Google.Cloud.Logging.NLog.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />

--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.csproj
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.DevTools.Common" Version="[2.0.0, 3.0.0)" />
-    <PackageReference Include="Google.Cloud.Logging.V2" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.DevTools.Common" Version="[2.1.0, 3.0.0)" />
+    <PackageReference Include="Google.Cloud.Logging.V2" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <PackageReference Include="NLog" Version="4.5.11" />

--- a/apis/Google.Cloud.Logging.Type/synth.metadata
+++ b/apis/Google.Cloud.Logging.Type/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/ConfigServiceV2Client.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/ConfigServiceV2Client.g.cs
@@ -385,6 +385,12 @@ namespace Google.Cloud.Logging.V2
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ConfigServiceV2Settings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ConfigServiceV2ClientBuilder()
+        {
+            UseJwtAccessWithScopes = ConfigServiceV2Client.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ConfigServiceV2Client client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ConfigServiceV2Client> task);
@@ -464,7 +470,19 @@ namespace Google.Cloud.Logging.V2
             "https://www.googleapis.com/auth/logging.read",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ConfigServiceV2Client"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.csproj
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Logging.Type" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Logging.Type" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/LoggingServiceV2Client.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/LoggingServiceV2Client.g.cs
@@ -163,6 +163,12 @@ namespace Google.Cloud.Logging.V2
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public LoggingServiceV2Settings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public LoggingServiceV2ClientBuilder()
+        {
+            UseJwtAccessWithScopes = LoggingServiceV2Client.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref LoggingServiceV2Client client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<LoggingServiceV2Client> task);
@@ -244,7 +250,19 @@ namespace Google.Cloud.Logging.V2
             "https://www.googleapis.com/auth/logging.write",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="LoggingServiceV2Client"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/MetricsServiceV2Client.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/MetricsServiceV2Client.g.cs
@@ -142,6 +142,12 @@ namespace Google.Cloud.Logging.V2
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public MetricsServiceV2Settings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public MetricsServiceV2ClientBuilder()
+        {
+            UseJwtAccessWithScopes = MetricsServiceV2Client.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref MetricsServiceV2Client client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<MetricsServiceV2Client> task);
@@ -223,7 +229,19 @@ namespace Google.Cloud.Logging.V2
             "https://www.googleapis.com/auth/logging.write",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="MetricsServiceV2Client"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Logging.V2/synth.metadata
+++ b/apis/Google.Cloud.Logging.V2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.csproj
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1/ManagedIdentitiesServiceClient.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1/ManagedIdentitiesServiceClient.g.cs
@@ -340,6 +340,12 @@ namespace Google.Cloud.ManagedIdentities.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ManagedIdentitiesServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ManagedIdentitiesServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = ManagedIdentitiesServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ManagedIdentitiesServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ManagedIdentitiesServiceClient> task);
@@ -444,7 +450,19 @@ namespace Google.Cloud.ManagedIdentities.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ManagedIdentitiesServiceClient"/> using the default credentials,

--- a/apis/Google.Cloud.ManagedIdentities.V1/synth.metadata
+++ b/apis/Google.Cloud.ManagedIdentities.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.MediaTranslation.V1Beta1/Google.Cloud.MediaTranslation.V1Beta1/Google.Cloud.MediaTranslation.V1Beta1.csproj
+++ b/apis/Google.Cloud.MediaTranslation.V1Beta1/Google.Cloud.MediaTranslation.V1Beta1/Google.Cloud.MediaTranslation.V1Beta1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.MediaTranslation.V1Beta1/Google.Cloud.MediaTranslation.V1Beta1/SpeechTranslationServiceClient.g.cs
+++ b/apis/Google.Cloud.MediaTranslation.V1Beta1/Google.Cloud.MediaTranslation.V1Beta1/SpeechTranslationServiceClient.g.cs
@@ -87,6 +87,12 @@ namespace Google.Cloud.MediaTranslation.V1Beta1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public SpeechTranslationServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public SpeechTranslationServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = SpeechTranslationServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref SpeechTranslationServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<SpeechTranslationServiceClient> task);
@@ -160,7 +166,19 @@ namespace Google.Cloud.MediaTranslation.V1Beta1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="SpeechTranslationServiceClient"/> using the default credentials,

--- a/apis/Google.Cloud.MediaTranslation.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.MediaTranslation.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "1d163315aecf9d8a3b77eb9e1549a0b353103b32"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1/CloudMemcacheClient.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1/CloudMemcacheClient.g.cs
@@ -253,6 +253,12 @@ namespace Google.Cloud.Memcache.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public CloudMemcacheSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public CloudMemcacheClientBuilder()
+        {
+            UseJwtAccessWithScopes = CloudMemcacheClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref CloudMemcacheClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<CloudMemcacheClient> task);
@@ -340,7 +346,19 @@ namespace Google.Cloud.Memcache.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="CloudMemcacheClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.csproj
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Memcache.V1/synth.metadata
+++ b/apis/Google.Cloud.Memcache.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2/CloudMemcacheClient.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2/CloudMemcacheClient.g.cs
@@ -285,6 +285,12 @@ namespace Google.Cloud.Memcache.V1Beta2
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public CloudMemcacheSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public CloudMemcacheClientBuilder()
+        {
+            UseJwtAccessWithScopes = CloudMemcacheClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref CloudMemcacheClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<CloudMemcacheClient> task);
@@ -372,7 +378,19 @@ namespace Google.Cloud.Memcache.V1Beta2
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="CloudMemcacheClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.csproj
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Memcache.V1Beta2/synth.metadata
+++ b/apis/Google.Cloud.Memcache.V1Beta2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1/DataprocMetastoreClient.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1/DataprocMetastoreClient.g.cs
@@ -453,6 +453,12 @@ namespace Google.Cloud.Metastore.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public DataprocMetastoreSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public DataprocMetastoreClientBuilder()
+        {
+            UseJwtAccessWithScopes = DataprocMetastoreClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref DataprocMetastoreClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<DataprocMetastoreClient> task);
@@ -542,7 +548,19 @@ namespace Google.Cloud.Metastore.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="DataprocMetastoreClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.csproj
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Metastore.V1/synth.metadata
+++ b/apis/Google.Cloud.Metastore.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "b6901e755abebb55b1907eb1c073ab95d5c5c749"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha/DataprocMetastoreClient.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha/DataprocMetastoreClient.g.cs
@@ -453,6 +453,12 @@ namespace Google.Cloud.Metastore.V1Alpha
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public DataprocMetastoreSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public DataprocMetastoreClientBuilder()
+        {
+            UseJwtAccessWithScopes = DataprocMetastoreClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref DataprocMetastoreClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<DataprocMetastoreClient> task);
@@ -542,7 +548,19 @@ namespace Google.Cloud.Metastore.V1Alpha
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="DataprocMetastoreClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.csproj
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.Metastore.V1Alpha/synth.metadata
+++ b/apis/Google.Cloud.Metastore.V1Alpha/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta/DataprocMetastoreClient.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta/DataprocMetastoreClient.g.cs
@@ -453,6 +453,12 @@ namespace Google.Cloud.Metastore.V1Beta
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public DataprocMetastoreSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public DataprocMetastoreClientBuilder()
+        {
+            UseJwtAccessWithScopes = DataprocMetastoreClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref DataprocMetastoreClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<DataprocMetastoreClient> task);
@@ -542,7 +548,19 @@ namespace Google.Cloud.Metastore.V1Beta
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="DataprocMetastoreClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.csproj
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.Metastore.V1Beta/synth.metadata
+++ b/apis/Google.Cloud.Metastore.V1Beta/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/AlertPolicyServiceClient.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/AlertPolicyServiceClient.g.cs
@@ -143,6 +143,12 @@ namespace Google.Cloud.Monitoring.V3
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public AlertPolicyServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public AlertPolicyServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = AlertPolicyServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref AlertPolicyServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<AlertPolicyServiceClient> task);
@@ -228,7 +234,19 @@ namespace Google.Cloud.Monitoring.V3
             "https://www.googleapis.com/auth/monitoring.read",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="AlertPolicyServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.csproj
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.csproj
@@ -11,8 +11,8 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.CommonProtos" Version="[2.3.0, 3.0.0)" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/GroupServiceClient.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/GroupServiceClient.g.cs
@@ -158,6 +158,12 @@ namespace Google.Cloud.Monitoring.V3
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public GroupServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public GroupServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = GroupServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref GroupServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<GroupServiceClient> task);
@@ -246,7 +252,19 @@ namespace Google.Cloud.Monitoring.V3
             "https://www.googleapis.com/auth/monitoring.read",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="GroupServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/MetricServiceClient.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/MetricServiceClient.g.cs
@@ -192,6 +192,12 @@ namespace Google.Cloud.Monitoring.V3
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public MetricServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public MetricServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = MetricServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref MetricServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<MetricServiceClient> task);
@@ -272,7 +278,19 @@ namespace Google.Cloud.Monitoring.V3
             "https://www.googleapis.com/auth/monitoring.write",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="MetricServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/NotificationChannelServiceClient.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/NotificationChannelServiceClient.g.cs
@@ -228,6 +228,12 @@ namespace Google.Cloud.Monitoring.V3
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public NotificationChannelServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public NotificationChannelServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = NotificationChannelServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref NotificationChannelServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<NotificationChannelServiceClient> task);
@@ -306,7 +312,19 @@ namespace Google.Cloud.Monitoring.V3
             "https://www.googleapis.com/auth/monitoring.read",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="NotificationChannelServiceClient"/> using the default credentials,

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/QueryServiceClient.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/QueryServiceClient.g.cs
@@ -75,6 +75,12 @@ namespace Google.Cloud.Monitoring.V3
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public QueryServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public QueryServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = QueryServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref QueryServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<QueryServiceClient> task);
@@ -154,7 +160,19 @@ namespace Google.Cloud.Monitoring.V3
             "https://www.googleapis.com/auth/monitoring.read",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="QueryServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/ServiceMonitoringServiceClient.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/ServiceMonitoringServiceClient.g.cs
@@ -224,6 +224,12 @@ namespace Google.Cloud.Monitoring.V3
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ServiceMonitoringServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ServiceMonitoringServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = ServiceMonitoringServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ServiceMonitoringServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ServiceMonitoringServiceClient> task);
@@ -304,7 +310,19 @@ namespace Google.Cloud.Monitoring.V3
             "https://www.googleapis.com/auth/monitoring.read",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ServiceMonitoringServiceClient"/> using the default credentials,

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/UptimeCheckServiceClient.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/UptimeCheckServiceClient.g.cs
@@ -161,6 +161,12 @@ namespace Google.Cloud.Monitoring.V3
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public UptimeCheckServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public UptimeCheckServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = UptimeCheckServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref UptimeCheckServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<UptimeCheckServiceClient> task);
@@ -245,7 +251,19 @@ namespace Google.Cloud.Monitoring.V3
             "https://www.googleapis.com/auth/monitoring.read",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="UptimeCheckServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Monitoring.V3/synth.metadata
+++ b/apis/Google.Cloud.Monitoring.V3/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.csproj
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/HubServiceClient.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/HubServiceClient.g.cs
@@ -385,6 +385,12 @@ namespace Google.Cloud.NetworkConnectivity.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public HubServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public HubServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = HubServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref HubServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<HubServiceClient> task);
@@ -460,7 +466,19 @@ namespace Google.Cloud.NetworkConnectivity.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="HubServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.NetworkConnectivity.V1/synth.metadata
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "411e51eea221af5b77f809cef2c6592df45f73d5"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.csproj
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1/HubServiceClient.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1/HubServiceClient.g.cs
@@ -321,6 +321,12 @@ namespace Google.Cloud.NetworkConnectivity.V1Alpha1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public HubServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public HubServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = HubServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref HubServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<HubServiceClient> task);
@@ -397,7 +403,19 @@ namespace Google.Cloud.NetworkConnectivity.V1Alpha1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="HubServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/synth.metadata
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.csproj
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/ReachabilityServiceClient.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/ReachabilityServiceClient.g.cs
@@ -225,6 +225,12 @@ namespace Google.Cloud.NetworkManagement.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ReachabilityServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ReachabilityServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = ReachabilityServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ReachabilityServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ReachabilityServiceClient> task);
@@ -305,7 +311,19 @@ namespace Google.Cloud.NetworkManagement.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ReachabilityServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.NetworkManagement.V1/synth.metadata
+++ b/apis/Google.Cloud.NetworkManagement.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "ac5d0130755d21daf6296f9f910200b334ee7b23"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.csproj
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1/NotebookServiceClient.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1/NotebookServiceClient.g.cs
@@ -582,6 +582,12 @@ namespace Google.Cloud.Notebooks.V1Beta1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public NotebookServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public NotebookServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = NotebookServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref NotebookServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<NotebookServiceClient> task);
@@ -655,7 +661,19 @@ namespace Google.Cloud.Notebooks.V1Beta1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="NotebookServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Notebooks.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1/EnvironmentsClient.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1/EnvironmentsClient.g.cs
@@ -186,6 +186,12 @@ namespace Google.Cloud.Orchestration.Airflow.Service.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public EnvironmentsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public EnvironmentsClientBuilder()
+        {
+            UseJwtAccessWithScopes = EnvironmentsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref EnvironmentsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<EnvironmentsClient> task);
@@ -259,7 +265,19 @@ namespace Google.Cloud.Orchestration.Airflow.Service.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="EnvironmentsClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.csproj
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1/ImageVersionsClient.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1/ImageVersionsClient.g.cs
@@ -76,6 +76,12 @@ namespace Google.Cloud.Orchestration.Airflow.Service.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ImageVersionsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ImageVersionsClientBuilder()
+        {
+            UseJwtAccessWithScopes = ImageVersionsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ImageVersionsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ImageVersionsClient> task);
@@ -149,7 +155,19 @@ namespace Google.Cloud.Orchestration.Airflow.Service.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ImageVersionsClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/synth.metadata
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "2e6b987a6f6e65c33ddefe0f2278dbbd38b46a91"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.OrgPolicy.V1/synth.metadata
+++ b/apis/Google.Cloud.OrgPolicy.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.csproj
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2/OrgPolicyClient.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2/OrgPolicyClient.g.cs
@@ -176,6 +176,12 @@ namespace Google.Cloud.OrgPolicy.V2
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public OrgPolicySettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public OrgPolicyClientBuilder()
+        {
+            UseJwtAccessWithScopes = OrgPolicyClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref OrgPolicyClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<OrgPolicyClient> task);
@@ -268,7 +274,19 @@ namespace Google.Cloud.OrgPolicy.V2
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="OrgPolicyClient"/> using the default credentials, endpoint and settings.

--- a/apis/Google.Cloud.OrgPolicy.V2/synth.metadata
+++ b/apis/Google.Cloud.OrgPolicy.V2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.csproj
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.csproj
@@ -11,8 +11,8 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.CommonProtos" Version="[2.3.0, 3.0.0)" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/OsConfigServiceClient.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/OsConfigServiceClient.g.cs
@@ -213,6 +213,12 @@ namespace Google.Cloud.OsConfig.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public OsConfigServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public OsConfigServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = OsConfigServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref OsConfigServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<OsConfigServiceClient> task);
@@ -289,7 +295,19 @@ namespace Google.Cloud.OsConfig.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="OsConfigServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.OsConfig.V1/synth.metadata
+++ b/apis/Google.Cloud.OsConfig.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.csproj
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha/OsConfigZonalServiceClient.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha/OsConfigZonalServiceClient.g.cs
@@ -326,6 +326,12 @@ namespace Google.Cloud.OsConfig.V1Alpha
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public OsConfigZonalServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public OsConfigZonalServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = OsConfigZonalServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref OsConfigZonalServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<OsConfigZonalServiceClient> task);
@@ -402,7 +408,19 @@ namespace Google.Cloud.OsConfig.V1Alpha
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="OsConfigZonalServiceClient"/> using the default credentials, endpoint

--- a/apis/Google.Cloud.OsConfig.V1Alpha/synth.metadata
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "82668866992e047531dfc57bd9301c77c6d8c950"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.OsLogin.Common/Google.Cloud.OsLogin.Common/Google.Cloud.OsLogin.Common.csproj
+++ b/apis/Google.Cloud.OsLogin.Common/Google.Cloud.OsLogin.Common/Google.Cloud.OsLogin.Common.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.CommonProtos" Version="[2.3.0, 3.0.0)" />
-    <PackageReference Include="Google.Api.Gax" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.OsLogin.Common/synth.metadata
+++ b/apis/Google.Cloud.OsLogin.Common/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.csproj
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.OsLogin.Common\Google.Cloud.OsLogin.Common\Google.Cloud.OsLogin.Common.csproj" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1/OsLoginServiceClient.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1/OsLoginServiceClient.g.cs
@@ -160,6 +160,12 @@ namespace Google.Cloud.OsLogin.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public OsLoginServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public OsLoginServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = OsLoginServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref OsLoginServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<OsLoginServiceClient> task);
@@ -238,7 +244,19 @@ namespace Google.Cloud.OsLogin.V1
             "https://www.googleapis.com/auth/compute",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="OsLoginServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.OsLogin.V1/synth.metadata
+++ b/apis/Google.Cloud.OsLogin.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.csproj
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.OsLogin.Common\Google.Cloud.OsLogin.Common\Google.Cloud.OsLogin.Common.csproj" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/OsLoginServiceClient.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/OsLoginServiceClient.g.cs
@@ -160,6 +160,12 @@ namespace Google.Cloud.OsLogin.V1Beta
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public OsLoginServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public OsLoginServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = OsLoginServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref OsLoginServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<OsLoginServiceClient> task);
@@ -242,7 +248,19 @@ namespace Google.Cloud.OsLogin.V1Beta
             "https://www.googleapis.com/auth/compute.readonly",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="OsLoginServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.OsLogin.V1Beta/synth.metadata
+++ b/apis/Google.Cloud.OsLogin.V1Beta/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1.csproj
+++ b/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1/PhishingProtectionServiceV1Beta1Client.g.cs
+++ b/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1/PhishingProtectionServiceV1Beta1Client.g.cs
@@ -79,6 +79,12 @@ namespace Google.Cloud.PhishingProtection.V1Beta1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public PhishingProtectionServiceV1Beta1Settings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public PhishingProtectionServiceV1Beta1ClientBuilder()
+        {
+            UseJwtAccessWithScopes = PhishingProtectionServiceV1Beta1Client.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref PhishingProtectionServiceV1Beta1Client client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<PhishingProtectionServiceV1Beta1Client> task);
@@ -153,7 +159,19 @@ namespace Google.Cloud.PhishingProtection.V1Beta1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="PhishingProtectionServiceV1Beta1Client"/> using the default credentials,

--- a/apis/Google.Cloud.PhishingProtection.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.PhishingProtection.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.PolicyTroubleshooter.V1/Google.Cloud.PolicyTroubleshooter.V1/Google.Cloud.PolicyTroubleshooter.V1.csproj
+++ b/apis/Google.Cloud.PolicyTroubleshooter.V1/Google.Cloud.PolicyTroubleshooter.V1/Google.Cloud.PolicyTroubleshooter.V1.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.PolicyTroubleshooter.V1/Google.Cloud.PolicyTroubleshooter.V1/IamCheckerClient.g.cs
+++ b/apis/Google.Cloud.PolicyTroubleshooter.V1/Google.Cloud.PolicyTroubleshooter.V1/IamCheckerClient.g.cs
@@ -74,6 +74,12 @@ namespace Google.Cloud.PolicyTroubleshooter.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public IamCheckerSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public IamCheckerClientBuilder()
+        {
+            UseJwtAccessWithScopes = IamCheckerClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref IamCheckerClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<IamCheckerClient> task);
@@ -149,7 +155,19 @@ namespace Google.Cloud.PolicyTroubleshooter.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="IamCheckerClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.PolicyTroubleshooter.V1/synth.metadata
+++ b/apis/Google.Cloud.PolicyTroubleshooter.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.PrivateCatalog.V1Beta1/Google.Cloud.PrivateCatalog.V1Beta1/Google.Cloud.PrivateCatalog.V1Beta1.csproj
+++ b/apis/Google.Cloud.PrivateCatalog.V1Beta1/Google.Cloud.PrivateCatalog.V1Beta1/Google.Cloud.PrivateCatalog.V1Beta1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.PrivateCatalog.V1Beta1/Google.Cloud.PrivateCatalog.V1Beta1/PrivateCatalogClient.g.cs
+++ b/apis/Google.Cloud.PrivateCatalog.V1Beta1/Google.Cloud.PrivateCatalog.V1Beta1/PrivateCatalogClient.g.cs
@@ -102,6 +102,12 @@ namespace Google.Cloud.PrivateCatalog.V1Beta1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public PrivateCatalogSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public PrivateCatalogClientBuilder()
+        {
+            UseJwtAccessWithScopes = PrivateCatalogClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref PrivateCatalogClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<PrivateCatalogClient> task);
@@ -195,7 +201,19 @@ namespace Google.Cloud.PrivateCatalog.V1Beta1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="PrivateCatalogClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.PrivateCatalog.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.PrivateCatalog.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "599fed858da3a3fdd59a2530046ee506928da25b"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.csproj
+++ b/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2/ProfilerServiceClient.g.cs
+++ b/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2/ProfilerServiceClient.g.cs
@@ -102,6 +102,12 @@ namespace Google.Cloud.Profiler.V2
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ProfilerServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ProfilerServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = ProfilerServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ProfilerServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ProfilerServiceClient> task);
@@ -184,7 +190,19 @@ namespace Google.Cloud.Profiler.V2
             "https://www.googleapis.com/auth/monitoring.write",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ProfilerServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Profiler.V2/synth.metadata
+++ b/apis/Google.Cloud.Profiler.V2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.IntegrationTests/Google.Cloud.PubSub.V1.IntegrationTests.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.IntegrationTests/Google.Cloud.PubSub.V1.IntegrationTests.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.Apis.CloudResourceManager.v1" Version="[1.53.0.2281, 2.0.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1.csproj" />

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/Google.Cloud.PubSub.V1.Snippets.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/Google.Cloud.PubSub.V1.Snippets.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.Apis.CloudResourceManager.v1" Version="[1.53.0.2281, 2.0.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1.csproj" />

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Tests/Google.Cloud.PubSub.V1.Tests.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Tests/Google.Cloud.PubSub.V1.Tests.csproj
@@ -11,7 +11,7 @@
     <DebugSymbols>True</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.Apis.CloudResourceManager.v1" Version="[1.53.0.2281, 2.0.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1.csproj" />

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/PublisherServiceApiClient.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/PublisherServiceApiClient.g.cs
@@ -212,6 +212,12 @@ namespace Google.Cloud.PubSub.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public PublisherServiceApiSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public PublisherServiceApiClientBuilder()
+        {
+            UseJwtAccessWithScopes = PublisherServiceApiClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref PublisherServiceApiClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<PublisherServiceApiClient> task);
@@ -288,7 +294,19 @@ namespace Google.Cloud.PubSub.V1
             "https://www.googleapis.com/auth/pubsub",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="PublisherServiceApiClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SchemaServiceClient.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SchemaServiceClient.g.cs
@@ -143,6 +143,12 @@ namespace Google.Cloud.PubSub.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public SchemaServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public SchemaServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = SchemaServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref SchemaServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<SchemaServiceClient> task);
@@ -218,7 +224,19 @@ namespace Google.Cloud.PubSub.V1
             "https://www.googleapis.com/auth/pubsub",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="SchemaServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberServiceApiClient.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberServiceApiClient.g.cs
@@ -328,6 +328,12 @@ namespace Google.Cloud.PubSub.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public SubscriberServiceApiSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public SubscriberServiceApiClientBuilder()
+        {
+            UseJwtAccessWithScopes = SubscriberServiceApiClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref SubscriberServiceApiClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<SubscriberServiceApiClient> task);
@@ -405,7 +411,19 @@ namespace Google.Cloud.PubSub.V1
             "https://www.googleapis.com/auth/pubsub",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="SubscriberServiceApiClient"/> using the default credentials, endpoint

--- a/apis/Google.Cloud.PubSub.V1/synth.metadata
+++ b/apis/Google.Cloud.PubSub.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7b6a2ceed6cacf676b3918b1703b3ddd6322444c"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.csproj
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1/RecaptchaEnterpriseServiceClient.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1/RecaptchaEnterpriseServiceClient.g.cs
@@ -163,6 +163,12 @@ namespace Google.Cloud.RecaptchaEnterprise.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public RecaptchaEnterpriseServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public RecaptchaEnterpriseServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = RecaptchaEnterpriseServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref RecaptchaEnterpriseServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<RecaptchaEnterpriseServiceClient> task);
@@ -236,7 +242,19 @@ namespace Google.Cloud.RecaptchaEnterprise.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="RecaptchaEnterpriseServiceClient"/> using the default credentials,

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/synth.metadata
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.csproj
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1/RecaptchaEnterpriseServiceV1Beta1Client.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1/RecaptchaEnterpriseServiceV1Beta1Client.g.cs
@@ -168,6 +168,12 @@ namespace Google.Cloud.RecaptchaEnterprise.V1Beta1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public RecaptchaEnterpriseServiceV1Beta1Settings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public RecaptchaEnterpriseServiceV1Beta1ClientBuilder()
+        {
+            UseJwtAccessWithScopes = RecaptchaEnterpriseServiceV1Beta1Client.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref RecaptchaEnterpriseServiceV1Beta1Client client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<RecaptchaEnterpriseServiceV1Beta1Client> task);
@@ -242,7 +248,19 @@ namespace Google.Cloud.RecaptchaEnterprise.V1Beta1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="RecaptchaEnterpriseServiceV1Beta1Client"/> using the default

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1/CatalogServiceClient.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1/CatalogServiceClient.g.cs
@@ -180,6 +180,12 @@ namespace Google.Cloud.RecommendationEngine.V1Beta1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public CatalogServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public CatalogServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = CatalogServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref CatalogServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<CatalogServiceClient> task);
@@ -253,7 +259,19 @@ namespace Google.Cloud.RecommendationEngine.V1Beta1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="CatalogServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.csproj
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1/PredictionApiKeyRegistryClient.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1/PredictionApiKeyRegistryClient.g.cs
@@ -117,6 +117,12 @@ namespace Google.Cloud.RecommendationEngine.V1Beta1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public PredictionApiKeyRegistrySettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public PredictionApiKeyRegistryClientBuilder()
+        {
+            UseJwtAccessWithScopes = PredictionApiKeyRegistryClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref PredictionApiKeyRegistryClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<PredictionApiKeyRegistryClient> task);
@@ -194,7 +200,19 @@ namespace Google.Cloud.RecommendationEngine.V1Beta1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="PredictionApiKeyRegistryClient"/> using the default credentials,

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1/PredictionServiceClient.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1/PredictionServiceClient.g.cs
@@ -79,6 +79,12 @@ namespace Google.Cloud.RecommendationEngine.V1Beta1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public PredictionServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public PredictionServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = PredictionServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref PredictionServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<PredictionServiceClient> task);
@@ -152,7 +158,19 @@ namespace Google.Cloud.RecommendationEngine.V1Beta1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="PredictionServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1/UserEventServiceClient.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1/UserEventServiceClient.g.cs
@@ -183,6 +183,12 @@ namespace Google.Cloud.RecommendationEngine.V1Beta1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public UserEventServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public UserEventServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = UserEventServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref UserEventServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<UserEventServiceClient> task);
@@ -256,7 +262,19 @@ namespace Google.Cloud.RecommendationEngine.V1Beta1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="UserEventServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7c8d16188e68347aac0053a40ab1dc2056a44899"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.csproj
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/RecommenderClient.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/RecommenderClient.g.cs
@@ -181,6 +181,12 @@ namespace Google.Cloud.Recommender.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public RecommenderSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public RecommenderClientBuilder()
+        {
+            UseJwtAccessWithScopes = RecommenderClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref RecommenderClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<RecommenderClient> task);
@@ -257,7 +263,19 @@ namespace Google.Cloud.Recommender.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="RecommenderClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Recommender.V1/synth.metadata
+++ b/apis/Google.Cloud.Recommender.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1/CloudRedisClient.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1/CloudRedisClient.g.cs
@@ -315,6 +315,12 @@ namespace Google.Cloud.Redis.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public CloudRedisSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public CloudRedisClientBuilder()
+        {
+            UseJwtAccessWithScopes = CloudRedisClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref CloudRedisClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<CloudRedisClient> task);
@@ -402,7 +408,19 @@ namespace Google.Cloud.Redis.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="CloudRedisClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.csproj
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Redis.V1/synth.metadata
+++ b/apis/Google.Cloud.Redis.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1/CloudRedisClient.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1/CloudRedisClient.g.cs
@@ -315,6 +315,12 @@ namespace Google.Cloud.Redis.V1Beta1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public CloudRedisSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public CloudRedisClientBuilder()
+        {
+            UseJwtAccessWithScopes = CloudRedisClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref CloudRedisClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<CloudRedisClient> task);
@@ -402,7 +408,19 @@ namespace Google.Cloud.Redis.V1Beta1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="CloudRedisClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.csproj
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.Redis.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.Redis.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/FoldersClient.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/FoldersClient.g.cs
@@ -313,6 +313,12 @@ namespace Google.Cloud.ResourceManager.V3
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public FoldersSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public FoldersClientBuilder()
+        {
+            UseJwtAccessWithScopes = FoldersClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref FoldersClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<FoldersClient> task);
@@ -390,7 +396,19 @@ namespace Google.Cloud.ResourceManager.V3
             "https://www.googleapis.com/auth/cloud-platform.read-only",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="FoldersClient"/> using the default credentials, endpoint and settings. 

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.csproj
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.38.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/OrganizationsClient.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/OrganizationsClient.g.cs
@@ -136,6 +136,12 @@ namespace Google.Cloud.ResourceManager.V3
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public OrganizationsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public OrganizationsClientBuilder()
+        {
+            UseJwtAccessWithScopes = OrganizationsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref OrganizationsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<OrganizationsClient> task);
@@ -211,7 +217,19 @@ namespace Google.Cloud.ResourceManager.V3
             "https://www.googleapis.com/auth/cloud-platform.read-only",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="OrganizationsClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/ProjectsClient.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/ProjectsClient.g.cs
@@ -313,6 +313,12 @@ namespace Google.Cloud.ResourceManager.V3
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ProjectsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ProjectsClientBuilder()
+        {
+            UseJwtAccessWithScopes = ProjectsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ProjectsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ProjectsClient> task);
@@ -388,7 +394,19 @@ namespace Google.Cloud.ResourceManager.V3
             "https://www.googleapis.com/auth/cloud-platform.read-only",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ProjectsClient"/> using the default credentials, endpoint and settings. 

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/TagBindingsClient.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/TagBindingsClient.g.cs
@@ -144,6 +144,12 @@ namespace Google.Cloud.ResourceManager.V3
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public TagBindingsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public TagBindingsClientBuilder()
+        {
+            UseJwtAccessWithScopes = TagBindingsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref TagBindingsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<TagBindingsClient> task);
@@ -220,7 +226,19 @@ namespace Google.Cloud.ResourceManager.V3
             "https://www.googleapis.com/auth/cloud-platform.read-only",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="TagBindingsClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/TagKeysClient.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/TagKeysClient.g.cs
@@ -235,6 +235,12 @@ namespace Google.Cloud.ResourceManager.V3
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public TagKeysSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public TagKeysClientBuilder()
+        {
+            UseJwtAccessWithScopes = TagKeysClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref TagKeysClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<TagKeysClient> task);
@@ -310,7 +316,19 @@ namespace Google.Cloud.ResourceManager.V3
             "https://www.googleapis.com/auth/cloud-platform.read-only",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="TagKeysClient"/> using the default credentials, endpoint and settings. 

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/TagValuesClient.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/TagValuesClient.g.cs
@@ -235,6 +235,12 @@ namespace Google.Cloud.ResourceManager.V3
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public TagValuesSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public TagValuesClientBuilder()
+        {
+            UseJwtAccessWithScopes = TagValuesClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref TagValuesClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<TagValuesClient> task);
@@ -310,7 +316,19 @@ namespace Google.Cloud.ResourceManager.V3
             "https://www.googleapis.com/auth/cloud-platform.read-only",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="TagValuesClient"/> using the default credentials, endpoint and settings.

--- a/apis/Google.Cloud.ResourceManager.V3/synth.metadata
+++ b/apis/Google.Cloud.ResourceManager.V3/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a3c4f2a82979c49c3b6e3fcbbdc1ec5b3434b4e9"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.ResourceSettings.V1/Google.Cloud.ResourceSettings.V1/Google.Cloud.ResourceSettings.V1.csproj
+++ b/apis/Google.Cloud.ResourceSettings.V1/Google.Cloud.ResourceSettings.V1/Google.Cloud.ResourceSettings.V1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.ResourceSettings.V1/Google.Cloud.ResourceSettings.V1/ResourceSettingsServiceClient.g.cs
+++ b/apis/Google.Cloud.ResourceSettings.V1/Google.Cloud.ResourceSettings.V1/ResourceSettingsServiceClient.g.cs
@@ -115,6 +115,12 @@ namespace Google.Cloud.ResourceSettings.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ResourceSettingsServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ResourceSettingsServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = ResourceSettingsServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ResourceSettingsServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ResourceSettingsServiceClient> task);
@@ -199,7 +205,19 @@ namespace Google.Cloud.ResourceSettings.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ResourceSettingsServiceClient"/> using the default credentials, endpoint

--- a/apis/Google.Cloud.ResourceSettings.V1/synth.metadata
+++ b/apis/Google.Cloud.ResourceSettings.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a9338c63a6ce5f375dbed0474ff27ed0acb121ad"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/CatalogServiceClient.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/CatalogServiceClient.g.cs
@@ -129,6 +129,12 @@ namespace Google.Cloud.Retail.V2
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public CatalogServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public CatalogServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = CatalogServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref CatalogServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<CatalogServiceClient> task);
@@ -202,7 +208,19 @@ namespace Google.Cloud.Retail.V2
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="CatalogServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/CompletionServiceClient.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/CompletionServiceClient.g.cs
@@ -115,6 +115,12 @@ namespace Google.Cloud.Retail.V2
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public CompletionServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public CompletionServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = CompletionServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref CompletionServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<CompletionServiceClient> task);
@@ -192,7 +198,19 @@ namespace Google.Cloud.Retail.V2
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="CompletionServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.csproj
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/PredictionServiceClient.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/PredictionServiceClient.g.cs
@@ -78,6 +78,12 @@ namespace Google.Cloud.Retail.V2
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public PredictionServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public PredictionServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = PredictionServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref PredictionServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<PredictionServiceClient> task);
@@ -151,7 +157,19 @@ namespace Google.Cloud.Retail.V2
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="PredictionServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/ProductServiceClient.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/ProductServiceClient.g.cs
@@ -286,6 +286,12 @@ namespace Google.Cloud.Retail.V2
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ProductServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ProductServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = ProductServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ProductServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ProductServiceClient> task);
@@ -360,7 +366,19 @@ namespace Google.Cloud.Retail.V2
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ProductServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/SearchServiceClient.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/SearchServiceClient.g.cs
@@ -79,6 +79,12 @@ namespace Google.Cloud.Retail.V2
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public SearchServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public SearchServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = SearchServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref SearchServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<SearchServiceClient> task);
@@ -156,7 +162,19 @@ namespace Google.Cloud.Retail.V2
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="SearchServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/UserEventServiceClient.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/UserEventServiceClient.g.cs
@@ -201,6 +201,12 @@ namespace Google.Cloud.Retail.V2
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public UserEventServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public UserEventServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = UserEventServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref UserEventServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<UserEventServiceClient> task);
@@ -274,7 +280,19 @@ namespace Google.Cloud.Retail.V2
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="UserEventServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Retail.V2/synth.metadata
+++ b/apis/Google.Cloud.Retail.V2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a47f0a4aa9ef834edf40d5b8269e9b6c277bb699"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1/CloudSchedulerClient.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1/CloudSchedulerClient.g.cs
@@ -178,6 +178,12 @@ namespace Google.Cloud.Scheduler.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public CloudSchedulerSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public CloudSchedulerClientBuilder()
+        {
+            UseJwtAccessWithScopes = CloudSchedulerClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref CloudSchedulerClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<CloudSchedulerClient> task);
@@ -252,7 +258,19 @@ namespace Google.Cloud.Scheduler.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="CloudSchedulerClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.csproj
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Scheduler.V1/synth.metadata
+++ b/apis/Google.Cloud.Scheduler.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.csproj
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1/SecretManagerServiceClient.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1/SecretManagerServiceClient.g.cs
@@ -272,6 +272,12 @@ namespace Google.Cloud.SecretManager.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public SecretManagerServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public SecretManagerServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = SecretManagerServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref SecretManagerServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<SecretManagerServiceClient> task);
@@ -351,7 +357,19 @@ namespace Google.Cloud.SecretManager.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="SecretManagerServiceClient"/> using the default credentials, endpoint

--- a/apis/Google.Cloud.SecretManager.V1/synth.metadata
+++ b/apis/Google.Cloud.SecretManager.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "2948f31dd210514f87ce6e1e08bce48ecf4660d1"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.csproj
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1/SecretManagerServiceClient.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1/SecretManagerServiceClient.g.cs
@@ -272,6 +272,12 @@ namespace Google.Cloud.SecretManager.V1Beta1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public SecretManagerServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public SecretManagerServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = SecretManagerServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref SecretManagerServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<SecretManagerServiceClient> task);
@@ -351,7 +357,19 @@ namespace Google.Cloud.SecretManager.V1Beta1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="SecretManagerServiceClient"/> using the default credentials, endpoint

--- a/apis/Google.Cloud.SecretManager.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1/CertificateAuthorityServiceClient.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1/CertificateAuthorityServiceClient.g.cs
@@ -831,6 +831,12 @@ namespace Google.Cloud.Security.PrivateCA.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public CertificateAuthorityServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public CertificateAuthorityServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = CertificateAuthorityServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref CertificateAuthorityServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<CertificateAuthorityServiceClient> task);
@@ -905,7 +911,19 @@ namespace Google.Cloud.Security.PrivateCA.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="CertificateAuthorityServiceClient"/> using the default credentials,

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.csproj
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.38.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Security.PrivateCA.V1/synth.metadata
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "077f0c624bb91709aea45b6f42bb4a2e84645cc3"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Security.PrivateCA.V1Beta1/Google.Cloud.Security.PrivateCA.V1Beta1/CertificateAuthorityServiceClient.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1Beta1/Google.Cloud.Security.PrivateCA.V1Beta1/CertificateAuthorityServiceClient.g.cs
@@ -565,6 +565,12 @@ namespace Google.Cloud.Security.PrivateCA.V1Beta1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public CertificateAuthorityServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public CertificateAuthorityServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = CertificateAuthorityServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref CertificateAuthorityServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<CertificateAuthorityServiceClient> task);
@@ -639,7 +645,19 @@ namespace Google.Cloud.Security.PrivateCA.V1Beta1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="CertificateAuthorityServiceClient"/> using the default credentials,

--- a/apis/Google.Cloud.Security.PrivateCA.V1Beta1/Google.Cloud.Security.PrivateCA.V1Beta1/Google.Cloud.Security.PrivateCA.V1Beta1.csproj
+++ b/apis/Google.Cloud.Security.PrivateCA.V1Beta1/Google.Cloud.Security.PrivateCA.V1Beta1/Google.Cloud.Security.PrivateCA.V1Beta1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.Security.PrivateCA.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.Security.PrivateCA.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.csproj
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1/SecurityCenterSettingsServiceClient.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1/SecurityCenterSettingsServiceClient.g.cs
@@ -288,6 +288,12 @@ namespace Google.Cloud.SecurityCenter.Settings.V1Beta1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public SecurityCenterSettingsServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public SecurityCenterSettingsServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = SecurityCenterSettingsServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref SecurityCenterSettingsServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<SecurityCenterSettingsServiceClient> task);
@@ -367,7 +373,19 @@ namespace Google.Cloud.SecurityCenter.Settings.V1Beta1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="SecurityCenterSettingsServiceClient"/> using the default credentials,

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.csproj
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/SecurityCenterClient.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/SecurityCenterClient.g.cs
@@ -425,6 +425,12 @@ namespace Google.Cloud.SecurityCenter.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public SecurityCenterSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public SecurityCenterClientBuilder()
+        {
+            UseJwtAccessWithScopes = SecurityCenterClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref SecurityCenterClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<SecurityCenterClient> task);
@@ -498,7 +504,19 @@ namespace Google.Cloud.SecurityCenter.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="SecurityCenterClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.SecurityCenter.V1/synth.metadata
+++ b/apis/Google.Cloud.SecurityCenter.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "5bf36f20f8e49c18620bf20a45645310f5bf6950"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.csproj
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/SecurityCenterClient.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/SecurityCenterClient.g.cs
@@ -425,6 +425,12 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public SecurityCenterSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public SecurityCenterClientBuilder()
+        {
+            UseJwtAccessWithScopes = SecurityCenterClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref SecurityCenterClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<SecurityCenterClient> task);
@@ -498,7 +504,19 @@ namespace Google.Cloud.SecurityCenter.V1P1Beta1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="SecurityCenterClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/synth.metadata
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "1d3573f5124e2f9ffdd174c6992269ea7f1e92a6"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1.csproj
+++ b/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Logging.Type" Version="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1/QuotaControllerClient.g.cs
+++ b/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1/QuotaControllerClient.g.cs
@@ -75,6 +75,12 @@ namespace Google.Cloud.ServiceControl.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public QuotaControllerSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public QuotaControllerClientBuilder()
+        {
+            UseJwtAccessWithScopes = QuotaControllerClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref QuotaControllerClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<QuotaControllerClient> task);
@@ -153,7 +159,19 @@ namespace Google.Cloud.ServiceControl.V1
             "https://www.googleapis.com/auth/servicecontrol",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="QuotaControllerClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1/ServiceControllerClient.g.cs
+++ b/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1/ServiceControllerClient.g.cs
@@ -91,6 +91,12 @@ namespace Google.Cloud.ServiceControl.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ServiceControllerSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ServiceControllerClientBuilder()
+        {
+            UseJwtAccessWithScopes = ServiceControllerClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ServiceControllerClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ServiceControllerClient> task);
@@ -169,7 +175,19 @@ namespace Google.Cloud.ServiceControl.V1
             "https://www.googleapis.com/auth/servicecontrol",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ServiceControllerClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.ServiceControl.V1/synth.metadata
+++ b/apis/Google.Cloud.ServiceControl.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "da5f84269f0dcdd50554c974cfa968d5137c2300"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.csproj
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1/LookupServiceClient.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1/LookupServiceClient.g.cs
@@ -78,6 +78,12 @@ namespace Google.Cloud.ServiceDirectory.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public LookupServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public LookupServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = LookupServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref LookupServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<LookupServiceClient> task);
@@ -151,7 +157,19 @@ namespace Google.Cloud.ServiceDirectory.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="LookupServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1/RegistrationServiceClient.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1/RegistrationServiceClient.g.cs
@@ -355,6 +355,12 @@ namespace Google.Cloud.ServiceDirectory.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public RegistrationServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public RegistrationServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = RegistrationServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref RegistrationServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<RegistrationServiceClient> task);
@@ -442,7 +448,19 @@ namespace Google.Cloud.ServiceDirectory.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="RegistrationServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.ServiceDirectory.V1/synth.metadata
+++ b/apis/Google.Cloud.ServiceDirectory.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.csproj
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/LookupServiceClient.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/LookupServiceClient.g.cs
@@ -78,6 +78,12 @@ namespace Google.Cloud.ServiceDirectory.V1Beta1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public LookupServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public LookupServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = LookupServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref LookupServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<LookupServiceClient> task);
@@ -151,7 +157,19 @@ namespace Google.Cloud.ServiceDirectory.V1Beta1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="LookupServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/RegistrationServiceClient.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/RegistrationServiceClient.g.cs
@@ -355,6 +355,12 @@ namespace Google.Cloud.ServiceDirectory.V1Beta1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public RegistrationServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public RegistrationServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = RegistrationServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref RegistrationServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<RegistrationServiceClient> task);
@@ -442,7 +448,19 @@ namespace Google.Cloud.ServiceDirectory.V1Beta1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="RegistrationServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "d69baf2e2d3c0071a117e64689c154f8dd46fb09"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.csproj
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.38.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1/ServiceManagerClient.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1/ServiceManagerClient.g.cs
@@ -394,6 +394,12 @@ namespace Google.Cloud.ServiceManagement.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ServiceManagerSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ServiceManagerClientBuilder()
+        {
+            UseJwtAccessWithScopes = ServiceManagerClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ServiceManagerClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ServiceManagerClient> task);
@@ -473,7 +479,19 @@ namespace Google.Cloud.ServiceManagement.V1
             "https://www.googleapis.com/auth/service.management.readonly",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ServiceManagerClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.ServiceManagement.V1/synth.metadata
+++ b/apis/Google.Cloud.ServiceManagement.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "7cde5d0df08801e00fc45df1546942aa2692d5c3"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1.csproj
+++ b/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.38.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1/ServiceUsageClient.g.cs
+++ b/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1/ServiceUsageClient.g.cs
@@ -198,6 +198,12 @@ namespace Google.Cloud.ServiceUsage.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ServiceUsageSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ServiceUsageClientBuilder()
+        {
+            UseJwtAccessWithScopes = ServiceUsageClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ServiceUsageClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ServiceUsageClient> task);
@@ -279,7 +285,19 @@ namespace Google.Cloud.ServiceUsage.V1
             "https://www.googleapis.com/auth/service.management",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ServiceUsageClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.ServiceUsage.V1/synth.metadata
+++ b/apis/Google.Cloud.ServiceUsage.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "599fed858da3a3fdd59a2530046ee506928da25b"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1/CloudShellServiceClient.g.cs
+++ b/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1/CloudShellServiceClient.g.cs
@@ -208,6 +208,12 @@ namespace Google.Cloud.Shell.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public CloudShellServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public CloudShellServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = CloudShellServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref CloudShellServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<CloudShellServiceClient> task);
@@ -287,7 +293,19 @@ namespace Google.Cloud.Shell.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="CloudShellServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.csproj
+++ b/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Shell.V1/synth.metadata
+++ b/apis/Google.Cloud.Shell.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "0d68bbb80a7620b69aff5ab0b497c8a396e73558"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/DatabaseAdminClient.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/DatabaseAdminClient.g.cs
@@ -401,6 +401,12 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public DatabaseAdminSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public DatabaseAdminClientBuilder()
+        {
+            UseJwtAccessWithScopes = DatabaseAdminClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref DatabaseAdminClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<DatabaseAdminClient> task);
@@ -481,7 +487,19 @@ namespace Google.Cloud.Spanner.Admin.Database.V1
             "https://www.googleapis.com/auth/spanner.admin",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="DatabaseAdminClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.csproj
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.csproj
@@ -10,11 +10,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.2.0, 3.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1.csproj" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.38.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/synth.metadata
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "2c6e4dd22260e34403b468cc6d19aa43a9c684ed"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.csproj
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.csproj
@@ -10,11 +10,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.2.0, 3.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1.csproj" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.38.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/InstanceAdminClient.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/InstanceAdminClient.g.cs
@@ -254,6 +254,12 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public InstanceAdminSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public InstanceAdminClientBuilder()
+        {
+            UseJwtAccessWithScopes = InstanceAdminClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref InstanceAdminClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<InstanceAdminClient> task);
@@ -349,7 +355,19 @@ namespace Google.Cloud.Spanner.Admin.Instance.V1
             "https://www.googleapis.com/auth/spanner.admin",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="InstanceAdminClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/synth.metadata
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "2c6e4dd22260e34403b468cc6d19aa43a9c684ed"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1.csproj
+++ b/apis/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/Google.Cloud.Spanner.Data.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/Google.Cloud.Spanner.Data.IntegrationTests.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CoreCompat.EnterpriseLibrary.TransientFaultHandling" Version="6.0.1304-r3" />
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[3.4.0, 4.0.0)" />
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.5.0, 4.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Spanner.Data\Google.Cloud.Spanner.Data.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/Google.Cloud.Spanner.Data.Snippets.csproj
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/Google.Cloud.Spanner.Data.Snippets.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CoreCompat.EnterpriseLibrary.TransientFaultHandling" Version="6.0.1304-r3" />
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[3.4.0, 4.0.0)" />
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.5.0, 4.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Spanner.Data\Google.Cloud.Spanner.Data.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/Google.Cloud.Spanner.Data.Tests.csproj
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/Google.Cloud.Spanner.Data.Tests.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CoreCompat.EnterpriseLibrary.TransientFaultHandling" Version="6.0.1304-r3" />
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[3.4.0, 4.0.0)" />
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.5.0, 4.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Spanner.Data\Google.Cloud.Spanner.Data.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.csproj
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.csproj
@@ -10,11 +10,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.Spanner.Admin.Database.V1\Google.Cloud.Spanner.Admin.Database.V1\Google.Cloud.Spanner.Admin.Database.V1.csproj" />
     <ProjectReference Include="..\..\Google.Cloud.Spanner.Admin.Instance.V1\Google.Cloud.Spanner.Admin.Instance.V1\Google.Cloud.Spanner.Admin.Instance.V1.csproj" />
     <ProjectReference Include="..\..\Google.Cloud.Spanner.V1\Google.Cloud.Spanner.V1\Google.Cloud.Spanner.V1.csproj" />
-    <PackageReference Include="Grpc.Core" Version="[2.38.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Grpc.Gcp" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.csproj
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1.csproj" />
-    <PackageReference Include="Grpc.Core" Version="[2.38.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SpannerClient.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SpannerClient.g.cs
@@ -299,6 +299,12 @@ namespace Google.Cloud.Spanner.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public SpannerSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public SpannerClientBuilder()
+        {
+            UseJwtAccessWithScopes = SpannerClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref SpannerClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<SpannerClient> task);
@@ -376,7 +382,19 @@ namespace Google.Cloud.Spanner.V1
             "https://www.googleapis.com/auth/spanner.data",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="SpannerClient"/> using the default credentials, endpoint and settings. 

--- a/apis/Google.Cloud.Spanner.V1/synth.metadata
+++ b/apis/Google.Cloud.Spanner.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "fb5c4fbc1ded09e6958d6be7ca36a9221dc7e52f"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.csproj
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/SpeechClient.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/SpeechClient.g.cs
@@ -126,6 +126,12 @@ namespace Google.Cloud.Speech.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public SpeechSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public SpeechClientBuilder()
+        {
+            UseJwtAccessWithScopes = SpeechClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref SpeechClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<SpeechClient> task);
@@ -198,7 +204,19 @@ namespace Google.Cloud.Speech.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="SpeechClient"/> using the default credentials, endpoint and settings. To

--- a/apis/Google.Cloud.Speech.V1/synth.metadata
+++ b/apis/Google.Cloud.Speech.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "10185d07a4db1d76a888a119aeab1f2287b35105"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/AdaptationClient.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/AdaptationClient.g.cs
@@ -194,6 +194,12 @@ namespace Google.Cloud.Speech.V1P1Beta1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public AdaptationSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public AdaptationClientBuilder()
+        {
+            UseJwtAccessWithScopes = AdaptationClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref AdaptationClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<AdaptationClient> task);
@@ -267,7 +273,19 @@ namespace Google.Cloud.Speech.V1P1Beta1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="AdaptationClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.csproj
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/SpeechClient.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/SpeechClient.g.cs
@@ -126,6 +126,12 @@ namespace Google.Cloud.Speech.V1P1Beta1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public SpeechSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public SpeechClientBuilder()
+        {
+            UseJwtAccessWithScopes = SpeechClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref SpeechClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<SpeechClient> task);
@@ -198,7 +204,19 @@ namespace Google.Cloud.Speech.V1P1Beta1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="SpeechClient"/> using the default credentials, endpoint and settings. To

--- a/apis/Google.Cloud.Speech.V1P1Beta1/synth.metadata
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "4fca877897a4639796bba0731c6f579724d80d72"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/Google.Cloud.Storage.V1.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/Google.Cloud.Storage.V1.IntegrationTests.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.Apis.Iam.v1" Version="[1.53.0.2394, 2.0.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\..\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1.csproj" />

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Snippets/Google.Cloud.Storage.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Snippets/Google.Cloud.Storage.V1.Snippets.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.Apis.Iam.v1" Version="[1.53.0.2394, 2.0.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\..\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1.csproj" />

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/Google.Cloud.Storage.V1.Tests.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/Google.Cloud.Storage.V1.Tests.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.Apis.Iam.v1" Version="[1.53.0.2394, 2.0.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\..\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1.csproj" />

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Rest" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Rest" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.Apis.Storage.v1" Version="[1.53.0.2234, 2.0.0.0)" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.csproj
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1/StorageTransferServiceClient.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1/StorageTransferServiceClient.g.cs
@@ -198,6 +198,12 @@ namespace Google.Cloud.StorageTransfer.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public StorageTransferServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public StorageTransferServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = StorageTransferServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref StorageTransferServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<StorageTransferServiceClient> task);
@@ -273,7 +279,19 @@ namespace Google.Cloud.StorageTransfer.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="StorageTransferServiceClient"/> using the default credentials, endpoint

--- a/apis/Google.Cloud.StorageTransfer.V1/synth.metadata
+++ b/apis/Google.Cloud.StorageTransfer.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "3744b86f39039fccaf7b2276db191d21f118f2b4"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/CompanyServiceClient.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/CompanyServiceClient.g.cs
@@ -138,6 +138,12 @@ namespace Google.Cloud.Talent.V4
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public CompanyServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public CompanyServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = CompanyServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref CompanyServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<CompanyServiceClient> task);
@@ -213,7 +219,19 @@ namespace Google.Cloud.Talent.V4
             "https://www.googleapis.com/auth/jobs",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="CompanyServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/CompletionClient.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/CompletionClient.g.cs
@@ -77,6 +77,12 @@ namespace Google.Cloud.Talent.V4
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public CompletionSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public CompletionClientBuilder()
+        {
+            UseJwtAccessWithScopes = CompletionClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref CompletionClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<CompletionClient> task);
@@ -151,7 +157,19 @@ namespace Google.Cloud.Talent.V4
             "https://www.googleapis.com/auth/jobs",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="CompletionClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/EventServiceClient.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/EventServiceClient.g.cs
@@ -74,6 +74,12 @@ namespace Google.Cloud.Talent.V4
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public EventServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public EventServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = EventServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref EventServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<EventServiceClient> task);
@@ -149,7 +155,19 @@ namespace Google.Cloud.Talent.V4
             "https://www.googleapis.com/auth/jobs",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="EventServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.csproj
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/JobServiceClient.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/JobServiceClient.g.cs
@@ -261,6 +261,12 @@ namespace Google.Cloud.Talent.V4
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public JobServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public JobServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = JobServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref JobServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<JobServiceClient> task);
@@ -335,7 +341,19 @@ namespace Google.Cloud.Talent.V4
             "https://www.googleapis.com/auth/jobs",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="JobServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/TenantServiceClient.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/TenantServiceClient.g.cs
@@ -139,6 +139,12 @@ namespace Google.Cloud.Talent.V4
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public TenantServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public TenantServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = TenantServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref TenantServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<TenantServiceClient> task);
@@ -214,7 +220,19 @@ namespace Google.Cloud.Talent.V4
             "https://www.googleapis.com/auth/jobs",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="TenantServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/ApplicationServiceClient.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/ApplicationServiceClient.g.cs
@@ -141,6 +141,12 @@ namespace Google.Cloud.Talent.V4Beta1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ApplicationServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ApplicationServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = ApplicationServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ApplicationServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ApplicationServiceClient> task);
@@ -217,7 +223,19 @@ namespace Google.Cloud.Talent.V4Beta1
             "https://www.googleapis.com/auth/jobs",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ApplicationServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/CompanyServiceClient.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/CompanyServiceClient.g.cs
@@ -139,6 +139,12 @@ namespace Google.Cloud.Talent.V4Beta1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public CompanyServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public CompanyServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = CompanyServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref CompanyServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<CompanyServiceClient> task);
@@ -214,7 +220,19 @@ namespace Google.Cloud.Talent.V4Beta1
             "https://www.googleapis.com/auth/jobs",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="CompanyServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/CompletionClient.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/CompletionClient.g.cs
@@ -77,6 +77,12 @@ namespace Google.Cloud.Talent.V4Beta1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public CompletionSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public CompletionClientBuilder()
+        {
+            UseJwtAccessWithScopes = CompletionClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref CompletionClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<CompletionClient> task);
@@ -151,7 +157,19 @@ namespace Google.Cloud.Talent.V4Beta1
             "https://www.googleapis.com/auth/jobs",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="CompletionClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/EventServiceClient.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/EventServiceClient.g.cs
@@ -75,6 +75,12 @@ namespace Google.Cloud.Talent.V4Beta1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public EventServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public EventServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = EventServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref EventServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<EventServiceClient> task);
@@ -150,7 +156,19 @@ namespace Google.Cloud.Talent.V4Beta1
             "https://www.googleapis.com/auth/jobs",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="EventServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.csproj
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/JobServiceClient.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/JobServiceClient.g.cs
@@ -242,6 +242,12 @@ namespace Google.Cloud.Talent.V4Beta1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public JobServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public JobServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = JobServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref JobServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<JobServiceClient> task);
@@ -316,7 +322,19 @@ namespace Google.Cloud.Talent.V4Beta1
             "https://www.googleapis.com/auth/jobs",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="JobServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/ProfileServiceClient.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/ProfileServiceClient.g.cs
@@ -151,6 +151,12 @@ namespace Google.Cloud.Talent.V4Beta1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ProfileServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ProfileServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = ProfileServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ProfileServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ProfileServiceClient> task);
@@ -227,7 +233,19 @@ namespace Google.Cloud.Talent.V4Beta1
             "https://www.googleapis.com/auth/jobs",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ProfileServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/TenantServiceClient.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/TenantServiceClient.g.cs
@@ -139,6 +139,12 @@ namespace Google.Cloud.Talent.V4Beta1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public TenantServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public TenantServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = TenantServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref TenantServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<TenantServiceClient> task);
@@ -214,7 +220,19 @@ namespace Google.Cloud.Talent.V4Beta1
             "https://www.googleapis.com/auth/jobs",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="TenantServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Talent.V4Beta1/synth.metadata
+++ b/apis/Google.Cloud.Talent.V4Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/CloudTasksClient.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/CloudTasksClient.g.cs
@@ -297,6 +297,12 @@ namespace Google.Cloud.Tasks.V2
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public CloudTasksSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public CloudTasksClientBuilder()
+        {
+            UseJwtAccessWithScopes = CloudTasksClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref CloudTasksClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<CloudTasksClient> task);
@@ -371,7 +377,19 @@ namespace Google.Cloud.Tasks.V2
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="CloudTasksClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.csproj
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Tasks.V2/synth.metadata
+++ b/apis/Google.Cloud.Tasks.V2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3/CloudTasksClient.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3/CloudTasksClient.g.cs
@@ -297,6 +297,12 @@ namespace Google.Cloud.Tasks.V2Beta3
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public CloudTasksSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public CloudTasksClientBuilder()
+        {
+            UseJwtAccessWithScopes = CloudTasksClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref CloudTasksClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<CloudTasksClient> task);
@@ -371,7 +377,19 @@ namespace Google.Cloud.Tasks.V2Beta3
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="CloudTasksClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.csproj
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.Tasks.V2Beta3/synth.metadata
+++ b/apis/Google.Cloud.Tasks.V2Beta3/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "df616b587f0b4302f15387f315c286035c3b8bb1"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.csproj
+++ b/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/TextToSpeechClient.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/TextToSpeechClient.g.cs
@@ -93,6 +93,12 @@ namespace Google.Cloud.TextToSpeech.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public TextToSpeechSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public TextToSpeechClientBuilder()
+        {
+            UseJwtAccessWithScopes = TextToSpeechClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref TextToSpeechClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<TextToSpeechClient> task);
@@ -166,7 +172,19 @@ namespace Google.Cloud.TextToSpeech.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="TextToSpeechClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.TextToSpeech.V1/synth.metadata
+++ b/apis/Google.Cloud.TextToSpeech.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.csproj
+++ b/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1/TextToSpeechClient.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1/TextToSpeechClient.g.cs
@@ -93,6 +93,12 @@ namespace Google.Cloud.TextToSpeech.V1Beta1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public TextToSpeechSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public TextToSpeechClientBuilder()
+        {
+            UseJwtAccessWithScopes = TextToSpeechClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref TextToSpeechClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<TextToSpeechClient> task);
@@ -166,7 +172,19 @@ namespace Google.Cloud.TextToSpeech.V1Beta1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="TextToSpeechClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.TextToSpeech.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.TextToSpeech.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "b210aa4a76ce4d531b09d0f4fd187b65b5fcaa63"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.csproj
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.38.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1/TpuClient.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1/TpuClient.g.cs
@@ -300,6 +300,12 @@ namespace Google.Cloud.Tpu.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public TpuSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public TpuClientBuilder()
+        {
+            UseJwtAccessWithScopes = TpuClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref TpuClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<TpuClient> task);
@@ -374,7 +380,19 @@ namespace Google.Cloud.Tpu.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="TpuClient"/> using the default credentials, endpoint and settings. To

--- a/apis/Google.Cloud.Tpu.V1/synth.metadata
+++ b/apis/Google.Cloud.Tpu.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "fb09da15d066185374d17d0a646e1cc0158f9483"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.csproj
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/TraceServiceClient.g.cs
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/TraceServiceClient.g.cs
@@ -111,6 +111,12 @@ namespace Google.Cloud.Trace.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public TraceServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public TraceServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = TraceServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref TraceServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<TraceServiceClient> task);
@@ -192,7 +198,19 @@ namespace Google.Cloud.Trace.V1
             "https://www.googleapis.com/auth/trace.readonly",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="TraceServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Trace.V1/synth.metadata
+++ b/apis/Google.Cloud.Trace.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.csproj
+++ b/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/TraceServiceClient.g.cs
+++ b/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/TraceServiceClient.g.cs
@@ -92,6 +92,12 @@ namespace Google.Cloud.Trace.V2
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public TraceServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public TraceServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = TraceServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref TraceServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<TraceServiceClient> task);
@@ -171,7 +177,19 @@ namespace Google.Cloud.Trace.V2
             "https://www.googleapis.com/auth/trace.append",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="TraceServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Trace.V2/synth.metadata
+++ b/apis/Google.Cloud.Trace.V2/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.csproj
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3/TranslationServiceClient.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3/TranslationServiceClient.g.cs
@@ -240,6 +240,12 @@ namespace Google.Cloud.Translate.V3
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public TranslationServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public TranslationServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = TranslationServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref TranslationServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<TranslationServiceClient> task);
@@ -315,7 +321,19 @@ namespace Google.Cloud.Translate.V3
             "https://www.googleapis.com/auth/cloud-translation",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="TranslationServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Translate.V3/synth.metadata
+++ b/apis/Google.Cloud.Translate.V3/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.csproj
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Rest" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Rest" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.Apis.Translate.v2" Version="[1.53.0.875, 2.0.0.0)" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.csproj
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1/TranscoderServiceClient.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1/TranscoderServiceClient.g.cs
@@ -169,6 +169,12 @@ namespace Google.Cloud.Video.Transcoder.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public TranscoderServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public TranscoderServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = TranscoderServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref TranscoderServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<TranscoderServiceClient> task);
@@ -247,7 +253,19 @@ namespace Google.Cloud.Video.Transcoder.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="TranscoderServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Video.Transcoder.V1/synth.metadata
+++ b/apis/Google.Cloud.Video.Transcoder.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "2d51c27db9bdbd7cc3a8fbe6c6e27bcca0b06f74"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Video.Transcoder.V1Beta1/Google.Cloud.Video.Transcoder.V1Beta1/Google.Cloud.Video.Transcoder.V1Beta1.csproj
+++ b/apis/Google.Cloud.Video.Transcoder.V1Beta1/Google.Cloud.Video.Transcoder.V1Beta1/Google.Cloud.Video.Transcoder.V1Beta1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.Video.Transcoder.V1Beta1/Google.Cloud.Video.Transcoder.V1Beta1/TranscoderServiceClient.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1Beta1/Google.Cloud.Video.Transcoder.V1Beta1/TranscoderServiceClient.g.cs
@@ -169,6 +169,12 @@ namespace Google.Cloud.Video.Transcoder.V1Beta1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public TranscoderServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public TranscoderServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = TranscoderServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref TranscoderServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<TranscoderServiceClient> task);
@@ -247,7 +253,19 @@ namespace Google.Cloud.Video.Transcoder.V1Beta1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="TranscoderServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Video.Transcoder.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.Video.Transcoder.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "9a7d19079b5e3c22a5a08eaa94273f5d1eebb317"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1.csproj
+++ b/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1/VideoIntelligenceServiceClient.g.cs
+++ b/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1/VideoIntelligenceServiceClient.g.cs
@@ -101,6 +101,12 @@ namespace Google.Cloud.VideoIntelligence.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public VideoIntelligenceServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public VideoIntelligenceServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = VideoIntelligenceServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref VideoIntelligenceServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<VideoIntelligenceServiceClient> task);
@@ -174,7 +180,19 @@ namespace Google.Cloud.VideoIntelligence.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="VideoIntelligenceServiceClient"/> using the default credentials,

--- a/apis/Google.Cloud.VideoIntelligence.V1/synth.metadata
+++ b/apis/Google.Cloud.VideoIntelligence.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.csproj
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ImageAnnotatorClient.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ImageAnnotatorClient.g.cs
@@ -167,6 +167,12 @@ namespace Google.Cloud.Vision.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ImageAnnotatorSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ImageAnnotatorClientBuilder()
+        {
+            UseJwtAccessWithScopes = ImageAnnotatorClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ImageAnnotatorClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ImageAnnotatorClient> task);
@@ -244,7 +250,19 @@ namespace Google.Cloud.Vision.V1
             "https://www.googleapis.com/auth/cloud-vision",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ImageAnnotatorClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ProductSearchClient.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ProductSearchClient.g.cs
@@ -411,6 +411,12 @@ namespace Google.Cloud.Vision.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ProductSearchSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ProductSearchClientBuilder()
+        {
+            UseJwtAccessWithScopes = ProductSearchClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ProductSearchClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ProductSearchClient> task);
@@ -499,7 +505,19 @@ namespace Google.Cloud.Vision.V1
             "https://www.googleapis.com/auth/cloud-vision",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ProductSearchClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Vision.V1/synth.metadata
+++ b/apis/Google.Cloud.Vision.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.csproj
+++ b/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.38.0, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1/VpcAccessServiceClient.g.cs
+++ b/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1/VpcAccessServiceClient.g.cs
@@ -156,6 +156,12 @@ namespace Google.Cloud.VpcAccess.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public VpcAccessServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public VpcAccessServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = VpcAccessServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref VpcAccessServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<VpcAccessServiceClient> task);
@@ -231,7 +237,19 @@ namespace Google.Cloud.VpcAccess.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="VpcAccessServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.VpcAccess.V1/synth.metadata
+++ b/apis/Google.Cloud.VpcAccess.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "95e75e5c62bbb54110428e9cc4ebb9aa2508df91"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.csproj
+++ b/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1/WebRiskServiceClient.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1/WebRiskServiceClient.g.cs
@@ -125,6 +125,12 @@ namespace Google.Cloud.WebRisk.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public WebRiskServiceSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public WebRiskServiceClientBuilder()
+        {
+            UseJwtAccessWithScopes = WebRiskServiceClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref WebRiskServiceClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<WebRiskServiceClient> task);
@@ -199,7 +205,19 @@ namespace Google.Cloud.WebRisk.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="WebRiskServiceClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.WebRisk.V1/synth.metadata
+++ b/apis/Google.Cloud.WebRisk.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1.csproj
+++ b/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1/WebRiskServiceV1Beta1Client.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1/WebRiskServiceV1Beta1Client.g.cs
@@ -113,6 +113,12 @@ namespace Google.Cloud.WebRisk.V1Beta1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public WebRiskServiceV1Beta1Settings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public WebRiskServiceV1Beta1ClientBuilder()
+        {
+            UseJwtAccessWithScopes = WebRiskServiceV1Beta1Client.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref WebRiskServiceV1Beta1Client client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<WebRiskServiceV1Beta1Client> task);
@@ -187,7 +193,19 @@ namespace Google.Cloud.WebRisk.V1Beta1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="WebRiskServiceV1Beta1Client"/> using the default credentials, endpoint

--- a/apis/Google.Cloud.WebRisk.V1Beta1/synth.metadata
+++ b/apis/Google.Cloud.WebRisk.V1Beta1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.csproj
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1/WebSecurityScannerClient.g.cs
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1/WebSecurityScannerClient.g.cs
@@ -261,6 +261,12 @@ namespace Google.Cloud.WebSecurityScanner.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public WebSecurityScannerSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public WebSecurityScannerClientBuilder()
+        {
+            UseJwtAccessWithScopes = WebSecurityScannerClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref WebSecurityScannerClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<WebSecurityScannerClient> task);
@@ -336,7 +342,19 @@ namespace Google.Cloud.WebSecurityScanner.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="WebSecurityScannerClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.WebSecurityScanner.V1/synth.metadata
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Workflows.Common.V1/Google.Cloud.Workflows.Common.V1/Google.Cloud.Workflows.Common.V1.csproj
+++ b/apis/Google.Cloud.Workflows.Common.V1/Google.Cloud.Workflows.Common.V1/Google.Cloud.Workflows.Common.V1.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Workflows.Common.V1Beta/Google.Cloud.Workflows.Common.V1Beta/Google.Cloud.Workflows.Common.V1Beta.csproj
+++ b/apis/Google.Cloud.Workflows.Common.V1Beta/Google.Cloud.Workflows.Common.V1Beta/Google.Cloud.Workflows.Common.V1Beta.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1/ExecutionsClient.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1/ExecutionsClient.g.cs
@@ -115,6 +115,12 @@ namespace Google.Cloud.Workflows.Executions.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ExecutionsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ExecutionsClientBuilder()
+        {
+            UseJwtAccessWithScopes = ExecutionsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ExecutionsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ExecutionsClient> task);
@@ -189,7 +195,19 @@ namespace Google.Cloud.Workflows.Executions.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ExecutionsClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.csproj
+++ b/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.Workflows.Common.V1\Google.Cloud.Workflows.Common.V1\Google.Cloud.Workflows.Common.V1.csproj" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Workflows.Executions.V1/synth.metadata
+++ b/apis/Google.Cloud.Workflows.Executions.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta/ExecutionsClient.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta/ExecutionsClient.g.cs
@@ -115,6 +115,12 @@ namespace Google.Cloud.Workflows.Executions.V1Beta
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public ExecutionsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public ExecutionsClientBuilder()
+        {
+            UseJwtAccessWithScopes = ExecutionsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref ExecutionsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<ExecutionsClient> task);
@@ -189,7 +195,19 @@ namespace Google.Cloud.Workflows.Executions.V1Beta
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="ExecutionsClient"/> using the default credentials, endpoint and

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.csproj
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.Workflows.Common.V1Beta\Google.Cloud.Workflows.Common.V1Beta\Google.Cloud.Workflows.Common.V1Beta.csproj" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/synth.metadata
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.csproj
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.Workflows.Common.V1\Google.Cloud.Workflows.Common.V1\Google.Cloud.Workflows.Common.V1.csproj" />
-    <PackageReference Include="Google.LongRunning" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1/WorkflowsClient.g.cs
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1/WorkflowsClient.g.cs
@@ -188,6 +188,12 @@ namespace Google.Cloud.Workflows.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public WorkflowsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public WorkflowsClientBuilder()
+        {
+            UseJwtAccessWithScopes = WorkflowsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref WorkflowsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<WorkflowsClient> task);
@@ -263,7 +269,19 @@ namespace Google.Cloud.Workflows.V1
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="WorkflowsClient"/> using the default credentials, endpoint and settings.

--- a/apis/Google.Cloud.Workflows.V1/synth.metadata
+++ b/apis/Google.Cloud.Workflows.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.csproj
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.Workflows.Common.V1Beta\Google.Cloud.Workflows.Common.V1Beta\Google.Cloud.Workflows.Common.V1Beta.csproj" />
     <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta/WorkflowsClient.g.cs
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta/WorkflowsClient.g.cs
@@ -188,6 +188,12 @@ namespace Google.Cloud.Workflows.V1Beta
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public WorkflowsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public WorkflowsClientBuilder()
+        {
+            UseJwtAccessWithScopes = WorkflowsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref WorkflowsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<WorkflowsClient> task);
@@ -263,7 +269,19 @@ namespace Google.Cloud.Workflows.V1Beta
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="WorkflowsClient"/> using the default credentials, endpoint and settings.

--- a/apis/Google.Cloud.Workflows.V1Beta/synth.metadata
+++ b/apis/Google.Cloud.Workflows.V1Beta/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Identity.AccessContextManager.Type/synth.metadata
+++ b/apis/Google.Identity.AccessContextManager.Type/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "e7d77d65f0e05ce584c1a824c7ecab53b411498b"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.Identity.AccessContextManager.V1/synth.metadata
+++ b/apis/Google.Identity.AccessContextManager.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "0b261def1cb4c61a9ddbb8bf14b103ce6add1bce"
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Google.LongRunning/Google.LongRunning.Snippets/Google.LongRunning.Snippets.csproj
+++ b/apis/Google.LongRunning/Google.LongRunning.Snippets/Google.LongRunning.Snippets.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.5.0, 4.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.LongRunning\Google.LongRunning.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />

--- a/apis/Google.LongRunning/Google.LongRunning.Tests/Google.LongRunning.Tests.csproj
+++ b/apis/Google.LongRunning/Google.LongRunning.Tests/Google.LongRunning.Tests.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[3.5.0, 4.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.LongRunning\Google.LongRunning.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />

--- a/apis/Google.LongRunning/Google.LongRunning/Google.LongRunning.csproj
+++ b/apis/Google.LongRunning/Google.LongRunning/Google.LongRunning.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.LongRunning/Google.LongRunning/OperationsClient.g.cs
+++ b/apis/Google.LongRunning/Google.LongRunning/OperationsClient.g.cs
@@ -140,6 +140,12 @@ namespace Google.LongRunning
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public OperationsSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public OperationsClientBuilder()
+        {
+            UseJwtAccessWithScopes = OperationsClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref OperationsClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<OperationsClient> task);
@@ -213,7 +219,19 @@ namespace Google.LongRunning
         /// <remarks>The default Operations scopes are:<list type="bullet"></list></remarks>
         public static scg::IReadOnlyList<string> DefaultScopes { get; } = new sco::ReadOnlyCollection<string>(new string[] { });
 
-        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes);
+        internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(DefaultScopes, UseJwtAccessWithScopes);
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Asynchronously creates a <see cref="OperationsClient"/> using the default credentials, endpoint and

--- a/apis/Google.LongRunning/synth.metadata
+++ b/apis/Google.LongRunning/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/Grafeas.V1/Grafeas.V1/Grafeas.V1.csproj
+++ b/apis/Grafeas.V1/Grafeas.V1/Grafeas.V1.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.3.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.36.4, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Grafeas.V1/Grafeas.V1/GrafeasClient.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1/GrafeasClient.g.cs
@@ -269,6 +269,12 @@ namespace Grafeas.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public GrafeasSettings Settings { get; set; }
 
+        /// <summary>Creates a new builder with default settings.</summary>
+        public GrafeasClientBuilder()
+        {
+            UseJwtAccessWithScopes = GrafeasClient.UseJwtAccessWithScopes;
+        }
+
         partial void InterceptBuild(ref GrafeasClient client);
 
         partial void InterceptBuildAsync(st::CancellationToken cancellationToken, ref stt::Task<GrafeasClient> task);
@@ -335,6 +341,18 @@ namespace Grafeas.V1
         /// <summary>The default Grafeas scopes.</summary>
         /// <remarks>The default Grafeas scopes are:<list type="bullet"></list></remarks>
         public static scg::IReadOnlyList<string> DefaultScopes { get; } = new sco::ReadOnlyCollection<string>(new string[] { });
+
+        internal static bool UseJwtAccessWithScopes
+        {
+            get
+            {
+                bool useJwtAccessWithScopes = true;
+                MaybeUseJwtAccessWithScopes(ref useJwtAccessWithScopes);
+                return useJwtAccessWithScopes;
+            }
+        }
+
+        static partial void MaybeUseJwtAccessWithScopes(ref bool useJwtAccessWithScopes);
 
         /// <summary>
         /// Creates a <see cref="GrafeasClient"/> which uses the specified call invoker for remote operations.

--- a/apis/Grafeas.V1/synth.metadata
+++ b/apis/Grafeas.V1/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "a1ab4d44db02d59ff58810c6d4182d84e4b9abaa"        
+        "sha": "a6c8dc7f72206eaff566f22593213cd9196d2bf2"
       }
     }
   ]

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -82,8 +82,8 @@
         "approval"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/cloud/accessapproval/v1"
@@ -100,9 +100,9 @@
         "gateway"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Google.LongRunning": "2.1.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Google.LongRunning": "2.2.0",
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/cloud/apigateway/v1"
@@ -139,8 +139,8 @@
         "hybrid"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
-        "Grpc.Core": "2.38.0"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/cloud/apigeeconnect/v1"
@@ -158,9 +158,9 @@
         "appengine"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Google.LongRunning": "2.1.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Google.LongRunning": "2.2.0",
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/appengine/v1"
@@ -178,7 +178,7 @@
         "containers"
       ],
       "dependencies": {
-        "Google.Cloud.Iam.V1": "2.1.0",
+        "Google.Cloud.Iam.V1": "2.2.0",
         "Google.LongRunning": "2.2.0"
       },
       "generator": "micro",
@@ -194,7 +194,7 @@
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Asset Inventory API (v1).",
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.Cloud.Iam.V1": "2.2.0",
         "Google.Cloud.OrgPolicy.V1": "2.2.0",
         "Google.Cloud.OsConfig.V1": "1.3.0",
@@ -253,9 +253,9 @@
       "type": "grpc",
       "description": "Recommended Google client library to access the AutoML API, which allows you to train high-quality custom machine learning models with minimal effort and machine learning expertise.",
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.LongRunning": "2.2.0",
-        "Grpc.Core": "2.36.4"
+        "Grpc.Core": "2.38.1"
       },
       "tags": [
         "automl",
@@ -274,7 +274,7 @@
         "connection"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.Cloud.Iam.V1": "2.2.0",
         "Grpc.Core": "2.38.1"
       },
@@ -291,8 +291,8 @@
       "type": "grpc",
       "description": "Recommended Google client library to access the BigQuery Data Transfer API, which transfers data from partner SaaS applications to Google BigQuery on a scheduled, managed basis.",
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Grpc.Core": "2.38.1"
       },
       "tags": [
         "BigQuery",
@@ -311,8 +311,8 @@
         "Reservation"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/cloud/bigquery/reservation/v1"
@@ -325,7 +325,7 @@
       "type": "rest",
       "description": "Recommended Google client library to access the BigQuery API. It wraps the Google.Apis.Bigquery.v2 client library, making common operations simpler in client code. BigQuery is a data platform for customers to create, manage, share and query data.",
       "dependencies": {
-        "Google.Api.Gax.Rest": "3.4.0",
+        "Google.Api.Gax.Rest": "3.5.0",
         "Google.Apis.Bigquery.v2": "1.54.0.2397"
       },
       "testDependencies": {
@@ -346,8 +346,8 @@
       "type": "grpc",
       "description": "Recommended Google client library to access the BigQuery Storage API.",
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
-        "Grpc.Core": "2.38.0"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Grpc.Core": "2.38.1"
       },
       "tags": [
         "BigQuery"
@@ -367,14 +367,14 @@
         "Bigtable"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Google.Cloud.Bigtable.Common.V2": "2.0.0",
-        "Google.Cloud.Iam.V1": "2.1.0",
-        "Google.LongRunning": "2.1.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Google.Cloud.Bigtable.Common.V2": "2.1.0",
+        "Google.Cloud.Iam.V1": "2.2.0",
+        "Google.LongRunning": "2.2.0",
+        "Grpc.Core": "2.38.1"
       },
       "testDependencies": {
-        "Google.Api.Gax.Grpc.Testing": "3.3.0"
+        "Google.Api.Gax.Grpc.Testing": "3.5.0"
       }
     },
     {
@@ -387,8 +387,8 @@
         "Bigtable"
       ],
       "dependencies": {
-        "Google.Api.Gax": "3.3.0",
-        "Google.Protobuf": "3.15.8"
+        "Google.Api.Gax": "3.5.0",
+        "Google.Protobuf": "3.17.3"
       }
     },
     {
@@ -406,13 +406,13 @@
         "Bigtable"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.Gcp": "3.3.0",
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Google.Cloud.Bigtable.Common.V2": "2.0.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.Gcp": "3.5.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Google.Cloud.Bigtable.Common.V2": "2.1.0",
+        "Grpc.Core": "2.38.1"
       },
       "testDependencies": {
-        "Google.Api.Gax.Grpc.Testing": "3.3.0",
+        "Google.Api.Gax.Grpc.Testing": "3.5.0",
         "Google.Cloud.Bigtable.Admin.V2": "project"
       }
     },
@@ -429,8 +429,8 @@
         "budget"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/cloud/billing/budgets/v1"
@@ -461,9 +461,9 @@
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Billing API, which allows you to define a budget plan and the rules to execute as spend is tracked against that plan.",
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Google.Cloud.Iam.V1": "2.1.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Google.Cloud.Iam.V1": "2.2.0",
+        "Grpc.Core": "2.38.1"
       },
       "tags": [
         "Billing"
@@ -499,9 +499,9 @@
         "reseller"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.LongRunning": "2.2.0",
-        "Grpc.Core": "2.38.0"
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/cloud/channel/v1"
@@ -518,7 +518,7 @@
         "cloudbuild"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.LongRunning": "2.2.0",
         "Grpc.Core": "2.38.1"
       },
@@ -537,9 +537,9 @@
         "migration"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.LongRunning": "2.2.0",
-        "Grpc.Core": "2.38.0"
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/cloud/clouddms/v1"
@@ -568,7 +568,7 @@
         "compute"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "3.5.0-beta01"
+        "Google.Api.Gax.Grpc": "3.5.0"
       },
       "generator": "regapic",
       "protoPath": "google/cloud/compute/v1"
@@ -601,7 +601,7 @@
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.",
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Grpc.Core": "2.38.1"
       },
       "tags": [
@@ -622,7 +622,7 @@
         "metadata"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.Cloud.Iam.V1": "2.2.0",
         "Grpc.Core": "2.38.1"
       }
@@ -705,9 +705,9 @@
         "Hadoop"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Google.LongRunning": "2.1.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Google.LongRunning": "2.2.0",
+        "Grpc.Core": "2.38.1"
       }
     },
     {
@@ -721,7 +721,7 @@
         "admin"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.LongRunning": "2.2.0",
         "Grpc.Core": "2.38.1"
       },
@@ -742,12 +742,12 @@
         "Datastore"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Grpc.Core": "2.36.4",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Grpc.Core": "2.38.1",
         "System.Linq.Async": "4.0.0"
       },
       "testDependencies": {
-        "Google.Api.Gax.Grpc.Testing": "3.3.0"
+        "Google.Api.Gax.Grpc.Testing": "3.5.0"
       }
     },
     {
@@ -783,9 +783,9 @@
         "Stackdriver"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.Cloud.DevTools.Common": "2.1.0",
-        "Grpc.Core": "2.36.4"
+        "Grpc.Core": "2.38.1"
       }
     },
     {
@@ -818,10 +818,10 @@
         "grafeas"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Google.Cloud.Iam.V1": "2.1.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Google.Cloud.Iam.V1": "2.2.0",
         "Grafeas.V1": "project",
-        "Grpc.Core": "2.36.4"
+        "Grpc.Core": "2.38.1"
       }
     },
     {
@@ -842,13 +842,13 @@
       ],
       "dependencies": {
         "Google.Cloud.Diagnostics.Common": "project",
-        "Grpc.Core": "2.38.0",
+        "Grpc.Core": "2.38.1",
         "Microsoft.AspNetCore.Hosting.Abstractions": "2.1.1",
         "Microsoft.AspNetCore.Http": "2.1.1",
         "Microsoft.AspNetCore.Http.Extensions": "2.1.1"
       },
       "testDependencies": {
-        "Google.Api.Gax.Testing": "3.4.0",
+        "Google.Api.Gax.Testing": "3.5.0",
         "Google.Cloud.Diagnostics.Common.IntegrationTests": "project",
         "Google.Cloud.Diagnostics.Common.Tests": "project"
       }
@@ -871,10 +871,10 @@
       ],
       "dependencies": {
         "Google.Cloud.Diagnostics.Common": "project",
-        "Grpc.Core": "2.38.0"
+        "Grpc.Core": "2.38.1"
       },
       "testDependencies": {
-        "Google.Api.Gax.Testing": "3.4.0",
+        "Google.Api.Gax.Testing": "3.5.0",
         "Google.Cloud.Diagnostics.Common.IntegrationTests": "project",
         "Google.Cloud.Diagnostics.Common.Tests": "project"
       }
@@ -895,7 +895,7 @@
         "Diagnostics"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.Cloud.Logging.V2": "3.3.0",
         "Google.Cloud.Trace.V1": "2.2.0",
         "Microsoft.Extensions.Http": "2.1.1",
@@ -919,7 +919,7 @@
         "agents"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.LongRunning": "2.2.0",
         "Grpc.Core": "2.38.1"
       },
@@ -940,7 +940,7 @@
         "iot"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.LongRunning": "2.2.0",
         "Grpc.Core": "2.38.1"
       },
@@ -958,8 +958,8 @@
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Data Loss Prevention API, which provides methods for detection of privacy-sensitive fragments in text, images, and Google Cloud Platform storage repositories.",
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Grpc.Core": "2.38.1"
       },
       "tags": [
         "DLP",
@@ -984,9 +984,9 @@
         "automl"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.LongRunning": "2.2.0",
-        "Grpc.Core": "2.38.0"
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/cloud/documentai/v1"
@@ -1056,8 +1056,8 @@
         "contacts"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/cloud/essentialcontacts/v1"
@@ -1074,9 +1074,9 @@
         "cloudevents"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.LongRunning": "2.2.0",
-        "Grpc.Core": "2.38.0"
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/cloud/eventarc/v1"
@@ -1089,10 +1089,10 @@
       "description": "The Cloud Filestore API is used for creating and managing cloud file servers.",
       "tags": [],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.Cloud.Common": "1.0.0",
         "Google.LongRunning": "2.2.0",
-        "Grpc.Core": "2.38.0"
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/cloud/filestore/v1"
@@ -1115,9 +1115,9 @@
         "admin"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.LongRunning": "2.2.0",
-        "Grpc.Core": "2.36.4"
+        "Grpc.Core": "2.38.1"
       }
     },
     {
@@ -1137,14 +1137,14 @@
       ],
       "dependencies": {
         "Google.Cloud.Firestore.V1": "project",
-        "Grpc.Core": "2.36.4",
+        "Grpc.Core": "2.38.1",
         "System.Collections.Immutable": "1.4.0",
         "System.Linq.Async": "4.0.0"
       },
       "testDependencies": {
-        "Google.Api.Gax.Grpc.Testing": "3.3.0",
-        "Google.Api.Gax.Testing": "3.3.0",
-        "Grpc.Core.Testing": "2.36.4",
+        "Google.Api.Gax.Grpc.Testing": "3.5.0",
+        "Google.Api.Gax.Testing": "3.5.0",
+        "Grpc.Core.Testing": "2.38.1",
         "System.ValueTuple": "4.5.0",
         "Xunit.Combinatorial": "1.4.1"
       }
@@ -1166,9 +1166,9 @@
         "firebase"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Google.LongRunning": "2.1.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Google.LongRunning": "2.2.0",
+        "Grpc.Core": "2.38.1"
       }
     },
     {
@@ -1182,10 +1182,10 @@
         "functions"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Google.Cloud.Iam.V1": "2.1.0",
-        "Google.LongRunning": "2.1.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Google.Cloud.Iam.V1": "2.2.0",
+        "Google.LongRunning": "2.2.0",
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/cloud/functions/v1"
@@ -1203,9 +1203,9 @@
         "add-ons"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.Apps.Script.Type": "project",
-        "Grpc.Core": "2.36.4"
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/cloud/gsuiteaddons/v1"
@@ -1222,9 +1222,9 @@
         "games"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.LongRunning": "2.2.0",
-        "Grpc.Core": "2.36.4"
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/cloud/gaming/v1"
@@ -1278,7 +1278,7 @@
         "anthos"
       ],
       "dependencies": {
-        "Google.LongRunning": "2.1.0"
+        "Google.LongRunning": "2.2.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/gkehub/v1beta1"
@@ -1296,7 +1296,7 @@
         "anthos"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.LongRunning": "2.2.0",
         "Grpc.Core": "2.38.1"
       },
@@ -1318,9 +1318,9 @@
         "admin"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.Cloud.Iam.V1": "2.2.0",
-        "Grpc.Core": "2.38.0"
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/iam/admin/v1"
@@ -1339,8 +1339,8 @@
         "account"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/iam/credentials/v1"
@@ -1361,8 +1361,8 @@
         "Access"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Grpc.Core": "2.38.1"
       }
     },
     {
@@ -1378,9 +1378,9 @@
         "access"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.Cloud.Iam.V1": "2.2.0",
-        "Grpc.Core": "2.38.0"
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/cloud/iap/v1"
@@ -1396,9 +1396,9 @@
         "iot"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Google.Cloud.Iam.V1": "2.1.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Google.Cloud.Iam.V1": "2.2.0",
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/cloud/iot/v1"
@@ -1419,7 +1419,7 @@
         "encryption"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.Cloud.Iam.V1": "2.2.0",
         "Grpc.Core": "2.38.1"
       }
@@ -1434,8 +1434,8 @@
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Natural Language API, which provides natural language understanding technologies to developers. Examples include sentiment analysis, entity recognition, and text annotations.",
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Grpc.Core": "2.38.1"
       },
       "tags": [
         "Language"
@@ -1472,14 +1472,14 @@
         "Stackdriver"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.Cloud.DevTools.Common": "2.1.0",
         "Google.Cloud.Logging.V2": "3.3.0",
-        "Grpc.Core": "2.36.4",
+        "Grpc.Core": "2.38.1",
         "log4net": "2.0.12"
       },
       "testDependencies": {
-        "Google.Api.Gax.Testing": "3.3.0"
+        "Google.Api.Gax.Testing": "3.5.0"
       }
     },
     {
@@ -1514,14 +1514,14 @@
         "Stackdriver"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.2.0",
-        "Google.Cloud.DevTools.Common": "2.0.0",
-        "Google.Cloud.Logging.V2": "3.2.0",
-        "Grpc.Core": "2.31.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Google.Cloud.DevTools.Common": "2.1.0",
+        "Google.Cloud.Logging.V2": "3.3.0",
+        "Grpc.Core": "2.38.1",
         "NLog": "4.5.11"
       },
       "testDependencies": {
-        "Google.Api.Gax.Testing": "3.2.0"
+        "Google.Api.Gax.Testing": "3.5.0"
       }
     },
     {
@@ -1554,9 +1554,9 @@
         "Stackdriver"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Google.Cloud.Logging.Type": "3.2.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Google.Cloud.Logging.Type": "3.3.0",
+        "Grpc.Core": "2.38.1"
       }
     },
     {
@@ -1574,9 +1574,9 @@
         "Active Directory"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Google.LongRunning": "2.1.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Google.LongRunning": "2.2.0",
+        "Grpc.Core": "2.38.1"
       }
     },
     {
@@ -1607,9 +1607,9 @@
         "Memorystore"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.LongRunning": "2.2.0",
-        "Grpc.Core": "2.36.4"
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/cloud/memcache/v1"
@@ -1624,9 +1624,9 @@
       "type": "grpc",
       "description": "Recommended Google client library to administer Cloud Memorystore for Memcache (v1beta2).",
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Google.LongRunning": "2.1.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Google.LongRunning": "2.2.0",
+        "Grpc.Core": "2.38.1"
       },
       "tags": [
         "Redis",
@@ -1645,9 +1645,9 @@
         "metastore"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.LongRunning": "2.2.0",
-        "Grpc.Core": "2.36.4"
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/cloud/metastore/v1"
@@ -1664,7 +1664,7 @@
         "metastore"
       ],
       "dependencies": {
-        "Google.LongRunning": "2.1.0"
+        "Google.LongRunning": "2.2.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/metastore/v1alpha"
@@ -1681,7 +1681,7 @@
         "metastore"
       ],
       "dependencies": {
-        "Google.LongRunning": "2.1.0"
+        "Google.LongRunning": "2.2.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/metastore/v1beta"
@@ -1701,8 +1701,8 @@
       ],
       "dependencies": {
         "Google.Api.CommonProtos": "2.3.0",
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Grpc.Core": "2.38.1"
       }
     },
     {
@@ -1756,7 +1756,7 @@
         "diagnostics"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.LongRunning": "2.2.0",
         "Grpc.Core": "2.38.1"
       },
@@ -1824,8 +1824,8 @@
         "governance"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.2.0",
-        "Grpc.Core": "2.31.0"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/cloud/orgpolicy/v2"
@@ -1848,8 +1848,8 @@
       ],
       "dependencies": {
         "Google.Api.CommonProtos": "2.3.0",
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Grpc.Core": "2.38.1"
       }
     },
     {
@@ -1886,7 +1886,7 @@
       ],
       "dependencies": {
         "Google.Api.CommonProtos": "2.3.0",
-        "Google.Api.Gax": "3.3.0"
+        "Google.Api.Gax": "3.5.0"
       },
       "noVersionHistory": true
     },
@@ -1904,9 +1904,9 @@
         "Login"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.Cloud.OsLogin.Common": "project",
-        "Grpc.Core": "2.36.4"
+        "Grpc.Core": "2.38.1"
       }
     },
     {
@@ -1924,9 +1924,9 @@
         "Login"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.Cloud.OsLogin.Common": "project",
-        "Grpc.Core": "2.36.4"
+        "Grpc.Core": "2.38.1"
       }
     },
     {
@@ -1955,9 +1955,9 @@
         "diagnostics"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.Cloud.Iam.V1": "2.2.0",
-        "Grpc.Core": "2.36.4"
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/cloud/policytroubleshooter/v1"
@@ -1991,8 +1991,8 @@
         "profiler"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/devtools/cloudprofiler/v2"
@@ -2008,12 +2008,12 @@
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.",
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.Cloud.Iam.V1": "2.2.0",
         "Grpc.Core": "2.38.1"
       },
       "testDependencies": {
-        "Google.Api.Gax.Testing": "3.4.0",
+        "Google.Api.Gax.Testing": "3.5.0",
         "Google.Apis.CloudResourceManager.v1": "1.53.0.2281",
         "System.ValueTuple": "4.5.0",
         "Xunit.Combinatorial": "1.4.1"
@@ -2035,8 +2035,8 @@
         "reCAPTCHA"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Grpc.Core": "2.38.1"
       }
     },
     {
@@ -2064,7 +2064,7 @@
         "recommendations"
       ],
       "dependencies": {
-        "Google.LongRunning": "2.1.0"
+        "Google.LongRunning": "2.2.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/recommendationengine/v1beta1"
@@ -2079,8 +2079,8 @@
       "type": "grpc",
       "description": "Recommended Google client library for the Recommender API, which provides usage recommendations for Cloud products and services.",
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Grpc.Core": "2.38.1"
       },
       "tags": [
         "Recommender"
@@ -2096,9 +2096,9 @@
       "type": "grpc",
       "description": "Recommended Google client library to administer Cloud Memorystore for Redis.",
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.LongRunning": "2.2.0",
-        "Grpc.Core": "2.36.4"
+        "Grpc.Core": "2.38.1"
       },
       "tags": [
         "Redis",
@@ -2134,10 +2134,10 @@
         "resources"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.Cloud.Iam.V1": "2.2.0",
         "Google.LongRunning": "2.2.0",
-        "Grpc.Core": "2.38.0"
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/cloud/resourcemanager/v3"
@@ -2154,7 +2154,7 @@
         "settings"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
@@ -2171,7 +2171,7 @@
         "retail"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.LongRunning": "2.2.0",
         "Grpc.Core": "2.38.1"
       },
@@ -2192,8 +2192,8 @@
         "cron"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Grpc.Core": "2.38.1"
       }
     },
     {
@@ -2206,7 +2206,7 @@
       "type": "grpc",
       "description": "Recommended Google client library to access the Secret Manager API.",
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.Cloud.Iam.V1": "2.2.0",
         "Grpc.Core": "2.38.1"
       },
@@ -2248,9 +2248,9 @@
         "private-ca"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.LongRunning": "2.2.0",
-        "Grpc.Core": "2.38.0"
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/cloud/security/privateca/v1"
@@ -2283,10 +2283,10 @@
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Security Command Center Settings API.",
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.Cloud.Iam.V1": "2.2.0",
         "Google.LongRunning": "2.2.0",
-        "Grpc.Core": "2.36.4"
+        "Grpc.Core": "2.38.1"
       },
       "tags": [
         "security",
@@ -2304,7 +2304,7 @@
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Security Command Center API, which helps security teams gather data, identify threats, and act on them before they result in business damage or loss.",
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.Cloud.Iam.V1": "2.2.0",
         "Google.LongRunning": "2.2.0",
         "Grpc.Core": "2.38.1"
@@ -2324,10 +2324,10 @@
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Security Command Center API version v1p1beta1, which helps security teams gather data, identify threats, and act on them before they result in business damage or loss.",
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.Cloud.Iam.V1": "2.2.0",
         "Google.LongRunning": "2.2.0",
-        "Grpc.Core": "2.36.4"
+        "Grpc.Core": "2.38.1"
       },
       "tags": [
         "security",
@@ -2346,7 +2346,7 @@
         "services"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.Cloud.Logging.Type": "3.3.0",
         "Grpc.Core": "2.38.1"
       },
@@ -2364,9 +2364,9 @@
         "services"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.Cloud.Iam.V1": "2.2.0",
-        "Grpc.Core": "2.36.4"
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/cloud/servicedirectory/v1"
@@ -2400,9 +2400,9 @@
         "management"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.LongRunning": "2.2.0",
-        "Grpc.Core": "2.38.0"
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/api/servicemanagement/v1"
@@ -2419,9 +2419,9 @@
         "apis"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.LongRunning": "2.2.0",
-        "Grpc.Core": "2.38.0"
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/api/serviceusage/v1"
@@ -2437,9 +2437,9 @@
         "shell"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.LongRunning": "2.2.0",
-        "Grpc.Core": "2.36.4"
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/cloud/shell/v1"
@@ -2458,11 +2458,11 @@
         "Spanner"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.Cloud.Iam.V1": "2.2.0",
         "Google.Cloud.Spanner.Common.V1": "project",
         "Google.LongRunning": "2.2.0",
-        "Grpc.Core": "2.38.0"
+        "Grpc.Core": "2.38.1"
       },
       "noVersionHistory": true
     },
@@ -2480,11 +2480,11 @@
         "Spanner"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.Cloud.Iam.V1": "2.2.0",
         "Google.Cloud.Spanner.Common.V1": "project",
         "Google.LongRunning": "2.2.0",
-        "Grpc.Core": "2.38.0"
+        "Grpc.Core": "2.38.1"
       },
       "noVersionHistory": true
     },
@@ -2501,17 +2501,17 @@
         "ADO"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.Cloud.Spanner.Admin.Database.V1": "project",
         "Google.Cloud.Spanner.Admin.Instance.V1": "project",
         "Google.Cloud.Spanner.V1": "project",
-        "Grpc.Core": "2.38.0",
+        "Grpc.Core": "2.38.1",
         "Grpc.Gcp": "2.0.0"
       },
       "testDependencies": {
         "CoreCompat.EnterpriseLibrary.TransientFaultHandling": "6.0.1304-r3",
-        "Google.Api.Gax.Grpc.Testing": "3.4.0",
-        "Google.Api.Gax.Testing": "3.4.0",
+        "Google.Api.Gax.Grpc.Testing": "3.5.0",
+        "Google.Api.Gax.Testing": "3.5.0",
         "Xunit.Combinatorial": "1.4.1"
       }
     },
@@ -2525,7 +2525,7 @@
         "Spanner"
       ],
       "dependencies": {
-        "Google.Api.Gax": "3.4.0"
+        "Google.Api.Gax": "3.5.0"
       },
       "noVersionHistory": true
     },
@@ -2544,9 +2544,9 @@
         "Spanner"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.Cloud.Spanner.Common.V1": "project",
-        "Grpc.Core": "2.38.0"
+        "Grpc.Core": "2.38.1"
       },
       "testDependencies": {
         "Xunit.Combinatorial": "1.4.1"
@@ -2567,7 +2567,7 @@
         "Speech"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.LongRunning": "2.2.0",
         "Grpc.Core": "2.38.1"
       }
@@ -2598,11 +2598,11 @@
       "type": "rest",
       "description": "Recommended Google client library to access the Google Cloud Storage API. It wraps the Google.Apis.Storage.v1 client library, making common operations simpler in client code. Google Cloud Storage stores and retrieves potentially large, immutable data objects.",
       "dependencies": {
-        "Google.Api.Gax.Rest": "3.3.0",
+        "Google.Api.Gax.Rest": "3.5.0",
         "Google.Apis.Storage.v1": "1.53.0.2234"
       },
       "testDependencies": {
-        "Google.Api.Gax.Testing": "3.3.0",
+        "Google.Api.Gax.Testing": "3.5.0",
         "Google.Apis.Iam.v1": "1.53.0.2394",
         "Google.Cloud.PubSub.V1": "project"
       },
@@ -2624,7 +2624,7 @@
         "gcs"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.LongRunning": "2.2.0",
         "Grpc.Core": "2.38.1"
       },
@@ -2643,9 +2643,9 @@
         "Jobs"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.LongRunning": "2.2.0",
-        "Grpc.Core": "2.36.4"
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/cloud/talent/v4"
@@ -2681,9 +2681,9 @@
         "Tasks"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.Cloud.Iam.V1": "2.2.0",
-        "Grpc.Core": "2.36.4"
+        "Grpc.Core": "2.38.1"
       }
     },
     {
@@ -2713,8 +2713,8 @@
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Text-to-Speech API v1, synthesizes natural-sounding speech by applying powerful neural network models.",
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Grpc.Core": "2.38.1"
       },
       "tags": [
         "Speech",
@@ -2747,9 +2747,9 @@
         "tpu"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.LongRunning": "2.2.0",
-        "Grpc.Core": "2.38.0"
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/cloud/tpu/v1"
@@ -2764,8 +2764,8 @@
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Trace API, which sends and retrieves trace data from Google Cloud Trace. Data is generated and available by default for all App Engine applications. Data from other applications can be written to Cloud Trace for display, reporting, and analysis.",
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Grpc.Core": "2.38.1"
       },
       "tags": [
         "Tracing",
@@ -2782,8 +2782,8 @@
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Trace V2 API, which sends and retrieves trace data from Google Cloud Trace. Data is generated and available by default for all App Engine applications. Data from other applications can be written to Cloud Trace for display, reporting, and analysis.",
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Grpc.Core": "2.38.1"
       },
       "tags": [
         "Tracing",
@@ -2800,9 +2800,9 @@
       "type": "grpc",
       "description": "Recommended Google client library to access the Translate v3 API. The Translate API translates text from one language to another.",
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.LongRunning": "2.2.0",
-        "Grpc.Core": "2.36.4"
+        "Grpc.Core": "2.38.1"
       },
       "tags": [
         "Translate",
@@ -2817,7 +2817,7 @@
       "type": "rest",
       "description": "Recommended Google client library to access the Translate v2 API. It wraps the Google.Apis.Translate.v2 client library, making common operations simpler in client code. The Translate API translates text from one language to another.",
       "dependencies": {
-        "Google.Api.Gax.Rest": "3.3.0",
+        "Google.Api.Gax.Rest": "3.5.0",
         "Google.Apis.Translate.v2": "1.53.0.875"
       },
       "tags": [
@@ -2871,9 +2871,9 @@
         "VideoIntelligence"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Google.LongRunning": "2.1.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Google.LongRunning": "2.2.0",
+        "Grpc.Core": "2.38.1"
       }
     },
     {
@@ -2890,9 +2890,9 @@
         "Vision"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Google.LongRunning": "2.1.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Google.LongRunning": "2.2.0",
+        "Grpc.Core": "2.38.1"
       }
     },
     {
@@ -2906,9 +2906,9 @@
         "vpc"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.4.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.LongRunning": "2.2.0",
-        "Grpc.Core": "2.38.0"
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/cloud/vpcaccess/v1"
@@ -2931,8 +2931,8 @@
         "url"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Grpc.Core": "2.38.1"
       }
     },
     {
@@ -2966,8 +2966,8 @@
         "scanner"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/cloud/websecurityscanner/v1"
@@ -2982,7 +2982,7 @@
         "Spanner"
       ],
       "dependencies": {
-        "Google.Api.Gax": "3.3.0"
+        "Google.Api.Gax": "3.5.0"
       },
       "noVersionHistory": true
     },
@@ -2996,7 +2996,7 @@
         "Spanner"
       ],
       "dependencies": {
-        "Google.Api.Gax": "3.3.0"
+        "Google.Api.Gax": "3.5.0"
       },
       "noVersionHistory": true
     },
@@ -3012,9 +3012,9 @@
         "workflows"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.Cloud.Workflows.Common.V1": "project",
-        "Grpc.Core": "2.36.4"
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/cloud/workflows/executions/v1"
@@ -3048,10 +3048,10 @@
         "workflows"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.Cloud.Workflows.Common.V1": "project",
-        "Google.LongRunning": "2.1.0",
-        "Grpc.Core": "2.36.4"
+        "Google.LongRunning": "2.2.0",
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/cloud/workflows/v1"
@@ -3121,11 +3121,11 @@
         "LongRunning"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Grpc.Core": "2.38.1"
       },
       "testDependencies": {
-        "Google.Api.Gax.Testing": "3.3.0"
+        "Google.Api.Gax.Testing": "3.5.0"
       }
     },
     {
@@ -3145,8 +3145,8 @@
         "grafeas"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.3.0",
-        "Grpc.Core": "2.36.4"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Grpc.Core": "2.38.1"
       }
     }
   ],

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -568,7 +568,7 @@
         "compute"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "3.5.0"
+        "Google.Api.Gax.Grpc": "3.6.0-beta01"
       },
       "generator": "regapic",
       "protoPath": "google/cloud/compute/v1"

--- a/tools/Google.Cloud.Tools.ReleaseManager/GenerateProjectsCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/GenerateProjectsCommand.cs
@@ -63,7 +63,7 @@ namespace Google.Cloud.Tools.ReleaseManager
         private const string ProjectVersionValue = "project";
         private const string DefaultVersionValue = "default";
         private const string GrpcPackage = "Grpc.Core";
-        private const string DefaultGaxVersion = "3.4.0";
+        private const string DefaultGaxVersion = "3.5.0";
         private const string GrpcVersion = "2.38.1";
         private static readonly Dictionary<string, string> DefaultPackageVersions = new Dictionary<string, string>
         {

--- a/tools/Google.Cloud.Tools.ReleaseManager/UpdateDependencies.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/UpdateDependencies.cs
@@ -1,0 +1,45 @@
+﻿// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Tools.Common;
+using System;
+using System.IO;
+
+namespace Google.Cloud.Tools.ReleaseManager
+{
+    public sealed class UpdateDependenciesCommand : CommandBase
+    {
+        public UpdateDependenciesCommand()
+            : base("update-dependencies", "Updates dependencies for all APIs")
+        {
+        }
+
+        protected override void ExecuteImpl(string[] args)
+        {
+            var catalog = ApiCatalog.Load();
+            var apiNames = catalog.CreateIdHashSet();
+
+            foreach (var api in catalog.Apis)
+            {
+                GenerateProjectsCommand.UpdateDependencies(catalog, api);
+                var layout = DirectoryLayout.ForApi(api.Id);
+                GenerateProjectsCommand.GenerateMetadataFile(layout.SourceDirectory, api);
+                GenerateProjectsCommand.GenerateProjects(layout.SourceDirectory, api, apiNames);
+            }
+            string formatted = catalog.FormatJson();
+            File.WriteAllText(ApiCatalog.CatalogPath, formatted);
+            Console.WriteLine("Updated apis.json");
+        }
+    }
+}


### PR DESCRIPTION
Currently this leaves Compute using self-signed JWTs. That appears to work, but we need more confirmation before the next release.