### PR TITLE
chore: Add Google.LongRunning dependency to Google.Cloud.Compute.V1

### DIFF
--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[3.6.0-beta01, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.3.0, 3.0.0)" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -554,7 +554,8 @@
         "compute"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "3.6.0-beta01"
+        "Google.Api.Gax.Grpc": "3.6.0-beta01",
+        "Google.LongRunning": "2.3.0"
       },
       "generator": "regapic",
       "protoPath": "google/cloud/compute/v1"


### PR DESCRIPTION
This should allow it to be regenerated successfully by Autosynth.