### PR TITLE
Release Google.Cloud.NetworkSecurity.V1Beta1 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.csproj
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Network Security API version v1beta1, which provides security management for Traffic Director.</Description>

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/docs/history.md
@@ -1,5 +1,8 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2022-01-18
+
+No API surface changes; just dependency updates.
 ## Version 1.0.0-beta01, released 2021-09-23
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1996,7 +1996,7 @@
     },
     {
       "id": "Google.Cloud.NetworkSecurity.V1Beta1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Network Security",
       "productUrl": "https://cloud.google.com/traffic-director/docs/security-overview",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
