### PR TITLE
Release Google.Cloud.Talent.V4Beta1 version 2.0.0-beta07

### DIFF
--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.csproj
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta06</Version>
+    <Version>2.0.0-beta07</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Talent solution API (v4 beta1) which provides the capability to create, read, update, and delete job postings, as well as search jobs based on keywords and filters.</Description>

--- a/apis/Google.Cloud.Talent.V4Beta1/docs/history.md
+++ b/apis/Google.Cloud.Talent.V4Beta1/docs/history.md
@@ -1,5 +1,8 @@
 # Version history
 
+## Version 2.0.0-beta07, released 2021-12-07
+
+- [Commit 54f0341](https://github.com/googleapis/google-cloud-dotnet/commit/54f0341): docs: fix docstring formatting
 ## Version 2.0.0-beta06, released 2021-09-06
 
 - [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2833,7 +2833,7 @@
       "protoPath": "google/cloud/talent/v4beta1",
       "productName": "Google Cloud Talent Solution",
       "productUrl": "https://cloud.google.com/talent-solution/",
-      "version": "2.0.0-beta06",
+      "version": "2.0.0-beta07",
       "releaseLevelOverride": "beta",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Talent solution API (v4 beta1) which provides the capability to create, read, update, and delete job postings, as well as search jobs based on keywords and filters.",


### PR DESCRIPTION

Changes in this release:

- [Commit 54f0341](https://github.com/googleapis/google-cloud-dotnet/commit/54f0341): docs: fix docstring formatting
