### PR TITLE
Release Google.Cloud.Retail.V2 version 1.5.0

### DIFF
--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.csproj
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.4.0</Version>
+    <Version>1.5.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Cloud Retail service enables customers to build end-to-end personalized recommendation systems without requiring a high level of expertise in machine learning, recommendation system, or Google Cloud.</Description>

--- a/apis/Google.Cloud.Retail.V2/docs/history.md
+++ b/apis/Google.Cloud.Retail.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.5.0, released 2021-12-07
+
+- [Commit 2925818](https://github.com/googleapis/google-cloud-dotnet/commit/2925818):
+  - docs: Keep the API doc up-to-date
+  - feat: update grpc service config settings to reflect correct API deadlines
+- [Commit deb7506](https://github.com/googleapis/google-cloud-dotnet/commit/deb7506): docs: fix docstring formatting
 ## Version 1.4.0, released 2021-10-20
 
 - [Commit 3c5e164](https://github.com/googleapis/google-cloud-dotnet/commit/3c5e164):

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2338,7 +2338,7 @@
     },
     {
       "id": "Google.Cloud.Retail.V2",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "type": "grpc",
       "productName": "Retail",
       "productUrl": "https://cloud.google.com/retail/docs",


### PR DESCRIPTION

Changes in this release:

- [Commit 2925818](https://github.com/googleapis/google-cloud-dotnet/commit/2925818):
  - docs: Keep the API doc up-to-date
  - feat: update grpc service config settings to reflect correct API deadlines
- [Commit deb7506](https://github.com/googleapis/google-cloud-dotnet/commit/deb7506): docs: fix docstring formatting
