### PR TITLE
fix: clone each SpannerParameter when cloning a parameter collection

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerCommandTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerCommandTests.cs
@@ -96,7 +96,7 @@ namespace Google.Cloud.Spanner.Data.Tests
             Assert.Equal(command.CommandText, command2.CommandText);
             Assert.Equal(command.Parameters.Count, command2.Parameters.Count);
             Assert.NotSame(command.Parameters, command2.Parameters);
-            Assert.True(command.Parameters.SequenceEqual(command2.Parameters));
+            Assert.True(command.Parameters.SequenceEqual(command2.Parameters, new SpannerParameterEqualityComparer()));
         }
 
         [Fact]

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerParameterCollection.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerParameterCollection.cs
@@ -280,6 +280,7 @@ namespace Google.Cloud.Spanner.Data
         /// Clones the collection.
         /// </summary>
         /// <returns>A cloned copy of this instance.</returns>
-        public SpannerParameterCollection Clone() => new SpannerParameterCollection(_innerList);
+        public SpannerParameterCollection Clone() =>
+            new SpannerParameterCollection(_innerList.Select(p => p.Clone() as SpannerParameter));
     }
 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerParameterCollection.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerParameterCollection.cs
@@ -281,6 +281,6 @@ namespace Google.Cloud.Spanner.Data
         /// </summary>
         /// <returns>A cloned copy of this instance.</returns>
         public SpannerParameterCollection Clone() =>
-            new SpannerParameterCollection(_innerList.Select(p => p.Clone() as SpannerParameter));
+            new SpannerParameterCollection(_innerList.Select(p => (SpannerParameter) p.Clone()));
     }
 }


### PR DESCRIPTION
Cloning a `SpannerParameterCollection` would not clone the individual `SpannerParameter` instances
in the collection. This would mean that if you cloned a `SpannerCommand` and then changed the
value of a parameter on the original command, the value would also be changed on the cloned
command.