### PR TITLE
Release Google.Analytics.Data.V1Beta version 1.0.0-beta07

### DIFF
--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.csproj
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta06</Version>
+    <Version>1.0.0-beta07</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Analytics Data API (v1beta)</Description>

--- a/apis/Google.Analytics.Data.V1Beta/docs/history.md
+++ b/apis/Google.Analytics.Data.V1Beta/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+# Version 1.0.0-beta07, released 2021-11-08
+
+- [Commit ebf6fab](https://github.com/googleapis/google-cloud-dotnet/commit/ebf6fab):
+  - feat: add the `schema_restriction_response` field to the `ResponseMetaData` type that contains the schema restrictions actively enforced in creating a report
+  - feat: add the `currency_code`, `time_zone` fields to the `ResponseMetaData` type
+  - feat: add the `empty_reason` field to the `ResponseMetaData` type that contains an empty report reason, if specified
+  - feat: add the `blocked_reasons` field to the `MetricMetadata` type that contains reasons why access was blocked to a certain metric in a report, if specified
+
 # Version 1.0.0-beta06, released 2021-09-24
 
 - [Commit 75ffe93](https://github.com/googleapis/google-cloud-dotnet/commit/75ffe93):

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -16,7 +16,7 @@
     },
     {
       "id": "Google.Analytics.Data.V1Beta",
-      "version": "1.0.0-beta06",
+      "version": "1.0.0-beta07",
       "type": "grpc",
       "productName": "Google Analytics Data",
       "productUrl": "https://developers.google.com/analytics",


### PR DESCRIPTION

Changes in this release:

- [Commit ebf6fab](https://github.com/googleapis/google-cloud-dotnet/commit/ebf6fab):
  - feat: add the `schema_restriction_response` field to the `ResponseMetaData` type that contains the schema restrictions actively enforced in creating a report
  - feat: add the `currency_code`, `time_zone` fields to the `ResponseMetaData` type
  - feat: add the `empty_reason` field to the `ResponseMetaData` type that contains an empty report reason, if specified
  - feat: add the `blocked_reasons` field to the `MetricMetadata` type that contains reasons why access was blocked to a certain metric in a report, if specified
