### PR TITLE
Pass the service config file into the generator

### DIFF
--- a/apis/Google.Cloud.AccessApproval.V1/midmicrogeneration.sh
+++ b/apis/Google.Cloud.AccessApproval.V1/midmicrogeneration.sh
@@ -8,3 +8,4 @@
 # It's not great to have to do this, but there are no nice alternatives.
 sed -i 's/^service AccessApproval /service AccessApprovalService /g' $GOOGLEAPIS/google/cloud/accessapproval/v1/accessapproval.proto
 sed -i 's/v1.AccessApproval/v1.AccessApprovalService/g' $GOOGLEAPIS/google/cloud/accessapproval/v1/accessapproval_grpc_service_config.json
+sed -i 's/v1.AccessApproval/v1.AccessApprovalService/g' $GOOGLEAPIS/google/cloud/accessapproval/v1/accessapproval_v1.yaml

--- a/apis/Google.Cloud.Bigtable.V2/midmicrogeneration.sh
+++ b/apis/Google.Cloud.Bigtable.V2/midmicrogeneration.sh
@@ -3,3 +3,4 @@
 # Rename the service to BigtableServiceApi
 sed -i 's/service Bigtable/service BigtableServiceApi/g' $GOOGLEAPIS/google/bigtable/v2/bigtable.proto
 sed -i 's/v2.Bigtable/v2.BigtableServiceApi/g' $GOOGLEAPIS/google/bigtable/v2/bigtable_grpc_service_config.json
+sed -i 's/v2.Bigtable/v2.BigtableServiceApi/g' $GOOGLEAPIS/google/bigtable/v2/bigtable_v2.yaml

--- a/apis/Google.Cloud.Bigtable.V2/postgeneration.sh
+++ b/apis/Google.Cloud.Bigtable.V2/postgeneration.sh
@@ -6,6 +6,7 @@ set -e
 # (Do this first so that if we have any failures in the remaining steps)
 git -C $GOOGLEAPIS checkout google/bigtable/v2/bigtable.proto
 git -C $GOOGLEAPIS checkout google/bigtable/v2/bigtable_grpc_service_config.json
+git -C $GOOGLEAPIS checkout google/bigtable/v2/bigtable_v2.yaml
 
 # Fix up the generated client for using Grpc.Gcp and other tweaks
 sed -i -r -f BigtableServiceApiClient.sed Google.Cloud.Bigtable.V2/BigtableServiceApiClient.g.cs

--- a/apis/Google.Cloud.PubSub.V1/midmicrogeneration.sh
+++ b/apis/Google.Cloud.PubSub.V1/midmicrogeneration.sh
@@ -3,6 +3,8 @@
 # Rename the services to {Publisher/Subscriber}ServiceApi
 sed -i 's/service Publisher/service PublisherServiceApi/g' $GOOGLEAPIS/google/pubsub/v1/pubsub.proto
 sed -i 's/v1.Publisher/v1.PublisherServiceApi/g' $GOOGLEAPIS/google/pubsub/v1/pubsub_grpc_service_config.json
+sed -i 's/v1.Publisher/v1.PublisherServiceApi/g' $GOOGLEAPIS/google/pubsub/v1/pubsub_v1.yaml
 
 sed -i 's/service Subscriber/service SubscriberServiceApi/g' $GOOGLEAPIS/google/pubsub/v1/pubsub.proto
 sed -i 's/v1.Subscriber/v1.SubscriberServiceApi/g' $GOOGLEAPIS/google/pubsub/v1/pubsub_grpc_service_config.json
+sed -i 's/v1.Subscriber/v1.SubscriberServiceApi/g' $GOOGLEAPIS/google/pubsub/v1/pubsub_v1.yaml

--- a/apis/Google.Cloud.PubSub.V1/postgeneration.sh
+++ b/apis/Google.Cloud.PubSub.V1/postgeneration.sh
@@ -5,6 +5,7 @@ set -e
 # Undo the changes in googleapis
 git -C $GOOGLEAPIS checkout google/pubsub/v1/pubsub.proto
 git -C $GOOGLEAPIS checkout google/pubsub/v1/pubsub_grpc_service_config.json
+git -C $GOOGLEAPIS checkout google/pubsub/v1/pubsub_v1.yaml
 
 # Fix up the generated client to use the right gRPC types
 sed -i s/PublisherServiceApi.PublisherServiceApiClient/Publisher.PublisherClient/g Google.Cloud.PubSub.V1/PublisherServiceApiClient.g.cs

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -121,7 +121,8 @@
       },
       "generator": "micro",
       "protoPath": "google/cloud/aiplatform/v1",
-      "shortName": "aiplatform"
+      "shortName": "aiplatform",
+      "serviceConfigFile": "aiplatform_v1.yaml"
     },
     {
       "id": "Google.Cloud.ApigeeConnect.V1",
@@ -1554,7 +1555,8 @@
       },
       "generator": "micro",
       "protoPath": "google/cloud/gkehub/v1",
-      "shortName": "gkehub"
+      "shortName": "gkehub",
+      "serviceConfigFile": "gkehub_v1.yaml"
     },
     {
       "id": "Google.Cloud.Iam.Admin.V1",
@@ -1621,7 +1623,8 @@
         "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
         "Grpc.Core": "2.38.1"
       },
-      "forceOwlBotRegeneration": "AuditData proto is generated in the wrong place."
+      "forceOwlBotRegeneration": "AuditData proto is generated in the wrong place.",
+      "serviceConfigFile": "iam_meta_api.yaml"
     },
     {
       "id": "Google.Cloud.Iap.V1",
@@ -1766,7 +1769,8 @@
         "Grpc.Core": "2.41.0"
       },
       "generator": "micro",
-      "protoPath": "google/cloud/location"
+      "protoPath": "google/cloud/location",
+      "serviceConfigFile": "location.yaml"
     },
     {
       "id": "Google.Cloud.Logging.Log4Net",
@@ -2283,7 +2287,8 @@
         "Google.Api.Gax": "3.5.0"
       },
       "noVersionHistory": true,
-      "forceOwlBotRegeneration": "OsLogin Common proto is generated in the wrong place."
+      "forceOwlBotRegeneration": "OsLogin Common proto is generated in the wrong place.",
+      "serviceConfigFile": "none"
     },
     {
       "id": "Google.Cloud.OsLogin.V1",
@@ -3693,7 +3698,8 @@
       "testDependencies": {
         "Google.Api.Gax.Testing": "3.5.0"
       },
-      "forceOwlBotRegeneration": "Post-processor requires googleapis repo."
+      "forceOwlBotRegeneration": "Post-processor requires googleapis repo.",
+      "serviceConfigFile": "longrunning.yaml"
     },
     {
       "id": "Grafeas.V1",
@@ -3715,7 +3721,8 @@
         "Google.Api.Gax.Grpc.GrpcCore": "3.6.0",
         "Grpc.Core": "2.41.0"
       },
-      "shortName": "containeranalysis"
+      "shortName": "containeranalysis",
+      "serviceConfigFile": "none"
     }
   ],
   "ignoredPaths": {


### PR DESCRIPTION
A few notes:

- This requires the latest (unreleased at the time of writing) version of the generator
- It currently fails for Google.Cloud.Iap.V1 as there's an additional API in the service config file; we're working out what to do about that
- I don't know why quite a few APIs didn't have a service config file in apis.json, but I've fixed them. A couple genuinely don't have service config files - I've used "none" to make it clear that's deliberate. (Generation will fail if the value doesn't exist at all.)
- The APIs which change the service names mid-generation need to change the service config file too

With a manual fix for IAP, and using the latest (unreleased generator, generation itself succeeds with this change. I have not validated that the results build or are correct, however.