### PR TITLE
Release Google.Cloud.Speech.V1P1Beta1 version 2.0.0-beta07

### DIFF
--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.csproj
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta06</Version>
+    <Version>2.0.0-beta07</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google client library to access the Google Cloud Speech API version v1p1beta1 with upcoming features.</Description>

--- a/apis/Google.Cloud.Speech.V1P1Beta1/docs/history.md
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 2.0.0-beta07, released 2021-12-07
+
+- [Commit bc7d94d](https://github.com/googleapis/google-cloud-dotnet/commit/bc7d94d): feat: add result_end_time to SpeechRecognitionResult
+
 ## Version 2.0.0-beta06, released 2021-09-23
 
 - [Commit 3f9793d](https://github.com/googleapis/google-cloud-dotnet/commit/3f9793d): feat: Add transcript normalization

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2754,7 +2754,7 @@
       "protoPath": "google/cloud/speech/v1p1beta1",
       "productName": "Google Cloud Speech",
       "productUrl": "https://cloud.google.com/speech",
-      "version": "2.0.0-beta06",
+      "version": "2.0.0-beta07",
       "releaseLevelOverride": "beta",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",


### PR DESCRIPTION

Changes in this release:

- [Commit bc7d94d](https://github.com/googleapis/google-cloud-dotnet/commit/bc7d94d): feat: add result_end_time to SpeechRecognitionResult
