### PR TITLE
chore: allow generateprojects command to accept api ids on the comman…

### DIFF
--- a/tools/Google.Cloud.Tools.ReleaseManager/CommandBase.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/CommandBase.cs
@@ -45,7 +45,7 @@ namespace Google.Cloud.Tools.ReleaseManager
             ExpectedArguments = string.Join(" ", argNames.Select(arg => $"<{arg}>"));
         }
 
-        public void Execute(string[] args)
+        public virtual void Execute(string[] args)
         {
             if (args.Length != _expectedArgCount)
             {

--- a/tools/Google.Cloud.Tools.ReleaseManager/GenerateProjectsCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/GenerateProjectsCommand.cs
@@ -156,6 +156,11 @@ namespace Google.Cloud.Tools.ReleaseManager
 
             foreach (var api in catalog.Apis)
             {
+                if (args.Length > 0 && !args.Contains(api.Id)) {
+                    // User requested projects to be generated for specific apis
+                    // and this api wasn't on the list.
+                    continue;
+                }
                 var path = Path.Combine(root, "apis", api.Id);
                 GenerateProjects(path, api, apiNames);
                 GenerateSolutionFiles(path, api);
@@ -164,6 +169,12 @@ namespace Google.Cloud.Tools.ReleaseManager
                 GenerateOwlBotConfiguration(path, api);
                 GenerateMetadataFile(path, api);
             }
+        }
+
+        public override void Execute(string[] args) {
+            // Skip the argument length check because this command accepts any
+            // number of arguments.
+            ExecuteImpl(args);
         }
 
         /// <summary>


### PR DESCRIPTION
…d line

I'm writing a script to mass migrate to Owl Bot, and this feature is necessary.