### PR TITLE
Release Google.Cloud.Compute.V1 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.Compute.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.Compute.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.Compute.V1",
-  "release_level": "preview",
+  "release_level": "stable",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Compute.V1/latest",
   "library_type": "GAPIC_AUTO",
   "api_shortname": "compute"

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta06</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Compute Engine API.</Description>

--- a/apis/Google.Cloud.Compute.V1/docs/history.md
+++ b/apis/Google.Cloud.Compute.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0, released 2022-01-11
+
+No API surface changes; just dependency updates for first GA release.
+
 ## Version 1.0.0-beta06, released 2021-12-06
 
 - [Commit 25e54fa](https://github.com/googleapis/google-cloud-dotnet/commit/25e54fa): fix!: handle GCP enum name start with uppercase IPProtocol

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -635,7 +635,7 @@
     },
     {
       "id": "Google.Cloud.Compute.V1",
-      "version": "1.0.0-beta06",
+      "version": "1.0.0",
       "type": "regapic",
       "productName": "Compute Engine",
       "productUrl": "https://cloud.google.com/compute",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates for first GA release.
