### PR TITLE
Release Google.Cloud.Dialogflow.V2 version 3.7.0

### DIFF
--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.csproj
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.6.0</Version>
+    <Version>3.7.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Dialogflow API.</Description>

--- a/apis/Google.Cloud.Dialogflow.V2/docs/history.md
+++ b/apis/Google.Cloud.Dialogflow.V2/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+# Version 3.7.0, released 2021-11-10
+
+- [Commit 6699f2e](https://github.com/googleapis/google-cloud-dotnet/commit/6699f2e): feat: added support to configure security settings, language code and time zone on conversation profile
+- [Commit dd18efd](https://github.com/googleapis/google-cloud-dotnet/commit/dd18efd):
+  - docs: clarified meaning of the legacy editions
+  - docs: clarified semantic of the streaming APIs
+
 # Version 3.6.0, released 2021-10-12
 
 - [Commit 03f91a3](https://github.com/googleapis/google-cloud-dotnet/commit/03f91a3): docs: recommend AnalyzeContent for future users

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1001,7 +1001,7 @@
       "protoPath": "google/cloud/dialogflow/v2",
       "productName": "Google Cloud Dialogflow",
       "productUrl": "https://cloud.google.com/dialogflow-enterprise/",
-      "version": "3.6.0",
+      "version": "3.7.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Dialogflow API.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

- [Commit 6699f2e](https://github.com/googleapis/google-cloud-dotnet/commit/6699f2e): feat: added support to configure security settings, language code and time zone on conversation profile
- [Commit dd18efd](https://github.com/googleapis/google-cloud-dotnet/commit/dd18efd):
  - docs: clarified meaning of the legacy editions
  - docs: clarified semantic of the streaming APIs
