### PR TITLE
fix: allow setting parameter size to the same as the current value

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerParameterTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerParameterTests.cs
@@ -141,5 +141,39 @@ namespace Google.Cloud.Spanner.Data.Tests
                     () => new SpannerParameter { SpannerDbType = spannerType.WithSize(size) });
             }
         }
+
+        public static IEnumerable<object[]> AllSpannerTypes()
+        {
+            yield return new object[] { SpannerDbType.Bytes };
+            yield return new object[] { SpannerDbType.String };
+            yield return new object[] { SpannerDbType.Bool };
+            yield return new object[] { SpannerDbType.Date };
+            yield return new object[] { SpannerDbType.Float64 };
+            yield return new object[] { SpannerDbType.Int64 };
+            yield return new object[] { SpannerDbType.Numeric };
+            yield return new object[] { SpannerDbType.Timestamp };
+            yield return new object[] { SpannerDbType.Json };
+            yield return new object[] { SpannerDbType.ArrayOf(SpannerDbType.Bytes) };
+            yield return new object[] { SpannerDbType.ArrayOf(SpannerDbType.String) };
+            yield return new object[] { SpannerDbType.ArrayOf(SpannerDbType.Bool) };
+            yield return new object[] { SpannerDbType.ArrayOf(SpannerDbType.Date) };
+            yield return new object[] { SpannerDbType.ArrayOf(SpannerDbType.Float64) };
+            yield return new object[] { SpannerDbType.ArrayOf(SpannerDbType.Int64) };
+            yield return new object[] { SpannerDbType.ArrayOf(SpannerDbType.Numeric) };
+            yield return new object[] { SpannerDbType.ArrayOf(SpannerDbType.Timestamp) };
+            yield return new object[] { SpannerDbType.ArrayOf(SpannerDbType.Json) };
+        }
+
+        [Theory]
+        [MemberData(nameof(AllSpannerTypes))]
+        public void SetDefaultSize(SpannerDbType spannerType)
+        {
+            var param = new SpannerParameter { SpannerDbType = spannerType };
+            // The default size should be 0 for all types.
+            Assert.Equal(0, param.Size);
+            // Setting the size to the same (default) value should be allowed for all types.
+            param.Size = 0;
+            Assert.Equal(0, param.Size);
+        }
     }
 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerParameter.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerParameter.cs
@@ -63,7 +63,8 @@ namespace Google.Cloud.Spanner.Data
         public override int Size
         {
             get => SpannerDbType.Size.GetValueOrDefault();
-            set => SpannerDbType = SpannerDbType.WithSize(value);
+            // Only change the size if the given size is different from the current value.
+            set => SpannerDbType = SpannerDbType.Size.GetValueOrDefault() == value ? SpannerDbType : SpannerDbType.WithSize(value);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Some frameworks (NHibernate) will automatically set the parameter size to either the default
value (zero) or to a value that is copied from another parameter. This fails for parameters
that are not of type String or Bytes for Spanner, although there is no reason to fail in that
case, as the actual state of the parameter does not change to an invalid state. This change
makes setting the size of a parameter to the same value as the current value a no-op.