### PR TITLE
fix: Add workaround to fix Google.Cloud.Asset.V1 build

### DIFF
--- a/apis/Google.Cloud.Asset.V1/postgeneration.sh
+++ b/apis/Google.Cloud.Asset.V1/postgeneration.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+# Undo the changes made in pregeneration.sh
+git -C $GOOGLEAPIS checkout google/cloud/asset/v1

--- a/apis/Google.Cloud.Asset.V1/pregeneration.sh
+++ b/apis/Google.Cloud.Asset.V1/pregeneration.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+# Insert an extra import into assets.proto to resolve a resource name.
+# It doesn't matter much where this goes; line 19 is the start of the
+# import block.
+sed -i '19 i import \"google/cloud/osconfig/v1/osconfig_service.proto\";' \
+  $GOOGLEAPIS/google/cloud/asset/v1/assets.proto


### PR DESCRIPTION
The imported OS Config inventory.proto refers to a resource defined
in another file. Just importing the other file fixes this. I suspect
this isn't a problem for any other language, due to the way that C#
uses resource names more thoroughly than others.

Fixes #7113.