### PR TITLE
Update Timed Buffer guidance to include mention of new --no-cpu-throttling flag

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/docs/index.md
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/docs/index.md
@@ -25,7 +25,7 @@ the deployed code.
 # Note
 When running on environments that limit or disable CPU usage for background activities, for instance
 [Google Cloud Run](https://cloud.google.com/run/docs/tips/general#avoiding_background_activities), take care
-not to use the timed buffer options for any of Logging, Tracing or Error Reporting. Take into account
+not to use the timed buffer options for any of Logging, Tracing or Error Reporting unless you deploy your container using Cloud Run's `--no-cpu-throttling` flag. Take into account
 that the timed buffer is used for all of these components by default so you will need to explicitly
 configure the buffers by using the `Google.Cloud.Diagnostics.AspNetCore.LoggerOptions`,
 `Google.Cloud.Diagnostics.Common.TraceOptions` and `Google.Cloud.Diagnostics.Common.ErrorReportingOptions` classes.


### PR DESCRIPTION
[Cloud Run is getting unthrottled CPU support.](https://twitter.com/kelseyhightower/status/1428485756423602179)

This effectively solves https://github.com/googleapis/google-cloud-dotnet/issues/5275. This PR adds a small note to the documentation.

This flag is currently in alpha. It may be some time before GA. Feel free to keep this PR open if you want to merge it when the feature is GA.