### PR TITLE
Release Google.Cloud.AppEngine.V1 version 1.2.0

### DIFF
--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.csproj
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the App Engine API, which provisions and manages developers' App Engine applications.</Description>

--- a/apis/Google.Cloud.AppEngine.V1/docs/history.md
+++ b/apis/Google.Cloud.AppEngine.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.2.0, released 2021-08-19
+
+- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
+
 # Version 1.1.0, released 2021-04-29
 
 - [Commit c78b2f8](https://github.com/googleapis/google-cloud-dotnet/commit/c78b2f8):

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -147,7 +147,7 @@
     },
     {
       "id": "Google.Cloud.AppEngine.V1",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "type": "grpc",
       "productName": "App Engine Audit Data",
       "productUrl": "https://cloud.google.com/appengine",


### PR DESCRIPTION

Changes in this release:

- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
