### PR TITLE
Release Google.Cloud.Functions.V1 version 1.2.0

### DIFF
--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.csproj
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Functions API, which manages lightweight user-provided functions executed in response to events.</Description>
@@ -12,7 +12,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.3.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.Functions.V1/docs/history.md
+++ b/apis/Google.Cloud.Functions.V1/docs/history.md
@@ -1,5 +1,14 @@
 # Version history
 
+# Version 1.2.0, released 2021-09-23
+
+- [Commit d4815e4](https://github.com/googleapis/google-cloud-dotnet/commit/d4815e4): feat: add SecurityLevel option on HttpsTrigger
+- [Commit 9ac0b1d](https://github.com/googleapis/google-cloud-dotnet/commit/9ac0b1d): docs: minor formatting fixes to Cloud Functions reference docs
+- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
+- [Commit 6aa7606](https://github.com/googleapis/google-cloud-dotnet/commit/6aa7606):
+  - fix: Updating behavior of source_upload_url during Get/List function calls
+  - Regenerating cloud functions docs
+
 # Version 1.1.0, released 2021-05-05
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1194,7 +1194,7 @@
     },
     {
       "id": "Google.Cloud.Functions.V1",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "type": "grpc",
       "productName": "Cloud Functions",
       "productUrl": "https://cloud.google.com/functions",
@@ -1205,7 +1205,7 @@
       "dependencies": {
         "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.Cloud.Iam.V1": "2.2.0",
-        "Google.LongRunning": "2.2.0",
+        "Google.LongRunning": "2.3.0",
         "Grpc.Core": "2.38.1"
       },
       "generator": "micro",


### PR DESCRIPTION

Changes in this release:

- [Commit d4815e4](https://github.com/googleapis/google-cloud-dotnet/commit/d4815e4): feat: add SecurityLevel option on HttpsTrigger
- [Commit 9ac0b1d](https://github.com/googleapis/google-cloud-dotnet/commit/9ac0b1d): docs: minor formatting fixes to Cloud Functions reference docs
- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
- [Commit 6aa7606](https://github.com/googleapis/google-cloud-dotnet/commit/6aa7606):
  - fix: Updating behavior of source_upload_url during Get/List function calls
  - Regenerating cloud functions docs
