### PR TITLE
tests: Fix config for the new Common.Snippets project.

### DIFF
--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Snippets/AssemblyInfo.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Snippets/AssemblyInfo.cs
@@ -1,0 +1,19 @@
+﻿// Copyright 2021 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+
+// This is needed to ensure trace tests that rely on the RateLimiter
+// do not affect each other.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Snippets/Google.Cloud.Diagnostics.Common.Snippets.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Snippets/Google.Cloud.Diagnostics.Common.Snippets.csproj
@@ -6,6 +6,12 @@
     <IsPackable>false</IsPackable>
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013;AD0001</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <DebugSymbols>true</DebugSymbols>
+    <Optimize Condition="'$(TargetFramework)' == 'net461'">false</Optimize>
+    <DebugType Condition="'$(TargetFramework)' == 'net461'">pdbonly</DebugType>
+    <DebugType Condition="'$(TargetFramework)' == 'netcoreapp2.1' or '$(TargetFramework)' == 'netcoreapp3.1'">portable</DebugType>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Google.Api.Gax.Testing" Version="[3.5.0, 4.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />


### PR DESCRIPTION
- We need the debug symbols and pdb because we check that the correct stacktrace information is added to error entries.
- We need that tests do not run in parallel because of the tracing rate limiter.