### PR TITLE
Release Google.Cloud.Notebooks.V1 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.csproj
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AI Platform Notebooks API (v1), which is used to manage notebook resources in Google Cloud.</Description>

--- a/apis/Google.Cloud.Notebooks.V1/docs/history.md
+++ b/apis/Google.Cloud.Notebooks.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2021-12-07
+
+- [Commit 2460a97](https://github.com/googleapis/google-cloud-dotnet/commit/2460a97):
+  - docs: fix typos and docstring formatting
 ## Version 1.0.0-beta01, released 2021-10-11
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1918,7 +1918,7 @@
     },
     {
       "id": "Google.Cloud.Notebooks.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "AI Platform Notebooks",
       "productUrl": "https://cloud.google.com/ai-platform-notebooks",


### PR DESCRIPTION

Changes in this release:

- [Commit 2460a97](https://github.com/googleapis/google-cloud-dotnet/commit/2460a97):
  - docs: fix typos and docstring formatting
