### PR TITLE
Release Google.Cloud.LifeSciences.V2Beta version 1.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.LifeSciences.V2Beta/Google.Cloud.LifeSciences.V2Beta/Google.Cloud.LifeSciences.V2Beta.csproj
+++ b/apis/Google.Cloud.LifeSciences.V2Beta/Google.Cloud.LifeSciences.V2Beta/Google.Cloud.LifeSciences.V2Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Life Sciences API, which is a suite of services and tools for managing, processing, and transforming life sciences data.</Description>

--- a/apis/Google.Cloud.LifeSciences.V2Beta/docs/history.md
+++ b/apis/Google.Cloud.LifeSciences.V2Beta/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.0.0-beta02, released 2021-08-31
+
+- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
+
 # Version 1.0.0-beta01, released 2021-06-08
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1443,7 +1443,7 @@
     },
     {
       "id": "Google.Cloud.LifeSciences.V2Beta",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Cloud Life Sciences",
       "productUrl": "https://cloud.google.com/life-sciences/docs/",


### PR DESCRIPTION

Changes in this release:

- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
