### PR TITLE
Release Google.Cloud.Dataproc.V1 version 3.4.0

### DIFF
--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.csproj
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.3.0</Version>
+    <Version>3.4.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Dataproc API, which manages Hadoop-based clusters and jobs on Google Cloud Platform.</Description>
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.6.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.3.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.41.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Dataproc.V1/docs/history.md
+++ b/apis/Google.Cloud.Dataproc.V1/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 3.4.0, released 2022-01-17
+
+### New features
+
+- Spark runtime versioning for Spark batches ([commit b6189ae](https://github.com/googleapis/google-cloud-dotnet/commit/b6189aeaa81e283d7eb9d0cd1652f5b594db2d0a))
+- Custom image containers for Spark batches ([commit b6189ae](https://github.com/googleapis/google-cloud-dotnet/commit/b6189aeaa81e283d7eb9d0cd1652f5b594db2d0a))
+- Auto-diagnostic of failed Spark batches ([commit b6189ae](https://github.com/googleapis/google-cloud-dotnet/commit/b6189aeaa81e283d7eb9d0cd1652f5b594db2d0a))
+- Local SSD NVME interface support for GCE clusters ([commit b6189ae](https://github.com/googleapis/google-cloud-dotnet/commit/b6189aeaa81e283d7eb9d0cd1652f5b594db2d0a))
 ## Version 3.3.0, released 2021-10-14
 
 - [Commit 7c1e526](https://github.com/googleapis/google-cloud-dotnet/commit/7c1e526): feat: add Dataproc Serverless for Spark Batches API

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -786,7 +786,7 @@
       "protoPath": "google/cloud/dataproc/v1",
       "productName": "Google Cloud Dataproc",
       "productUrl": "https://cloud.google.com/dataproc/docs/concepts/overview",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Dataproc API, which manages Hadoop-based clusters and jobs on Google Cloud Platform.",
       "tags": [
@@ -794,9 +794,9 @@
         "Hadoop"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.6.0",
         "Google.LongRunning": "2.3.0",
-        "Grpc.Core": "2.38.1"
+        "Grpc.Core": "2.41.0"
       },
       "shortName": "dataproc"
     },


### PR DESCRIPTION

Changes in this release:

### New features

- Spark runtime versioning for Spark batches ([commit b6189ae](https://github.com/googleapis/google-cloud-dotnet/commit/b6189aeaa81e283d7eb9d0cd1652f5b594db2d0a))
- Custom image containers for Spark batches ([commit b6189ae](https://github.com/googleapis/google-cloud-dotnet/commit/b6189aeaa81e283d7eb9d0cd1652f5b594db2d0a))
- Auto-diagnostic of failed Spark batches ([commit b6189ae](https://github.com/googleapis/google-cloud-dotnet/commit/b6189aeaa81e283d7eb9d0cd1652f5b594db2d0a))
- Local SSD NVME interface support for GCE clusters ([commit b6189ae](https://github.com/googleapis/google-cloud-dotnet/commit/b6189aeaa81e283d7eb9d0cd1652f5b594db2d0a))
