### PR TITLE
Release Google.Cloud.NetworkConnectivity.V1 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.NetworkConnectivity.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.NetworkConnectivity.V1",
-  "release_level": "beta",
+  "release_level": "ga",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.NetworkConnectivity.V1/latest",
   "library_type": "GAPIC_AUTO"
 }

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.csproj
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Network Connectivity API, which provides access to Network Connectivity Center.</Description>

--- a/apis/Google.Cloud.NetworkConnectivity.V1/docs/history.md
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+# Version 1.0.0, released 2021-11-10
+
+First GA release.
+
+No API surface changes; just dependency updates.
+
 # Version 1.0.0-beta02, released 2021-09-23
 
 - [Commit c64998e](https://github.com/googleapis/google-cloud-dotnet/commit/c64998e):

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1827,7 +1827,7 @@
     },
     {
       "id": "Google.Cloud.NetworkConnectivity.V1",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Network Connectivity",
       "productUrl": "https://cloud.google.com/network-connectivity/docs/",
@@ -1838,7 +1838,9 @@
         "vpc"
       ],
       "dependencies": {
-        "Google.LongRunning": "2.3.0"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Google.LongRunning": "2.3.0",
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/cloud/networkconnectivity/v1"


### PR DESCRIPTION

Changes in this release:

First GA release.

No API surface changes; just dependency updates.
