### PR TITLE
Release Google.Cloud.GkeHub.V1Beta1 version 1.0.0-beta03

### DIFF
--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.csproj
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the GKE Hub API, version v1beta1.</Description>
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.3.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.GkeHub.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+# Version 1.0.0-beta03, released 2021-09-23
+
+- [Commit 1d19cbd](https://github.com/googleapis/google-cloud-dotnet/commit/1d19cbd):
+  - feat: Add request_id under `DeleteMembershipRequest` and `UpdateMembershipRequest`
+  - feat: Add `OnPremCluster` and `MultiCloudCluster` as `GkeCluster` equivalent field
+  - fix!: Move `GkeCluster` under oneof
+- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
+
 # Version 1.0.0-beta02, released 2021-04-29
 
 - [Commit a204405](https://github.com/googleapis/google-cloud-dotnet/commit/a204405): chore: Use correct markdown for code block

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1288,7 +1288,7 @@
     },
     {
       "id": "Google.Cloud.GkeHub.V1Beta1",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0-beta03",
       "type": "grpc",
       "productName": "GKE Hub",
       "productUrl": "https://cloud.google.com/anthos/multicluster-management/connect/registering-a-cluster",
@@ -1299,7 +1299,7 @@
         "anthos"
       ],
       "dependencies": {
-        "Google.LongRunning": "2.2.0"
+        "Google.LongRunning": "2.3.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/gkehub/v1beta1"


### PR DESCRIPTION

Changes in this release:

- [Commit 1d19cbd](https://github.com/googleapis/google-cloud-dotnet/commit/1d19cbd):
  - feat: Add request_id under `DeleteMembershipRequest` and `UpdateMembershipRequest`
  - feat: Add `OnPremCluster` and `MultiCloudCluster` as `GkeCluster` equivalent field
  - fix!: Move `GkeCluster` under oneof
- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
