### PR TITLE
Release Google.Cloud.RecaptchaEnterprise.V1 version 1.3.0

### DIFF
--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.csproj
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud reCAPTCHA for Enterprise API v1.</Description>

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/docs/history.md
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.3.0, released 2021-09-01
+
+- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
+
 # Version 1.2.0, released 2021-05-26
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2029,7 +2029,7 @@
       "protoPath": "google/cloud/recaptchaenterprise/v1",
       "productName": "Google Cloud reCAPTCHA Enterprise",
       "productUrl": "https://cloud.google.com/recaptcha-enterprise/",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud reCAPTCHA for Enterprise API v1.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
