### PR TITLE
Release Google.Cloud.Dialogflow.Cx.V3 version 1.6.0

### DIFF
--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.csproj
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.5.0</Version>
+    <Version>1.6.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Builds conversational interfaces (for example, chatbots, and voice-powered apps and devices).</Description>

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/docs/history.md
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+# Version 1.6.0, released 2021-11-10
+
+- [Commit 36bae8f](https://github.com/googleapis/google-cloud-dotnet/commit/36bae8f):
+  - feat: added API for changelogs
+  - docs: clarified semantic of the streaming APIs
 # Version 1.5.0, released 2021-10-12
 
 - [Commit 74b880a](https://github.com/googleapis/google-cloud-dotnet/commit/74b880a):

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -977,7 +977,7 @@
     },
     {
       "id": "Google.Cloud.Dialogflow.Cx.V3",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "type": "grpc",
       "productName": "Dialogflow",
       "productUrl": "https://cloud.google.com/dialogflow/cx/docs",


### PR DESCRIPTION

Changes in this release:

- [Commit 36bae8f](https://github.com/googleapis/google-cloud-dotnet/commit/36bae8f):
  - feat: added API for changelogs
  - docs: clarified semantic of the streaming APIs
