### PR TITLE
chore: Fix Google.LongRunning postgeneration

### DIFF
--- a/apis/Google.LongRunning/postgeneration.sh
+++ b/apis/Google.LongRunning/postgeneration.sh
@@ -7,6 +7,7 @@ set -e
 # google.longrunning) but it's too late to fix that now.
 cd ../..
 source toolversions.sh
+install_protoc
 declare -r CORE_PROTOS_ROOT=$PROTOBUF_TOOLS_ROOT/tools
 
 $PROTOC \


### PR DESCRIPTION
When running in OwlBot, we need to make sure protoc is actually installed.