### PR TITLE
chore: Add support for OwlBot

### DIFF
--- a/generateapis.sh
+++ b/generateapis.sh
@@ -328,11 +328,13 @@ generate_api() {
     fi
   fi
 
-  # Record the commit in synth.metadata, using either googleapis or googleapis-discovery
-  # depending on the generator.
-  if [[ "$GENERATOR" == "regapic" ]]
+  if [[ -f $PACKAGE_DIR/synth.ph ]]
   then
-    cat > $PACKAGE_DIR/synth.metadata <<END
+    # Record the commit in synth.metadata, using either googleapis or googleapis-discovery
+    # depending on the generator.
+    if [[ "$GENERATOR" == "regapic" ]]
+    then
+      cat > $PACKAGE_DIR/synth.metadata <<END
 {
   "sources": [
     {
@@ -352,8 +354,8 @@ generate_api() {
   ]
 }
 END
-  else
-    cat > $PACKAGE_DIR/synth.metadata <<END
+    else
+      cat > $PACKAGE_DIR/synth.metadata <<END
 {
   "sources": [
     {
@@ -366,6 +368,7 @@ END
   ]
 }
 END
+    fi
   fi
 }
 
@@ -394,6 +397,9 @@ then
   packages=$($PYTHON3 tools/listapis.py apis/apis.json --test generator)
 fi
 
+# TODO: For OwlBot APIs, should we just copy from googleapis-gen,
+# unless we're testing a generator change? (Using two different generation
+# paths may end up causing issues.)
 for package in $packages
 do
   generate_api $package

--- a/tools/Google.Cloud.Tools.Common/ApiMetadata.cs
+++ b/tools/Google.Cloud.Tools.Common/ApiMetadata.cs
@@ -122,11 +122,33 @@ namespace Google.Cloud.Tools.Common
         // Using a SortedDictionary means we'll keep dependencies in alphabetical order.
         public SortedDictionary<string, string> Dependencies { get; set; } = new SortedDictionary<string, string>(StringComparer.Ordinal);
         public SortedDictionary<string, string> TestDependencies { get; set; } = new SortedDictionary<string, string>(StringComparer.Ordinal);
-        
+
         /// <summary>
         /// The type of generator used to generate source code for this API.
         /// </summary>
-        public GeneratorType Generator { get; set;  }
+        public GeneratorType Generator { get; set; }
+
+        /// <summary>
+        /// The autogenerator type used to maintain this API, when specified explicitly.
+        /// </summary>
+        public AutoGeneratorType? AutoGenerator { get; set; }
+
+        /// <summary>
+        /// Determines the autogenerator type for this API based on what's explicitly configured,
+        /// and sensible defaults otherwise.
+        /// </summary>
+        public AutoGeneratorType DetermineAutoGeneratorType(string apiDirectory)
+        {
+            if (AutoGenerator != null)
+            {
+                return AutoGenerator.Value;
+            }
+
+            // Currently, default to just "synthtool if anything". Once we have confidence that
+            // we've got the OwlBot configuration right, we can return check whether there are any pre/mid/post-generation
+            // scripts, and opt into OwlBot automatically when there aren't.
+            return Generator == GeneratorType.None ? AutoGeneratorType.None : AutoGeneratorType.Synthtool;
+        }
         
         /// <summary>
         /// The path within googleapis for the API protos.

--- a/tools/Google.Cloud.Tools.Common/AutoGeneratorType.cs
+++ b/tools/Google.Cloud.Tools.Common/AutoGeneratorType.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Google.Cloud.Tools.Common
+{
+    /// <summary>
+    /// The infrastructure responsible for automatically regenerating a package
+    /// when the generator or source protos change.
+    /// </summary>
+    public enum AutoGeneratorType
+    {
+        /// <summary>
+        /// No automated maintenance.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Maintenance via Synthtool/Autosynth. See https://github.com/googleapis/synthtool
+        /// </summary>
+        Synthtool = 1,
+
+        /// <summary>
+        /// Maintenance via OwlBot.
+        /// </summary>
+        OwlBot = 2
+    }
+}


### PR DESCRIPTION
Initially, the "autogenerator" type can be specified in JSON, and
never defaults to OwlBot. This will allow us to test OwlBot.
After this is complete, we can default to using OwlBot for any cases
where there are no scripts that tinker with the generation process.

cc @SurferJeffAtGoogle 