### PR TITLE
Release Cloud Workflows V1 libraries version 1.2.0

### DIFF
--- a/apis/Google.Cloud.Workflows.Common.V1/Google.Cloud.Workflows.Common.V1/Google.Cloud.Workflows.Common.V1.csproj
+++ b/apis/Google.Cloud.Workflows.Common.V1/Google.Cloud.Workflows.Common.V1/Google.Cloud.Workflows.Common.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Common resource names used by all Workflows V1 APIs</Description>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax" Version="[3.6.0, 4.0.0)" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.csproj
+++ b/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Workflow Executions API v1, used to manage user-provided workflows.</Description>
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.6.0, 4.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.Workflows.Common.V1\Google.Cloud.Workflows.Common.V1\Google.Cloud.Workflows.Common.V1.csproj" />
-    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.41.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Workflows.Executions.V1/docs/history.md
+++ b/apis/Google.Cloud.Workflows.Executions.V1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 1.2.0, released 2022-01-18
+
+### New features
+
+- Add a stack_trace field to the Error messages specifying where the error occured
+- Add call_log_level field to Execution messages
+
+### Documentation improvements
+
+- Clarify requirement to escape strings within JSON arguments ([commit 141a9c3](https://github.com/googleapis/google-cloud-dotnet/commit/141a9c35a4a70aee171f13e2a3dbb98f4c6e129e))
+
 ## Version 1.1.0, released 2021-09-20
 
 - [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.csproj
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Workflows API v1.</Description>
@@ -10,10 +10,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.6.0, 4.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.Workflows.Common.V1\Google.Cloud.Workflows.Common.V1\Google.Cloud.Workflows.Common.V1.csproj" />
     <PackageReference Include="Google.LongRunning" Version="[2.3.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.41.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Workflows.V1/docs/history.md
+++ b/apis/Google.Cloud.Workflows.V1/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 1.2.0, released 2022-01-18
+
+### Documentation improvements
+
+- Clarified when revision_id of a workflow is updated
+- Clarified format and semantics of service_account field
+- Documented expanded workflow size limit ([commit a797ee8](https://github.com/googleapis/google-cloud-dotnet/commit/a797ee86afba93eaee0592c133d2aea9c6c38563))
+
 ## Version 1.1.0, released 2021-09-20
 
 - [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3336,13 +3336,13 @@
       "id": "Google.Cloud.Workflows.Common.V1",
       "type": "other",
       "targetFrameworks": "netstandard2.0;net461",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "description": "Common resource names used by all Workflows V1 APIs",
       "tags": [
         "Spanner"
       ],
       "dependencies": {
-        "Google.Api.Gax": "3.5.0"
+        "Google.Api.Gax": "3.6.0"
       },
       "noVersionHistory": true
     },
@@ -3362,7 +3362,7 @@
     },
     {
       "id": "Google.Cloud.Workflows.Executions.V1",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "commonResourcesConfig": "apis/Google.Cloud.Workflows.Common.V1/CommonResourcesConfig.json",
       "type": "grpc",
       "productName": "Workflow Executions",
@@ -3372,9 +3372,9 @@
         "workflows"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.6.0",
         "Google.Cloud.Workflows.Common.V1": "project",
-        "Grpc.Core": "2.38.1"
+        "Grpc.Core": "2.41.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/workflows/executions/v1",
@@ -3400,7 +3400,7 @@
     },
     {
       "id": "Google.Cloud.Workflows.V1",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "commonResourcesConfig": "apis/Google.Cloud.Workflows.Common.V1/CommonResourcesConfig.json",
       "type": "grpc",
       "productName": "Workflows",
@@ -3410,10 +3410,10 @@
         "workflows"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.6.0",
         "Google.Cloud.Workflows.Common.V1": "project",
         "Google.LongRunning": "2.3.0",
-        "Grpc.Core": "2.38.1"
+        "Grpc.Core": "2.41.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/workflows/v1",


### PR DESCRIPTION

Changes in Google.Cloud.Workflows.Executions.V1 version 1.2.0:

### New features

- Add a stack_trace field to the Error messages specifying where the error occured
- Add call_log_level field to Execution messages

### Documentation improvements

- Clarify requirement to escape strings within JSON arguments ([commit 141a9c3](https://github.com/googleapis/google-cloud-dotnet/commit/141a9c35a4a70aee171f13e2a3dbb98f4c6e129e))

Changes in Google.Cloud.Workflows.V1 version 1.2.0:

### Documentation improvements

- Clarified when revision_id of a workflow is updated
- Clarified format and semantics of service_account field
- Documented expanded workflow size limit ([commit a797ee8](https://github.com/googleapis/google-cloud-dotnet/commit/a797ee86afba93eaee0592c133d2aea9c6c38563))

Packages in this release:
- Release Google.Cloud.Workflows.Common.V1 version 1.2.0
- Release Google.Cloud.Workflows.Executions.V1 version 1.2.0
- Release Google.Cloud.Workflows.V1 version 1.2.0
