### PR TITLE
Release Google.Cloud.Dialogflow.V2 version 3.9.0

### DIFF
--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.csproj
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.8.0</Version>
+    <Version>3.9.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Dialogflow API.</Description>
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.6.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.3.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.41.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Dialogflow.V2/docs/history.md
+++ b/apis/Google.Cloud.Dialogflow.V2/docs/history.md
@@ -1,5 +1,20 @@
 # Version history
 
+## Version 3.9.0, released 2022-01-17
+
+### New features
+
+- Added export documentation method ([commit 46cbdd5](https://github.com/googleapis/google-cloud-dotnet/commit/46cbdd55de24ce6ca9560c16458322c4bbf16ab5))
+- Added filter in list documentations request ([commit 46cbdd5](https://github.com/googleapis/google-cloud-dotnet/commit/46cbdd55de24ce6ca9560c16458322c4bbf16ab5))
+- Added option to import custom metadata from Google Cloud Storage in reload document request ([commit 46cbdd5](https://github.com/googleapis/google-cloud-dotnet/commit/46cbdd55de24ce6ca9560c16458322c4bbf16ab5))
+- Added option to apply partial update to the smart messaging allowlist in reload document request ([commit 46cbdd5](https://github.com/googleapis/google-cloud-dotnet/commit/46cbdd55de24ce6ca9560c16458322c4bbf16ab5))
+- Added filter in list knowledge bases request ([commit 46cbdd5](https://github.com/googleapis/google-cloud-dotnet/commit/46cbdd55de24ce6ca9560c16458322c4bbf16ab5))
+- Removed OPTIONAL for speech model variant ([commit 853d986](https://github.com/googleapis/google-cloud-dotnet/commit/853d98625a880a54c32b07d87f47924a7d65f84e))
+
+### Documentation improvements
+
+- Added more docs for speech model variant and improved docs format for participant ([commit 853d986](https://github.com/googleapis/google-cloud-dotnet/commit/853d98625a880a54c32b07d87f47924a7d65f84e))
+
 ## Version 3.8.0, released 2021-11-18
 
 - [Commit d033f77](https://github.com/googleapis/google-cloud-dotnet/commit/d033f77): feat: support document metadata filter in article suggestion and smart reply model in human agent assistant

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1048,7 +1048,7 @@
       "protoPath": "google/cloud/dialogflow/v2",
       "productName": "Google Cloud Dialogflow",
       "productUrl": "https://cloud.google.com/dialogflow-enterprise/",
-      "version": "3.8.0",
+      "version": "3.9.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Dialogflow API.",
       "tags": [
@@ -1056,9 +1056,9 @@
         "iot"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.6.0",
         "Google.LongRunning": "2.3.0",
-        "Grpc.Core": "2.38.1"
+        "Grpc.Core": "2.41.0"
       },
       "testDependencies": {
         "Microsoft.AspNetCore.Mvc.Core": "2.1.16"


### PR DESCRIPTION

Changes in this release:

### New features

- Added export documentation method ([commit 46cbdd5](https://github.com/googleapis/google-cloud-dotnet/commit/46cbdd55de24ce6ca9560c16458322c4bbf16ab5))
- Added filter in list documentations request ([commit 46cbdd5](https://github.com/googleapis/google-cloud-dotnet/commit/46cbdd55de24ce6ca9560c16458322c4bbf16ab5))
- Added option to import custom metadata from Google Cloud Storage in reload document request ([commit 46cbdd5](https://github.com/googleapis/google-cloud-dotnet/commit/46cbdd55de24ce6ca9560c16458322c4bbf16ab5))
- Added option to apply partial update to the smart messaging allowlist in reload document request ([commit 46cbdd5](https://github.com/googleapis/google-cloud-dotnet/commit/46cbdd55de24ce6ca9560c16458322c4bbf16ab5))
- Added filter in list knowledge bases request ([commit 46cbdd5](https://github.com/googleapis/google-cloud-dotnet/commit/46cbdd55de24ce6ca9560c16458322c4bbf16ab5))
- Removed OPTIONAL for speech model variant ([commit 853d986](https://github.com/googleapis/google-cloud-dotnet/commit/853d98625a880a54c32b07d87f47924a7d65f84e))

### Documentation improvements

- Added more docs for speech model variant and improved docs format for participant ([commit 853d986](https://github.com/googleapis/google-cloud-dotnet/commit/853d98625a880a54c32b07d87f47924a7d65f84e))
