### PR TITLE
Release diagnostics libraries version 4.3.0-beta08

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.3.0-beta07</Version>
+    <Version>4.3.0-beta08</Version>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core.</Description>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/docs/history.md
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+# Version 4.3.0-beta08, released 2021-10-25
+
+Version 4.3.0-beta07 was not released because of CI errors.
+
+No API surface changes; just dependency updates.
+
 # Version 4.3.0-beta07, released 2021-10-20
 
 No API surface changes; just dependency updates.

--- a/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.3.0-beta07</Version>
+    <Version>4.3.0-beta08</Version>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core 3.</Description>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore3/docs/history.md
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore3/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+# Version 4.3.0-beta08, released 2021-10-25
+
+Version 4.3.0-beta07 was not released because of CI errors.
+
+No API surface changes; just dependency updates.
+
 # Version 4.3.0-beta07, released 2021-10-20
 
 No API surface changes; just dependency updates.

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.3.0-beta07</Version>
+    <Version>4.3.0-beta08</Version>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries Common Components.</Description>

--- a/apis/Google.Cloud.Diagnostics.Common/docs/history.md
+++ b/apis/Google.Cloud.Diagnostics.Common/docs/history.md
@@ -1,5 +1,25 @@
 # Version history
 
+# Version 4.3.0-beta08, released 2021-10-25
+
+Version 4.3.0-beta07 was not released because of CI errors.
+This version also contains the changes described for the unreleased version 4.3.0-beta07.
+
+- [Commit 99307c0](https://github.com/googleapis/google-cloud-dotnet/commit/99307c0):
+  - tests: Always reset the trace rate limiter before registering Diagnostics services.
+  - Else, services are registered with the existing trace rate limiter which migh make tests flaky.
+  - This is probably part of the reason of some long standing test flakiness in tracing.
+  - Note that this only affects tests, as on production code rate limiting is determined by configuration options.
+- [Commit f77f48b](https://github.com/googleapis/google-cloud-dotnet/commit/f77f48b):
+  - fix: Skip DI scope validation for the trace context provider.
+  - Logging may happen outside a scope, i.e. a web server starting where each request is a scope.
+  - The trace context provider is by defintion scoped.
+  - When logging outside a scope we simply don't add trace information to the log entry.
+  - As extra info:
+  - Scope validation is only enabled by default on a development environment.
+  - Diagnostics, by default, ignores logging exceptions.
+  - To reproduce the issue this commit fixes both scope validation and Diagnostis exception propagation needed to be enabled.
+
 # Version 4.3.0-beta07, released 2021-10-20
 
 - [Commit 6e34e22](https://github.com/googleapis/google-cloud-dotnet/commit/6e34e22): refactor: Fully standardize error reporting options.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -890,7 +890,7 @@
     },
     {
       "id": "Google.Cloud.Diagnostics.AspNetCore",
-      "version": "4.3.0-beta07",
+      "version": "4.3.0-beta08",
       "type": "other",
       "metadataType": "INTEGRATION",
       "targetFrameworks": "netstandard2.0",
@@ -918,7 +918,7 @@
     },
     {
       "id": "Google.Cloud.Diagnostics.AspNetCore3",
-      "version": "4.3.0-beta07",
+      "version": "4.3.0-beta08",
       "type": "other",
       "metadataType": "INTEGRATION",
       "targetFrameworks": "netcoreapp3.1",
@@ -943,7 +943,7 @@
     },
     {
       "id": "Google.Cloud.Diagnostics.Common",
-      "version": "4.3.0-beta07",
+      "version": "4.3.0-beta08",
       "type": "other",
       "targetFrameworks": "netstandard2.0",
       "testTargetFrameworks": "netcoreapp2.1;netcoreapp3.1;net461",


### PR DESCRIPTION

Changes in Google.Cloud.Diagnostics.AspNetCore version 4.3.0-beta08:

Version 4.3.0-beta07 was not released because of CI errors.

No API surface changes; just dependency updates.

Changes in Google.Cloud.Diagnostics.AspNetCore3 version 4.3.0-beta08:

Version 4.3.0-beta07 was not released because of CI errors.

No API surface changes; just dependency updates.

Changes in Google.Cloud.Diagnostics.Common version 4.3.0-beta08:

Version 4.3.0-beta07 was not released because of CI errors. This version also contains the changes described for the unreleased version 4.3.0-beta07.

- [Commit 99307c0](https://github.com/googleapis/google-cloud-dotnet/commit/99307c0):
  - tests: Always reset the trace rate limiter before registering Diagnostics services.
  - Else, services are registered with the existing trace rate limiter which migh make tests flaky.
  - This is probably part of the reason of some long standing test flakiness in tracing.
  - Note that this only affects tests, as on production code rate limiting is determined by configuration options.
- [Commit f77f48b](https://github.com/googleapis/google-cloud-dotnet/commit/f77f48b):
  - fix: Skip DI scope validation for the trace context provider.
  - Logging may happen outside a scope, i.e. a web server starting where each request is a scope.
  - The trace context provider is by defintion scoped.
  - When logging outside a scope we simply don't add trace information to the log entry.
  - As extra info:
  - Scope validation is only enabled by default on a development environment.
  - Diagnostics, by default, ignores logging exceptions.
  - To reproduce the issue this commit fixes both scope validation and Diagnostis exception propagation needed to be enabled.

Packages in this release:
- Release Google.Cloud.Diagnostics.AspNetCore version 4.3.0-beta08
- Release Google.Cloud.Diagnostics.AspNetCore3 version 4.3.0-beta08
- Release Google.Cloud.Diagnostics.Common version 4.3.0-beta08
