### PR TITLE
Release Google.Cloud.Speech.V1 version 2.6.0

### DIFF
--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.csproj
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.5.0</Version>
+    <Version>2.6.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Speech API, which performs speech recognition.</Description>

--- a/apis/Google.Cloud.Speech.V1/docs/history.md
+++ b/apis/Google.Cloud.Speech.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+# Version 2.6.0, released 2021-10-12
+
+- [Commit dc07468](https://github.com/googleapis/google-cloud-dotnet/commit/dc07468):
+  - feat: update gapic-generator-csharp to 1.3.11
+  - feat: update rules_gapic to 0.8.0
+
 # Version 2.5.0, released 2021-09-24
 
 - [Commit 09c3f7d](https://github.com/googleapis/google-cloud-dotnet/commit/09c3f7d): feat: add output_config request field

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2647,7 +2647,7 @@
       "protoPath": "google/cloud/speech/v1",
       "productName": "Google Cloud Speech",
       "productUrl": "https://cloud.google.com/speech",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Speech API, which performs speech recognition.",


### PR DESCRIPTION

Changes in this release:

- [Commit dc07468](https://github.com/googleapis/google-cloud-dotnet/commit/dc07468):
  - feat: update gapic-generator-csharp to 1.3.11
  - feat: update rules_gapic to 0.8.0
