### PR TITLE
Release Google.Cloud.VMMigration.V1 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.VMMigration.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.VMMigration.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.VMMigration.V1",
-  "release_level": "preview",
+  "release_level": "stable",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.VMMigration.V1/latest",
   "library_type": "GAPIC_AUTO",
   "api_shortname": "vmmigration"

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.csproj
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the VM Migration API, which allows you to programmatically migrate workloads.</Description>

--- a/apis/Google.Cloud.VMMigration.V1/docs/history.md
+++ b/apis/Google.Cloud.VMMigration.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0, released 2022-01-25
+
+No API surface changes; just dependency updates and promotion to 1.0.0.
+
 ## Version 1.0.0-beta01, released 2021-11-15
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3296,7 +3296,7 @@
     },
     {
       "id": "Google.Cloud.VMMigration.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "VM Migration",
       "productUrl": "https://cloud.google.com/migrate/compute-engine/docs/",
@@ -3307,7 +3307,9 @@
         "virtual-machine"
       ],
       "dependencies": {
-        "Google.LongRunning": "2.3.0"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.6.0",
+        "Google.LongRunning": "2.3.0",
+        "Grpc.Core": "2.41.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/vmmigration/v1",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates and promotion to 1.0.0.
