### PR TITLE
deps: Update renovate rules for Diagnostics.

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -208,9 +208,10 @@
         "major",
         "minor"
       ],
-      "excludePackageNames": [
+      "matchPackageNames": [
         "Microsoft.Extensions.Hosting"
-      ]
+      ],
+      "allowedVersions": "<1.0.0"
     }
   ],
   "schedule": [


### PR DESCRIPTION
Trying again after #7328

The `allowedVersions` here is just a trick to not allow anything, but just for major and minor, patches have no restrictions.