### PR TITLE
chore: Skip a commit in version histories

### DIFF
--- a/tools/Google.Cloud.Tools.ReleaseManager/History/overrides.json
+++ b/tools/Google.Cloud.Tools.ReleaseManager/History/overrides.json
@@ -28,4 +28,5 @@
   "f5e5ec7": "skip", // Rename GrpcCtorCompatibility.g.cs
   "84832b8": "skip", // Regenerate with later protoc; adds GeneratedCodeAttribute
   "5105bbd": "skip", // Regenerate for retry status code documentation
+  "b56517e": "skip", // Regenerate with updated protobuf
 }


### PR DESCRIPTION
This was intended to happen automatically, but I used "Release
notes" instead of "Version history" in the commit :(