### PR TITLE
Release Google.Cloud.BinaryAuthorization.V1Beta1 version 1.0.0-beta04

### DIFF
--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.csproj
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta03</Version>
+    <Version>1.0.0-beta04</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Binary Authorization API v1beta1, providing policy control for images deployed to Kubernetes Engine clusters.</Description>

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+# Version 1.0.0-beta04, released 2021-09-23
+
+- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
+- [Commit e711ab9](https://github.com/googleapis/google-cloud-dotnet/commit/e711ab9): docs: Replace "global policy" with "system policy" in Binary Authorization documentation
+
 # Version 1.0.0-beta03, released 2021-06-22
 
 - [Commit 9e5abc8](https://github.com/googleapis/google-cloud-dotnet/commit/9e5abc8): feat: Publish Binary Authorization ContinuousValidationEvent proto. This is used in the new [Continuous Validation](https://cloud.google.com/binary-authorization/docs/overview-cv) feature

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -471,7 +471,7 @@
     },
     {
       "id": "Google.Cloud.BinaryAuthorization.V1Beta1",
-      "version": "1.0.0-beta03",
+      "version": "1.0.0-beta04",
       "type": "grpc",
       "productName": "Binary Authorization",
       "productUrl": "https://cloud.google.com/binary-authorization/docs/reference/rpc",


### PR DESCRIPTION

Changes in this release:

- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
- [Commit e711ab9](https://github.com/googleapis/google-cloud-dotnet/commit/e711ab9): docs: Replace "global policy" with "system policy" in Binary Authorization documentation
