### PR TITLE
Release Google.Analytics.Admin.V1Alpha version 1.0.0-alpha09

### DIFF
--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha08</Version>
+    <Version>1.0.0-alpha09</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Analytics Admin API (v1alpha)</Description>

--- a/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
+++ b/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
@@ -1,5 +1,23 @@
 # Version history
 
+# Version 1.0.0-alpha09, released 2021-09-23
+
+- [Commit 31dfcff](https://github.com/googleapis/google-cloud-dotnet/commit/31dfcff):
+  - feat: add `GetDataRetentionSettings`, `UpdateDataRetentionSettings` methods to the API
+  - feat: add `GetDisplayVideo360AdvertiserLink`, `ListDisplayVideo360AdvertiserLinks`, `CreateDisplayVideo360AdvertiserLink`, `DeleteDisplayVideo360AdvertiserLink` methods to the API
+  - feat: add `GetDisplayVideo360AdvertiserLinkProposal`, `ListDisplayVideo360AdvertiserLinkProposals`,`DeleteDisplayVideo360AdvertiserLinkProposal`, `CancelDisplayVideo360AdvertiserLinkProposal` methods to the API
+  - feat: add `LinkProposalStatusDetails`, `DisplayVideo360AdvertiserLinkProposal`, `DisplayVideo360AdvertiserLink`
+  - `LinkProposalState`, `LinkProposalInitiatingProduct`, `ServiceLevel`, `DataRetentionSettings` types to the API
+  - feat: add `service_level` field to `Property` type
+  - feat: add `display_video_360_advertiser_link`, `display_video_360_advertiser_link_proposal`, `data_retention_settings` fields to `ChangeHistoryChange.resource` oneof field.
+  - feat: add `custom` output only field to `ConversionEvent` type
+  - feat: change `measurement_unit` field to mutable in `CustomMetric` type
+  - fix!: remove `UpdateFirebaseLink` method from the API
+  - fix!: rename `is_deletable` field of `ConversionEvent` type to `deletable`
+  - fix!: rename `email_address` field of `GoogleAdsLink` type to `creator_email_address`
+  - fix!: remove `maximum_user_access` field from `FirebaseLink` type
+  - fix!: remove `MaximumUserAccess` enum from the API
+
 # Version 1.0.0-alpha08, released 2021-08-18
 
 - [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2,7 +2,7 @@
   "apis": [
     {
       "id": "Google.Analytics.Admin.V1Alpha",
-      "version": "1.0.0-alpha08",
+      "version": "1.0.0-alpha09",
       "type": "grpc",
       "productName": "Analytics Admin",
       "productUrl": "https://developers.google.com/analytics",


### PR DESCRIPTION

Changes in this release:

- [Commit 31dfcff](https://github.com/googleapis/google-cloud-dotnet/commit/31dfcff):
  - feat: add `GetDataRetentionSettings`, `UpdateDataRetentionSettings` methods to the API
  - feat: add `GetDisplayVideo360AdvertiserLink`, `ListDisplayVideo360AdvertiserLinks`, `CreateDisplayVideo360AdvertiserLink`, `DeleteDisplayVideo360AdvertiserLink` methods to the API
  - feat: add `GetDisplayVideo360AdvertiserLinkProposal`, `ListDisplayVideo360AdvertiserLinkProposals`,`DeleteDisplayVideo360AdvertiserLinkProposal`, `CancelDisplayVideo360AdvertiserLinkProposal` methods to the API
  - feat: add `LinkProposalStatusDetails`, `DisplayVideo360AdvertiserLinkProposal`, `DisplayVideo360AdvertiserLink`
  - `LinkProposalState`, `LinkProposalInitiatingProduct`, `ServiceLevel`, `DataRetentionSettings` types to the API
  - feat: add `service_level` field to `Property` type
  - feat: add `display_video_360_advertiser_link`, `display_video_360_advertiser_link_proposal`, `data_retention_settings` fields to `ChangeHistoryChange.resource` oneof field.
  - feat: add `custom` output only field to `ConversionEvent` type
  - feat: change `measurement_unit` field to mutable in `CustomMetric` type
  - fix!: remove `UpdateFirebaseLink` method from the API
  - fix!: rename `is_deletable` field of `ConversionEvent` type to `deletable`
  - fix!: rename `email_address` field of `GoogleAdsLink` type to `creator_email_address`
  - fix!: remove `maximum_user_access` field from `FirebaseLink` type
  - fix!: remove `MaximumUserAccess` enum from the API
