### PR TITLE
Release Google.Cloud.Firestore.Admin.V1 version 2.3.0

### DIFF
--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.csproj
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.2.0</Version>
+    <Version>2.3.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Firestore Admin API.</Description>

--- a/apis/Google.Cloud.Firestore.Admin.V1/docs/history.md
+++ b/apis/Google.Cloud.Firestore.Admin.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 2.3.0, released 2021-08-31
+
+- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
+
 # Version 2.2.0, released 2021-05-26
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1106,7 +1106,7 @@
       "productUrl": "https://firebase.google.com",
       "targetFrameworks": "netstandard2.0;net461",
       "testTargetFrameworks": "netcoreapp2.1;net461",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Firestore Admin API.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
