### PR TITLE
tests: Change expected translations in Translate API tests.

### DIFF
--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.IntegrationTests/AdvancedTranslationClientTest.cs
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.IntegrationTests/AdvancedTranslationClientTest.cs
@@ -20,7 +20,7 @@ namespace Google.Cloud.Translation.V2.IntegrationTests
     public class AdvancedTranslationClientTest
     {
         private static readonly string LargeText = TranslationClientTest.LoadResource("independence.txt");
-        private const string ExpectedTranslationContent = "dans le cours des";
+        private const string ExpectedTranslationContent = "cours des";
         private const int ApiLimit = 30 * 1024;
         private static readonly string VeryLargeText = string.Join("\n", Enumerable.Repeat(LargeText, ApiLimit / LargeText.Length));
 

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.IntegrationTests/TranslationClientTest.cs
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.IntegrationTests/TranslationClientTest.cs
@@ -23,7 +23,7 @@ namespace Google.Cloud.Translation.V2.IntegrationTests
     public class TranslationClientTest
     {
         private static readonly string LargeText = LoadResource("independence.txt");
-        private const string ExpectedTranslationContent = "dans le cours des";
+        private const string ExpectedTranslationContent = "cours des";
         private const int ApiLimit = 30 * 1024;
         private static readonly string VeryLargeText = string.Join("\n", Enumerable.Repeat(LargeText, ApiLimit / LargeText.Length));
 


### PR DESCRIPTION
The model changed back, probably because the new one is rolling out. This change should make it work for both models.