### PR TITLE
Release diagnostics libraries version 4.3.1

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.3.0</Version>
+    <Version>4.3.1</Version>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core.</Description>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore/docs/history.md
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 4.3.1, released 2021-11-09
+
+No API surface changes; just dependency updates.
+
 # Version 4.3.0, released 2021-11-01
 
 No API surface changes; just releasing a stable version.

--- a/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.3.0</Version>
+    <Version>4.3.1</Version>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core 3.</Description>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore3/docs/history.md
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore3/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 4.3.1, released 2021-11-09
+
+No API surface changes; just dependency updates.
+
 # Version 4.3.0, released 2021-11-01
 
 No API surface changes; just releasing a stable version.

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.3.0</Version>
+    <Version>4.3.1</Version>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries Common Components.</Description>

--- a/apis/Google.Cloud.Diagnostics.Common/docs/history.md
+++ b/apis/Google.Cloud.Diagnostics.Common/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+# Version 4.3.1, released 2021-11-09
+
+- [Commit b1318ac](https://github.com/googleapis/google-cloud-dotnet/commit/b1318ac):
+  - fix: Respects the service client set through error reporting options.
+  - Adds missing tests for all options.
+  - Closes [issue 7448](https://github.com/googleapis/google-cloud-dotnet/issues/7448)
+
 # Version 4.3.0, released 2021-11-01
 
 No API surface changes; just releasing a stable version.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -891,7 +891,7 @@
     },
     {
       "id": "Google.Cloud.Diagnostics.AspNetCore",
-      "version": "4.3.0",
+      "version": "4.3.1",
       "type": "other",
       "metadataType": "INTEGRATION",
       "targetFrameworks": "netstandard2.0",
@@ -919,7 +919,7 @@
     },
     {
       "id": "Google.Cloud.Diagnostics.AspNetCore3",
-      "version": "4.3.0",
+      "version": "4.3.1",
       "type": "other",
       "metadataType": "INTEGRATION",
       "targetFrameworks": "netcoreapp3.1",
@@ -944,7 +944,7 @@
     },
     {
       "id": "Google.Cloud.Diagnostics.Common",
-      "version": "4.3.0",
+      "version": "4.3.1",
       "type": "other",
       "targetFrameworks": "netstandard2.0",
       "testTargetFrameworks": "netcoreapp2.1;netcoreapp3.1;net461",


### PR DESCRIPTION

Changes in Google.Cloud.Diagnostics.AspNetCore version 4.3.1:

No API surface changes; just dependency updates.

Changes in Google.Cloud.Diagnostics.AspNetCore3 version 4.3.1:

No API surface changes; just dependency updates.

Changes in Google.Cloud.Diagnostics.Common version 4.3.1:

- [Commit b1318ac](https://github.com/googleapis/google-cloud-dotnet/commit/b1318ac):
  - fix: Respects the service client set through error reporting options.
  - Adds missing tests for all options.
  - Closes [issue 7448](https://github.com/googleapis/google-cloud-dotnet/issues/7448)

Packages in this release:
- Release Google.Cloud.Diagnostics.AspNetCore version 4.3.1
- Release Google.Cloud.Diagnostics.AspNetCore3 version 4.3.1
- Release Google.Cloud.Diagnostics.Common version 4.3.1
