### PR TITLE
Release Google.Cloud.Video.Transcoder.V1 version 1.0.0-beta03

### DIFF
--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.csproj
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Transcoder API version v1, which converts video files into formats suitable for consumer distribution.</Description>

--- a/apis/Google.Cloud.Video.Transcoder.V1/docs/history.md
+++ b/apis/Google.Cloud.Video.Transcoder.V1/docs/history.md
@@ -1,5 +1,14 @@
 # Version history
 
+# Version 1.0.0-beta03, released 2021-10-12
+
+- [Commit 18a65f3](https://github.com/googleapis/google-cloud-dotnet/commit/18a65f3):
+  - docs: clarify that project number is used as the canonical project identifier for job and job template names
+  - docs: fix broken link and code formatting
+  - feat: add support for allow_missing param on DELETE request
+  - fix!: remove Encryption settings that were published due to a sync issue
+  - BREAKING CHANGE: requests specifying Encryption settings are rejected by the server
+
 # Version 1.0.0-beta02, released 2021-09-23
 
 - [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2915,7 +2915,7 @@
     },
     {
       "id": "Google.Cloud.Video.Transcoder.V1",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0-beta03",
       "type": "grpc",
       "productName": "Transcoder",
       "productUrl": "https://cloud.google.com/transcoder/docs",


### PR DESCRIPTION

Changes in this release:

- [Commit 18a65f3](https://github.com/googleapis/google-cloud-dotnet/commit/18a65f3):
  - docs: clarify that project number is used as the canonical project identifier for job and job template names
  - docs: fix broken link and code formatting
  - feat: add support for allow_missing param on DELETE request
  - fix!: remove Encryption settings that were published due to a sync issue
  - BREAKING CHANGE: requests specifying Encryption settings are rejected by the server
