### PR TITLE
chore: Update GAPIC generator version

### DIFF
--- a/generateapis.sh
+++ b/generateapis.sh
@@ -171,7 +171,6 @@ generate_microgenerator() {
   # types can use the messages in them, but nothing will be generated.
   $PROTOC \
     --gapic_out=$API_TMP_DIR \
-    --gapic_opt=metadata \
     $SERVICE_CONFIG_OPTION \
     $COMMON_RESOURCES_OPTION \
     --plugin=protoc-gen-gapic=$GAPIC_PLUGIN \
@@ -224,7 +223,6 @@ generate_microgenerator_regapic() {
   # Client generation.
   $PROTOC \
     --gapic_out=$API_TMP_DIR \
-    --gapic_opt=metadata \
     $SERVICE_CONFIG_OPTION \
     --plugin=protoc-gen-gapic=$GAPIC_PLUGIN \
     -I $GOOGLEAPIS_DISCOVERY \

--- a/toolversions.sh
+++ b/toolversions.sh
@@ -11,7 +11,7 @@ declare -r DOTCOVER_VERSION=2019.3.4
 declare -r REPORTGENERATOR_VERSION=2.4.5.0
 declare -r PROTOC_VERSION=3.18.1
 declare -r GRPC_VERSION=2.39.1
-declare -r GAPIC_GENERATOR_VERSION=1.3.12
+declare -r GAPIC_GENERATOR_VERSION=1.3.13
 
 # Tools that only run under Windows (at the moment)
 declare -r DOCFX=$TOOL_PACKAGES/docfx.$DOCFX_VERSION/docfx.exe


### PR DESCRIPTION
This now always emits gapic_metadata.json, so we need to remove the
flag in our generation script.