### PR TITLE
Release Google.Cloud.BigQuery.Reservation.V1 version 1.4.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery Reservation API, which allows you to modify your BigQuery flat-rate reservations.</Description>

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/docs/history.md
@@ -1,5 +1,18 @@
 # Version history
 
+# Version 1.4.0, released 2021-09-24
+
+- [Commit 7c0622f](https://github.com/googleapis/google-cloud-dotnet/commit/7c0622f):
+  - feat: Deprecated SearchAssignments in favor of SearchAllAssignments
+  - feat: Reservation objects now contain a creation time and an update time
+  - feat: Added commitment_start_time to capacity commitments
+  - feat: Force deleting capacity commitments is allowed while reservations with active assignments exist
+  - feat: ML_EXTERNAL job type is supported
+  - feat: Optional id can be passed into CreateCapacityCommitment and CreateAssignment
+  - docs: Clarified docs for None assignments
+  - fix!: Fixed pattern for BiReservation object
+  - BREAKING_CHANGE: Changed from `bireservation` to `biReservation`
+
 # Version 1.3.0, released 2021-08-19
 
 - [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -301,7 +301,7 @@
     },
     {
       "id": "Google.Cloud.BigQuery.Reservation.V1",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "type": "grpc",
       "productName": "BigQuery Reservation",
       "productUrl": "https://cloud.google.com/bigquery/docs/reference/reservations",


### PR DESCRIPTION

Changes in this release:

- [Commit 7c0622f](https://github.com/googleapis/google-cloud-dotnet/commit/7c0622f):
  - feat: Deprecated SearchAssignments in favor of SearchAllAssignments
  - feat: Reservation objects now contain a creation time and an update time
  - feat: Added commitment_start_time to capacity commitments
  - feat: Force deleting capacity commitments is allowed while reservations with active assignments exist
  - feat: ML_EXTERNAL job type is supported
  - feat: Optional id can be passed into CreateCapacityCommitment and CreateAssignment
  - docs: Clarified docs for None assignments
  - fix!: Fixed pattern for BiReservation object
  - BREAKING_CHANGE: Changed from `bireservation` to `biReservation`
