### PR TITLE
Release diagnostics libraries version 4.3.0-beta07

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.3.0-beta06</Version>
+    <Version>4.3.0-beta07</Version>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core.</Description>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/docs/history.md
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 4.3.0-beta07, released 2021-10-20
+
+No API surface changes; just dependency updates.
+
 # Version 4.3.0-beta06, released 2021-10-13
 
 Versions 4.3.0-beta04 and 4.3.0-beta05 were not released because of CI errors.

--- a/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.3.0-beta06</Version>
+    <Version>4.3.0-beta07</Version>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core 3.</Description>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore3/docs/history.md
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore3/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 4.3.0-beta07, released 2021-10-20
+
+No API surface changes; just dependency updates.
+
 # Version 4.3.0-beta06, released 2021-10-13
 
 Versions 4.3.0-beta04 and 4.3.0-beta05 were not released because of CI errors.

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.3.0-beta06</Version>
+    <Version>4.3.0-beta07</Version>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries Common Components.</Description>

--- a/apis/Google.Cloud.Diagnostics.Common/docs/history.md
+++ b/apis/Google.Cloud.Diagnostics.Common/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 4.3.0-beta07, released 2021-10-20
+
+- [Commit 6e34e22](https://github.com/googleapis/google-cloud-dotnet/commit/6e34e22): refactor: Fully standardize error reporting options.
+
 # Version 4.3.0-beta06, released 2021-10-13
 
 Versions 4.3.0-beta04 and 4.3.0-beta05 were not released because of CI errors.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -890,7 +890,7 @@
     },
     {
       "id": "Google.Cloud.Diagnostics.AspNetCore",
-      "version": "4.3.0-beta06",
+      "version": "4.3.0-beta07",
       "type": "other",
       "metadataType": "INTEGRATION",
       "targetFrameworks": "netstandard2.0",
@@ -918,7 +918,7 @@
     },
     {
       "id": "Google.Cloud.Diagnostics.AspNetCore3",
-      "version": "4.3.0-beta06",
+      "version": "4.3.0-beta07",
       "type": "other",
       "metadataType": "INTEGRATION",
       "targetFrameworks": "netcoreapp3.1",
@@ -943,7 +943,7 @@
     },
     {
       "id": "Google.Cloud.Diagnostics.Common",
-      "version": "4.3.0-beta06",
+      "version": "4.3.0-beta07",
       "type": "other",
       "targetFrameworks": "netstandard2.0",
       "testTargetFrameworks": "netcoreapp2.1;netcoreapp3.1;net461",


### PR DESCRIPTION

Changes in Google.Cloud.Diagnostics.AspNetCore version 4.3.0-beta07:

No API surface changes; just dependency updates.

Changes in Google.Cloud.Diagnostics.AspNetCore3 version 4.3.0-beta07:

No API surface changes; just dependency updates.

Changes in Google.Cloud.Diagnostics.Common version 4.3.0-beta07:

- [Commit 6e34e22](https://github.com/googleapis/google-cloud-dotnet/commit/6e34e22): refactor: Fully standardize error reporting options.

Packages in this release:
- Release Google.Cloud.Diagnostics.AspNetCore version 4.3.0-beta07
- Release Google.Cloud.Diagnostics.AspNetCore3 version 4.3.0-beta07
- Release Google.Cloud.Diagnostics.Common version 4.3.0-beta07
