### PR TITLE
Release Google.Cloud.Redis.V1Beta1 version 2.0.0-beta07

### DIFF
--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.csproj
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta06</Version>
+    <Version>2.0.0-beta07</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to administer Cloud Memorystore for Redis (V1 Beta 1 API).</Description>

--- a/apis/Google.Cloud.Redis.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.Redis.V1Beta1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.0.0-beta07, released 2022-01-17
+
+### Bug fixes
+
+- [Cloud Memorystore for Redis] Add missing fields for TLS and Maintenance Window features ([commit 7dc9e4c](https://github.com/googleapis/google-cloud-dotnet/commit/7dc9e4c2ddf74ef3ab49b137df07af8c9a57a517))
+
 ## Version 2.0.0-beta06, released 2021-11-10
 
 - [Commit bdfaff0](https://github.com/googleapis/google-cloud-dotnet/commit/bdfaff0): feat: Support Multiple Read Replicas when creating Instance

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2407,7 +2407,7 @@
       "protoPath": "google/cloud/redis/v1beta1",
       "productName": "Google Cloud Memorystore for Redis",
       "productUrl": "https://cloud.google.com/memorystore/",
-      "version": "2.0.0-beta06",
+      "version": "2.0.0-beta07",
       "releaseLevelOverride": "preview",
       "type": "grpc",
       "description": "Recommended Google client library to administer Cloud Memorystore for Redis (V1 Beta 1 API).",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- [Cloud Memorystore for Redis] Add missing fields for TLS and Maintenance Window features ([commit 7dc9e4c](https://github.com/googleapis/google-cloud-dotnet/commit/7dc9e4c2ddf74ef3ab49b137df07af8c9a57a517))
