### PR TITLE
Release Google.Cloud.TextToSpeech.V1 version 2.4.0

### DIFF
--- a/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.csproj
+++ b/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Text-to-Speech API v1, synthesizes natural-sounding speech by applying powerful neural network models.</Description>

--- a/apis/Google.Cloud.TextToSpeech.V1/docs/history.md
+++ b/apis/Google.Cloud.TextToSpeech.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 2.4.0, released 2021-11-18
+
+- [Commit fc5df69](https://github.com/googleapis/google-cloud-dotnet/commit/fc5df69):
+  - feat: Add Mulaw and Alaw values to AudioEncoding
+  - feat: Generate a resource name for Model
+- [Commit 6b42688](https://github.com/googleapis/google-cloud-dotnet/commit/6b42688): docs: fix docstring formatting
+
 ## Version 2.3.0, released 2021-09-06
 
 - [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2884,7 +2884,7 @@
       "protoPath": "google/cloud/texttospeech/v1",
       "productName": "Google Cloud Text-to-Speech",
       "productUrl": "https://cloud.google.com/text-to-speech",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Text-to-Speech API v1, synthesizes natural-sounding speech by applying powerful neural network models.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

- [Commit fc5df69](https://github.com/googleapis/google-cloud-dotnet/commit/fc5df69):
  - feat: Add Mulaw and Alaw values to AudioEncoding
  - feat: Generate a resource name for Model
- [Commit 6b42688](https://github.com/googleapis/google-cloud-dotnet/commit/6b42688): docs: fix docstring formatting
