### PR TITLE
Release Google.Cloud.Translate.V3 version 2.4.0

### DIFF
--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.csproj
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Translate v3 API. The Translate API translates text from one language to another.</Description>
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.3.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.Translate.V3/docs/history.md
+++ b/apis/Google.Cloud.Translate.V3/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 2.4.0, released 2021-10-20
+
+- [Commit 294aefe](https://github.com/googleapis/google-cloud-dotnet/commit/294aefe): fix: add model signature for batch document translation
+
 # Version 2.3.0, released 2021-08-31
 
 - [Commit 1440a7c](https://github.com/googleapis/google-cloud-dotnet/commit/1440a7c): feat: added v3 proto for online/batch document translation and updated v3beta1 proto for format conversion

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2903,12 +2903,12 @@
       "productUrl": "https://cloud.google.com/translate/",
       "generator": "micro",
       "protoPath": "google/cloud/translate/v3",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Translate v3 API. The Translate API translates text from one language to another.",
       "dependencies": {
         "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
-        "Google.LongRunning": "2.2.0",
+        "Google.LongRunning": "2.3.0",
         "Grpc.Core": "2.38.1"
       },
       "tags": [


### PR DESCRIPTION

Changes in this release:

- [Commit 294aefe](https://github.com/googleapis/google-cloud-dotnet/commit/294aefe): fix: add model signature for batch document translation
