### PR TITLE
Release Google.Cloud.Bigtable.V2 version 2.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.BigQuery.Storage.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.BigQuery.Storage.V1/latest) | 2.3.0 | [Google BigQuery Storage](https://cloud.google.com/bigquery/docs/reference/storage/) |
 | [Google.Cloud.Bigtable.Admin.V2](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Bigtable.Admin.V2/latest) | 2.4.0 | [Google Cloud Bigtable Administration](https://cloud.google.com/bigtable/) |
 | [Google.Cloud.Bigtable.Common.V2](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Bigtable.Common.V2/latest) | 2.1.0 | Common code used by Bigtable V2 APIs |
-| [Google.Cloud.Bigtable.V2](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Bigtable.V2/latest) | 2.2.0 | [Google Bigtable](https://cloud.google.com/bigtable/) |
+| [Google.Cloud.Bigtable.V2](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Bigtable.V2/latest) | 2.3.0 | [Google Bigtable](https://cloud.google.com/bigtable/) |
 | [Google.Cloud.Billing.Budgets.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Billing.Budgets.V1/latest) | 1.1.0 | [Cloud Billing Budget (V1 API)](https://cloud.google.com/billing/docs/how-to/budget-api-overview) |
 | [Google.Cloud.Billing.Budgets.V1Beta1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Billing.Budgets.V1Beta1/latest) | 1.0.0-beta03 | [Cloud Billing Budget (V1Beta1 API)](https://cloud.google.com/billing/docs/how-to/budget-api-overview) |
 | [Google.Cloud.Billing.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Billing.V1/latest) | 2.2.0 | [Google Cloud Billing](https://cloud.google.com/billing/docs/) |

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.2.0</Version>
+    <Version>2.3.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Bigtable API.</Description>

--- a/apis/Google.Cloud.Bigtable.V2/docs/history.md
+++ b/apis/Google.Cloud.Bigtable.V2/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+# Version 2.3.0, released 2021-08-18
+
+- [Commit b58fa0b](https://github.com/googleapis/google-cloud-dotnet/commit/b58fa0b): Fix Bigtable for self-signed JWTs
+- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): Regenerate all APIs with self-signed JWT support
+
+This release fixes a subtle bug that would cause BigtableServiceApiClient.Create() to fail when used with GAX 3.5.0, as well as enabling self-signed JWT support.
+
 # Version 2.2.0, released 2021-05-05
 
 - [Commit 9f5f0aa](https://github.com/googleapis/google-cloud-dotnet/commit/9f5f0aa): fix: Regenerate server-streaming calls with Google request params. Fixes [issue 6310](https://github.com/googleapis/google-cloud-dotnet/issues/6310).

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -397,7 +397,7 @@
       "protoPath": "google/bigtable/v2",
       "productName": "Google Bigtable",
       "productUrl": "https://cloud.google.com/bigtable/",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "commonResourcesConfig": "apis/Google.Cloud.Bigtable.Common.V2/CommonResourcesConfig.json",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",


### PR DESCRIPTION

Changes in this release:

- [Commit b58fa0b](https://github.com/googleapis/google-cloud-dotnet/commit/b58fa0b): Fix Bigtable for self-signed JWTs
- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): Regenerate all APIs with self-signed JWT support

This release fixes a subtle bug that would cause BigtableServiceApiClient.Create() to fail when used with GAX 3.5.0, as well as enabling self-signed JWT support.
