### PR TITLE
Release Google.Cloud.Datastream.V1Alpha1 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.csproj
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Datastream API (v1alpha1), which allows you to synchronize data across heterogeneous databases and applications reliably, and with minimal latency and downtime.</Description>
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.3.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.Datastream.V1Alpha1/docs/history.md
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+# Version 1.0.0-beta02, released 2021-09-23
+
+- [Commit dd74fcc](https://github.com/googleapis/google-cloud-dotnet/commit/dd74fcc): fix(datastream)!: Change a few resource pattern variables from camelCase to snake_case
+- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
+
 # Version 1.0.0-beta01, released 2021-06-30
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -752,7 +752,7 @@
     },
     {
       "id": "Google.Cloud.Datastream.V1Alpha1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "DataStream",
       "productUrl": "https://cloud.google.com/datastream/docs",
@@ -762,7 +762,7 @@
         "synchronization"
       ],
       "dependencies": {
-        "Google.LongRunning": "2.2.0"
+        "Google.LongRunning": "2.3.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/datastream/v1alpha1"


### PR DESCRIPTION

Changes in this release:

- [Commit dd74fcc](https://github.com/googleapis/google-cloud-dotnet/commit/dd74fcc): fix(datastream)!: Change a few resource pattern variables from camelCase to snake_case
- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
