### PR TITLE
First step towards package groups

### DIFF
--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3162,5 +3162,78 @@
     "google/maps/routespreferred/v1": "Non-Cloud",
     "google/storage/v1": "Relying on REST API for now",
     "google/watcher/v1": "Meta-API, mostly replaced by PubSub"
-  }
+  },
+  "packageGroups": [
+    {
+      "id": "Google.Cloud.Spanner",
+      "displayName": "Spanner",
+      "packageIds": [
+        "Google.Cloud.Spanner.Admin.Database.V1",
+        "Google.Cloud.Spanner.Admin.Instance.V1",
+        "Google.Cloud.Spanner.Data",
+        "Google.Cloud.Spanner.Common.V1",
+        "Google.Cloud.Spanner.V1"
+      ]
+    },
+    {
+      "id": "Google.Cloud.Diagnostics",
+      "displayName": "diagnostics",
+      "packageIds": [
+        "Google.Cloud.Diagnostics.AspNetCore",
+        "Google.Cloud.Diagnostics.AspNetCore3",
+        "Google.Cloud.Diagnostics.Common"
+      ]
+    },
+    {
+      "id": "Google.Cloud.DevTools.ContainerAnalysis",
+      "displayName": "Container Analysis",
+      "packageIds": [
+        "Google.Cloud.DevTools.ContainerAnalysis.V1",
+        "Grafeas.V1"
+      ]
+    },
+    {
+      "id": "Google.Cloud.Firestore",
+      "displayName": "Firestore",
+      "packageIds": [
+        "Google.Cloud.Firestore",
+        "Google.Cloud.Firestore.V1"
+      ]
+    },
+    {
+      "id": "Google.Cloud.GSuite",
+      "displayName": "GSuite Add-Ons",
+      "packageIds": [
+        "Google.Apps.Script.Type",
+        "Google.Cloud.GSuiteAddOns.V1"
+      ]
+    },
+    {
+      "id": "Google.Cloud.OsLogin",
+      "displayName": "OS Login",
+      "packageIds": [
+        "Google.Cloud.OsLogin.Common",
+        "Google.Cloud.OsLogin.V1",
+        "Google.Cloud.OsLogin.V1Beta"
+      ]
+    },
+    {
+      "id": "Google.Cloud.Workflows.V1",
+      "displayName": "Cloud Workflows V1",
+      "packageIds": [
+        "Google.Cloud.Workflows.Common.V1",
+        "Google.Cloud.Workflows.Executions.V1",
+        "Google.Cloud.Workflows.V1"
+      ]
+    },
+    {
+      "id": "Google.Cloud.Workflows.V1Beta",
+      "displayName": "Cloud Workflows V1Beta",
+      "packageIds": [
+        "Google.Cloud.Workflows.Common.V1Beta",
+        "Google.Cloud.Workflows.Executions.V1Beta",
+        "Google.Cloud.Workflows.V1Beta"
+      ]
+    }
+  ]
 }

--- a/tools/Google.Cloud.Tools.Common/ApiMetadata.cs
+++ b/tools/Google.Cloud.Tools.Common/ApiMetadata.cs
@@ -208,6 +208,14 @@ namespace Google.Cloud.Tools.Common
         /// by <see cref="ApiCatalog.FromJson(string)"/> and <see cref="ApiCatalog.Load"/>, and
         /// the token is part of <see cref="ApiCatalog.Json"/>.
         /// </summary>
+        [JsonIgnore]
         public JToken Json { get; set; }
+
+        /// <summary>
+        /// The package group that this package is part of. This is populated
+        /// by <see cref="ApiCatalog.FromJson(string)"/> and <see cref="ApiCatalog.Load"/>.
+        /// </summary>
+        [JsonIgnore]
+        public PackageGroup PackageGroup { get; set; }
     }
 }

--- a/tools/Google.Cloud.Tools.Common/PackageGroup.cs
+++ b/tools/Google.Cloud.Tools.Common/PackageGroup.cs
@@ -1,0 +1,39 @@
+﻿// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+
+namespace Google.Cloud.Tools.Common
+{
+    /// <summary>
+    /// A group of packages which are always released together.
+    /// </summary>
+    public sealed class PackageGroup
+    {
+        /// <summary>
+        /// The ID of the package group, used for release manager commands.
+        /// </summary>
+        public string Id { get; set; }
+
+        /// <summary>
+        /// The display name used for commit messages.
+        /// </summary>
+        public string DisplayName { get; set; }
+
+        /// <summary>
+        /// The IDs of the packages within the group.
+        /// </summary>
+        public List<string> PackageIds { get; } = new List<string>();
+    }
+}


### PR DESCRIPTION
This introduces package groups into the API catalog, and validates that all project references occur within package groups.

Next steps will be to update commit commands for release manager, and then batch releasing.

Towards #7021