### PR TITLE
Release Google.Cloud.Talent.V4 version 1.2.0

### DIFF
--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.csproj
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Talent solution API (v4) which provides the capability to create, read, update, and delete job postings, as well as search jobs based on keywords and filters.</Description>
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.3.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.Talent.V4/docs/history.md
+++ b/apis/Google.Cloud.Talent.V4/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+# Version 1.2.0, released 2021-09-23
+
+- [Commit 87bf8a2](https://github.com/googleapis/google-cloud-dotnet/commit/87bf8a2):
+  - feat: Added a new `KeywordMatchMode` field to support more keyword matching options
+  - feat: Added more `DiversificationLevel` configuration options
+- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
+- [Commit 4dfd11f](https://github.com/googleapis/google-cloud-dotnet/commit/4dfd11f):
+  - feat: Add new commute methods in Search APIs
+  - feat: Add new histogram type 'publish_time_in_day'
+  - feat: Support filtering by requisitionId is ListJobs API
+
 # Version 1.1.0, released 2021-05-26
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2679,7 +2679,7 @@
     },
     {
       "id": "Google.Cloud.Talent.V4",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "type": "grpc",
       "productName": "Google Cloud Talent Solution",
       "productUrl": "https://cloud.google.com/talent-solution/",
@@ -2690,7 +2690,7 @@
       ],
       "dependencies": {
         "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
-        "Google.LongRunning": "2.2.0",
+        "Google.LongRunning": "2.3.0",
         "Grpc.Core": "2.38.1"
       },
       "generator": "micro",


### PR DESCRIPTION

Changes in this release:

- [Commit 87bf8a2](https://github.com/googleapis/google-cloud-dotnet/commit/87bf8a2):
  - feat: Added a new `KeywordMatchMode` field to support more keyword matching options
  - feat: Added more `DiversificationLevel` configuration options
- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
- [Commit 4dfd11f](https://github.com/googleapis/google-cloud-dotnet/commit/4dfd11f):
  - feat: Add new commute methods in Search APIs
  - feat: Add new histogram type 'publish_time_in_day'
  - feat: Support filtering by requisitionId is ListJobs API
