### PR TITLE
Release Google.Cloud.Datastore.V1 version 3.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Dataflow.V1Beta3](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Dataflow.V1Beta3/latest) | 1.0.0-beta01 | [Dataflow](https://cloud.google.com/dataflow/docs/) |
 | [Google.Cloud.Dataproc.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Dataproc.V1/latest) | 3.1.0 | [Google Cloud Dataproc](https://cloud.google.com/dataproc/docs/concepts/overview) |
 | [Google.Cloud.Datastore.Admin.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Datastore.Admin.V1/latest) | 1.2.0 | Cloud Datastore |
-| [Google.Cloud.Datastore.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Datastore.V1/latest) | 3.2.0 | [Google Cloud Datastore](https://cloud.google.com/datastore/docs/concepts/overview) |
+| [Google.Cloud.Datastore.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Datastore.V1/latest) | 3.3.0 | [Google Cloud Datastore](https://cloud.google.com/datastore/docs/concepts/overview) |
 | [Google.Cloud.Datastream.V1Alpha1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Datastream.V1Alpha1/latest) | 1.0.0-beta01 | [DataStream](https://cloud.google.com/datastream/docs) |
 | [Google.Cloud.Debugger.V2](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Debugger.V2/latest) | 2.3.0 | [Google Cloud Debugger](https://cloud.google.com/debugger/) |
 | [Google.Cloud.DevTools.Common](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.DevTools.Common/latest) | 2.1.0 | Common Protocol Buffer messages for Google Cloud Developer Tools APIs |

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.2.0</Version>
+    <Version>3.3.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Datastore API, which accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.</Description>

--- a/apis/Google.Cloud.Datastore.V1/docs/history.md
+++ b/apis/Google.Cloud.Datastore.V1/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+# Version 3.3.0, released 2021-08-18
+
+- [Commit d9a3648](https://github.com/googleapis/google-cloud-dotnet/commit/d9a3648): Fix Firestore and Datastore for self-signed JWTs
+- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): Regenerate all APIs to support self-signed JWTs
+
 # Version 3.2.0, released 2021-05-05
 
 - [Commit 8bb2981](https://github.com/googleapis/google-cloud-dotnet/commit/8bb2981): Use CopySettingsForEmulator in DatastoreDbBuilder

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -734,7 +734,7 @@
       "protoPath": "google/datastore/v1",
       "productName": "Google Cloud Datastore",
       "productUrl": "https://cloud.google.com/datastore/docs/concepts/overview",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Datastore API, which accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.",


### PR DESCRIPTION

Changes in this release:

- [Commit d9a3648](https://github.com/googleapis/google-cloud-dotnet/commit/d9a3648): Fix Firestore and Datastore for self-signed JWTs
- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): Regenerate all APIs to support self-signed JWTs
