### PR TITLE
Release Google.Cloud.TextToSpeech.V1Beta1 version 1.0.0-beta04

### DIFF
--- a/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.csproj
+++ b/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta03</Version>
+    <Version>1.0.0-beta04</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Text-to-Speech API v1beta1, synthesizes natural-sounding speech by applying powerful neural network models.</Description>

--- a/apis/Google.Cloud.TextToSpeech.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.TextToSpeech.V1Beta1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta04, released 2022-01-17
+
+### Documentation improvements
+
+- Update comments for ListVoicesRequest ([commit d517082](https://github.com/googleapis/google-cloud-dotnet/commit/d517082c8a79b3fb61f176cd95b65507fd6f5cb6))
+
 ## Version 1.0.0-beta03, released 2021-11-18
 
 - [Commit 2260d7c](https://github.com/googleapis/google-cloud-dotnet/commit/2260d7c):

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3050,7 +3050,7 @@
     },
     {
       "id": "Google.Cloud.TextToSpeech.V1Beta1",
-      "version": "1.0.0-beta03",
+      "version": "1.0.0-beta04",
       "type": "grpc",
       "productName": "Google Cloud Text-to-Speech",
       "productUrl": "https://cloud.google.com/text-to-speech",


### PR DESCRIPTION

Changes in this release:

### Documentation improvements

- Update comments for ListVoicesRequest ([commit d517082](https://github.com/googleapis/google-cloud-dotnet/commit/d517082c8a79b3fb61f176cd95b65507fd6f5cb6))
