### PR TITLE
Add a "release all" criterion to batch release all changed packages.

### DIFF
--- a/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/BatchReleaseConfig.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/BatchReleaseConfig.cs
@@ -46,6 +46,11 @@ namespace Google.Cloud.Tools.ReleaseManager.BatchRelease
         // Library selection criteria. These properties are effectively mutually exclusive.
 
         /// <summary>
+        /// Release everything that has changed and already has at least one release.
+        /// </summary>
+        public ReleaseAllCriterion ReleaseAll { get; set; }
+
+        /// <summary>
         /// Find all libraries with changes matching the given set of commits.
         /// </summary>
         public KnownCommitsCriterion KnownCommits { get; set; }
@@ -54,22 +59,6 @@ namespace Google.Cloud.Tools.ReleaseManager.BatchRelease
         /// Match exactly the APIs specified.
         /// </summary>
         public List<string> SpecifiedApis { get; set; }
-
-        /// <summary>
-        /// Validates that this configuration is reasonable.
-        /// </summary>
-        public void Validate()
-        {
-            var specifiedCriteria = new object[]
-            {
-                KnownCommits,
-                SpecifiedApis
-            }.Count(c => c is object);
-            if (specifiedCriteria != 1)
-            {
-                throw new UserErrorException("A batch release must specify exactly one criterion.");
-            }
-        }
 
         internal IEnumerable<IBatchCriterion> GetCriteria()
         {
@@ -80,6 +69,10 @@ namespace Google.Cloud.Tools.ReleaseManager.BatchRelease
             if (SpecifiedApis is object)
             {
                 yield return new SpecifiedApisCriterion(SpecifiedApis);
+            }
+            if (ReleaseAll is object)
+            {
+                yield return ReleaseAll;
             }
         }
     }

--- a/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/KnownCommitsCriterion.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/KnownCommitsCriterion.cs
@@ -20,7 +20,7 @@ using System.Linq;
 
 namespace Google.Cloud.Tools.ReleaseManager.BatchRelease
 {
-    public sealed class KnownCommitsCriterion: IBatchCriterion
+    public sealed class KnownCommitsCriterion : IBatchCriterion
     {
         /// <summary>
         /// If set, override the natural history with this text.

--- a/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/ReleaseAllCriterion.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/ReleaseAllCriterion.cs
@@ -1,0 +1,54 @@
+﻿// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Tools.Common;
+using LibGit2Sharp;
+using System.Collections.Generic;
+
+namespace Google.Cloud.Tools.ReleaseManager.BatchRelease
+{
+    /// <summary>
+    /// Criterion for "just release everything that has changes", currently
+    /// with no additional config.
+    /// </summary>
+    public sealed class ReleaseAllCriterion : IBatchCriterion
+    {
+        IEnumerable<ReleaseProposal> IBatchCriterion.GetProposals(ApiCatalog catalog)
+        {
+            var root = DirectoryLayout.DetermineRootDirectory();
+            using var repo = new Repository(root);
+            var pendingChangesByApi = GitHelpers.GetPendingChangesByApi(repo, catalog);
+
+            foreach (var api in catalog.Apis)
+            {
+                // Don't even bother proposing package groups at the moment.
+                if (api.PackageGroup is object)
+                {
+                    continue;
+                }
+                // Don't propose packages that haven't changed.
+                // Note that this will also not propose a release for APIs that haven't
+                // yet *been* released - which is probably fine. (We don't want to accidentally
+                // launch something due to not paying attention.)
+                if (pendingChangesByApi[api].Commits.Count == 0)
+                {
+                    continue;
+                }
+                var newVersion = api.StructuredVersion.AfterIncrement();
+
+                yield return ReleaseProposal.CreateFromHistory(repo, api.Id, newVersion);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is useful for general catchup.

(Also a tiny bit of extra tidy-up in the batch release command.)

Sample config file:

```json
{
  "DryRun": true,
  "ShowHistory": false,
  "ReleaseAll": {}
}
```