### PR TITLE
Release Google.Cloud.BigQuery.Connection.V1 version 1.4.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery connection API, which allows users to manage BigQuery connections to external data sources.</Description>

--- a/apis/Google.Cloud.BigQuery.Connection.V1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.4.0, released 2021-08-19
+
+- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
+
 # Version 1.3.0, released 2021-08-10
 
 - [Commit e425177](https://github.com/googleapis/google-cloud-dotnet/commit/e425177): feat: add cloud spanner connection support

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -264,7 +264,7 @@
     },
     {
       "id": "Google.Cloud.BigQuery.Connection.V1",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "type": "grpc",
       "productName": "BigQuery Connection",
       "productUrl": "https://cloud.google.com/bigquery/docs/reference/bigqueryconnection",


### PR DESCRIPTION

Changes in this release:

- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
