### PR TITLE
Release Google.Cloud.Firestore.V1 version 2.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Filestore.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Filestore.V1/latest) | 1.0.0 | Cloud Filestore |
 | [Google.Cloud.Firestore.Admin.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Firestore.Admin.V1/latest) | 2.2.0 | [Firestore Administration (e.g. index management)](https://firebase.google.com) |
 | [Google.Cloud.Firestore](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Firestore/latest) | 2.4.0 | [Firestore high-level library](https://firebase.google.com/docs/firestore/) |
-| [Google.Cloud.Firestore.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Firestore.V1/latest) | 2.3.0 | [Firestore low-level API access](https://firebase.google.com) |
+| [Google.Cloud.Firestore.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Firestore.V1/latest) | 2.4.0 | [Firestore low-level API access](https://firebase.google.com) |
 | [Google.Cloud.Functions.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Functions.V1/latest) | 1.1.0 | [Cloud Functions](https://cloud.google.com/functions) |
 | [Google.Cloud.GSuiteAddOns.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.GSuiteAddOns.V1/latest) | 1.0.0 | [Google Workspace Add-ons](https://developers.google.com/gsuite/add-ons/overview) |
 | [Google.Cloud.Gaming.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Gaming.V1/latest) | 1.1.0 | [Game Services](https://cloud.google.com/solutions/gaming) |

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.csproj
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Low-level Google client library to access the Firestore API. Users are recommended to use the Google.Cloud.Firestore package instead.</Description>

--- a/apis/Google.Cloud.Firestore.V1/docs/history.md
+++ b/apis/Google.Cloud.Firestore.V1/docs/history.md
@@ -4,6 +4,11 @@ This package is primarily a dependency of Google.Cloud.Firestore. See the
 [Google.Cloud.Firestore version history](https://googleapis.dev/dotnet/Google.Cloud.Firestore/latest/history.html)
 for more details.
 
+# Version 2.4.0, released 2021-08-18
+
+- [Commit d9a3648](https://github.com/googleapis/google-cloud-dotnet/commit/d9a3648): Fix Firestore and Datastore for self-signed JWTs
+- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): Regenerate all APIs to support self-signed JWTs
+
 # Version 2.3.0, released 2021-05-05
 
 - [Commit 9f5f0aa](https://github.com/googleapis/google-cloud-dotnet/commit/9f5f0aa): Regenerate server-streaming calls with Google request params

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1156,7 +1156,7 @@
       "productName": "Firestore",
       "productUrl": "https://firebase.google.com",
       "listingDescription": "Firestore low-level API access",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "type": "grpc",
       "targetFrameworks": "netstandard2.0;net461",
       "testTargetFrameworks": "netcoreapp2.1;net461",

--- a/known-commits-config.json
+++ b/known-commits-config.json
@@ -1,0 +1,7 @@
+{
+  "ShowHistory": false,
+  "KnownCommits": {
+    "Commits": ["ac367e2"],
+    "HistoryOverride": "Enables support for self-signed JWTs\nSecond line"
+  }
+}

--- a/specified-apis-config.json
+++ b/specified-apis-config.json
@@ -1,0 +1,4 @@
+{
+  "DryRun": false,
+  "SpecifiedApis": ["Google.Cloud.Firestore.V1","Google.Cloud.Datastore.V1"]
+}

--- a/specified-apis-config.json
+++ b/specified-apis-config.json
@@ -1,4 +1,4 @@
 {
   "DryRun": false,
-  "SpecifiedApis": ["Google.Cloud.Firestore.V1","Google.Cloud.Datastore.V1"]
+  "SpecifiedApis": ["Google.Cloud.Firestore.V1"]
 }

--- a/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/BatchReleaseCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/BatchReleaseCommand.cs
@@ -1,0 +1,49 @@
+﻿// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Tools.Common;
+using Newtonsoft.Json;
+using System.IO;
+using System.Linq;
+
+namespace Google.Cloud.Tools.ReleaseManager.BatchRelease
+{
+    public sealed class BatchReleaseCommand : CommandBase
+    {
+        public BatchReleaseCommand()
+            : base("batch-release", "Release multiple APIs", "config-file")
+        {
+        }
+
+        protected override void ExecuteImpl(string[] args)
+        {
+            string configFile = args[0];
+            var json = File.ReadAllText(configFile);
+            var config = JsonConvert.DeserializeObject<BatchReleaseConfig>(json);
+
+            var criteria = config.GetCriteria().ToList();
+            if (criteria.Count != 1)
+            {
+                throw new UserErrorException("Batch release config must specify exactly one criterion.");
+            }
+
+            var catalog = ApiCatalog.Load();
+            foreach (var api in catalog.Apis)
+            {
+
+            }
+        }
+    }
+
+}

--- a/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/BatchReleaseConfig.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/BatchReleaseConfig.cs
@@ -1,0 +1,80 @@
+﻿// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Tools.Common;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Google.Cloud.Tools.ReleaseManager.BatchRelease
+{
+    /// <summary>
+    /// Configuration for the BatchReleaseCommand.
+    /// </summary>
+    public class BatchReleaseConfig
+    {
+        /// <summary>
+        /// When true, each release (and history) is confirmed manually at the console.
+        /// Defaults to true.
+        /// </summary>
+        public bool ConfirmRelease { get; set; } = true;
+
+        /// <summary>
+        /// When true, indicates which libraries would be released and what the history update would
+        /// look like, but doesn't make any changes or release anything. Defaults to true.
+        /// </summary>
+        public bool DryRun { get; set; } = true;
+
+        // Library selection criteria. These properties are effectively mutually exclusive.
+
+        /// <summary>
+        /// Find all libraries with changes matching the given set of commits.
+        /// </summary>
+        public KnownCommitsCriterion KnownCommits { get; set; }
+
+        /// <summary>
+        /// Match exactly the APIs specified.
+        /// </summary>
+        public List<string> SpecifiedApis { get; set; }
+
+        /// <summary>
+        /// Validates that this configuration is reasonable.
+        /// </summary>
+        public void Validate()
+        {
+            var specifiedCriteria = new object[]
+            {
+                KnownCommits,
+                SpecifiedApis
+            }.Count(c => c is object);
+            if (specifiedCriteria != 1)
+            {
+                throw new UserErrorException("A batch release must specify exactly one criterion.");
+            }
+        }
+
+        internal IEnumerable<IBatchCriterion> GetCriteria()
+        {
+            if (KnownCommits is object)
+            {
+                yield return KnownCommits;
+            }
+            if (SpecifiedApis is object)
+            {
+                yield return new SpecifiedApisCriterion(SpecifiedApis);
+            }
+        }
+    }
+}

--- a/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/BatchReleaseConfig.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/BatchReleaseConfig.cs
@@ -37,6 +37,12 @@ namespace Google.Cloud.Tools.ReleaseManager.BatchRelease
         /// </summary>
         public bool DryRun { get; set; } = true;
 
+        /// <summary>
+        /// When true, display the new history text (both in dry-run mode and "do it" mode).
+        /// Defaults to true. Typically this is only disabled when everything will have the same history.
+        /// </summary>
+        public bool ShowHistory { get; set; } = true;
+
         // Library selection criteria. These properties are effectively mutually exclusive.
 
         /// <summary>

--- a/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/IBatchCriterion.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/IBatchCriterion.cs
@@ -1,0 +1,27 @@
+﻿// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Tools.Common;
+using System.Collections.Generic;
+
+namespace Google.Cloud.Tools.ReleaseManager.BatchRelease
+{
+    internal interface IBatchCriterion
+    {
+        /// <summary>
+        /// Returns the proposed releases for all APIs in the catalog
+        /// </summary>
+        IEnumerable<ReleaseProposal> GetProposals(ApiCatalog catalog);
+    }
+}

--- a/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/KnownCommitsCriterion.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/KnownCommitsCriterion.cs
@@ -30,7 +30,7 @@ namespace Google.Cloud.Tools.ReleaseManager.BatchRelease
         /// </summary>
         public HashSet<string> Commits { get; set; }
 
-        ReleaseProposal IBatchCriterion.GetProposal(ApiMetadata api)
+        IEnumerable<ReleaseProposal> IBatchCriterion.GetProposals(ApiCatalog catalog)
         {
             return null;
         }

--- a/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/KnownCommitsCriterion.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/KnownCommitsCriterion.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Tools.Common;
+using System.Collections.Generic;
+
+namespace Google.Cloud.Tools.ReleaseManager.BatchRelease
+{
+    public sealed class KnownCommitsCriterion: IBatchCriterion
+    {
+        /// <summary>
+        /// If set, override the natural history with this text.
+        /// </summary>
+        public string HistoryOverride { get; set; }
+
+        /// <summary>
+        /// The set of commits to expect. Only libraries with exactly this set of
+        /// commits since the previous release are bumped.
+        /// </summary>
+        public HashSet<string> Commits { get; set; }
+
+        ReleaseProposal IBatchCriterion.GetProposal(ApiMetadata api)
+        {
+            return null;
+        }
+    }
+}

--- a/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/ReleaseProposal.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/ReleaseProposal.cs
@@ -1,0 +1,30 @@
+﻿// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Tools.Common;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Google.Cloud.Tools.ReleaseManager.BatchRelease
+{
+    /// <summary>
+    /// The details of what might be released.
+    /// </summary>
+    internal class ReleaseProposal
+    {
+        public StructuredVersion NewVersion { get; set; }
+        public string NewHistoryText { get; set; }
+    }
+}

--- a/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/ReleaseProposal.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/ReleaseProposal.cs
@@ -14,6 +14,11 @@
 
 using Google.Cloud.Tools.Common;
 using Google.Cloud.Tools.ReleaseManager.History;
+using LibGit2Sharp;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
 
 namespace Google.Cloud.Tools.ReleaseManager.BatchRelease
 {
@@ -22,8 +27,158 @@ namespace Google.Cloud.Tools.ReleaseManager.BatchRelease
     /// </summary>
     internal class ReleaseProposal
     {
-        public StructuredVersion NewVersion { get; set; }
-        public string NewHistoryText { get; set; }
-        public HistoryFile HistoryFile { get; set; }
+        public string Id { get; }
+        public StructuredVersion OldVersion { get; }
+        public StructuredVersion NewVersion { get; }
+        private HistoryFile ModifiedHistoryFile { get; }
+
+        /// <summary>
+        /// The history file section being added, or null if this API does not have a version history.
+        /// </summary>
+        public HistoryFile.Section NewHistorySection
+        {
+            get => ModifiedHistoryFile.Sections.Count > 1 ? ModifiedHistoryFile.Sections[1] : null;
+            set
+            {
+                if (ModifiedHistoryFile.Sections.Count > 1)
+                {
+                    ModifiedHistoryFile.Sections[1] = value;
+                }
+                else
+                {
+                    throw new InvalidOperationException("Proposal has no new history section to replace");
+                }
+            }
+        }
+
+        // Handy for debugging
+        public override string ToString() => $"Update {Id} from {OldVersion} to {NewVersion}";
+
+        private ReleaseProposal(string id, StructuredVersion oldVersion, StructuredVersion newVersion, HistoryFile historyFile) =>
+            (Id, OldVersion, NewVersion, ModifiedHistoryFile) = (id, oldVersion, newVersion, historyFile);
+
+        public static ReleaseProposal CreateFromHistory(Repository repo, string id, StructuredVersion newVersion)
+        {
+            var catalog = ApiCatalog.Load();
+            var api = catalog[id];
+            var oldVersion = api.StructuredVersion;
+            api.Version = newVersion.ToString();
+            var releases = Release.LoadReleases(repo, catalog, api).ToList();
+            string historyFilePath = HistoryFile.GetPathForPackage(api.Id);
+            var historyFile = HistoryFile.Load(historyFilePath);
+            if (!api.NoVersionHistory)
+            {
+                var sectionsInserted = historyFile.MergeReleases(releases);
+                if (sectionsInserted.Count != 1)
+                {
+                    throw new UserErrorException($"API {api.Id} would have {sectionsInserted.Count} new history sections");
+                }
+            }
+            return new ReleaseProposal(api.Id, oldVersion, newVersion, historyFile);
+        }
+
+        public void Execute(BatchReleaseConfig config)
+        {
+            Console.WriteLine(this);
+
+            if (config.ShowHistory)
+            {
+                if (ModifiedHistoryFile.Sections.Count > 1)
+                {
+                    Console.WriteLine("New history text:");
+                    foreach (var line in NewHistorySection.Lines)
+                    {
+                        Console.WriteLine($"  {line}");
+                    }
+                }
+                else
+                {
+                    Console.WriteLine("(No history text)");
+                }
+            }
+            if (config.DryRun)
+            {
+                return;
+            }
+
+            if (config.ConfirmRelease)
+            {
+                if (!ConfirmRelease())
+                {
+                    return;
+                }
+            }
+
+            var root = DirectoryLayout.DetermineRootDirectory();
+            using var repo = new Repository(root);
+
+            var original = repo.Head;
+
+            // Create a new branch with the desired changes
+            var branchName = $"release-{Id}-{NewVersion}";
+            var releaseBranch = repo.CreateBranch(branchName);
+            Commands.Checkout(repo, releaseBranch);
+
+            new SetVersionCommand().InternalExecute(Id, NewVersion.ToString());
+            ModifiedHistoryFile.Save(HistoryFile.GetPathForPackage(Id));
+            new CommitCommand().InternalExecute();
+            //new PushCommand().InternalExecute();
+
+            // Go back to our current branch
+            Commands.Checkout(repo, original);
+
+            Console.WriteLine("At this point I'd create a new branch, set the version, update the history file, commit and push");
+        }
+
+        /// <summary>
+        /// Asks for confirmation, with optional editing.
+        /// </summary>
+        /// <returns>true if the release should go ahead; false to skip this release.</returns>
+        private bool ConfirmRelease()
+        {
+            while (true)
+            {
+                Console.Write("Proceed with release? (y/n/edit) ");
+                string response = Console.ReadLine();
+                switch (response)
+                {
+                    case "y":
+                        return true;
+                    case "n":
+                        return false;
+                    case "edit":
+                        EditNewHistory();
+                        break;
+                    default:
+                        Console.WriteLine($"Unexpected response '{response}'.");
+                        continue;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Saves the new history section as a temporary file and invokes the editor stored in
+        /// the VISUAL environment variable. Once the process has exited, the file is re-read
+        /// and the changes are stored in both NewHistoryText and the first section of the history file.
+        /// </summary>
+        private void EditNewHistory()
+        {
+            var editor = Environment.GetEnvironmentVariable("VISUAL");
+            if (string.IsNullOrEmpty(editor))
+            {
+                throw new UserErrorException("Unable to determine text editor. Please set the VISUAL environment variable");
+            }
+            string tempFile = Path.GetTempFileName();
+            File.WriteAllLines(tempFile, ModifiedHistoryFile.Sections[1].Lines);
+            var process = Process.Start(editor, tempFile);
+            process.WaitForExit();
+
+            if (process.ExitCode != 0)
+            {
+                Console.WriteLine($"Process exited with code {process.ExitCode}. Ignoring changes.");
+            }
+            var lines = File.ReadAllLines(tempFile).ToList();
+            NewHistorySection = new HistoryFile.Section(NewVersion, lines);
+        }
     }
 }

--- a/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/ReleaseProposal.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/ReleaseProposal.cs
@@ -13,9 +13,7 @@
 // limitations under the License.
 
 using Google.Cloud.Tools.Common;
-using System;
-using System.Collections.Generic;
-using System.Text;
+using Google.Cloud.Tools.ReleaseManager.History;
 
 namespace Google.Cloud.Tools.ReleaseManager.BatchRelease
 {
@@ -26,5 +24,6 @@ namespace Google.Cloud.Tools.ReleaseManager.BatchRelease
     {
         public StructuredVersion NewVersion { get; set; }
         public string NewHistoryText { get; set; }
+        public HistoryFile HistoryFile { get; set; }
     }
 }

--- a/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/SpecifiedApisCriterion.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/SpecifiedApisCriterion.cs
@@ -1,0 +1,41 @@
+﻿// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Tools.Common;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Google.Cloud.Tools.ReleaseManager.BatchRelease
+{
+    internal sealed class SpecifiedApisCriterion : IBatchCriterion
+    {
+        private readonly List<string> _apis;
+
+        internal SpecifiedApisCriterion(IEnumerable<string> apis)
+        {
+            _apis = apis.ToList();
+        }
+
+        public ReleaseProposal GetProposal(ApiMetadata api)
+        {
+            if (!_apis.Contains(api.Id))
+            {
+                return null;
+            }
+            return null;
+        }
+    }
+}

--- a/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/SpecifiedApisCriterion.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/SpecifiedApisCriterion.cs
@@ -29,13 +29,9 @@ namespace Google.Cloud.Tools.ReleaseManager.BatchRelease
             _apis = apis.ToList();
         }
 
-        public ReleaseProposal GetProposal(ApiMetadata api)
+        public IEnumerable<ReleaseProposal> GetProposals(ApiCatalog catalog)
         {
-            if (!_apis.Contains(api.Id))
-            {
-                return null;
-            }
-            return null;
+            throw new NotImplementedException();
         }
     }
 }

--- a/tools/Google.Cloud.Tools.ReleaseManager/CommitCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/CommitCommand.cs
@@ -29,7 +29,9 @@ namespace Google.Cloud.Tools.ReleaseManager
         {
         }
 
-        protected override void ExecuteImpl(string[] args)
+        protected override void ExecuteImpl(string[] args) => InternalExecute();
+
+        internal void InternalExecute()
         {
             var diffs = FindChangedVersions();
             if (diffs.Count != 1)

--- a/tools/Google.Cloud.Tools.ReleaseManager/History/GitCommit.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/History/GitCommit.cs
@@ -38,7 +38,7 @@ namespace Google.Cloud.Tools.ReleaseManager.History
 
         private readonly Commit _libGit2Commit;
 
-        private string Hash { get; }
+        public string Hash { get; }
         private string Url { get; }
 
         internal GitCommit(Commit libGit2Commit)

--- a/tools/Google.Cloud.Tools.ReleaseManager/History/HistoryFile.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/History/HistoryFile.cs
@@ -27,6 +27,7 @@ namespace Google.Cloud.Tools.ReleaseManager.History
     /// </summary>
     internal sealed class HistoryFile
     {
+        private static readonly string[] PreambleLines = new[] { "# Version history", "", "" };
         private const string MarkdownFile = "history.md";
         private static readonly Regex SectionHeader = new Regex(@"# Version (.*), released \d{4}-\d{2}-\d{2}");
 
@@ -42,6 +43,12 @@ namespace Google.Cloud.Tools.ReleaseManager.History
         public static HistoryFile Load(string file)
         {
             var sections = new List<Section>();
+            if (!File.Exists(file))
+            {
+                sections.Add(new Section(null, PreambleLines.ToList()));
+                return new HistoryFile(sections);
+            }
+
             var lines = File.ReadAllLines(file);
 
             StructuredVersion currentVersion = null;

--- a/tools/Google.Cloud.Tools.ReleaseManager/History/HistoryFile.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/History/HistoryFile.cs
@@ -27,7 +27,7 @@ namespace Google.Cloud.Tools.ReleaseManager.History
     /// </summary>
     internal sealed class HistoryFile
     {
-        private static readonly string[] PreambleLines = new[] { "# Version history", "", "" };
+        private static readonly string[] PreambleLines = new[] { "# Version history", "" };
         private const string MarkdownFile = "history.md";
         private static readonly Regex SectionHeader = new Regex(@"# Version (.*), released \d{4}-\d{2}-\d{2}");
 

--- a/tools/Google.Cloud.Tools.ReleaseManager/History/HistoryFile.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/History/HistoryFile.cs
@@ -32,7 +32,7 @@ namespace Google.Cloud.Tools.ReleaseManager.History
         private static readonly Regex SectionHeader = new Regex(@"# Version (.*), released \d{4}-\d{2}-\d{2}");
 
         /// <summary>
-        /// The sections within the history file.
+        /// The sections within the history file, in file order (reverse chronological).
         /// </summary>
         public List<Section> Sections { get; }
 

--- a/tools/Google.Cloud.Tools.ReleaseManager/History/Release.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/History/Release.cs
@@ -26,12 +26,56 @@ namespace Google.Cloud.Tools.ReleaseManager.History
         public IReadOnlyList<GitCommit> Commits { get; }
         public DateTime ReleaseDate { get; }
 
+        private Release(StructuredVersion version, DateTimeOffset? releaseDate, IEnumerable<GitCommit> commits) =>
+            (Version, ReleaseDate, Commits) = (version, (releaseDate ?? DateTimeOffset.Now).UtcDateTime, commits.ToList().AsReadOnly());
+
         public Release(StructuredVersion version, Commit tagCommit, IEnumerable<GitCommit> commits)
+            : this(version, tagCommit?.GetDate(), commits)
         {
-            Version = version;
-            Commits = commits.ToList().AsReadOnly();
-            // Assume that if a release isn't tagged yet, it's because we're releasing it today.
-            ReleaseDate = tagCommit?.GetDate().UtcDateTime ?? DateTime.Today;
+        }
+
+        public Release(StructuredVersion version, Tag tag, IEnumerable<GitCommit> commits)
+            : this(version, tag?.GetDate(), commits)
+        {
+        }
+
+        public static IEnumerable<Release> LoadReleases(Repository repo, ApiCatalog catalog, ApiMetadata api)
+        {
+            var id = api.Id;
+            var commitPredicate = GitHelpers.CreateCommitPredicate(repo, catalog, api);
+
+            List<Release> releases = new List<Release>();
+            StructuredVersion currentVersion = StructuredVersion.FromString(api.Version);
+            Commit currentTagCommit = null;
+
+            // "Pending" as in "haven't been yielded in a release yet"
+            List<GitCommit> pendingCommits = new List<GitCommit>();
+
+            var tagPrefix = $"{id}-";
+            var versionsCommitId = repo.Tags
+                .Where(tag => tag.FriendlyName.StartsWith(tagPrefix))
+                .ToDictionary(tag => tag.Target.Id, tag => tag.FriendlyName.Substring(tagPrefix.Length));
+
+            foreach (var commit in repo.Head.Commits)
+            {
+                if (commitPredicate(commit))
+                {
+                    pendingCommits.Add(new GitCommit(commit));
+                }
+                if (versionsCommitId.TryGetValue(commit.Id, out string version) && !version.StartsWith("0."))
+                {
+                    yield return new Release(currentVersion, currentTagCommit, pendingCommits);
+                    // Release constructor clones the list, so we're safe to clear it.
+                    pendingCommits.Clear();
+                    currentTagCommit = commit;
+                    currentVersion = StructuredVersion.FromString(version);
+                }
+            }
+
+            if (pendingCommits.Count != 0)
+            {
+                yield return new Release(currentVersion, currentTagCommit, pendingCommits);
+            }
         }
     }
 }

--- a/tools/Google.Cloud.Tools.ReleaseManager/IncrementVersionCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/IncrementVersionCommand.cs
@@ -32,34 +32,8 @@ namespace Google.Cloud.Tools.ReleaseManager
             // is annoying too, but it's insignficant really - and at least the code is simple.
             var catalog = ApiCatalog.Load();
             var api = catalog[id];
-            var version = IncrementStructuredVersion(api.StructuredVersion).ToString();
+            var version = api.StructuredVersion.AfterIncrement().ToString();
             new SetVersionCommand().Execute(new[] { id, version });
-
-            StructuredVersion IncrementStructuredVersion(StructuredVersion originalVersion)
-            {
-                // Any GA version just increments the minor version.
-                if (originalVersion.Prerelease is null)
-                {
-                    return StructuredVersion.FromMajorMinorPatch(originalVersion.Major, originalVersion.Minor + 1, 0, null);
-                }
-
-                // For prereleases, expect something like "beta01" which should be incremented to "beta02".
-                var prereleasePattern = new Regex(@"^([^\d]*)(\d+)$");
-                var match = prereleasePattern.Match(originalVersion.Prerelease);
-                if (!match.Success)
-                {
-                    throw new UserErrorException($"Don't know how to auto-increment version '{originalVersion}'");
-                }
-                var prefix = match.Groups[1].Value;
-                var suffix = match.Groups[2].Value;
-                if (!int.TryParse(suffix, out var counter))
-                {
-                    throw new UserErrorException($"Don't know how to auto-increment version '{originalVersion}'");
-                }
-                counter++;
-                var newSuffix = counter.ToString().PadLeft(suffix.Length, '0');
-                return StructuredVersion.FromMajorMinorPatch(originalVersion.Major, originalVersion.Minor, originalVersion.Patch, $"{prefix}{newSuffix}");
-            }
         }
     }
 }

--- a/tools/Google.Cloud.Tools.ReleaseManager/PushCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/PushCommand.cs
@@ -38,7 +38,9 @@ namespace Google.Cloud.Tools.ReleaseManager
         {
         }
 
-        protected override void ExecuteImpl(string[] args)
+        protected override void ExecuteImpl(string[] args) => InternalExecute();
+
+        internal void InternalExecute()
         {
             string gitHubToken = Environment.GetEnvironmentVariable(AccessTokenEnvironmentVariable);
             if (string.IsNullOrEmpty(gitHubToken))

--- a/tools/Google.Cloud.Tools.ReleaseManager/SetVersionCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/SetVersionCommand.cs
@@ -29,7 +29,11 @@ namespace Google.Cloud.Tools.ReleaseManager
         {
             string id = args[0];
             string version = args[1];
+            InternalExecute(id, version);
+        }
 
+        internal void InternalExecute(string id, string version)
+        {
             var catalog = ApiCatalog.Load();
             var api = catalog[id];
 


### PR DESCRIPTION

Changes in this release:

- [Commit d9a3648](https://github.com/googleapis/google-cloud-dotnet/commit/d9a3648): Fix Firestore and Datastore for self-signed JWTs
- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): Regenerate all APIs to support self-signed JWTs
