### PR TITLE
Release Google.Cloud.RecaptchaEnterprise.V1 version 1.6.0

### DIFF
--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.csproj
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.5.0</Version>
+    <Version>1.6.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud reCAPTCHA for Enterprise API v1.</Description>

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/docs/history.md
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.6.0, released 2021-12-07
+
+- [Commit 308c733](https://github.com/googleapis/google-cloud-dotnet/commit/308c733): feat: add new reCAPTCHA Enterprise fraud annotations
+
 ## Version 1.5.0, released 2021-11-10
 
 - [Commit fcce878](https://github.com/googleapis/google-cloud-dotnet/commit/fcce878):

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2204,7 +2204,7 @@
       "protoPath": "google/cloud/recaptchaenterprise/v1",
       "productName": "Google Cloud reCAPTCHA Enterprise",
       "productUrl": "https://cloud.google.com/recaptcha-enterprise/",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud reCAPTCHA for Enterprise API v1.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

- [Commit 308c733](https://github.com/googleapis/google-cloud-dotnet/commit/308c733): feat: add new reCAPTCHA Enterprise fraud annotations
