### PR TITLE
Release Google.Cloud.Kms.V1 version 2.5.0

### DIFF
--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.csproj
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.4.0</Version>
+    <Version>2.5.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Key Management Service API, which manages encryption for your cloud services the same way you do on-premises. You can generate, use, rotate, and destroy AES256 encryption keys.</Description>

--- a/apis/Google.Cloud.Kms.V1/docs/history.md
+++ b/apis/Google.Cloud.Kms.V1/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+# Version 2.5.0, released 2021-09-23
+
+- [Commit b91de3f](https://github.com/googleapis/google-cloud-dotnet/commit/b91de3f): feat: add support for Key Reimport
+- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
+
 # Version 2.4.0, released 2021-08-10
 
 - [Commit f62f458](https://github.com/googleapis/google-cloud-dotnet/commit/f62f458): feat: add support for HMAC, Variable Key Destruction, and GenerateRandom

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1430,7 +1430,7 @@
       "protoPath": "google/cloud/kms/v1",
       "productName": "Google Cloud Key Management Service",
       "productUrl": "https://cloud.google.com/kms/",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Key Management Service API, which manages encryption for your cloud services the same way you do on-premises. You can generate, use, rotate, and destroy AES256 encryption keys.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

- [Commit b91de3f](https://github.com/googleapis/google-cloud-dotnet/commit/b91de3f): feat: add support for Key Reimport
- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
