### PR TITLE
Release Google.Cloud.Asset.V1 version 2.10.0

### DIFF
--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.csproj
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.9.0</Version>
+    <Version>2.10.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Asset Inventory API (v1).</Description>
@@ -16,7 +16,7 @@
     <PackageReference Include="Google.Cloud.OsConfig.V1" Version="[1.3.0, 2.0.0)" />
     <PackageReference Include="Google.Identity.AccessContextManager.Type" Version="[1.1.0, 2.0.0)" />
     <PackageReference Include="Google.Identity.AccessContextManager.V1" Version="[1.3.0, 2.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.3.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.Asset.V1/docs/history.md
+++ b/apis/Google.Cloud.Asset.V1/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+# Version 2.10.0, released 2021-09-23
+
+- [Commit b71303f](https://github.com/googleapis/google-cloud-dotnet/commit/b71303f): feat: Release of relationships in v1, Add content type Relationship to support relationship search
+- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
+
 # Version 2.9.0, released 2021-08-10
 
 - [Commit ba29ee0](https://github.com/googleapis/google-cloud-dotnet/commit/ba29ee0):

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -190,7 +190,7 @@
       "protoPath": "google/cloud/asset/v1",
       "productName": "Google Cloud Asset Inventory",
       "productUrl": "https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Asset Inventory API (v1).",
       "dependencies": {
@@ -200,7 +200,7 @@
         "Google.Cloud.OsConfig.V1": "1.3.0",
         "Google.Identity.AccessContextManager.Type": "1.1.0",
         "Google.Identity.AccessContextManager.V1": "1.3.0",
-        "Google.LongRunning": "2.2.0",
+        "Google.LongRunning": "2.3.0",
         "Grpc.Core": "2.38.1"
       },
       "tags": [


### PR DESCRIPTION

Changes in this release:

- [Commit b71303f](https://github.com/googleapis/google-cloud-dotnet/commit/b71303f): feat: Release of relationships in v1, Add content type Relationship to support relationship search
- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
