### PR TITLE
Release Google.Analytics.Data.V1Alpha version 1.0.0-alpha06

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Each package name links to the documentation for that package.
 | Package | Latest version | Description |
 |---------|----------------|-------------|
 | [Google.Analytics.Admin.V1Alpha](https://googleapis.dev/dotnet/Google.Analytics.Admin.V1Alpha/1.0.0-alpha08) | 1.0.0-alpha08 | [Analytics Admin](https://developers.google.com/analytics) |
-| [Google.Analytics.Data.V1Alpha](https://googleapis.dev/dotnet/Google.Analytics.Data.V1Alpha/1.0.0-alpha05) | 1.0.0-alpha05 | [Google Analytics Data (V1Alpha API)](https://developers.google.com/analytics) |
+| [Google.Analytics.Data.V1Alpha](https://googleapis.dev/dotnet/Google.Analytics.Data.V1Alpha/1.0.0-alpha06) | 1.0.0-alpha06 | [Google Analytics Data (V1Alpha API)](https://developers.google.com/analytics) |
 | [Google.Analytics.Data.V1Beta](https://googleapis.dev/dotnet/Google.Analytics.Data.V1Beta/1.0.0-beta05) | 1.0.0-beta05 | [Google Analytics Data (V1Beta API)](https://developers.google.com/analytics) |
 | [Google.Apps.Script.Type](https://cloud.google.com/dotnet/docs/reference/Google.Apps.Script.Type/latest) | 1.0.0 | Version-agnostic types for Apps Script APIs |
 | [Google.Area120.Tables.V1Alpha1](https://googleapis.dev/dotnet/Google.Area120.Tables.V1Alpha1/1.0.0-alpha04) | 1.0.0-alpha04 | Google Area 120 Tables |

--- a/apis/Google.Analytics.Data.V1Alpha/Google.Analytics.Data.V1Alpha/Google.Analytics.Data.V1Alpha.csproj
+++ b/apis/Google.Analytics.Data.V1Alpha/Google.Analytics.Data.V1Alpha/Google.Analytics.Data.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha05</Version>
+    <Version>1.0.0-alpha06</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Analytics Data API (v1alpha)</Description>

--- a/apis/Google.Analytics.Data.V1Alpha/docs/history.md
+++ b/apis/Google.Analytics.Data.V1Alpha/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.0.0-alpha06, released 2021-08-18
+
+- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
+
 # Version 1.0.0-alpha05, released 2021-05-25
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -16,7 +16,7 @@
     },
     {
       "id": "Google.Analytics.Data.V1Alpha",
-      "version": "1.0.0-alpha05",
+      "version": "1.0.0-alpha06",
       "type": "grpc",
       "productName": "Google Analytics Data",
       "productUrl": "https://developers.google.com/analytics",


### PR DESCRIPTION

Changes in this release:

- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
