### PR TITLE
Release Google.Cloud.Metastore.V1Beta version 1.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.csproj
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Dataproc Metastore API (v1beta) which is used to manage the lifecycle and configuration of metastore services.</Description>

--- a/apis/Google.Cloud.Metastore.V1Beta/docs/history.md
+++ b/apis/Google.Cloud.Metastore.V1Beta/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.0.0-beta02, released 2021-08-31
+
+- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
+
 # Version 1.0.0-beta01, released 2021-03-10
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1671,7 +1671,7 @@
     },
     {
       "id": "Google.Cloud.Metastore.V1Beta",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Dataproc Metastore",
       "productUrl": "https://cloud.google.com/dataproc-metastore/docs",


### PR DESCRIPTION

Changes in this release:

- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
