### PR TITLE
Implement group commands for increment and commit

### DIFF
--- a/PROCESSES.md
+++ b/PROCESSES.md
@@ -174,6 +174,10 @@ check this is really what you meant to do.
     This just avoids you having to look up the current version number
     if you don't already know it. If you want to look up the version
     number anyway, use `./prepare-release.sh show-version <api>`.
+    
+    If the API you're releasing is part of a package group (multiple
+    packages that need to be released together), the `increment-version`
+    command will automatically increment all of them.
 
 3. If you want to perform an API surface comparison,
 run `./prepare-release.sh compare`. This will build the code
@@ -195,10 +199,9 @@ changes, with a message taken from the version history for the
 package. Use `git commit --amend` to change the commit message if
 you need to.
 
-    If you're releasing more than one package, use
-    `./prepare-release.sh commit-multiple <commit title>`, e.g.
-    `./prepare-release.sh commit-multiple "Release Spanner libraries version 3.3.0"`.
-    Alternatively, create the commit manually, including one line per package of the form
+    If you're releasing a package group, use
+    `./prepare-release.sh commit-group`. Alternatively, create
+    the commit manually, including one line per package of the form
     `- Release XYZ version ABC`.
 
     **Note:** If you're using the Dockerfile described in

--- a/tools/Google.Cloud.Tools.ReleaseManager/CommitCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/CommitCommand.cs
@@ -36,7 +36,7 @@ namespace Google.Cloud.Tools.ReleaseManager
             var diffs = FindChangedVersions();
             if (diffs.Count != 1)
             {
-                throw new UserErrorException($"Can only automate a single-package release commit with exactly 1 release. Found {diffs.Count}. Did you mean 'commit-multiple'?");
+                throw new UserErrorException($"Can only automate a single-package release commit with exactly 1 release. Found {diffs.Count}. Did you mean 'commit-group'?");
             }
             var diff = diffs[0];
             if (diff.NewVersion is null)

--- a/tools/Google.Cloud.Tools.ReleaseManager/History/overrides.json
+++ b/tools/Google.Cloud.Tools.ReleaseManager/History/overrides.json
@@ -24,5 +24,7 @@
   "d8d8eb7": "skip",
   "a78cbb2": "skip",
   "209588c": "skip",
-  "7b76d4e": "skip"
+  "7b76d4e": "skip",
+  "f5e5ec7": "skip", // Rename GrpcCtorCompatibility.g.cs
+  "84832b8": "skip", // Regenerate with later protoc; adds GeneratedCodeAttribute
 }


### PR DESCRIPTION
Sample session (omitting most of the output):

```sh
$ ./prepare-release.sh increment-version Google.Cloud.Spanner.V1
API 'Google.Cloud.Spanner.V1' is in package group 'Google.Cloud.Spanner'. Incrementing all APIs.
[...]

$ ./prepare-release.sh update-history
[...]

$ ./prepare-release.sh commit-group
Created commit af9105e49e0a67c0e579ba9b19228dcf89409c42. Review the message and amend if necessary.
```