### PR TITLE
Release Google.Cloud.ServiceControl.V1 version 1.4.0

### DIFF
--- a/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1.csproj
+++ b/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Service Control API, which provides control plane functionality to managed services, such as logging, monitoring, and status checks.</Description>

--- a/apis/Google.Cloud.ServiceControl.V1/docs/history.md
+++ b/apis/Google.Cloud.ServiceControl.V1/docs/history.md
@@ -1,5 +1,8 @@
 # Version history
 
+## Version 1.4.0, released 2021-12-07
+
+- [Commit db2e28f](https://github.com/googleapis/google-cloud-dotnet/commit/db2e28f): docs: fix docstring formatting
 ## Version 1.3.0, released 2021-09-01
 
 - [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2512,7 +2512,7 @@
     },
     {
       "id": "Google.Cloud.ServiceControl.V1",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "type": "grpc",
       "productName": "Service Control",
       "productUrl": "https://cloud.google.com/service-infrastructure/docs/service-control/reference/rpc",


### PR DESCRIPTION

Changes in this release:

- [Commit db2e28f](https://github.com/googleapis/google-cloud-dotnet/commit/db2e28f): docs: fix docstring formatting
