### PR TITLE
Change how Owl Bot decides to regenerate locally

### DIFF
--- a/apis/Google.Cloud.AIPlatform.V1/.OwlBot-ForceRegeneration.txt
+++ b/apis/Google.Cloud.AIPlatform.V1/.OwlBot-ForceRegeneration.txt
@@ -1,0 +1,1 @@
+API requires pre/mid-generation tweaks.

--- a/apis/Google.Cloud.AccessApproval.V1/.OwlBot-ForceRegeneration.txt
+++ b/apis/Google.Cloud.AccessApproval.V1/.OwlBot-ForceRegeneration.txt
@@ -1,0 +1,1 @@
+API requires pre/mid-generation tweaks.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/.OwlBot-ForceRegeneration.txt
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/.OwlBot-ForceRegeneration.txt
@@ -1,0 +1,1 @@
+API uses a custom resources configuration.

--- a/apis/Google.Cloud.Bigtable.V2/.OwlBot-ForceRegeneration.txt
+++ b/apis/Google.Cloud.Bigtable.V2/.OwlBot-ForceRegeneration.txt
@@ -1,0 +1,2 @@
+API requires pre/mid-generation tweaks.
+API uses a custom resources configuration.

--- a/apis/Google.Cloud.Dialogflow.V2/.OwlBot-ForceRegeneration.txt
+++ b/apis/Google.Cloud.Dialogflow.V2/.OwlBot-ForceRegeneration.txt
@@ -1,0 +1,1 @@
+API requires pre/mid-generation tweaks.

--- a/apis/Google.Cloud.DocumentAI.V1/.OwlBot-ForceRegeneration.txt
+++ b/apis/Google.Cloud.DocumentAI.V1/.OwlBot-ForceRegeneration.txt
@@ -1,0 +1,1 @@
+API requires pre/mid-generation tweaks.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/.OwlBot-ForceRegeneration.txt
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/.OwlBot-ForceRegeneration.txt
@@ -1,0 +1,1 @@
+API requires pre/mid-generation tweaks.

--- a/apis/Google.Cloud.GkeHub.V1/.OwlBot-ForceRegeneration.txt
+++ b/apis/Google.Cloud.GkeHub.V1/.OwlBot-ForceRegeneration.txt
@@ -1,0 +1,1 @@
+API requires pre/mid-generation tweaks.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/.OwlBot-ForceRegeneration.txt
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/.OwlBot-ForceRegeneration.txt
@@ -1,0 +1,1 @@
+API requires pre/mid-generation tweaks.

--- a/apis/Google.Cloud.OsLogin.Common/.OwlBot-ForceRegeneration.txt
+++ b/apis/Google.Cloud.OsLogin.Common/.OwlBot-ForceRegeneration.txt
@@ -1,0 +1,1 @@
+OsLogin Common proto is generated in the wrong place.

--- a/apis/Google.Cloud.OsLogin.V1/.OwlBot-ForceRegeneration.txt
+++ b/apis/Google.Cloud.OsLogin.V1/.OwlBot-ForceRegeneration.txt
@@ -1,0 +1,1 @@
+OsLogin Common proto is generated and copied when it shouldn't be.

--- a/apis/Google.Cloud.OsLogin.V1Beta/.OwlBot-ForceRegeneration.txt
+++ b/apis/Google.Cloud.OsLogin.V1Beta/.OwlBot-ForceRegeneration.txt
@@ -1,0 +1,1 @@
+OsLogin Common proto is generated and copied when it shouldn't be.

--- a/apis/Google.Cloud.PubSub.V1/.OwlBot-ForceRegeneration.txt
+++ b/apis/Google.Cloud.PubSub.V1/.OwlBot-ForceRegeneration.txt
@@ -1,0 +1,1 @@
+API requires pre/mid-generation tweaks.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/.OwlBot-ForceRegeneration.txt
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/.OwlBot-ForceRegeneration.txt
@@ -1,0 +1,1 @@
+API uses a custom resources configuration.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/.OwlBot-ForceRegeneration.txt
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/.OwlBot-ForceRegeneration.txt
@@ -1,0 +1,1 @@
+API uses a custom resources configuration.

--- a/apis/Google.Cloud.Spanner.V1/.OwlBot-ForceRegeneration.txt
+++ b/apis/Google.Cloud.Spanner.V1/.OwlBot-ForceRegeneration.txt
@@ -1,0 +1,1 @@
+API uses a custom resources configuration.

--- a/apis/Google.Cloud.Talent.V4/.OwlBot-ForceRegeneration.txt
+++ b/apis/Google.Cloud.Talent.V4/.OwlBot-ForceRegeneration.txt
@@ -1,0 +1,1 @@
+Google.Cloud.Common proto is generated and copied when it shouldn't be.

--- a/apis/Google.Cloud.Workflows.Executions.V1/.OwlBot-ForceRegeneration.txt
+++ b/apis/Google.Cloud.Workflows.Executions.V1/.OwlBot-ForceRegeneration.txt
@@ -1,0 +1,1 @@
+API uses a custom resources configuration.

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/.OwlBot-ForceRegeneration.txt
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/.OwlBot-ForceRegeneration.txt
@@ -1,0 +1,1 @@
+API uses a custom resources configuration.

--- a/apis/Google.Cloud.Workflows.V1/.OwlBot-ForceRegeneration.txt
+++ b/apis/Google.Cloud.Workflows.V1/.OwlBot-ForceRegeneration.txt
@@ -1,0 +1,1 @@
+API uses a custom resources configuration.

--- a/apis/Google.Cloud.Workflows.V1Beta/.OwlBot-ForceRegeneration.txt
+++ b/apis/Google.Cloud.Workflows.V1Beta/.OwlBot-ForceRegeneration.txt
@@ -1,0 +1,1 @@
+API uses a custom resources configuration.

--- a/apis/README.md
+++ b/apis/README.md
@@ -36,3 +36,7 @@ Fields:
 - `commonResourceConfig`: Path to a file providing additional common
   resource configuration, augmenting the root `CommonResourcesConfig.json` file. Typically multiple APIs (e.g. all of
   the Spanner APIs) will refer to the same file in a common package, containing the resource names described in the config file.
+- `forceOwlBotRegeneration`: The reason why the OwlBot postprocessor
+  should regenerate this API locally, for corner cases. (Custom
+  resource configuration and pre/mid-processor tweaks are handled
+  automatically.)

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2059,7 +2059,8 @@
         "Google.Api.CommonProtos": "2.3.0",
         "Google.Api.Gax": "3.5.0"
       },
-      "noVersionHistory": true
+      "noVersionHistory": true,
+      "forceOwlBotRegeneration": "OsLogin Common proto is generated in the wrong place."
     },
     {
       "id": "Google.Cloud.OsLogin.V1",
@@ -2078,7 +2079,8 @@
         "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.Cloud.OsLogin.Common": "project",
         "Grpc.Core": "2.38.1"
-      }
+      },
+      "forceOwlBotRegeneration": "OsLogin Common proto is generated and copied when it shouldn't be."
     },
     {
       "id": "Google.Cloud.OsLogin.V1Beta",
@@ -2098,7 +2100,8 @@
         "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Google.Cloud.OsLogin.Common": "project",
         "Grpc.Core": "2.38.1"
-      }
+      },
+      "forceOwlBotRegeneration": "OsLogin Common proto is generated and copied when it shouldn't be."
     },
     {
       "id": "Google.Cloud.PhishingProtection.V1Beta1",
@@ -2819,7 +2822,8 @@
         "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
-      "protoPath": "google/cloud/talent/v4"
+      "protoPath": "google/cloud/talent/v4",
+      "forceOwlBotRegeneration": "Google.Cloud.Common proto is generated and copied when it shouldn't be."
     },
     {
       "id": "Google.Cloud.Talent.V4Beta1",

--- a/owl-bot-post-processor/main.sh
+++ b/owl-bot-post-processor/main.sh
@@ -34,12 +34,15 @@ copy_one_api() {
   PACKAGE_DIR=apis/$1
 
   # We don't expect googleapis-gen to contain the right (or potentially
-  # even valid) code for APIs which have pre/mid-generation tweak scripts.
-  # It's not clear whether they'll even be fully generated in googleapis-gen,
-  # but for now we can still use OwlBot to notice that something has changed,
+  # even valid) code for APIs which have pre/mid-generation tweak scripts,
+  # or custom resource configurations - or a few other corner cases.
+  # Some APIs may not even be fully generated in googleapis-gen.
+  # We can still use OwlBot to notice that something has changed,
   # and simply running our local generation script against the right commit
-  # for googleapis/googleapis.
-  if [[ -f $PACKAGE_DIR/pregeneration.sh || -f $PACKAGE_DIR/midmicrogeneration.sh ]]
+  # for googleapis/googleapis. The project generator determines whether any
+  # given API requires regeneration here, and creates a marker .OwlBot-ForceRegeneration.txt
+  # file if so.
+  if [[ -f $PACKAGE_DIR/.OwlBot-ForceRegeneration.txt ]]
   then
     # Determine the commit for googleapis to use based on the Source-Link in
     # the comment from the last commit in the local directory.

--- a/tools/Google.Cloud.Tools.Common/ApiMetadata.cs
+++ b/tools/Google.Cloud.Tools.Common/ApiMetadata.cs
@@ -203,6 +203,12 @@ namespace Google.Cloud.Tools.Common
         public string CommonResourcesConfig { get; set; }
 
         /// <summary>
+        /// Reason to force local regeneration of the API in OwlBot PRs, due to some corner case.
+        /// This reason ends up in the .OwlBot-ForceRegeneration.txt file.
+        /// </summary>
+        public string ForceOwlBotRegeneration { get; set; }
+
+        /// <summary>
         /// Indicates whether the given package name denotes a Cloud API, documented on cloud.google.com.
         /// Note that this is only expected to "know" about API libraries, not support libraries (GAX, protobuf etc).
         /// </summary>


### PR DESCRIPTION
This is rather more flexible, and puts logic in C# instead of in the shell script