### PR TITLE
Release Google.Cloud.BinaryAuthorization.V1Beta1 version 1.0.0-beta05

### DIFF
--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.csproj
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta04</Version>
+    <Version>1.0.0-beta05</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Binary Authorization API v1beta1, providing policy control for images deployed to Kubernetes Engine clusters.</Description>

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+# Version 1.0.0-beta05, released 2021-11-10
+
+- [Commit b85ccc6](https://github.com/googleapis/google-cloud-dotnet/commit/b85ccc6):
+  - feat: add new admission rule types to Policy
+  - feat: update SignatureAlgorithm enum to match algorithm names in KMS
+  - feat: add SystemPolicyV1Beta1 service
+
 # Version 1.0.0-beta04, released 2021-09-23
 
 - [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -515,7 +515,7 @@
     },
     {
       "id": "Google.Cloud.BinaryAuthorization.V1Beta1",
-      "version": "1.0.0-beta04",
+      "version": "1.0.0-beta05",
       "type": "grpc",
       "productName": "Binary Authorization",
       "productUrl": "https://cloud.google.com/binary-authorization/docs/reference/rpc",


### PR DESCRIPTION

Changes in this release:

- [Commit b85ccc6](https://github.com/googleapis/google-cloud-dotnet/commit/b85ccc6):
  - feat: add new admission rule types to Policy
  - feat: update SignatureAlgorithm enum to match algorithm names in KMS
  - feat: add SystemPolicyV1Beta1 service
