### PR TITLE
Release Google.Cloud.Iam.Credentials.V1 version 1.2.0

### DIFF
--- a/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.csproj
+++ b/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google IAM Service Account Credentials API, which creates short-lived, limited-privilege credentials for IAM service accounts.</Description>

--- a/apis/Google.Cloud.Iam.Credentials.V1/docs/history.md
+++ b/apis/Google.Cloud.Iam.Credentials.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.2.0, released 2021-08-31
+
+- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
+
 # Version 1.1.0, released 2021-05-26
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1327,7 +1327,7 @@
     },
     {
       "id": "Google.Cloud.Iam.Credentials.V1",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "type": "grpc",
       "productName": "IAM Service Account Credentials",
       "productUrl": "https://cloud.google.com/iam/docs/reference/credentials/rest",


### PR DESCRIPTION

Changes in this release:

- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
