### PR TITLE
fix: Fix the link canonicalizer to handle pages in Google.Apis pages better

### DIFF
--- a/tools/Google.Cloud.Tools.GenerateCanonicalLinks.Tests/CanonicalizerTest.cs
+++ b/tools/Google.Cloud.Tools.GenerateCanonicalLinks.Tests/CanonicalizerTest.cs
@@ -64,6 +64,8 @@ namespace Google.Cloud.Tools.GenerateCanonicalLinks.Tests
         [InlineData("Google.Cloud.Debugger.V2", "api/toc.html")]
         [InlineData("Google.Apis.Storage.v1", "api/Google.Apis.Storage.v1.html")]
         [InlineData("Google.Apis.AdSense.v1_4", "api/Google.Apis.AdSense.v1_4.AccountsResource.html")]
+        [InlineData("Google.Apis.Auth.AspNetCore", "api/Microsoft.Extensions.DependencyInjection.GoogleOpenIdConnectExtensions.html")]
+        [InlineData("Google.Apis.Logging.v2", "api/Google.Apis.CloudResourceManager.v2.CloudResourceManagerBaseServiceRequest-1.AltEnum.html")]
         public void GetUrl_NotOnDevsite(string package, string page) =>
             Assert.Null(Canonicalizer.GetUrl(package, page));
     }

--- a/tools/Google.Cloud.Tools.GenerateCanonicalLinks/Canonicalizer.cs
+++ b/tools/Google.Cloud.Tools.GenerateCanonicalLinks/Canonicalizer.cs
@@ -38,6 +38,7 @@ namespace Google.Cloud.Tools.GenerateCanonicalLinks
         };
 
         // Note: list rather than a dictionary, as order is important.
+        // This is a list of prefixes of *pages* and how they map to packages.
         private static readonly List<(string prefix, string package)> Prefixes = new List<(string, string)>
         {
             { ("Grpc", "Grpc.Core") },
@@ -153,6 +154,13 @@ namespace Google.Cloud.Tools.GenerateCanonicalLinks
             var parts = page.Split('.');
             // Single-part pages are always guides.
             if (parts.Length == 1)
+            {
+                return package;
+            }
+
+            // Anything that's in a package beginning with Google.Apis but isn't just "Google.Apis"
+            // will be ignored by the calling code. It's not on DevSite.
+            if (package.StartsWith("Google.Apis"))
             {
                 return package;
             }


### PR DESCRIPTION
Fixes #7233.

There's still a question in my mind about what's causing the second
one of these to be generated anyway, but it's safe to return "that
doesn't have a page on DevSite" in this case.