### PR TITLE
Release Google.LongRunning version 2.3.0

### DIFF
--- a/apis/Google.LongRunning/Google.LongRunning/Google.LongRunning.csproj
+++ b/apis/Google.LongRunning/Google.LongRunning/Google.LongRunning.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.2.0</Version>
+    <Version>2.3.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>gRPC services for the Google Long Running Operations API. This library is typically used as a dependency for other API client libraries.</Description>

--- a/apis/Google.LongRunning/docs/history.md
+++ b/apis/Google.LongRunning/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+# Version 2.3.0, released 2021-09-06
+
+- [Commit 604c39b](https://github.com/googleapis/google-cloud-dotnet/commit/604c39b): Regenerated Google.LongRunning with extended_operations.proto ([issue 7117](https://github.com/googleapis/google-cloud-dotnet/issues/7117))
+- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
+
 # Version 2.2.0, released 2021-05-19
 
 No API surface changes since 2.1.0, just dependency and comment updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3114,7 +3114,7 @@
       "generator": "micro",
       "protoPath": "google/longrunning",
       "listingDescription": "Support for the Long-Running Operations API pattern",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "type": "grpc",
       "metadataType": "CORE",
       "description": "gRPC services for the Google Long Running Operations API. This library is typically used as a dependency for other API client libraries.",


### PR DESCRIPTION

Changes in this release:

- [Commit 604c39b](https://github.com/googleapis/google-cloud-dotnet/commit/604c39b): Regenerated Google.LongRunning with extended_operations.proto ([issue 7117](https://github.com/googleapis/google-cloud-dotnet/issues/7117))
- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
