### PR TITLE
Release Google.Cloud.Domains.V1 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.Domains.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.Domains.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.Domains.V1",
-  "release_level": "beta",
+  "release_level": "ga",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Domains.V1/latest",
   "library_type": "GAPIC_AUTO"
 }

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.csproj
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Domains API v1, which enables management and configuration of domain names.</Description>

--- a/apis/Google.Cloud.Domains.V1/docs/history.md
+++ b/apis/Google.Cloud.Domains.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0, released 2021-11-18
+
+No API surface changes; just dependency updates and promotion to GA.
+
 ## Version 1.0.0-beta01, released 2021-10-20
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1085,7 +1085,7 @@
     },
     {
       "id": "Google.Cloud.Domains.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Cloud Domains",
       "productUrl": "https://cloud.google.com/domains/",
@@ -1094,7 +1094,9 @@
         "domains"
       ],
       "dependencies": {
-        "Google.LongRunning": "2.3.0"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Google.LongRunning": "2.3.0",
+        "Grpc.Core": "2.38.1"
       },
       "generator": "micro",
       "protoPath": "google/cloud/domains/v1"


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates and promotion to GA.
