### PR TITLE
Release Google.Cloud.Video.Transcoder.V1 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.csproj
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Transcoder API version v1, which converts video files into formats suitable for consumer distribution.</Description>

--- a/apis/Google.Cloud.Video.Transcoder.V1/docs/history.md
+++ b/apis/Google.Cloud.Video.Transcoder.V1/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+# Version 1.0.0-beta02, released 2021-09-23
+
+- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
+- [Commit ead80b6](https://github.com/googleapis/google-cloud-dotnet/commit/ead80b6): feat: Enables generation of client libraries for C#, php and ruby.
+
 # Version 1.0.0-beta01, released 2021-07-09
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2873,7 +2873,7 @@
     },
     {
       "id": "Google.Cloud.Video.Transcoder.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Transcoder",
       "productUrl": "https://cloud.google.com/transcoder/docs",


### PR DESCRIPTION

Changes in this release:

- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
- [Commit ead80b6](https://github.com/googleapis/google-cloud-dotnet/commit/ead80b6): feat: Enables generation of client libraries for C#, php and ruby.
