### PR TITLE
Release Google.Cloud.AccessApproval.V1 version 1.2.0

### DIFF
--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.csproj
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>An API for controlling access to data by Google personnel.</Description>

--- a/apis/Google.Cloud.AccessApproval.V1/docs/history.md
+++ b/apis/Google.Cloud.AccessApproval.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.2.0, released 2021-08-19
+
+- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
+
 # Version 1.1.0, released 2021-05-25
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -72,7 +72,7 @@
     },
     {
       "id": "Google.Cloud.AccessApproval.V1",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "type": "grpc",
       "productName": "Access Approval",
       "productUrl": "https://cloud.google.com/access-approval/docs/",


### PR DESCRIPTION

Changes in this release:

- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
