### PR TITLE
Release Google.Cloud.Deploy.V1 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.csproj
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Deploy API, which automates delivery of your applications to a series of target environments in a defined sequence.</Description>

--- a/apis/Google.Cloud.Deploy.V1/docs/history.md
+++ b/apis/Google.Cloud.Deploy.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.0.0-beta02, released 2021-10-20
+
+- [Commit 1c771ae](https://github.com/googleapis/google-cloud-dotnet/commit/1c771ae): docs: fix docstring formatting
+
 # Version 1.0.0-beta01, released 2021-09-23
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -833,7 +833,7 @@
     },
     {
       "id": "Google.Cloud.Deploy.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Google Cloud Deploy",
       "productUrl": "https://cloud.google.com/deploy/",


### PR DESCRIPTION

Changes in this release:

- [Commit 1c771ae](https://github.com/googleapis/google-cloud-dotnet/commit/1c771ae): docs: fix docstring formatting
