### PR TITLE
Release Google.Cloud.Filestore.V1 version 1.2.0

### DIFF
--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.csproj
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>The Cloud Filestore API is used for creating and managing cloud file servers.</Description>

--- a/apis/Google.Cloud.Filestore.V1/docs/history.md
+++ b/apis/Google.Cloud.Filestore.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.2.0, released 2021-10-12
+
+- [Commit 4ab10f4](https://github.com/googleapis/google-cloud-dotnet/commit/4ab10f4): fix(filestore): add missing operation_metadata.proto import
+
 # Version 1.1.0, released 2021-09-23
 
 - [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1128,7 +1128,7 @@
     },
     {
       "id": "Google.Cloud.Filestore.V1",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "type": "grpc",
       "productName": "Cloud Filestore",
       "description": "The Cloud Filestore API is used for creating and managing cloud file servers.",


### PR DESCRIPTION

Changes in this release:

- [Commit 4ab10f4](https://github.com/googleapis/google-cloud-dotnet/commit/4ab10f4): fix(filestore): add missing operation_metadata.proto import
