### PR TITLE
Release Google.Cloud.NetworkConnectivity.V1 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.csproj
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Network Connectivity API, which provides access to Network Connectivity Center.</Description>
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.3.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.NetworkConnectivity.V1/docs/history.md
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/docs/history.md
@@ -1,5 +1,14 @@
 # Version history
 
+# Version 1.0.0-beta02, released 2021-09-23
+
+- [Commit c64998e](https://github.com/googleapis/google-cloud-dotnet/commit/c64998e):
+  - fix!: Remove ActivateSpoke and DeactivateSpoke methods
+  - BREAKING_CHANGE: ActivateSpoke and DeactivateSpoke were included in a previous change by mistake
+  - feat: Add hub.routing_vpcs field
+  - docs: Specify that site_to_site_data_transfer field must be set to true
+- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
+
 # Version 1.0.0-beta01, released 2021-08-12
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1729,7 +1729,7 @@
     },
     {
       "id": "Google.Cloud.NetworkConnectivity.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Network Connectivity",
       "productUrl": "https://cloud.google.com/network-connectivity/docs/",
@@ -1740,7 +1740,7 @@
         "vpc"
       ],
       "dependencies": {
-        "Google.LongRunning": "2.2.0"
+        "Google.LongRunning": "2.3.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/networkconnectivity/v1"


### PR DESCRIPTION

Changes in this release:

- [Commit c64998e](https://github.com/googleapis/google-cloud-dotnet/commit/c64998e):
  - fix!: Remove ActivateSpoke and DeactivateSpoke methods
  - BREAKING_CHANGE: ActivateSpoke and DeactivateSpoke were included in a previous change by mistake
  - feat: Add hub.routing_vpcs field
  - docs: Specify that site_to_site_data_transfer field must be set to true
- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
