### PR TITLE
Release Google.Cloud.Monitoring.V3 version 2.4.0

### DIFF
--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.csproj
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Monitoring API, which manages your Google Cloud Monitoring data and configurations.</Description>
@@ -12,7 +12,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.CommonProtos" Version="[2.3.0, 3.0.0)" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.3.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.Monitoring.V3/docs/history.md
+++ b/apis/Google.Cloud.Monitoring.V3/docs/history.md
@@ -1,5 +1,18 @@
 # Version history
 
+# Version 2.4.0, released 2021-10-14
+
+- [Commit 556147f](https://github.com/googleapis/google-cloud-dotnet/commit/556147f):
+  - fix: Reintroduce deprecated field/enum for backward compatibility
+  - docs: Use absolute link targets in comments
+- [Commit 4a255f9](https://github.com/googleapis/google-cloud-dotnet/commit/4a255f9): docs: fix typo in alert.proto
+- [Commit 3450957](https://github.com/googleapis/google-cloud-dotnet/commit/3450957): feat: add CreateServiceTimeSeries RPC
+- [Commit e724d81](https://github.com/googleapis/google-cloud-dotnet/commit/e724d81):
+  - feat: Added support for logs-based alerts: https://cloud.google.com/logging/docs/alerting/log-based-alerts
+  - feat: Added support for user-defined labels on cloud monitoring's Service and ServiceLevelObjective objects
+  - fix!: mark required fields in QueryTimeSeriesRequest as required
+- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
+
 # Version 2.3.0, released 2021-04-29
 
 - [Commit 770bd47](https://github.com/googleapis/google-cloud-dotnet/commit/770bd47):

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1739,7 +1739,7 @@
       "protoPath": "google/monitoring/v3",
       "productName": "Google Cloud Monitoring",
       "productUrl": "https://cloud.google.com/monitoring/api/v3/",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Monitoring API, which manages your Google Cloud Monitoring data and configurations.",
       "tags": [
@@ -1749,7 +1749,7 @@
       "dependencies": {
         "Google.Api.CommonProtos": "2.3.0",
         "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
-        "Google.LongRunning": "2.2.0",
+        "Google.LongRunning": "2.3.0",
         "Grpc.Core": "2.38.1"
       }
     },


### PR DESCRIPTION

Changes in this release:

- [Commit 556147f](https://github.com/googleapis/google-cloud-dotnet/commit/556147f):
  - fix: Reintroduce deprecated field/enum for backward compatibility
  - docs: Use absolute link targets in comments
- [Commit 4a255f9](https://github.com/googleapis/google-cloud-dotnet/commit/4a255f9): docs: fix typo in alert.proto
- [Commit 3450957](https://github.com/googleapis/google-cloud-dotnet/commit/3450957): feat: add CreateServiceTimeSeries RPC
- [Commit e724d81](https://github.com/googleapis/google-cloud-dotnet/commit/e724d81):
  - feat: Added support for logs-based alerts: https://cloud.google.com/logging/docs/alerting/log-based-alerts
  - feat: Added support for user-defined labels on cloud monitoring's Service and ServiceLevelObjective objects
  - fix!: mark required fields in QueryTimeSeriesRequest as required
- [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs
