### PR TITLE
chore: Remove now-unnecessary proto changes for Compute

### DIFF
--- a/apis/Google.Cloud.Compute.V1/postgeneration.sh
+++ b/apis/Google.Cloud.Compute.V1/postgeneration.sh
@@ -2,9 +2,6 @@
 
 set -e
 
-# Undo the changes made in pregeneration.sh
-git -C $GOOGLEAPIS checkout google/cloud/compute/v1
-
 # Fix up Grpc.Core parts
 # We have a hand-written piece at the moment for the adapter.
 sed -i 's/using gaxgrpccore = Google.Api.Gax.Grpc.GrpcCore;//g' Google.Cloud.Compute.V1/*.g.cs

--- a/apis/Google.Cloud.Compute.V1/pregeneration.sh
+++ b/apis/Google.Cloud.Compute.V1/pregeneration.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-# Remove extraneous proto
-rm $GOOGLEAPIS/google/cloud/compute/v1/compute_small.proto


### PR DESCRIPTION
(The extraneous "small" proto and corresponding files have been
moved.)