### PR TITLE
Release GSuite Add-Ons libraries version 1.1.0

### DIFF
--- a/apis/Google.Apps.Script.Type/Google.Apps.Script.Type/Google.Apps.Script.Type.csproj
+++ b/apis/Google.Apps.Script.Type/Google.Apps.Script.Type/Google.Apps.Script.Type.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Version-agnostic types for Apps Script APIs.</Description>

--- a/apis/Google.Apps.Script.Type/docs/history.md
+++ b/apis/Google.Apps.Script.Type/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.1.0, released 2021-09-20
+
+No API surface changes; just dependency updates.
+
 # Version 1.0.0, released 2021-06-08
 
 - [Commit 19b4d05](https://github.com/googleapis/google-cloud-dotnet/commit/19b4d05): fix: add outer classname for addon_widget_set proto for java

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.csproj
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Workspace Add-ons API</Description>

--- a/apis/Google.Cloud.GSuiteAddOns.V1/docs/history.md
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.1.0, released 2021-09-20
+
+- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
+
 # Version 1.0.0, released 2021-06-08
 
 No API surface changes; just dependency updates and promotion to GA.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -44,7 +44,7 @@
     },
     {
       "id": "Google.Apps.Script.Type",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "targetFrameworks": "netstandard2.0;net461",
       "type": "other",
       "description": "Version-agnostic types for Apps Script APIs.",
@@ -1192,7 +1192,7 @@
     },
     {
       "id": "Google.Cloud.GSuiteAddOns.V1",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "grpc",
       "productName": "Google Workspace Add-ons",
       "productUrl": "https://developers.google.com/gsuite/add-ons/overview",


### PR DESCRIPTION

Changes in Google.Apps.Script.Type version 1.1.0:

No API surface changes; just dependency updates.

Changes in Google.Cloud.GSuiteAddOns.V1 version 1.1.0:

- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs

Packages in this release:
- Release Google.Apps.Script.Type version 1.1.0
- Release Google.Cloud.GSuiteAddOns.V1 version 1.1.0
