### PR TITLE
Release diagnostics libraries version 4.3.0-beta05

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.3.0-beta04</Version>
+    <Version>4.3.0-beta05</Version>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core.</Description>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/docs/history.md
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+# Version 4.3.0-beta05, released 2021-10-13
+
+Version 4.3.0-beta04 was not released because of a CI error.
+This version contains all changes described for the unreleased version 4.3.0-beta04.
+
 # Version 4.3.0-beta04, released 2021-10-12
 
 - [Commit 03eb674](https://github.com/googleapis/google-cloud-dotnet/commit/03eb674):

--- a/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.3.0-beta04</Version>
+    <Version>4.3.0-beta05</Version>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core 3.</Description>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore3/docs/history.md
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore3/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+# Version 4.3.0-beta05, released 2021-10-13
+
+Version 4.3.0-beta04 was not released because of a CI error.
+This version contains all changes described for the unreleased version 4.3.0-beta04.
+
 # Version 4.3.0-beta04, released 2021-10-12
 
 - [Commit 03eb674](https://github.com/googleapis/google-cloud-dotnet/commit/03eb674):

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.3.0-beta04</Version>
+    <Version>4.3.0-beta05</Version>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries Common Components.</Description>

--- a/apis/Google.Cloud.Diagnostics.Common/docs/history.md
+++ b/apis/Google.Cloud.Diagnostics.Common/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+# Version 4.3.0-beta05, released 2021-10-13
+
+Version 4.3.0-beta04 was not released because of a CI error.
+This version contains all changes described for the unreleased version 4.3.0-beta04.
+
 # Version 4.3.0-beta04, released 2021-10-12
 
 - [Commit 6c3117a](https://github.com/googleapis/google-cloud-dotnet/commit/6c3117a): process: Add the correct license header.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -873,7 +873,7 @@
     },
     {
       "id": "Google.Cloud.Diagnostics.AspNetCore",
-      "version": "4.3.0-beta04",
+      "version": "4.3.0-beta05",
       "type": "other",
       "metadataType": "INTEGRATION",
       "targetFrameworks": "netstandard2.0",
@@ -901,7 +901,7 @@
     },
     {
       "id": "Google.Cloud.Diagnostics.AspNetCore3",
-      "version": "4.3.0-beta04",
+      "version": "4.3.0-beta05",
       "type": "other",
       "metadataType": "INTEGRATION",
       "targetFrameworks": "netcoreapp3.1",
@@ -926,7 +926,7 @@
     },
     {
       "id": "Google.Cloud.Diagnostics.Common",
-      "version": "4.3.0-beta04",
+      "version": "4.3.0-beta05",
       "type": "other",
       "targetFrameworks": "netstandard2.0",
       "testTargetFrameworks": "netcoreapp2.1;netcoreapp3.1;net461",


### PR DESCRIPTION

Changes in Google.Cloud.Diagnostics.AspNetCore version 4.3.0-beta05:

Version 4.3.0-beta04 was not released because of a CI error. This version contains all changes described for the unreleased version 4.3.0-beta04.

Changes in Google.Cloud.Diagnostics.AspNetCore3 version 4.3.0-beta05:

Version 4.3.0-beta04 was not released because of a CI error. This version contains all changes described for the unreleased version 4.3.0-beta04.

Changes in Google.Cloud.Diagnostics.Common version 4.3.0-beta05:

Version 4.3.0-beta04 was not released because of a CI error. This version contains all changes described for the unreleased version 4.3.0-beta04.

Packages in this release:
- Release Google.Cloud.Diagnostics.AspNetCore version 4.3.0-beta05
- Release Google.Cloud.Diagnostics.AspNetCore3 version 4.3.0-beta05
- Release Google.Cloud.Diagnostics.Common version 4.3.0-beta05
