### PR TITLE
Release Google.Cloud.Recommender.V1 version 2.7.0

### DIFF
--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.csproj
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library for the Recommender API, which provides usage recommendations for Cloud products and services.</Description>

--- a/apis/Google.Cloud.Recommender.V1/docs/history.md
+++ b/apis/Google.Cloud.Recommender.V1/docs/history.md
@@ -1,5 +1,8 @@
 # Version history
 
+## Version 2.7.0, released 2021-12-07
+
+- [Commit 35a1949](https://github.com/googleapis/google-cloud-dotnet/commit/35a1949): docs: fix docstring formatting
 ## Version 2.6.0, released 2021-09-01
 
 - [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2251,7 +2251,7 @@
       "protoPath": "google/cloud/recommender/v1",
       "productName": "Google Cloud Recommender",
       "productUrl": "https://cloud.google.com/recommender/",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "type": "grpc",
       "description": "Recommended Google client library for the Recommender API, which provides usage recommendations for Cloud products and services.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

- [Commit 35a1949](https://github.com/googleapis/google-cloud-dotnet/commit/35a1949): docs: fix docstring formatting
