### PR TITLE
Release Google.Cloud.Compute.V1 version 1.0.0-beta05

### DIFF
--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta04</Version>
+    <Version>1.0.0-beta05</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Compute Engine API.</Description>

--- a/apis/Google.Cloud.Compute.V1/docs/history.md
+++ b/apis/Google.Cloud.Compute.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 1.0.0-beta05, released 2021-12-01
+
+- [Commit 5f323c1](https://github.com/googleapis/google-cloud-dotnet/commit/5f323c1): fix: make parent_id fields required compute move and insert methods ([issue 686](https://github.com/googleapis/google-cloud-dotnet/issues/686))
+- [Commit f8f4704](https://github.com/googleapis/google-cloud-dotnet/commit/f8f4704): feat: Add classes with generated constants for enums for Compute
+- [Commit 238f43c](https://github.com/googleapis/google-cloud-dotnet/commit/238f43c): feat: Add helper methods for converting Compute enum values
+- [Commit 5d969a2](https://github.com/googleapis/google-cloud-dotnet/commit/5d969a2): feat: Switch to string enums for compute ([issue 685](https://github.com/googleapis/google-cloud-dotnet/issues/685))
+
 ## Version 1.0.0-beta04, released 2021-11-10
 
 - [Commit 41d3129](https://github.com/googleapis/google-cloud-dotnet/commit/41d3129): fix: Convert HTTP status codes to gRPC status codes when converting LROs

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -606,7 +606,7 @@
     },
     {
       "id": "Google.Cloud.Compute.V1",
-      "version": "1.0.0-beta04",
+      "version": "1.0.0-beta05",
       "type": "regapic",
       "productName": "Compute Engine",
       "productUrl": "https://cloud.google.com/compute",


### PR DESCRIPTION

Changes in this release:

- [Commit 5f323c1](https://github.com/googleapis/google-cloud-dotnet/commit/5f323c1): fix: make parent_id fields required compute move and insert methods ([issue 686](https://github.com/googleapis/google-cloud-dotnet/issues/686))
- [Commit f8f4704](https://github.com/googleapis/google-cloud-dotnet/commit/f8f4704): feat: Add classes with generated constants for enums for Compute
- [Commit 238f43c](https://github.com/googleapis/google-cloud-dotnet/commit/238f43c): feat: Add helper methods for converting Compute enum values
- [Commit 5d969a2](https://github.com/googleapis/google-cloud-dotnet/commit/5d969a2): feat: Switch to string enums for compute ([issue 685](https://github.com/googleapis/google-cloud-dotnet/issues/685))
