### PR TITLE
fix: Adds AddGoogleDiagnostics empty overload.

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/DiagnosticsTests.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore/Google.Cloud.Diagnostics.AspNetCore.IntegrationTests/DiagnosticsTests.cs
@@ -65,7 +65,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
             using var client = server.CreateClient();
             await TestTrace(testId, startTime, client);
             await TestLogging(testId, startTime, client);
-            await TestErrorReporting(testId, client);
+            await TestErrorReporting(testId, client, verifyServiceAndVersion: false);
         }
 
         [Fact]
@@ -182,7 +182,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore.IntegrationTests
             Assert.False(response.Headers.Contains(TraceHeaderContext.TraceHeader));
         }
 
-        private static async Task TestErrorReporting(string testId, HttpClient client)
+        private static async Task TestErrorReporting(string testId, HttpClient client, bool verifyServiceAndVersion = true)
         {
             await Assert.ThrowsAsync<Exception>(() => client.GetAsync($"/ErrorReporting/{nameof(ErrorReportingController.ThrowsException)}/{testId}"));
             var errorEvent = ErrorEventEntryVerifiers.VerifySingle(ErrorEventEntryPolling.Default, testId);

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/ErrorReporting/ErrorEventEntryVerifiers.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/ErrorReporting/ErrorEventEntryVerifiers.cs
@@ -50,9 +50,10 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
         /// Checks that an <see cref="ErrorEvent"/> contains valid data,
         /// including HTTP Context data.
         /// </summary>
-        public static void VerifyFullErrorEventLogged(ErrorEvent errorEvent, string testId, string functionName, bool verifyHttpContext = true)
+        public static void VerifyFullErrorEventLogged(ErrorEvent errorEvent, string testId, string functionName,
+            bool verifyHttpContext = true, bool verifyServiceAndVersion = true)
         {
-            VerifyErrorEventLogged(errorEvent, testId, functionName);
+            VerifyErrorEventLogged(errorEvent, testId, functionName, verifyServiceAndVersion);
             if (verifyHttpContext)
             {
                 VerifyHttpContextLogged(errorEvent);
@@ -66,10 +67,13 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
         /// Google.Cloud.Diagnostics.GoogleExceptionLogger is used instead of the
         /// Google.Cloud.Diagnostics.GoogleWebApiExceptionLogger.
         /// </summary>
-        public static void VerifyErrorEventLogged(ErrorEvent errorEvent, string testId, string functionName)
+        public static void VerifyErrorEventLogged(ErrorEvent errorEvent, string testId, string functionName, bool verifyServiceAndVersion = true)
         {
-            Assert.Equal(EntryData.Service, errorEvent.ServiceContext.Service);
-            Assert.Equal(EntryData.Version, errorEvent.ServiceContext.Version);
+            if (verifyServiceAndVersion)
+            {
+                Assert.Equal(EntryData.Service, errorEvent.ServiceContext.Service);
+                Assert.Equal(EntryData.Version, errorEvent.ServiceContext.Version);
+            }
 
             Assert.Contains(functionName, errorEvent.Message);
             Assert.Contains(testId, errorEvent.Message);

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/GoogleDiagnosticsExtensions.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/GoogleDiagnosticsExtensions.cs
@@ -25,6 +25,21 @@ namespace Google.Cloud.Diagnostics.Common
         /// Configures Google Diagnostics to be used in non ASP.NET Core applications.
         /// </summary>
         /// <remarks>
+        /// Note that the Google Cloud Project ID to use is required and it can only be
+        /// obtained from the environment if running on GCP. This means that this overload
+        /// can only be used when running on GCP. If you are not running on GCP or need to specify
+        /// the Google Cloud Project ID, you can use any of
+        /// <see cref="AddGoogleDiagnostics(IServiceCollection, TraceServiceOptions, LoggingServiceOptions, ErrorReportingServiceOptions)"/>
+        /// or 
+        /// <see cref="AddGoogleDiagnostics(IServiceCollection, string, string, string, TraceOptions, LoggingOptions, ErrorReportingOptions)"/>.
+        /// </remarks>
+        public static IServiceCollection AddGoogleDiagnostics(this IServiceCollection services) =>
+            services.AddGoogleDiagnostics((TraceServiceOptions)null);
+
+        /// <summary>
+        /// Configures Google Diagnostics to be used in non ASP.NET Core applications.
+        /// </summary>
+        /// <remarks>
         /// Options may be null in which case defaults will be used. Note that the
         /// Google Cloud Project ID to use is required. If not set via options, it will be
         /// obtained from the environment, but only if running on GCP.


### PR DESCRIPTION
To avoid ambiguity, which results in a compiler error, when not specifying any of the optional parameters for the other overloads.
This is the same as what was done on #7642 for the ASP.NET Core packages, but for the Common package instead, which had the same issue.