### PR TITLE
Release Google.Analytics.Admin.V1Alpha version 1.0.0-alpha10

### DIFF
--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha09</Version>
+    <Version>1.0.0-alpha10</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Analytics Admin API (v1alpha)</Description>

--- a/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
+++ b/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
@@ -1,5 +1,22 @@
 # Version history
 
+## Version 1.0.0-alpha10, released 2022-01-17
+
+### Bug fixes
+
+- **BREAKING CHANGE** Remove `GetEnhancedMeasurementSettings`, `UpdateEnhancedMeasurementSettingsRequest`, `UpdateEnhancedMeasurementSettingsRequest` operations from the API ([commit 2a70fba](https://github.com/googleapis/google-cloud-dotnet/commit/2a70fbab54fb4c9fdac5b742a382e0f17b73d853))
+
+### New features
+
+- Add the `AcknowledgeUserDataCollection` operation which acknowledges the terms of user data collection for the specified property ([commit 2a70fba](https://github.com/googleapis/google-cloud-dotnet/commit/2a70fbab54fb4c9fdac5b742a382e0f17b73d853))
+- Add the new resource type `DataStream`, which is planned to eventually replace `WebDataStream`, `IosAppDataStream`, `AndroidAppDataStream` resources ([commit 2a70fba](https://github.com/googleapis/google-cloud-dotnet/commit/2a70fbab54fb4c9fdac5b742a382e0f17b73d853))
+- Add `CreateDataStream`, `DeleteDataStream`, `UpdateDataStream`, `ListDataStreams` operations to support the new `DataStream` resource ([commit 2a70fba](https://github.com/googleapis/google-cloud-dotnet/commit/2a70fbab54fb4c9fdac5b742a382e0f17b73d853))
+- Add `DISPLAY_VIDEO_360_ADVERTISER_LINK`,  `DISPLAY_VIDEO_360_ADVERTISER_LINK_PROPOSAL` fields to `ChangeHistoryResourceType` enum ([commit 2a70fba](https://github.com/googleapis/google-cloud-dotnet/commit/2a70fbab54fb4c9fdac5b742a382e0f17b73d853))
+- Add the `account` field to the `Property` type ([commit 2a70fba](https://github.com/googleapis/google-cloud-dotnet/commit/2a70fbab54fb4c9fdac5b742a382e0f17b73d853))
+
+### Documentation improvements
+
+- Update the documentation with a new list of valid values for `UserLink.direct_roles` field ([commit 2a70fba](https://github.com/googleapis/google-cloud-dotnet/commit/2a70fbab54fb4c9fdac5b742a382e0f17b73d853))
 ## Version 1.0.0-alpha09, released 2021-09-23
 
 - [Commit 31dfcff](https://github.com/googleapis/google-cloud-dotnet/commit/31dfcff):

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2,7 +2,7 @@
   "apis": [
     {
       "id": "Google.Analytics.Admin.V1Alpha",
-      "version": "1.0.0-alpha09",
+      "version": "1.0.0-alpha10",
       "type": "grpc",
       "productName": "Analytics Admin",
       "productUrl": "https://developers.google.com/analytics",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- **BREAKING CHANGE** Remove `GetEnhancedMeasurementSettings`, `UpdateEnhancedMeasurementSettingsRequest`, `UpdateEnhancedMeasurementSettingsRequest` operations from the API ([commit 2a70fba](https://github.com/googleapis/google-cloud-dotnet/commit/2a70fbab54fb4c9fdac5b742a382e0f17b73d853))

### New features

- Add the `AcknowledgeUserDataCollection` operation which acknowledges the terms of user data collection for the specified property ([commit 2a70fba](https://github.com/googleapis/google-cloud-dotnet/commit/2a70fbab54fb4c9fdac5b742a382e0f17b73d853))
- Add the new resource type `DataStream`, which is planned to eventually replace `WebDataStream`, `IosAppDataStream`, `AndroidAppDataStream` resources ([commit 2a70fba](https://github.com/googleapis/google-cloud-dotnet/commit/2a70fbab54fb4c9fdac5b742a382e0f17b73d853))
- Add `CreateDataStream`, `DeleteDataStream`, `UpdateDataStream`, `ListDataStreams` operations to support the new `DataStream` resource ([commit 2a70fba](https://github.com/googleapis/google-cloud-dotnet/commit/2a70fbab54fb4c9fdac5b742a382e0f17b73d853))
- Add `DISPLAY_VIDEO_360_ADVERTISER_LINK`,  `DISPLAY_VIDEO_360_ADVERTISER_LINK_PROPOSAL` fields to `ChangeHistoryResourceType` enum ([commit 2a70fba](https://github.com/googleapis/google-cloud-dotnet/commit/2a70fbab54fb4c9fdac5b742a382e0f17b73d853))
- Add the `account` field to the `Property` type ([commit 2a70fba](https://github.com/googleapis/google-cloud-dotnet/commit/2a70fbab54fb4c9fdac5b742a382e0f17b73d853))

### Documentation improvements

- Update the documentation with a new list of valid values for `UserLink.direct_roles` field ([commit 2a70fba](https://github.com/googleapis/google-cloud-dotnet/commit/2a70fbab54fb4c9fdac5b742a382e0f17b73d853))
