### PR TITLE
Release Google.Cloud.Retail.V2 version 1.3.0

### DIFF
--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.csproj
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Cloud Retail service enables customers to build end-to-end personalized recommendation systems without requiring a high level of expertise in machine learning, recommendation system, or Google Cloud.</Description>
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.3.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.Retail.V2/docs/history.md
+++ b/apis/Google.Cloud.Retail.V2/docs/history.md
@@ -1,5 +1,14 @@
 # Version history
 
+# Version 1.3.0, released 2021-09-23
+
+- [Commit 672325d](https://github.com/googleapis/google-cloud-dotnet/commit/672325d):
+  - docs: Keep the API doc up-to-date
+  - feat: update grpc service config settings to reflect correct API deadlines
+  - chore: remove relative private links from search service comments to prevent crashing client lib generation tool
+- [Commit 51b50d0](https://github.com/googleapis/google-cloud-dotnet/commit/51b50d0): docs: Keep the API doc up-to-date
+- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
+
 # Version 1.2.0, released 2021-08-10
 
 - [Commit 130477c](https://github.com/googleapis/google-cloud-dotnet/commit/130477c): docs(retail): Quote several literal expressions for better rendering

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2207,7 +2207,7 @@
     },
     {
       "id": "Google.Cloud.Retail.V2",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "type": "grpc",
       "productName": "Retail",
       "productUrl": "https://cloud.google.com/retail/docs",
@@ -2217,7 +2217,7 @@
       ],
       "dependencies": {
         "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
-        "Google.LongRunning": "2.2.0",
+        "Google.LongRunning": "2.3.0",
         "Grpc.Core": "2.38.1"
       },
       "generator": "micro",


### PR DESCRIPTION

Changes in this release:

- [Commit 672325d](https://github.com/googleapis/google-cloud-dotnet/commit/672325d):
  - docs: Keep the API doc up-to-date
  - feat: update grpc service config settings to reflect correct API deadlines
  - chore: remove relative private links from search service comments to prevent crashing client lib generation tool
- [Commit 51b50d0](https://github.com/googleapis/google-cloud-dotnet/commit/51b50d0): docs: Keep the API doc up-to-date
- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
