### PR TITLE
Release Google.Cloud.BigQuery.DataTransfer.V1 version 3.2.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.1.0</Version>
+    <Version>3.2.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery Data Transfer API, which transfers data from partner SaaS applications to Google BigQuery on a scheduled, managed basis.</Description>

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+# Version 3.2.0, released 2021-09-23
+
+- [Commit edaadae](https://github.com/googleapis/google-cloud-dotnet/commit/edaadae): docs: Improvements to various message and field descriptions
+- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
+
 # Version 3.1.0, released 2021-05-25
 
 - [Commit 3717e0d](https://github.com/googleapis/google-cloud-dotnet/commit/3717e0d): Regenerate all APIs with generator change for deprecation

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -287,7 +287,7 @@
       "protoPath": "google/cloud/bigquery/datatransfer/v1",
       "productName": "Google BigQuery Data Transfer",
       "productUrl": "https://cloud.google.com/bigquery/transfer/",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the BigQuery Data Transfer API, which transfers data from partner SaaS applications to Google BigQuery on a scheduled, managed basis.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

- [Commit edaadae](https://github.com/googleapis/google-cloud-dotnet/commit/edaadae): docs: Improvements to various message and field descriptions
- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
