### PR TITLE
Use service version instead of name

### DIFF
--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/ErrorReporting/ErrorReportingContextExceptionLogger.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/ErrorReporting/ErrorReportingContextExceptionLogger.cs
@@ -77,7 +77,7 @@ namespace Google.Cloud.Diagnostics.Common
 
             var serviceContext = CreateServiceContext(
                 Project.GetServiceName(options.ServiceName, errorReportingOptions.MonitoredResource),
-                Project.GetServiceName(options.Version, errorReportingOptions.MonitoredResource))
+                Project.GetServiceVersion(options.Version, errorReportingOptions.MonitoredResource))
                 ?? new Struct();
 
             IConsumer<LogEntry> consumer = LogConsumer.Create(client, errorReportingOptions.BufferOptions, errorReportingOptions.RetryOptions);


### PR DESCRIPTION
In [this refactor](https://github.com/googleapis/google-cloud-dotnet/commit/6e34e22a0666dadc7a7a1d7645415220c7939d48#diff-09fd4adfdaa66895eb50b1b0f516edd5b7464563e10b4df1f2266e17edc2f460L76-R81) `Project.GetServiceName` is accidentally used for the service _version_ rather than the `Project.GetServiceVersion` method. This causes Google Cloud Error Reporting to use the service name for both the name and version when they're detected from the platform.

cc @amanda-tarafa 