### PR TITLE
docs: Move manual emulator connection snippet

### DIFF
--- a/docs/devsite-help/emulators.md
+++ b/docs/devsite-help/emulators.md
@@ -55,4 +55,4 @@ to `ChannelCredentials.Insecure`.
 
 Example for PubSub (although the techniques above are preferred):
 
-[!code-cs[](../examples/help.Faq.txt#Emulator)]
+[!code-cs[](../examples/help.Emulator.txt#ManualConnection)]

--- a/tools/Google.Cloud.Docs.Snippets/EmulatorSnippets.cs
+++ b/tools/Google.Cloud.Docs.Snippets/EmulatorSnippets.cs
@@ -14,6 +14,8 @@
 
 using Google.Api.Gax;
 using Google.Cloud.PubSub.V1;
+using Grpc.Core;
+using System;
 
 namespace Google.Cloud.Docs.Snippets
 {
@@ -38,8 +40,19 @@ namespace Google.Cloud.Docs.Snippets
             SubscriberClient client = SubscriberClient.Create(subscription, clientCreationSettings);
             // End sample
         }
-        
-        // Note: the "manual connection" snippet is in FaqSnippets.cs. We can move it here at some point,
-        // but it means that at least temporarily, links to the source code would be broken.
+
+        public void ManualConnection()
+        {
+            // Sample: ManualConnection
+            // For example, "localhost:8615"
+            string emulatorHostAndPort = Environment.GetEnvironmentVariable("PUBSUB_EMULATOR_HOST");
+
+            PublisherServiceApiClient client = new PublisherServiceApiClientBuilder
+            {
+                Endpoint = emulatorHostAndPort,
+                ChannelCredentials = ChannelCredentials.Insecure
+            }.Build();
+            // End sample
+        }
     }
 }

--- a/tools/Google.Cloud.Docs.Snippets/FaqSnippets.cs
+++ b/tools/Google.Cloud.Docs.Snippets/FaqSnippets.cs
@@ -13,45 +13,16 @@
 // limitations under the License.
 
 using Google.Apis.Logging;
-using Google.Cloud.PubSub.V1;
+using Google.Cloud.Scheduler.V1;
 using Google.Cloud.Translation.V2;
-using static Google.Apis.Http.ConfigurableMessageHandler;
-using Grpc.Core;
-using System;
-using Google.Api.Gax.ResourceNames;
 using Google.Cloud.Vision.V1;
 using System.Collections.Generic;
-using Google.Cloud.Scheduler.V1;
-
-// Unfortunately Scheduler now has a TopicName class too; this is just an unfortunate combination of APIs
-// to pick snippets from.
-using TopicName = Google.Cloud.PubSub.V1.TopicName;
+using static Google.Apis.Http.ConfigurableMessageHandler;
 
 namespace Google.Cloud.Tools.Snippets
 {
     public class FaqSnippets
     {
-        public void Emulator()
-        {
-            // Sample: Emulator
-            // [START pubsub_use_emulator]
-            // For example, "localhost:8615"
-            string emulatorHostAndPort = Environment.GetEnvironmentVariable("PUBSUB_EMULATOR_HOST");
-
-            PublisherServiceApiClient client = new PublisherServiceApiClientBuilder
-            {
-                Endpoint = emulatorHostAndPort,
-                ChannelCredentials = ChannelCredentials.Insecure
-            }.Build();
-            client.CreateTopic(new TopicName("project", "topic"));
-            foreach (var topic in client.ListTopics(new ProjectName("project")))
-            {
-                Console.WriteLine(topic.Name);
-            }
-            // [END pubsub_use_emulator]
-            // End sample
-        }
-        
         public void RestLogging()
         {
             // Sample: RestLogging


### PR DESCRIPTION
This is feasible due to the PubSub product snippet now being in the
samples repo.