### PR TITLE
Release Google.Cloud.BinaryAuthorization.V1 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.BinaryAuthorization.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.BinaryAuthorization.V1",
-  "release_level": "beta",
+  "release_level": "ga",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.BinaryAuthorization.V1/latest",
   "library_type": "GAPIC_AUTO"
 }

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.csproj
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Binary Authorization API v1, providing policy control for images deployed to Kubernetes Engine clusters.</Description>

--- a/apis/Google.Cloud.BinaryAuthorization.V1/docs/history.md
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+# Version 1.0.0, released 2021-11-10
+
+First GA release.
+
+No API surface changes; just dependency updates.
+
 # Version 1.0.0-beta01, released 2021-10-11
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -495,7 +495,7 @@
     },
     {
       "id": "Google.Cloud.BinaryAuthorization.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Binary Authorization",
       "productUrl": "https://cloud.google.com/binary-authorization/docs/reference/rpc",
@@ -508,7 +508,9 @@
         "kubernetes"
       ],
       "dependencies": {
-        "Grafeas.V1": "2.3.0"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Grafeas.V1": "2.3.0",
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/cloud/binaryauthorization/v1"


### PR DESCRIPTION

Changes in this release:

First GA release.

No API surface changes; just dependency updates.
