### PR TITLE
Tidy up output for batch releasing

### DIFF
--- a/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/ReleaseProposal.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/ReleaseProposal.cs
@@ -120,7 +120,7 @@ namespace Google.Cloud.Tools.ReleaseManager.BatchRelease
             var releaseBranch = repo.CreateBranch(branchName, CommandBase.PrimaryBranch);
             Commands.Checkout(repo, releaseBranch);
 
-            new SetVersionCommand().InternalExecute(Id, NewVersion.ToString());
+            new SetVersionCommand().InternalExecute(Id, NewVersion.ToString(), quiet: true);
             ModifiedHistoryFile.Save(HistoryFile.GetPathForPackage(Id));
             new CommitCommand().InternalExecute();
             new PushCommand().InternalExecute();

--- a/tools/Google.Cloud.Tools.ReleaseManager/PushCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/PushCommand.cs
@@ -160,8 +160,8 @@ namespace Google.Cloud.Tools.ReleaseManager
                 }
                 await gitHubClient.Issue.Update(RepositoryOwner, RepositoryName, pullRequest.Number, issueUpdate);
 
-                // We put the pull request URL on a line on its own to make it easier to copy/paste. 
-                Console.WriteLine($"Created release PR: {pullRequest.HtmlUrl} with remote branch {branch}");
+                // The PR link is useful to be able to click on, and occasionally the release branch is useful.
+                Console.WriteLine($"Created branch {branch} and PR {pullRequest.HtmlUrl}");
             }
         }
 

--- a/tools/Google.Cloud.Tools.ReleaseManager/SetVersionCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/SetVersionCommand.cs
@@ -29,10 +29,10 @@ namespace Google.Cloud.Tools.ReleaseManager
         {
             string id = args[0];
             string version = args[1];
-            InternalExecute(id, version);
+            InternalExecute(id, version, quiet: false);
         }
 
-        internal void InternalExecute(string id, string version)
+        internal void InternalExecute(string id, string version, bool quiet)
         {
             var catalog = ApiCatalog.Load();
             var api = catalog[id];
@@ -45,6 +45,8 @@ namespace Google.Cloud.Tools.ReleaseManager
             }
             var layout = DirectoryLayout.ForApi(id);
             var apiNames = catalog.CreateIdHashSet();
+            // This will still write output, even if "quiet" is true, but that's probably
+            // okay for batch releasing.
             GenerateProjectsCommand.GenerateMetadataFile(layout.SourceDirectory, api);
             GenerateProjectsCommand.GenerateProjects(layout.SourceDirectory, api, apiNames);
             GenerateProjectsCommand.RewriteReadme(catalog);
@@ -53,9 +55,12 @@ namespace Google.Cloud.Tools.ReleaseManager
             api.Json["version"] = version;
             string formatted = catalog.FormatJson();
             File.WriteAllText(ApiCatalog.CatalogPath, formatted);
-            Console.WriteLine("Updated apis.json");
-            Console.WriteLine();
-            Console.WriteLine(new ApiVersionPair(id, oldVersion, version));
+            if (!quiet)
+            {
+                Console.WriteLine("Updated apis.json");
+                Console.WriteLine();
+                Console.WriteLine(new ApiVersionPair(id, oldVersion, version));
+            }
         }
     }
 }


### PR DESCRIPTION
The change to the push format is primarily to make it all fit on one line in a default-width terminal