### PR TITLE
Release Google.Cloud.OsConfig.V1 version 1.6.0

### DIFF
--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.csproj
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.5.0</Version>
+    <Version>1.6.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library for the Cloud OS Config API (v1). These are OS management tools that can be used for patch management, patch compliance, and configuration management on VM instances.</Description>

--- a/apis/Google.Cloud.OsConfig.V1/docs/history.md
+++ b/apis/Google.Cloud.OsConfig.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+# Version 1.6.0, released 2021-11-10
+
+- [Commit 8f1e976](https://github.com/googleapis/google-cloud-dotnet/commit/8f1e976): feat: OSConfig: add OS policy assignment rpcs
+
 # Version 1.5.0, released 2021-10-20
 
 - [Commit 5cd7c96](https://github.com/googleapis/google-cloud-dotnet/commit/5cd7c96): feat: Update osconfig v1 and v1alpha RecurringSchedule.Frequency with DAILY frequency

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2004,7 +2004,7 @@
       "protoPath": "google/cloud/osconfig/v1",
       "productName": "Google Cloud OS Config",
       "productUrl": "https://cloud.google.com/compute/docs/osconfig/rest",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "type": "grpc",
       "description": "Recommended Google client library for the Cloud OS Config API (v1). These are OS management tools that can be used for patch management, patch compliance, and configuration management on VM instances.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

- [Commit 8f1e976](https://github.com/googleapis/google-cloud-dotnet/commit/8f1e976): feat: OSConfig: add OS policy assignment rpcs
