### PR TITLE
Release Google.LongRunning version 2.3.0

### DIFF
--- a/tools/Google.Cloud.Tools.GenerateCanonicalLinks.Tests/CanonicalizerTest.cs
+++ b/tools/Google.Cloud.Tools.GenerateCanonicalLinks.Tests/CanonicalizerTest.cs
@@ -45,6 +45,8 @@ namespace Google.Cloud.Tools.GenerateCanonicalLinks.Tests
         [InlineData("Google.Cloud.Debugger.V2", "api/Google.Cloud.DevTools.Source.V1.AliasContext.html", "Google.Cloud.DevTools.Common/latest/Google.Cloud.DevTools.Source.V1.AliasContext")]
         [InlineData("Google.Cloud.Filestore.V1", "api/Google.Cloud.Common.html", "Google.Cloud.Common/latest/Google.Cloud.Common")]
         [InlineData("Google.Cloud.Filestore.V1", "api/Google.Cloud.Common.OperationMetadata.html", "Google.Cloud.Common/latest/Google.Cloud.Common.OperationMetadata")]
+        [InlineData("Google.LongRunning", "api/Google.Cloud.ExtendedOperationsExtensions.html", "Google.LongRunning/latest/Google.Cloud.ExtendedOperationsExtensions")]
+        [InlineData("Google.LongRunning", "api/Google.Cloud.html", "Google.LongRunning/latest/Google.Cloud")]
         public void GetUrl(string package, string page, string expectedSuffix)
         {
             var actualUrl = Canonicalizer.GetUrl(package, page);

--- a/tools/Google.Cloud.Tools.GenerateCanonicalLinks/Canonicalizer.cs
+++ b/tools/Google.Cloud.Tools.GenerateCanonicalLinks/Canonicalizer.cs
@@ -135,6 +135,13 @@ namespace Google.Cloud.Tools.GenerateCanonicalLinks
             {
                 return overriddenPackage;
             }
+
+            // Exception which doesn't neatly fit elsewhere: Google.LongRunning contains some Google.Cloud files.
+            if (package == "Google.LongRunning" && page.StartsWith("Google.Cloud"))
+            {
+                return package;
+            }
+
             // If the page looks like it's genuinely in the package, that's probably fine.
             if (page.StartsWith(package))
             {


### PR DESCRIPTION
Changes in this release:

- [Commit 604c39b](https://github.com/googleapis/google-cloud-dotnet/commit/604c39b): Regenerated Google.LongRunning with extended_operations.proto ([issue 7117](https://github.com/googleapis/google-cloud-dotnet/issues/7117))
- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs

(This commit supercedes [commit 788ebbf](https://github.com/googleapis/google-cloud-dotnet/commit/788ebbf8fd71091825a9e9b97dccad9e610e2f5a) which failed to release due to a tooling bug.)