### PR TITLE
tests(Translate): Reduce the size of the large text to translate.

### DIFF
--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.IntegrationTests/AdvancedTranslationClientTest.cs
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.IntegrationTests/AdvancedTranslationClientTest.cs
@@ -20,7 +20,7 @@ namespace Google.Cloud.Translation.V2.IntegrationTests
     public class AdvancedTranslationClientTest
     {
         private static readonly string LargeText = TranslationClientTest.LoadResource("independence.txt");
-        private const int ApiLimit = 100 * 1024;
+        private const int ApiLimit = 30 * 1024;
         private static readonly string VeryLargeText = string.Join("\n", Enumerable.Repeat(LargeText, ApiLimit / LargeText.Length));
 
         [Fact]

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.IntegrationTests/TranslationClientTest.cs
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.IntegrationTests/TranslationClientTest.cs
@@ -23,7 +23,7 @@ namespace Google.Cloud.Translation.V2.IntegrationTests
     public class TranslationClientTest
     {
         private static readonly string LargeText = LoadResource("independence.txt");
-        private const int ApiLimit = 100 * 1024;
+        private const int ApiLimit = 30 * 1024;
         private static readonly string VeryLargeText = string.Join("\n", Enumerable.Repeat(LargeText, ApiLimit / LargeText.Length));
 
         [Fact]


### PR DESCRIPTION
Translating our original large text has started failing with 503. We are looking into this internally.