### PR TITLE
Release Google.Cloud.Translate.V3 version 2.3.0

### DIFF
--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.csproj
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.2.0</Version>
+    <Version>2.3.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Translate v3 API. The Translate API translates text from one language to another.</Description>

--- a/apis/Google.Cloud.Translate.V3/docs/history.md
+++ b/apis/Google.Cloud.Translate.V3/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+# Version 2.3.0, released 2021-08-31
+
+- [Commit 1440a7c](https://github.com/googleapis/google-cloud-dotnet/commit/1440a7c): feat: added v3 proto for online/batch document translation and updated v3beta1 proto for format conversion
+- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
+
 # Version 2.2.0, released 2021-05-26
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2797,7 +2797,7 @@
       "productUrl": "https://cloud.google.com/translate/",
       "generator": "micro",
       "protoPath": "google/cloud/translate/v3",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Translate v3 API. The Translate API translates text from one language to another.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

- [Commit 1440a7c](https://github.com/googleapis/google-cloud-dotnet/commit/1440a7c): feat: added v3 proto for online/batch document translation and updated v3beta1 proto for format conversion
- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
