### PR TITLE
docs: Update help pages with respect to gRPC

### DIFF
--- a/docs/devsite-help/platforms.md
+++ b/docs/devsite-help/platforms.md
@@ -8,6 +8,13 @@ The latest libraries (the ones with dependencies on Google.Api.Gax
 3.x) target the **netstandard2.0** and **net461** [Target
 Framework Monikers](https://docs.microsoft.com/en-us/nuget/schema/target-frameworks).
 
+> Note: Grpc.Core, the current default impementation of gRPC, does
+> not support Apple M1 CPUs. If you are developing on a device using
+> an M1, please adapt your client creation code to specify the
+> Grpc.Net.Client implemenation [as shown here](https://github.com/googleapis/google-cloud-dotnet/issues/7560#issuecomment-975414370).
+> This will become the default implementation in the next major
+> version of the libraries.
+
 Older versions of libraries (targeting Google.Api.Gax 2.x) support
 older frameworks (netstandard1.3 or netstandard1.5, and net45) but
 those are incompatible with the latest versions of Grpc.Core and

--- a/docs/devsite-help/troubleshooting.md
+++ b/docs/devsite-help/troubleshooting.md
@@ -2,6 +2,10 @@
 
 ## How can I trace gRPC issues?
 
+> Note: this guidance only applies when using Grpc.Core, which is currently the
+> default gRPC implementation. We intend to update this documentation with
+> respect to Grpc.Net.Client before adopting that as the default implementation.
+
 For libraries that use gRPC, it can be very useful to hook into the
 gRPC logging framework. There are two aspects to this:
 


### PR DESCRIPTION
Ideally we'd have more comprehensive documentation about choosing
the gRPC adapter (rather than linking to an issue) - but all that
would need to change substantially in a few months anyway. We should
revisit all of this documentation when the next major version ships.