### PR TITLE
Release Google.Cloud.Ids.V1 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.csproj
+++ b/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud IDS API. Cloud IDS (Cloud Intrusion Detection System) detects malware, spyware, command-and-control attacks, and other network-based threats.</Description>

--- a/apis/Google.Cloud.Ids.V1/docs/history.md
+++ b/apis/Google.Cloud.Ids.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2022-01-18
+
+No API surface changes; just dependency updates.
+
 ## Version 1.0.0-beta01, released 2021-11-09
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1560,7 +1560,7 @@
     },
     {
       "id": "Google.Cloud.Ids.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Cloud IDS",
       "productUrl": "https://cloud.google.com/intrusion-detection-system",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
