### PR TITLE
Release Google.Cloud.Firestore.V1 version 2.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Each package name links to the documentation for that package.
 | [Google.Cloud.Filestore.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Filestore.V1/latest) | 1.0.0 | Cloud Filestore |
 | [Google.Cloud.Firestore.Admin.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Firestore.Admin.V1/latest) | 2.2.0 | [Firestore Administration (e.g. index management)](https://firebase.google.com) |
 | [Google.Cloud.Firestore](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Firestore/latest) | 2.4.0 | [Firestore high-level library](https://firebase.google.com/docs/firestore/) |
-| [Google.Cloud.Firestore.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Firestore.V1/latest) | 2.3.0 | [Firestore low-level API access](https://firebase.google.com) |
+| [Google.Cloud.Firestore.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Firestore.V1/latest) | 2.4.0 | [Firestore low-level API access](https://firebase.google.com) |
 | [Google.Cloud.Functions.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Functions.V1/latest) | 1.1.0 | [Cloud Functions](https://cloud.google.com/functions) |
 | [Google.Cloud.GSuiteAddOns.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.GSuiteAddOns.V1/latest) | 1.0.0 | [Google Workspace Add-ons](https://developers.google.com/gsuite/add-ons/overview) |
 | [Google.Cloud.Gaming.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Gaming.V1/latest) | 1.1.0 | [Game Services](https://cloud.google.com/solutions/gaming) |

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.csproj
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Low-level Google client library to access the Firestore API. Users are recommended to use the Google.Cloud.Firestore package instead.</Description>

--- a/apis/Google.Cloud.Firestore.V1/docs/history.md
+++ b/apis/Google.Cloud.Firestore.V1/docs/history.md
@@ -4,6 +4,11 @@ This package is primarily a dependency of Google.Cloud.Firestore. See the
 [Google.Cloud.Firestore version history](https://googleapis.dev/dotnet/Google.Cloud.Firestore/latest/history.html)
 for more details.
 
+# Version 2.4.0, released 2021-08-18
+
+- [Commit d9a3648](https://github.com/googleapis/google-cloud-dotnet/commit/d9a3648): fix: Fix Firestore and Datastore for self-signed JWTs
+- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
+
 # Version 2.3.0, released 2021-05-05
 
 - [Commit 9f5f0aa](https://github.com/googleapis/google-cloud-dotnet/commit/9f5f0aa): Regenerate server-streaming calls with Google request params

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1156,7 +1156,7 @@
       "productName": "Firestore",
       "productUrl": "https://firebase.google.com",
       "listingDescription": "Firestore low-level API access",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "type": "grpc",
       "targetFrameworks": "netstandard2.0;net461",
       "testTargetFrameworks": "netcoreapp2.1;net461",


### PR DESCRIPTION

Changes in this release:

- [Commit d9a3648](https://github.com/googleapis/google-cloud-dotnet/commit/d9a3648): fix: Fix Firestore and Datastore for self-signed JWTs
- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
