### PR TITLE
docs: Fix the documentation for BigtableServiceApiSettings

### DIFF
--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableServiceApiClientPartial.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableServiceApiClientPartial.cs
@@ -43,7 +43,7 @@ namespace Google.Cloud.Bigtable.V2
         /// <item><description>Retry maximum delay: 60000 milliseconds</description></item>
         /// </list>
         /// Retry will be attempted on the following response status codes on individual mutations:
-        /// <list>
+        /// <list type="bullet">
         /// <item><description><see cref="StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="StatusCode.Unavailable"/></description></item>
         /// </list>
@@ -70,7 +70,7 @@ namespace Google.Cloud.Bigtable.V2
         /// <item><description>Retry maximum delay: 60000 milliseconds</description></item>
         /// </list>
         /// Retry will be attempted on the following response status codes on individual mutations:
-        /// <list>
+        /// <list type="bullet">
         /// <item><description><see cref="StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="StatusCode.Unavailable"/></description></item>
         /// </list>


### PR DESCRIPTION
The XML doc comments had `list` elements without a type, and docfx
doesn't render those at all.