### PR TITLE
Release Google.Cloud.Video.Transcoder.V1 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.Video.Transcoder.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.Video.Transcoder.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.Video.Transcoder.V1",
-  "release_level": "preview",
+  "release_level": "stable",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Video.Transcoder.V1/latest",
   "library_type": "GAPIC_AUTO",
   "api_shortname": "transcoder"

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.csproj
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta03</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Transcoder API version v1, which converts video files into formats suitable for consumer distribution.</Description>

--- a/apis/Google.Cloud.Video.Transcoder.V1/docs/history.md
+++ b/apis/Google.Cloud.Video.Transcoder.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0, released 2022-01-25
+
+No API surface changes; just dependency updates and promotion to 1.0.0.
+
 ## Version 1.0.0-beta03, released 2021-10-12
 
 - [Commit 18a65f3](https://github.com/googleapis/google-cloud-dotnet/commit/18a65f3):

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3355,7 +3355,7 @@
     },
     {
       "id": "Google.Cloud.Video.Transcoder.V1",
-      "version": "1.0.0-beta03",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Transcoder",
       "productUrl": "https://cloud.google.com/transcoder/docs",
@@ -3365,7 +3365,10 @@
         "transcoder",
         "transcoding"
       ],
-      "dependencies": {},
+      "dependencies": {
+        "Google.Api.Gax.Grpc.GrpcCore": "3.6.0",
+        "Grpc.Core": "2.41.0"
+      },
       "generator": "micro",
       "protoPath": "google/cloud/video/transcoder/v1",
       "shortName": "transcoder",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates and promotion to 1.0.0.
