### PR TITLE
Release Google.Cloud.ApiGateway.V1 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.csproj
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the API Gateway API, which enables you to provide secure access to your backend services with an API that is consistent across all of your services, regardless of the service implementation</Description>

--- a/apis/Google.Cloud.ApiGateway.V1/docs/history.md
+++ b/apis/Google.Cloud.ApiGateway.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.1.0, released 2021-08-19
+
+- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
+
 # Version 1.0.0, released 2021-05-11
 
 First GA release. No API surface changes since 1.0.0-beta01; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -90,7 +90,7 @@
     },
     {
       "id": "Google.Cloud.ApiGateway.V1",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "grpc",
       "productName": "API Gateway",
       "productUrl": "https://cloud.google.com/api-gateway/docs",


### PR DESCRIPTION

Changes in this release:

- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
