### PR TITLE
Release Google.Cloud.DataFusion.V1 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.DataFusion.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.DataFusion.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.DataFusion.V1",
-  "release_level": "beta",
+  "release_level": "ga",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.DataFusion.V1/latest",
   "library_type": "GAPIC_AUTO"
 }

--- a/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.csproj
+++ b/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Data Fusion API. Cloud Data Fusion is a fully-managed, cloud native, enterprise data integration service for quickly building and managing data pipelines.</Description>
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.3.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.DataFusion.V1/docs/history.md
+++ b/apis/Google.Cloud.DataFusion.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+# Version 1.0.0, released 2021-11-10
+
+First GA release.
+
+No API surface changes; just dependency updates.
+
 # Version 1.0.0-beta02, released 2021-08-19
 
 - [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -675,7 +675,7 @@
     },
     {
       "id": "Google.Cloud.DataFusion.V1",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Cloud Data Fusion",
       "productUrl": "https://cloud.google.com/data-fusion/docs/",
@@ -686,7 +686,9 @@
         "data"
       ],
       "dependencies": {
-        "Google.LongRunning": "2.2.0"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Google.LongRunning": "2.3.0",
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/cloud/datafusion/v1"


### PR DESCRIPTION

Changes in this release:

First GA release.

No API surface changes; just dependency updates.
