### PR TITLE
Release Google.Cloud.AutoML.V1 version 2.5.0

### DIFF
--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.csproj
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.4.0</Version>
+    <Version>2.5.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AutoML API, which allows you to train high-quality custom machine learning models with minimal effort and machine learning expertise.</Description>
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.6.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.3.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.41.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.AutoML.V1/docs/history.md
+++ b/apis/Google.Cloud.AutoML.V1/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 2.5.0, released 2022-01-17
+
+### Bug fixes
+
+- Proto field markdown comment for the display_name field in annotation_payload.proto to point the correct public v1/ version ([commit c26a158](https://github.com/googleapis/google-cloud-dotnet/commit/c26a15832ac35576ec09cf8f54e18170443dd8bf))
+- Add back java_multiple_files option to the text_sentiment.proto to match with the previous published version of text_sentiment proto ([commit c26a158](https://github.com/googleapis/google-cloud-dotnet/commit/c26a15832ac35576ec09cf8f54e18170443dd8bf))
+- **BREAKING CHANGE** One of the fields now have field_behavior as REQUIRED in cloud/automl/v1 service definition. ([commit b1398f1](https://github.com/googleapis/google-cloud-dotnet/commit/b1398f19035a33d46b0574b486aaf6d80fe86b6e))
+
+### New features
+
+- Publish updated protos for cloud/automl/v1 service ([commit b1398f1](https://github.com/googleapis/google-cloud-dotnet/commit/b1398f19035a33d46b0574b486aaf6d80fe86b6e))
+
 ## Version 2.4.0, released 2021-12-07
 
 - [Commit f182ed9](https://github.com/googleapis/google-cloud-dotnet/commit/f182ed9): docs: fix docstring formatting

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -287,13 +287,13 @@
       "protoPath": "google/cloud/automl/v1",
       "productName": "Google AutoML",
       "productUrl": "https://cloud.google.com/automl/",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the AutoML API, which allows you to train high-quality custom machine learning models with minimal effort and machine learning expertise.",
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.6.0",
         "Google.LongRunning": "2.3.0",
-        "Grpc.Core": "2.38.1"
+        "Grpc.Core": "2.41.0"
       },
       "tags": [
         "automl",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Proto field markdown comment for the display_name field in annotation_payload.proto to point the correct public v1/ version ([commit c26a158](https://github.com/googleapis/google-cloud-dotnet/commit/c26a15832ac35576ec09cf8f54e18170443dd8bf))
- Add back java_multiple_files option to the text_sentiment.proto to match with the previous published version of text_sentiment proto ([commit c26a158](https://github.com/googleapis/google-cloud-dotnet/commit/c26a15832ac35576ec09cf8f54e18170443dd8bf))
- **BREAKING CHANGE** One of the fields now have field_behavior as REQUIRED in cloud/automl/v1 service definition. ([commit b1398f1](https://github.com/googleapis/google-cloud-dotnet/commit/b1398f19035a33d46b0574b486aaf6d80fe86b6e))

### New features

- Publish updated protos for cloud/automl/v1 service ([commit b1398f1](https://github.com/googleapis/google-cloud-dotnet/commit/b1398f19035a33d46b0574b486aaf6d80fe86b6e))
