### PR TITLE
chore: Ignore GeneratedSnippets when generating libraries.

### DIFF
--- a/generateapis.sh
+++ b/generateapis.sh
@@ -126,6 +126,7 @@ generate_microgenerator() {
 
   # Remove the newly generated standalone snippets until they are ready for surfacing.
   rm -rf $API_TMP_DIR/$1.StandaloneSnippets
+  rm -rf $API_TMP_DIR/$1.GeneratedSnippets
 
   # We generate our own project files
   rm $(find tmp -name '*.csproj')

--- a/owl-bot-post-processor/main.sh
+++ b/owl-bot-post-processor/main.sh
@@ -74,6 +74,7 @@ copy_one_api() {
 
   # Remove the newly generated standalone snippets until they are ready for surfacing.
   rm -rf "$STAGING_DIR/$1.StandaloneSnippets"
+  rm -rf "$STAGING_DIR/$1.GeneratedSnippets"
 
   # We generate our own project files
   rm -f $(find "$STAGING_DIR" -name '*.csproj')


### PR DESCRIPTION
This is so we can change StandaloneSnippets to GeneratedSnippets.