### PR TITLE
Release Google.Cloud.Speech.V1P1Beta1 version 2.0.0-beta06

### DIFF
--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.csproj
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta05</Version>
+    <Version>2.0.0-beta06</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google client library to access the Google Cloud Speech API version v1p1beta1 with upcoming features.</Description>
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.3.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.Speech.V1P1Beta1/docs/history.md
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+# Version 2.0.0-beta06, released 2021-09-23
+
+- [Commit 3f9793d](https://github.com/googleapis/google-cloud-dotnet/commit/3f9793d): feat: Add transcript normalization
+- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
+
 # Version 2.0.0-beta05, released 2021-07-28
 
 - [Commit 1b4497f](https://github.com/googleapis/google-cloud-dotnet/commit/1b4497f):

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2624,7 +2624,7 @@
       "protoPath": "google/cloud/speech/v1p1beta1",
       "productName": "Google Cloud Speech",
       "productUrl": "https://cloud.google.com/speech",
-      "version": "2.0.0-beta05",
+      "version": "2.0.0-beta06",
       "releaseLevelOverride": "beta",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
@@ -2633,7 +2633,7 @@
         "Speech"
       ],
       "dependencies": {
-        "Google.LongRunning": "2.2.0"
+        "Google.LongRunning": "2.3.0"
       }
     },
     {


### PR DESCRIPTION

Changes in this release:

- [Commit 3f9793d](https://github.com/googleapis/google-cloud-dotnet/commit/3f9793d): feat: Add transcript normalization
- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
