### PR TITLE
Release Google.Cloud.Eventarc.V1 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.csproj
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Eventarc API</Description>

--- a/apis/Google.Cloud.Eventarc.V1/docs/history.md
+++ b/apis/Google.Cloud.Eventarc.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.1.0, released 2021-08-31
+
+- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
+
 # Version 1.0.0, released 2021-07-05
 
 No API surface changes; just dependency updates and promotion to GA.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1064,7 +1064,7 @@
     },
     {
       "id": "Google.Cloud.Eventarc.V1",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "grpc",
       "productName": "Eventarc",
       "productUrl": "https://cloud.google.com/eventarc/docs",


### PR DESCRIPTION

Changes in this release:

- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
