### PR TITLE
Release Google.Cloud.Tasks.V2Beta3 version 2.0.0-beta07

### DIFF
--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.csproj
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta06</Version>
+    <Version>2.0.0-beta07</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Tasks API (v2beta3), which manages the execution of large numbers of distributed requests.</Description>

--- a/apis/Google.Cloud.Tasks.V2Beta3/docs/history.md
+++ b/apis/Google.Cloud.Tasks.V2Beta3/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 2.0.0-beta07, released 2021-09-06
+
+- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
+
 # Version 2.0.0-beta06, released 2021-06-22
 
 - [Commit db0b36e](https://github.com/googleapis/google-cloud-dotnet/commit/db0b36e): docs: fix grammar in documentation.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2693,7 +2693,7 @@
       "protoPath": "google/cloud/tasks/v2beta3",
       "productName": "Google Cloud Tasks",
       "productUrl": "https://cloud.google.com/tasks/",
-      "version": "2.0.0-beta06",
+      "version": "2.0.0-beta07",
       "releaseLevelOverride": "beta",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Tasks API (v2beta3), which manages the execution of large numbers of distributed requests.",


### PR DESCRIPTION

Changes in this release:

- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
