### PR TITLE
Release Google.Cloud.Audit version 1.1.0

### DIFF
--- a/apis/Google.Cloud.Audit/Google.Cloud.Audit/Google.Cloud.Audit.csproj
+++ b/apis/Google.Cloud.Audit/Google.Cloud.Audit/Google.Cloud.Audit.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Protobuf messages for Google Cloud audit logs.</Description>

--- a/apis/Google.Cloud.Audit/docs/history.md
+++ b/apis/Google.Cloud.Audit/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.1.0, released 2021-09-23
+
+- [Commit 5504481](https://github.com/googleapis/google-cloud-dotnet/commit/5504481): feat: Add BigQueryAuditMetadata proto. The BigQueryAuditMetadata proto is used by BigQuery Cloud Audit Logging. It is encoded as a google.protobuf.Struct message inside the metadata field of the AuditLog proto
+
 # Version 1.0.0, released 2021-08-16
 
 No API surface changes; just promotion to GA.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -228,7 +228,7 @@
     },
     {
       "id": "Google.Cloud.Audit",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "targetFrameworks": "netstandard2.0;net461",
       "productName": "Google Cloud Audit",
       "productUrl": "https://cloud.google.com/logging/docs/audit",


### PR DESCRIPTION

Changes in this release:

- [Commit 5504481](https://github.com/googleapis/google-cloud-dotnet/commit/5504481): feat: Add BigQueryAuditMetadata proto. The BigQueryAuditMetadata proto is used by BigQuery Cloud Audit Logging. It is encoded as a google.protobuf.Struct message inside the metadata field of the AuditLog proto
