### PR TITLE
Release Google.Cloud.AssuredWorkloads.V1Beta1 version 1.0.0-beta07

### DIFF
--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.csproj
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta06</Version>
+    <Version>1.0.0-beta07</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Assured Workloads API (v1beta1)</Description>
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.3.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+# Version 1.0.0-beta07, released 2021-09-24
+
+- [Commit aff9821](https://github.com/googleapis/google-cloud-dotnet/commit/aff9821):
+  - feat: Add Canada Regions And Support compliance regime
+  - fix: ResourceType CONSUMER_PROJECT is deprecated
+  - feat: ResourceType CONSUMER_FOLDER and KEYRING are added
+  - feat: display_name is added to ResourceSettings
+  - fix: billing_account is now optional in Workload
+  - feat: resource_settings is added to CreateWorkloadOperationMetadata
+
 # Version 1.0.0-beta06, released 2021-08-19
 
 - [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -211,7 +211,7 @@
     },
     {
       "id": "Google.Cloud.AssuredWorkloads.V1Beta1",
-      "version": "1.0.0-beta06",
+      "version": "1.0.0-beta07",
       "type": "grpc",
       "productName": "Assured Workloads",
       "productUrl": "https://cloud.google.com/assured-workloads/docs",
@@ -221,7 +221,7 @@
         "compilance"
       ],
       "dependencies": {
-        "Google.LongRunning": "2.2.0"
+        "Google.LongRunning": "2.3.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/assuredworkloads/v1beta1"


### PR DESCRIPTION

Changes in this release:

- [Commit aff9821](https://github.com/googleapis/google-cloud-dotnet/commit/aff9821):
  - feat: Add Canada Regions And Support compliance regime
  - fix: ResourceType CONSUMER_PROJECT is deprecated
  - feat: ResourceType CONSUMER_FOLDER and KEYRING are added
  - feat: display_name is added to ResourceSettings
  - fix: billing_account is now optional in Workload
  - feat: resource_settings is added to CreateWorkloadOperationMetadata
