### PR TITLE
fix: Adjust the common Bigtable Table resource service

### DIFF
--- a/apis/Google.Cloud.Bigtable.Common.V2/CommonResourcesConfig.json
+++ b/apis/Google.Cloud.Bigtable.Common.V2/CommonResourcesConfig.json
@@ -1,7 +1,7 @@
 {
   "common_resources": [
     {
-      "type": "bigtable.googleapis.com/Table",
+      "type": "bigtableadmin.googleapis.com/Table",
       "csharp_package_name": "Google.Cloud.Bigtable.Common.V2",
       "csharp_namespace": "Google.Cloud.Bigtable.Common.V2",
       "csharp_class_name":  "TableName"


### PR DESCRIPTION
This was changed in protos, and needs to be changed manually here to
allow both the Bigtable and Bigtable Admin APIs to pick it up when
being regenerated.