### PR TITLE
Release Spanner libraries version 3.13.0

### DIFF
--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.csproj
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.12.0</Version>
+    <Version>3.13.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Spanner Database Admin API.</Description>
@@ -11,9 +11,9 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.3.0, 3.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1.csproj" />
-    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.3.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.csproj
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.12.0</Version>
+    <Version>3.13.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Spanner Instance Admin API.</Description>
@@ -11,9 +11,9 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.3.0, 3.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1.csproj" />
-    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.3.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1.csproj
+++ b/apis/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.12.0</Version>
+    <Version>3.13.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Common resource names used by all Spanner V1 APIs</Description>

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.csproj
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.12.0</Version>
+    <Version>3.13.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google ADO.NET Provider for Google Cloud Spanner.</Description>

--- a/apis/Google.Cloud.Spanner.Data/docs/history.md
+++ b/apis/Google.Cloud.Spanner.Data/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 3.13.0, released 2021-12-01
+
+- [Commit 02b16d7](https://github.com/googleapis/google-cloud-dotnet/commit/02b16d7): fix: clone each SpannerParameter when cloning a parameter collection
+- [Commit c653720](https://github.com/googleapis/google-cloud-dotnet/commit/c653720): feat: add support for DataReader.GetBytes ([issue 7395](https://github.com/googleapis/google-cloud-dotnet/issues/7395))
+- [Commit 9bc116d](https://github.com/googleapis/google-cloud-dotnet/commit/9bc116d): fix: allow setting parameter size to the same as the current value ([issue 7401](https://github.com/googleapis/google-cloud-dotnet/issues/7401))
+- [Commit 0666123](https://github.com/googleapis/google-cloud-dotnet/commit/0666123): feat: Spanner Read API
+
 ## Version 3.12.0, released 2021-08-24
 
 - [Commit 7c6a6f1](https://github.com/googleapis/google-cloud-dotnet/commit/7c6a6f1): feat: add support for JSON data type in Spanner ([issue 6390](https://github.com/googleapis/google-cloud-dotnet/issues/6390))

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.csproj
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.12.0</Version>
+    <Version>3.13.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Low-level Google client library to access the Google Cloud Spanner API. The ADO.NET provider (Google.Cloud.Spanner.Data) which depends on this package is generally preferred for Spanner access.</Description>

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2626,7 +2626,7 @@
       "protoPath": "google/spanner/admin/database/v1",
       "productName": "Google Cloud Spanner Database Administration",
       "productUrl": "https://cloud.google.com/spanner/",
-      "version": "3.12.0",
+      "version": "3.13.0",
       "commonResourcesConfig": "apis/Google.Cloud.Spanner.Common.V1/CommonResourcesConfig.json",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Spanner Database Admin API.",
@@ -2635,9 +2635,9 @@
       ],
       "dependencies": {
         "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
-        "Google.Cloud.Iam.V1": "2.2.0",
+        "Google.Cloud.Iam.V1": "2.3.0",
         "Google.Cloud.Spanner.Common.V1": "project",
-        "Google.LongRunning": "2.2.0",
+        "Google.LongRunning": "2.3.0",
         "Grpc.Core": "2.38.1"
       },
       "noVersionHistory": true
@@ -2648,7 +2648,7 @@
       "protoPath": "google/spanner/admin/instance/v1",
       "productName": "Google Cloud Spanner Instance Administration",
       "productUrl": "https://cloud.google.com/spanner/",
-      "version": "3.12.0",
+      "version": "3.13.0",
       "commonResourcesConfig": "apis/Google.Cloud.Spanner.Common.V1/CommonResourcesConfig.json",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Spanner Instance Admin API.",
@@ -2657,9 +2657,9 @@
       ],
       "dependencies": {
         "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
-        "Google.Cloud.Iam.V1": "2.2.0",
+        "Google.Cloud.Iam.V1": "2.3.0",
         "Google.Cloud.Spanner.Common.V1": "project",
-        "Google.LongRunning": "2.2.0",
+        "Google.LongRunning": "2.3.0",
         "Grpc.Core": "2.38.1"
       },
       "noVersionHistory": true
@@ -2668,7 +2668,7 @@
       "id": "Google.Cloud.Spanner.Data",
       "targetFrameworks": "netstandard2.0;net461",
       "testTargetFrameworks": "netcoreapp2.1;net461",
-      "version": "3.12.0",
+      "version": "3.13.0",
       "type": "other",
       "metadataType": "INTEGRATION",
       "description": "Google ADO.NET Provider for Google Cloud Spanner.",
@@ -2695,7 +2695,7 @@
       "id": "Google.Cloud.Spanner.Common.V1",
       "type": "other",
       "targetFrameworks": "netstandard2.0;net461",
-      "version": "3.12.0",
+      "version": "3.13.0",
       "description": "Common resource names used by all Spanner V1 APIs",
       "tags": [
         "Spanner"
@@ -2711,7 +2711,7 @@
       "protoPath": "google/spanner/v1",
       "productName": "Google Cloud Spanner",
       "productUrl": "https://cloud.google.com/spanner/",
-      "version": "3.12.0",
+      "version": "3.13.0",
       "commonResourcesConfig": "apis/Google.Cloud.Spanner.Common.V1/CommonResourcesConfig.json",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",


### PR DESCRIPTION

Changes in Google.Cloud.Spanner.Data version 3.13.0:

- [Commit 02b16d7](https://github.com/googleapis/google-cloud-dotnet/commit/02b16d7): fix: clone each SpannerParameter when cloning a parameter collection
- [Commit c653720](https://github.com/googleapis/google-cloud-dotnet/commit/c653720): feat: add support for DataReader.GetBytes ([issue 7395](https://github.com/googleapis/google-cloud-dotnet/issues/7395))
- [Commit 9bc116d](https://github.com/googleapis/google-cloud-dotnet/commit/9bc116d): fix: allow setting parameter size to the same as the current value ([issue 7401](https://github.com/googleapis/google-cloud-dotnet/issues/7401))
- [Commit 0666123](https://github.com/googleapis/google-cloud-dotnet/commit/0666123): feat: Spanner Read API

Packages in this release:
- Release Google.Cloud.Spanner.Admin.Database.V1 version 3.13.0
- Release Google.Cloud.Spanner.Admin.Instance.V1 version 3.13.0
- Release Google.Cloud.Spanner.Common.V1 version 3.13.0
- Release Google.Cloud.Spanner.Data version 3.13.0
- Release Google.Cloud.Spanner.V1 version 3.13.0
