### PR TITLE
Release Google.Cloud.Video.Transcoder.V1Beta1 version 1.0.0-beta04

### DIFF
--- a/apis/Google.Cloud.Video.Transcoder.V1Beta1/Google.Cloud.Video.Transcoder.V1Beta1/Google.Cloud.Video.Transcoder.V1Beta1.csproj
+++ b/apis/Google.Cloud.Video.Transcoder.V1Beta1/Google.Cloud.Video.Transcoder.V1Beta1/Google.Cloud.Video.Transcoder.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta03</Version>
+    <Version>1.0.0-beta04</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Transcoder API version v1beta1, which converts video files into formats suitable for consumer distribution.</Description>

--- a/apis/Google.Cloud.Video.Transcoder.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.Video.Transcoder.V1Beta1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.0.0-beta04, released 2021-09-06
+
+- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
+
 # Version 1.0.0-beta03, released 2021-08-10
 
 - [Commit 972b006](https://github.com/googleapis/google-cloud-dotnet/commit/972b006):

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2844,7 +2844,7 @@
     },
     {
       "id": "Google.Cloud.Video.Transcoder.V1Beta1",
-      "version": "1.0.0-beta03",
+      "version": "1.0.0-beta04",
       "type": "grpc",
       "productName": "Transcoder",
       "productUrl": "https://cloud.google.com/transcoder/docs",


### PR DESCRIPTION

Changes in this release:

- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
