### PR TITLE
Release Google.Cloud.Metastore.V1 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.csproj
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Dataproc Metastore API which is used to manage the lifecycle and configuration of metastore services.</Description>
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.3.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.Metastore.V1/docs/history.md
+++ b/apis/Google.Cloud.Metastore.V1/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+# Version 1.1.0, released 2021-09-23
+
+- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
+- [Commit 95dd8f3](https://github.com/googleapis/google-cloud-dotnet/commit/95dd8f3):
+  - feat: Added the Backup resource and Backup resource GetIamPolicy/SetIamPolicy to V1
+  - feat: Added the RestoreService method to V1
+  - Promoted additional Dataproc Metastore metadata management methods to V1
+
 # Version 1.0.0, released 2021-06-08
 
 No API surface changes; just promoting to GA.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1656,7 +1656,7 @@
     },
     {
       "id": "Google.Cloud.Metastore.V1",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "grpc",
       "productName": "Dataproc Metastore",
       "productUrl": "https://cloud.google.com/dataproc-metastore/docs",
@@ -1667,7 +1667,7 @@
       ],
       "dependencies": {
         "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
-        "Google.LongRunning": "2.2.0",
+        "Google.LongRunning": "2.3.0",
         "Grpc.Core": "2.38.1"
       },
       "generator": "micro",


### PR DESCRIPTION

Changes in this release:

- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
- [Commit 95dd8f3](https://github.com/googleapis/google-cloud-dotnet/commit/95dd8f3):
  - feat: Added the Backup resource and Backup resource GetIamPolicy/SetIamPolicy to V1
  - feat: Added the RestoreService method to V1
  - Promoted additional Dataproc Metastore metadata management methods to V1
