### PR TITLE
Release Google.Area120.Tables.V1Alpha1 version 1.0.0-alpha04

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Each package name links to the documentation for that package.
 | [Google.Analytics.Data.V1Alpha](https://googleapis.dev/dotnet/Google.Analytics.Data.V1Alpha/1.0.0-alpha05) | 1.0.0-alpha05 | [Google Analytics Data (V1Alpha API)](https://developers.google.com/analytics) |
 | [Google.Analytics.Data.V1Beta](https://googleapis.dev/dotnet/Google.Analytics.Data.V1Beta/1.0.0-beta04) | 1.0.0-beta04 | [Google Analytics Data (V1Beta API)](https://developers.google.com/analytics) |
 | [Google.Apps.Script.Type](https://cloud.google.com/dotnet/docs/reference/Google.Apps.Script.Type/latest) | 1.0.0 | Version-agnostic types for Apps Script APIs |
-| [Google.Area120.Tables.V1Alpha1](https://googleapis.dev/dotnet/Google.Area120.Tables.V1Alpha1/1.0.0-alpha03) | 1.0.0-alpha03 | Google Area 120 Tables |
+| [Google.Area120.Tables.V1Alpha1](https://googleapis.dev/dotnet/Google.Area120.Tables.V1Alpha1/1.0.0-alpha04) | 1.0.0-alpha04 | Google Area 120 Tables |
 | [Google.Cloud.AccessApproval.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.AccessApproval.V1/latest) | 1.1.0 | [Access Approval](https://cloud.google.com/access-approval/docs/) |
 | [Google.Cloud.ApiGateway.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.ApiGateway.V1/latest) | 1.0.0 | [API Gateway](https://cloud.google.com/api-gateway/docs) |
 | [Google.Cloud.AIPlatform.V1](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.AIPlatform.V1/latest) | 1.0.0-beta02 | [Cloud AI Platform](https://cloud.google.com/ai-platform/docs/) |

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.csproj
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha03</Version>
+    <Version>1.0.0-alpha04</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Area 120 Tables API</Description>

--- a/apis/Google.Area120.Tables.V1Alpha1/docs/history.md
+++ b/apis/Google.Area120.Tables.V1Alpha1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.0.0-alpha04, released 2021-08-18
+
+- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
+
 # Version 1.0.0-alpha03, released 2021-04-28
 
 - [Commit 294f56e](https://github.com/googleapis/google-cloud-dotnet/commit/294f56e): feat: Added ListWorkspaces, GetWorkspace, BatchDeleteRows APIs.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -59,7 +59,7 @@
     },
     {
       "id": "Google.Area120.Tables.V1Alpha1",
-      "version": "1.0.0-alpha03",
+      "version": "1.0.0-alpha04",
       "type": "grpc",
       "productName": "Google Area 120 Tables",
       "description": "Recommended Google client library to access the Area 120 Tables API",


### PR DESCRIPTION

Changes in this release:

- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
