### PR TITLE
Release Google.Cloud.ServiceUsage.V1 version 1.2.0

### DIFF
--- a/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1.csproj
+++ b/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Service Usage API, which enables services that service consumers want to use on Google Cloud Platform, lists the available or enabled services, or disables services that service consumers no longer use.</Description>

--- a/apis/Google.Cloud.ServiceUsage.V1/docs/history.md
+++ b/apis/Google.Cloud.ServiceUsage.V1/docs/history.md
@@ -1,5 +1,8 @@
 # Version history
 
+## Version 1.2.0, released 2021-12-07
+
+- [Commit 66b9405](https://github.com/googleapis/google-cloud-dotnet/commit/66b9405): docs: Remove erroneous space in a docstring
 ## Version 1.1.0, released 2021-09-06
 
 - [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2585,7 +2585,7 @@
     },
     {
       "id": "Google.Cloud.ServiceUsage.V1",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "type": "grpc",
       "productName": "Service Usage",
       "productUrl": "https://cloud.google.com/service-usage/docs/",


### PR DESCRIPTION

Changes in this release:

- [Commit 66b9405](https://github.com/googleapis/google-cloud-dotnet/commit/66b9405): docs: Remove erroneous space in a docstring
