### PR TITLE
chore: Fix use of commit overrides file

### DIFF
--- a/tools/Google.Cloud.Tools.ReleaseManager/History/GitCommit.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/History/GitCommit.cs
@@ -64,7 +64,7 @@ namespace Google.Cloud.Tools.ReleaseManager.History
         internal IEnumerable<ReleaseNoteElement> GetReleaseNoteElements()
         {
             // Use the override if one has been provided for this commit, or the commit message otherwise.
-            string message = CommitOverrides.HashPrefixToMessageMap.GetValueOrDefault(Hash, _libGit2Commit.Message);
+            string message = CommitOverrides.HashPrefixToMessageMap.GetValueOrDefault(HashPrefix, _libGit2Commit.Message);
 
             var messageLines = SplitCommitMessage(message);
 

--- a/tools/Google.Cloud.Tools.ReleaseManager/History/overrides.json
+++ b/tools/Google.Cloud.Tools.ReleaseManager/History/overrides.json
@@ -30,4 +30,5 @@
   "5105bbd": "skip", // Regenerate for retry status code documentation
   "b56517e": "skip", // Regenerate with updated protobuf
   "8fb35a3": "skip", // Regenerate with more .g.cs extensions
+  "44186b5": "skip", // Update copyright year (2022)
 }


### PR DESCRIPTION
(This was broken when we started generating "smarter" release notes.)