### PR TITLE
Release Google.Cloud.Dialogflow.Cx.V3 version 1.5.0

### DIFF
--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.csproj
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.4.0</Version>
+    <Version>1.5.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Builds conversational interfaces (for example, chatbots, and voice-powered apps and devices).</Description>

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/docs/history.md
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+# Version 1.5.0, released 2021-10-12
+
+- [Commit 74b880a](https://github.com/googleapis/google-cloud-dotnet/commit/74b880a):
+  - feat: added deployment API
+  - feat: exposed DTMF input info in the query result
+  - docs: added notes on long running operation
+- [Commit de40ef5](https://github.com/googleapis/google-cloud-dotnet/commit/de40ef5):
+  - feat: update gapic-generator-csharp to 1.3.11
+  - feat: update rules_gapic to 0.8.0
+
 # Version 1.4.0, released 2021-09-23
 
 - [Commit 6b21a68](https://github.com/googleapis/google-cloud-dotnet/commit/6b21a68):

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -952,7 +952,7 @@
     },
     {
       "id": "Google.Cloud.Dialogflow.Cx.V3",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "type": "grpc",
       "autoGenerator": "OwlBot",
       "productName": "Dialogflow",


### PR DESCRIPTION

Changes in this release:

- [Commit 74b880a](https://github.com/googleapis/google-cloud-dotnet/commit/74b880a):
  - feat: added deployment API
  - feat: exposed DTMF input info in the query result
  - docs: added notes on long running operation
- [Commit de40ef5](https://github.com/googleapis/google-cloud-dotnet/commit/de40ef5):
  - feat: update gapic-generator-csharp to 1.3.11
  - feat: update rules_gapic to 0.8.0
