### PR TITLE
tests(Diagnostics): Improvements on entry polling

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/LogValidatingFixture.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/LogValidatingFixture.cs
@@ -39,7 +39,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
     {
         private static readonly TimeSpan s_canaryMessageTimeout = TimeSpan.FromMinutes(7);
         private static readonly TimeSpan s_delayBetweenCanaryAttempts = TimeSpan.FromSeconds(10);
-        private static readonly TimeSpan s_totalValidationTimeout = TimeSpan.FromMinutes(10);
+        private static readonly TimeSpan s_totalValidationTimeout = TimeSpan.FromMinutes(20);
         private static readonly TimeSpan s_delayBetweenValidationAttempts = TimeSpan.FromSeconds(30);
         private static readonly TimeSpan s_delayBetweenPages = TimeSpan.FromSeconds(3);
 

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Logging/LoggingTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/Logging/LoggingTest.cs
@@ -50,7 +50,6 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         // Used in tests that check logs are properly associated to traces.
         private static readonly TraceIdFactory s_traceIdFactory = TraceIdFactory.Create();
         private static readonly SpanIdFactory s_spanIdFactory = SpanIdFactory.Create();
-        private static readonly TraceEntryPolling s_tracePolling = new TraceEntryPolling();
 
         private readonly LogValidatingFixture _fixture;
 
@@ -269,7 +268,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
                 Assert.Contains(traceId, entry.Trace);
 
                 // Let's get our trace.
-                var trace = s_tracePolling.GetTrace(traceId);
+                var trace = TraceEntryPolling.NoEntry.GetTrace(traceId);
                 Assert.NotNull(trace);
 
                 // The span associated to our entry needs to be part of that trace.
@@ -306,7 +305,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
                 Assert.Contains(traceId, entry.Trace);
 
                 // Let's get our trace.
-                var trace = s_tracePolling.GetTrace(traceId);
+                var trace = TraceEntryPolling.NoEntry.GetTrace(traceId);
                 Assert.NotNull(trace);
 
                 // The span associated to our entry needs to be part of that trace.
@@ -356,7 +355,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
                 });
 
                 // Let's get our trace.
-                var trace = s_tracePolling.GetTrace(traceId);
+                var trace = TraceEntryPolling.NoEntry.GetTrace(traceId);
                 Assert.NotNull(trace);
 
                 // Let's check that all the entries are associated to the correct spans.
@@ -385,7 +384,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         [Fact]
         public async Task Logging_Trace_Implicit()
         {
-            Timestamp startTime = Timestamp.FromDateTime(DateTime.UtcNow);
+            DateTimeOffset startTime = DateTimeOffset.UtcNow;
             string testId = IdGenerator.FromGuid();
 
             string url = $"/Main/Critical/{testId}";
@@ -398,7 +397,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
             _fixture.AddValidator(testId, results =>
             {
                 // Let's get our trace.
-                var trace = s_tracePolling.GetTrace(url, startTime);
+                var trace = TraceEntryPolling.NoEntry.GetTrace(url, startTime);
                 Assert.NotNull(trace);
 
                 // We only have one log entry.
@@ -420,7 +419,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         [Fact]
         public async Task Logging_Trace()
         {
-            Timestamp startTime = Timestamp.FromDateTime(DateTime.UtcNow);
+            DateTimeOffset startTime = DateTimeOffset.UtcNow;
             string testId = IdGenerator.FromGuid();
 
             string spanPrefix;
@@ -433,7 +432,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
             _fixture.AddValidator(testId, results =>
             {
                 // Let's get our trace.
-                var trace = s_tracePolling.GetTrace(spanPrefix, startTime);
+                var trace = TraceEntryPolling.NoEntry.GetTrace(spanPrefix, startTime);
                 Assert.NotNull(trace);
 
                 // We only have one log entry.
@@ -455,7 +454,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
         [Fact]
         public async Task Logging_Trace_MultipleSpans()
         {
-            Timestamp startTime = Timestamp.FromDateTime(DateTime.UtcNow);
+            DateTimeOffset startTime = DateTimeOffset.UtcNow;
             string testId = IdGenerator.FromGuid();
 
             string spanPrefix;
@@ -477,7 +476,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
                 string projectId = TestEnvironment.GetTestProjectId();
 
                 // Let's get our trace.
-                var trace = s_tracePolling.GetTrace(spanPrefix, startTime);
+                var trace = TraceEntryPolling.NoEntry.GetTrace(spanPrefix, startTime);
                 Assert.NotNull(trace);
 
                 // We have 3 logs.

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/ErrorReportingSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/ErrorReportingSnippets.cs
@@ -38,8 +38,6 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
     [SnippetOutputCollector]
     public class ErrorReportingSnippetsTests : IDisposable
     {
-        private static readonly ErrorEventEntryPolling s_polling = new ErrorEventEntryPolling();
-
         private readonly string _testId;
 
         private readonly TestServer _server;
@@ -64,7 +62,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
             await Assert.ThrowsAsync<Exception>(()
                 => _client.GetAsync($"/ErrorLoggingSamples/{nameof(ErrorLoggingSamplesController.ThrowsException)}/{_testId}"));
 
-            var errorEvent = ErrorEventEntryVerifiers.VerifySingle(s_polling, _testId);
+            var errorEvent = ErrorEventEntryVerifiers.VerifySingle(ErrorEventEntryPolling.Default, _testId);
             ErrorEventEntryVerifiers.VerifyFullErrorEventLogged(errorEvent, _testId, nameof(ErrorLoggingSamplesController.ThrowsException));
         }
 
@@ -81,7 +79,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-            var errorEvent = ErrorEventEntryVerifiers.VerifySingle(s_polling, _testId);
+            var errorEvent = ErrorEventEntryVerifiers.VerifySingle(ErrorEventEntryPolling.Default, _testId);
 
             // Verifying with function name ThrowsExceptions because that is the function
             // that actually throws the Exception so will be the one included as

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/LoggingSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/LoggingSnippets.cs
@@ -52,7 +52,6 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
     public class LoggingSnippetsTests
     {
         private const string ExpectedGcpLogBaseUrl = "https://console.cloud.google.com/logs/viewer";
-        private static readonly LogEntryPolling s_polling = new LogEntryPolling();
 
         private readonly string _testId;
         private readonly DateTime _startTime;
@@ -121,7 +120,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
             }
             server.Dispose();
 
-            PollAndVerifyLog(_startTime, _testId);
+            PollAndVerifyLog(LogEntryPolling.Default, _startTime, _testId);
         }
 
         /// <summary>
@@ -143,9 +142,9 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
             Assert.Equal(StatusCode.NotFound, rpcException.StatusCode);
         }
 
-        internal static void PollAndVerifyLog(DateTime startTime, string testId)
+        internal static void PollAndVerifyLog(LogEntryPolling poller, DateTimeOffset startTime, string testId)
         {
-            var results = s_polling.GetEntries(startTime, testId, 1, LogSeverity.Info);
+            var results = poller.GetEntries(startTime, testId, 1, LogSeverity.Info);
             results = from result in results
                       where result.JsonPayload?.Fields["log_name"]?.StringValue?.Equals(typeof(LoggingSamplesController).FullName) ?? false
                       select result;

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/StandaloneTraceSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/StandaloneTraceSnippets.cs
@@ -28,16 +28,14 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
     {
         private static readonly string ProjectId = TestEnvironment.GetTestProjectId();
 
-        private static readonly TraceEntryPolling s_polling = new TraceEntryPolling();
-
         private readonly string _testId;
 
-        private readonly Timestamp _startTime;
+        private readonly DateTimeOffset _startTime;
 
         public StandaloneTraceSnippets()
         {
             _testId = IdGenerator.FromDateTime();
-            _startTime = Timestamp.FromDateTime(DateTime.UtcNow);
+            _startTime = DateTimeOffset.UtcNow;
 
             // The rate limiter instance is static and only set once.  If we do not reset it at the
             // beginning of each tests the qps will not change.  This is dependent on the tests not
@@ -88,7 +86,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
                     // End sample
                 }
 
-                var trace = s_polling.GetTrace(_testId, _startTime);
+                var trace = TraceEntryPolling.Default.GetTrace(_testId, _startTime);
                 TraceEntryVerifiers.AssertParentChildSpan(trace, _testId, "standalone_tracing");
                 Assert.Equal(traceContext.TraceId, trace.TraceId);
             }

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/TraceSnippets.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.Snippets/TraceSnippets.cs
@@ -41,14 +41,12 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
     [SnippetOutputCollector]
     public class TraceSnippetsTests : IDisposable
     {
-        private static readonly TraceEntryPolling s_polling = new TraceEntryPolling();
-
         private readonly string _testId;
 
         private readonly TestServer _server;
         private readonly HttpClient _client;
 
-        private readonly Timestamp _startTime;
+        private readonly DateTimeOffset _startTime;
 
         public TraceSnippetsTests()
         {
@@ -57,7 +55,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
             _server = GetTestServer<TraceTestApplication.Startup>();
             _client = _server.CreateClient();
 
-            _startTime = Timestamp.FromDateTime(DateTime.UtcNow);
+            _startTime = DateTimeOffset.UtcNow;
 
             // The rate limiter instance is static and only set once.  If we do not reset it at the
             // beginning of each tests the qps will not change.  This is dependent on the tests not
@@ -71,7 +69,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
             var uri = $"/TraceSamples/{nameof(TraceSamplesController.TraceHelloWorld)}/{_testId}";
             var response = await _client.GetAsync(uri);
 
-            var trace = s_polling.GetTrace(uri, _startTime);
+            var trace = TraceEntryPolling.Default.GetTrace(uri, _startTime);
 
             TraceEntryVerifiers.AssertParentChildSpan(trace, uri, _testId);
             TraceEntryVerifiers.AssertSpanLabelsContains(
@@ -85,7 +83,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
             var uri = $"/TraceSamples/{nameof(TraceSamplesController.TraceHelloWorldRunIn)}/{_testId}";
             var response = await _client.GetAsync(uri);
 
-            var trace = s_polling.GetTrace(uri, _startTime);
+            var trace = TraceEntryPolling.Default.GetTrace(uri, _startTime);
 
             TraceEntryVerifiers.AssertParentChildSpan(trace, uri, _testId);
             TraceEntryVerifiers.AssertSpanLabelsContains(
@@ -99,7 +97,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
             var uri = $"/TraceSamplesConstructor/{nameof(TraceSamplesConstructorController.TraceHelloWorld)}/{_testId}";
             var response = await _client.GetAsync(uri);
 
-            var trace = s_polling.GetTrace(uri, _startTime);
+            var trace = TraceEntryPolling.Default.GetTrace(uri, _startTime);
 
             TraceEntryVerifiers.AssertParentChildSpan(trace, uri, _testId);
             TraceEntryVerifiers.AssertSpanLabelsContains(
@@ -113,7 +111,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
             var uri = $"/TraceSamplesMethod/{nameof(TraceSamplesMethodController.TraceHelloWorld)}/{_testId}";
             var response = await _client.GetAsync(uri);
 
-            var trace = s_polling.GetTrace(uri, _startTime);
+            var trace = TraceEntryPolling.Default.GetTrace(uri, _startTime);
 
             TraceEntryVerifiers.AssertParentChildSpan(trace, uri, _testId);
             TraceEntryVerifiers.AssertSpanLabelsContains(
@@ -127,7 +125,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
             var uri = $"/TraceSamples/{nameof(TraceSamplesController.TraceOutgoing)}/{_testId}";
             var response = await _client.GetAsync(uri);
 
-            var trace = s_polling.GetTrace(uri, _startTime);
+            var trace = TraceEntryPolling.Default.GetTrace(uri, _startTime);
 
             TraceEntryVerifiers.AssertParentChildSpan(trace, uri, "http://weather.com/");
             TraceEntryVerifiers.AssertSpanLabelsContains(
@@ -144,7 +142,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
             using var client = server.CreateClient();
             var response = await client.GetAsync(uri);
 
-            var trace = s_polling.GetTrace(uri, _startTime);
+            var trace = TraceEntryPolling.Default.GetTrace(uri, _startTime);
 
             TraceEntryVerifiers.AssertParentChildSpan(trace, uri, "http://weather.com/");
             TraceEntryVerifiers.AssertSpanLabelsContains(
@@ -166,7 +164,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
             };
             var response = await client.SendAsync(request);
 
-            var trace = s_polling.GetTrace(uri, _startTime);
+            var trace = TraceEntryPolling.Default.GetTrace(uri, _startTime);
 
             TraceEntryVerifiers.AssertParentChildSpan(trace, uri, _testId);
             TraceEntryVerifiers.AssertSpanLabelsContains(
@@ -371,6 +369,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.Snippets
         // Sample: CustomTraceContext
         public void ConfigureServices(IServiceCollection services)
         {
+
             // Register a trace context provider method that inspects the request and
             // extracts the trace context information.
             services.AddScoped(CustomTraceContextProvider);

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/ErrorReporting/ErrorEventEntryPolling.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/ErrorReporting/ErrorEventEntryPolling.cs
@@ -36,8 +36,13 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
         /// <summary>Project to run the test on.</summary>
         private readonly ProjectName _projectName = new ProjectName(TestEnvironment.GetTestProjectId());
 
-        // Give the error reporting events a little extra time to be processed.
-        internal ErrorEventEntryPolling() : base(TimeSpan.FromSeconds(600), TimeSpan.FromSeconds(30)) { }
+        private ErrorEventEntryPolling(TimeSpan? timeout, TimeSpan? sleepInterval)
+            : base(timeout, sleepInterval)
+        { }
+
+        public static ErrorEventEntryPolling Default { get; } = new ErrorEventEntryPolling(null, null);
+
+        public static ErrorEventEntryPolling NoRetry { get; } = new ErrorEventEntryPolling(TimeSpan.Zero, TimeSpan.Zero);
 
         /// <summary>
         /// Gets error events that contain the passed in testId in the message.  Will poll

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Trace/TraceHeaderPropagatingHandlerTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Trace/TraceHeaderPropagatingHandlerTest.cs
@@ -29,14 +29,13 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
     public class TraceHeaderPropagatingHandlerTest : IDisposable
     {
         private static readonly TraceIdFactory _traceIdFactory = TraceIdFactory.Create();
-        private static readonly TraceEntryPolling _polling = new TraceEntryPolling();
 
         private readonly string _testId;
 
         private readonly IConsumer<TraceProto> _consumer;
         private readonly IManagedTracer _tracer;
 
-        private readonly Timestamp _startTime;
+        private readonly DateTimeOffset _startTime;
 
         public TraceHeaderPropagatingHandlerTest()
         {
@@ -45,7 +44,7 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
             _consumer = new GrpcTraceConsumer(TraceServiceClient.Create());
             _tracer = SimpleManagedTracer.Create(_consumer, TestEnvironment.GetTestProjectId(), _traceIdFactory.NextId(), null);
 
-            _startTime = Timestamp.FromDateTime(DateTime.UtcNow);
+            _startTime = DateTimeOffset.UtcNow;
         }
 
         [Fact]
@@ -56,7 +55,7 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
 
             await TraceOutGoingRequest(spanName, googleUri, false);
 
-            var trace = _polling.GetTrace(spanName, _startTime);
+            var trace = TraceEntryPolling.Default.GetTrace(spanName, _startTime);
 
             TraceEntryVerifiers.AssertParentChildSpan(trace, spanName, googleUri);
             TraceEntryVerifiers.AssertSpanLabelsExact(
@@ -71,7 +70,7 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
 
             await TraceOutGoingRequest(spanName, fakeUri, true);
 
-            var trace = _polling.GetTrace(spanName, _startTime);
+            var trace = TraceEntryPolling.Default.GetTrace(spanName, _startTime);
 
             TraceEntryVerifiers.AssertParentChildSpan(trace, spanName, fakeUri);
             var span = trace.Spans.Where(s => s.Name == fakeUri).Single();
@@ -91,7 +90,7 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
 
             await TraceOutGoingRequest(spanName, fakeUri, false);
 
-            var trace = _polling.GetTrace(spanName, _startTime);
+            var trace = TraceEntryPolling.Default.GetTrace(spanName, _startTime);
 
             TraceEntryVerifiers.AssertParentChildSpan(trace, spanName, fakeUri);
             TraceEntryVerifiers.AssertSpanLabelsExact(trace.Spans.Where(s => s.Name == fakeUri).Single(),


### PR DESCRIPTION
This is to try and avoid some flakiness.

These changes have a twofold effect, on one side we are waiting more if needed, on the other we attempt to find what we are looking for sooner so we wait less if we find it.
There's still one test that might need tweaking (increase waiting times), that is Trace_QPS, but I'll let it run as is for a while and see what happens.