### PR TITLE
chore: remove facility to generate a "protogrpc" package

### DIFF
--- a/generateapis.sh
+++ b/generateapis.sh
@@ -256,23 +256,6 @@ generate_proto() {
     2>&1 | grep -v "is unused" || true # Ignore import warnings (and grep exit code)
 }
 
-generate_protogrpc() {
-  # Delete previously-generated files
-  delete_generated apis/$1/$1
-
-  API_SRC_DIR=$GOOGLEAPIS/$($PYTHON3 tools/getapifield.py apis/apis.json $1 protoPath)
-  $PROTOC \
-    --csharp_out=apis/$1/$1 \
-    --csharp_opt=base_namespace=$1,file_extension=.g.cs \
-    --grpc_out=apis/$1/$1 \
-    --grpc_opt=file_suffix=Grpc.g.cs \
-    -I $GOOGLEAPIS \
-    -I $CORE_PROTOS_ROOT \
-    --plugin=protoc-gen-grpc=$GRPC_PLUGIN \
-    $API_SRC_DIR/*.proto \
-    2>&1 | grep -v "is unused" || true # Ignore import warnings (and grep exit code)
-}
-
 generate_api() {
   PACKAGE=$1
   PACKAGE_DIR=apis/$1
@@ -294,9 +277,6 @@ generate_api() {
       ;;
     proto)
       generate_proto $1
-      ;;
-    protogrpc)
-      generate_protogrpc $1
       ;;
     *)
       echo "Unknown generator: $GENERATOR"

--- a/tools/Google.Cloud.Tools.Common/GeneratorType.cs
+++ b/tools/Google.Cloud.Tools.Common/GeneratorType.cs
@@ -20,7 +20,6 @@ namespace Google.Cloud.Tools.Common
         Gapic,
         Micro,
         Proto,
-        ProtoGrpc,
         Regapic
     }
 }


### PR DESCRIPTION
The "protogrpc" generator type ran protoc with the standard C# and
C# gRPC plugins, but not GAPIC. Google.Cloud.Iam.V1 was the only
package to use this, and it's now gone full-GAPIC. We don't expect
to ever use this facility again, so let's remove it.