### PR TITLE
feat: First pass at prettier release notes

### DIFF
--- a/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/KnownCommitsCriterion.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/KnownCommitsCriterion.cs
@@ -43,7 +43,7 @@ namespace Google.Cloud.Tools.ReleaseManager.BatchRelease
             foreach (var api in catalog.Apis)
             {
                 var pendingChanges = pendingChangesByApi[api];
-                var pendingCommits = pendingChanges.Commits.Select(commit => commit.Hash);
+                var pendingCommits = pendingChanges.Commits.Select(commit => commit.HashPrefix);
                 if (!Commits.SetEquals(pendingCommits))
                 {
                     continue;

--- a/tools/Google.Cloud.Tools.ReleaseManager/CommitCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/CommitCommand.cs
@@ -56,6 +56,10 @@ namespace Google.Cloud.Tools.ReleaseManager
             {
                 throw new UserErrorException($"Unable to find history file section for {diff.NewVersion}. Cannot automate a release commit in this state.");
             }
+            if (section.Lines.Any(line => line.Contains(HistoryFile.FixmeBlockingRelease)))
+            {
+                throw new UserErrorException("History file requires editing before release");
+            }
 
             string header = $"Release {diff.Id} version {diff.NewVersion}";
             var message = string.Join("\n", new[] { header, "", "Changes in this release:", "" }.Concat(section.Lines.Skip(2)));

--- a/tools/Google.Cloud.Tools.ReleaseManager/GitHelpers.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/GitHelpers.cs
@@ -95,7 +95,8 @@ namespace Google.Cloud.Tools.ReleaseManager
         internal static DateTimeOffset GetDate(this Commit commit) =>
             (commit.Author ?? commit.Committer).When;
 
-        internal static string GetHashPrefix(this Commit commit) => commit.Sha.Substring(0, 7);
+        internal static string GetHashPrefix(this Commit commit) => GetHashPrefix(commit.Sha);
+        internal static string GetHashPrefix(string hash) => hash.Substring(0, 7);
 
         /// <summary>
         /// Gets the set of pending changes for each API. Note that the release in the dictionary value

--- a/tools/Google.Cloud.Tools.ReleaseManager/History/ReleaseNoteElement.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/History/ReleaseNoteElement.cs
@@ -1,0 +1,95 @@
+﻿// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Text;
+
+namespace Google.Cloud.Tools.ReleaseManager.History
+{
+    /// <summary>
+    /// One element of a release note, representing a single feature, fix etc.
+    /// </summary>
+    internal sealed class ReleaseNoteElement
+    {
+        /// <summary>
+        /// The commit within google-cloud-dotnet responsible for the change.
+        /// </summary>
+        public string CommitHash { get; }
+
+        /// <summary>
+        /// The type of the element, as derived from the conventional commit.
+        /// </summary>
+        public ReleaseNoteElementType Type { get; }
+
+        /// <summary>
+        /// Whether or not this is a breaking change.
+        /// </summary>
+        public bool BreakingChange { get; }
+
+        /// <summary>
+        /// The text of the element, not including any conventional commit prefix.
+        /// </summary>
+        public string Text { get; }
+
+        private ReleaseNoteElement(string commitHash, string text, ReleaseNoteElementType type, bool breakingChange) =>
+            (CommitHash, Text, Type, BreakingChange) = (commitHash, text, type, breakingChange);
+
+        public override string ToString()
+        {
+            StringBuilder builder = new StringBuilder();
+            if (BreakingChange)
+            {
+                builder.Append("**BREAKING CHANGE** ");
+            }
+            builder.Append(Text);
+            builder.Append($" ([commit {GitHelpers.GetHashPrefix(CommitHash)}](https://github.com/googleapis/google-cloud-dotnet/commit/{CommitHash}))");
+            return builder.ToString();
+        }
+
+        /// <summary>
+        /// Parses the given text, expecting it to be a conventional commit message.
+        /// </summary>
+        /// <param name="text">The message</param>
+        /// <param name="hash">The git commit hash that this element is part of.</param>
+        /// <returns>The parsed release note element</returns>
+        public static ReleaseNoteElement Parse(string hash, string text)
+        {
+            string[] parts = text.Split(':', 2);
+
+            if (parts.Length == 1)
+            {
+                // Note a conventional commit message. Register it as unknown,
+                // and let a human sort it out.
+                return new ReleaseNoteElement(hash, text, ReleaseNoteElementType.Unknown, false);
+            }
+            string prefix = parts[0];
+            bool breakingChange = prefix.Contains('!');
+            ReleaseNoteElementType type = prefix.Replace("!", "").Split('(')[0] switch
+            {
+                "feat" => ReleaseNoteElementType.Feature,
+                "fix" => ReleaseNoteElementType.Fix,
+                "chore" => ReleaseNoteElementType.Chore,
+                "docs" => ReleaseNoteElementType.Docs,
+                "doc"  => ReleaseNoteElementType.Docs,
+                _ => ReleaseNoteElementType.Unknown
+            };
+            string message = parts[1].Trim();
+            if (message == "")
+            {
+                message = "(No details.)";
+            }
+            message = char.ToUpperInvariant(message[0]) + message.Substring(1);
+            return new ReleaseNoteElement(hash, message, type, breakingChange);
+        }
+    }
+}

--- a/tools/Google.Cloud.Tools.ReleaseManager/History/ReleaseNoteElementType.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/History/ReleaseNoteElementType.cs
@@ -1,0 +1,29 @@
+﻿// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Google.Cloud.Tools.ReleaseManager.History
+{
+    /// <summary>
+    /// Note: the ordering here is the order in which the results are shown in the
+    /// release notes.
+    /// </summary>
+    internal enum ReleaseNoteElementType
+    {
+        Fix,
+        Feature,
+        Docs,
+        Chore,
+        Unknown,
+    }
+}


### PR DESCRIPTION
These are used in both the version histories and the GitHub release
pages.

This currently assumes that every line in a production code commit
message is a feature/fix/etc. In reality, we'll need to handle
comments like the one on this commit, which are longer - but that
should be reasonably rare, and easily done by hand.

"Chore" commits are discarded, but any other commits with unknown
(or missing) conventional commit types end up in a section of the
history document which prevents ReleaseManager from committing until
it's cleaned up.