### PR TITLE
Release Google.Cloud.ContactCenterInsights.V1 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.ContactCenterInsights.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.ContactCenterInsights.V1",
-  "release_level": "beta",
+  "release_level": "ga",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.ContactCenterInsights.V1/latest",
   "library_type": "GAPIC_AUTO"
 }

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.csproj
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta03</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Contact Center AI Insights API, which helps users detect and visualize patterns in their contact center data. Understanding conversational data drives business value, improves operational efficiency, and provides a voice for customer feedback.</Description>

--- a/apis/Google.Cloud.ContactCenterInsights.V1/docs/history.md
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+# Version 1.0.0, released 2021-11-10
+
+First GA release.
+
+- [Commit 6cf6933](https://github.com/googleapis/google-cloud-dotnet/commit/6cf6933):
+  - feat: Add ability to update phrase matchers
+  - feat: Add issue model stats to time series
+  - feat: Add display name to issue model stats
+- [Commit f7c2450](https://github.com/googleapis/google-cloud-dotnet/commit/f7c2450):
+  - feat: deprecate issue_matches
+  - docs: if conversation medium is unspecified, it will default to PHONE_CALL
+
 # Version 1.0.0-beta03, released 2021-09-29
 
 - [Commit ddab19e](https://github.com/googleapis/google-cloud-dotnet/commit/ddab19e):

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -621,7 +621,7 @@
     },
     {
       "id": "Google.Cloud.ContactCenterInsights.V1",
-      "version": "1.0.0-beta03",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Contact Center AI Insights",
       "productUrl": "https://cloud.google.com/contact-center/insights/docs",
@@ -632,7 +632,9 @@
         "feedback"
       ],
       "dependencies": {
-        "Google.LongRunning": "2.3.0"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Google.LongRunning": "2.3.0",
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/cloud/contactcenterinsights/v1"


### PR DESCRIPTION

Changes in this release:

First GA release.

- [Commit 6cf6933](https://github.com/googleapis/google-cloud-dotnet/commit/6cf6933):
  - feat: Add ability to update phrase matchers
  - feat: Add issue model stats to time series
  - feat: Add display name to issue model stats
- [Commit f7c2450](https://github.com/googleapis/google-cloud-dotnet/commit/f7c2450):
  - feat: deprecate issue_matches
  - docs: if conversation medium is unspecified, it will default to PHONE_CALL
