### PR TITLE
Release Google.Analytics.Data.V1Beta version 1.0.0-beta06

### DIFF
--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.csproj
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta05</Version>
+    <Version>1.0.0-beta06</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Analytics Data API (v1beta)</Description>

--- a/apis/Google.Analytics.Data.V1Beta/docs/history.md
+++ b/apis/Google.Analytics.Data.V1Beta/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+# Version 1.0.0-beta06, released 2021-09-24
+
+- [Commit 75ffe93](https://github.com/googleapis/google-cloud-dotnet/commit/75ffe93):
+  - feat: add `CheckCompatibility` method to the API
+  - feat: add `DimensionCompatibility`, `MetricCompatibility`, `Compatibility` types to the API
+  - feat: add `category` field to `DimensionMetadata`, `MetricMetadata` types
+
 # Version 1.0.0-beta05, released 2021-08-18
 
 - [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -30,7 +30,7 @@
     },
     {
       "id": "Google.Analytics.Data.V1Beta",
-      "version": "1.0.0-beta05",
+      "version": "1.0.0-beta06",
       "type": "grpc",
       "productName": "Google Analytics Data",
       "productUrl": "https://developers.google.com/analytics",


### PR DESCRIPTION

Changes in this release:

- [Commit 75ffe93](https://github.com/googleapis/google-cloud-dotnet/commit/75ffe93):
  - feat: add `CheckCompatibility` method to the API
  - feat: add `DimensionCompatibility`, `MetricCompatibility`, `Compatibility` types to the API
  - feat: add `category` field to `DimensionMetadata`, `MetricMetadata` types
