### PR TITLE
Prototype of recording content metadata while downloading

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/DownloadObjectTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/DownloadObjectTest.cs
@@ -45,7 +45,10 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
         {
             using (var stream = new MemoryStream())
             {
-                await _fixture.Client.DownloadObjectAsync(_fixture.ReadBucket, _fixture.SmallObject, stream);
+                var metadata = await _fixture.Client.DownloadObjectAsync(_fixture.ReadBucket, _fixture.SmallObject, stream);
+                Assert.NotNull(metadata.Hash);
+                Assert.NotNull(metadata.Generation);
+                Assert.NotNull(metadata.Metageneration);
                 Assert.Equal(_fixture.SmallContent, stream.ToArray());
             }
         }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/CodeHealthTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/CodeHealthTest.cs
@@ -28,7 +28,9 @@ namespace Google.Cloud.Storage.V1.Tests
         [Fact]
         public void SealedClasses()
         {
-            CodeHealthTester.AssertClassesAreSealedOrAbstract(typeof(StorageClient));
+            CodeHealthTester.AssertClassesAreSealedOrAbstract(typeof(StorageClient),
+                // Deliberately neither sealed nor abstract
+                exemptedTypes: new[] { typeof(ContentMetadataRecordingMediaDownloader) });
         }
     }
 }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/ContentMetadata.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/ContentMetadata.cs
@@ -1,0 +1,51 @@
+﻿// Copyright 2022 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Google.Cloud.Storage.V1
+{
+    // FIXME: provide a public constructor of some kind, for test purposes.
+
+    /// <summary>
+    /// Provided metadata about the content that has been downloaded with a call to
+    /// <see cref="StorageClient.DownloadObject(string, string, System.IO.Stream, DownloadObjectOptions, IProgress{Apis.Download.IDownloadProgress})"/>
+    /// (or overloads and async equivalents). This is not the complete object metadata as returned by <see cref="StorageClient.GetObject(string, string, GetObjectOptions)"/>
+    /// and related calls; it only provides the information returned by the server in HTTP headers along with the content.
+    /// </summary>
+    public sealed class ContentMetadata
+    {
+        /// <summary>
+        /// FIXME
+        /// </summary>
+        public long? Generation { get; }
+
+        /// <summary>
+        /// FIXME
+        /// </summary>
+        public long? Metageneration { get; }
+
+        /// <summary>
+        /// FIXME
+        /// </summary>
+        public string Hash { get; }
+
+        internal ContentMetadata(long? generation, long? metageneration, string hash)
+        {
+            Generation = generation;
+            Metageneration = metageneration;
+            Hash = hash;
+        }
+    }
+}

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/ContentMetadataRecordingMediaDownloader.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/ContentMetadataRecordingMediaDownloader.cs
@@ -1,0 +1,66 @@
+﻿// Copyright 2022 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Download;
+using Google.Apis.Services;
+using System.Globalization;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+namespace Google.Cloud.Storage.V1
+{
+    /// <summary>
+    /// MediaDownloader subclass which creates a <see cref="ContentMetadata"/> instance
+    /// from the headers it sees on a successful response. Note: if this ever becomes public,
+    /// we should put more effort into naming it carefully.
+    /// </summary>
+    internal class ContentMetadataRecordingMediaDownloader : MediaDownloader
+    {
+        // TODO: Expose this? Storage class? Uploader ID?
+        //private const string ETagHeader = "ETag";
+        private const string GenerationHeader = "X-Goog-Generation";
+        private const string MetagenerationHeader = "X-Goog-Metageneration";
+        private const string HashHeader = "X-Goog-Hash";
+
+        internal ContentMetadata ContentMetadata { get; private set; }
+
+        /// <summary>Constructs a new downloader with the given client service.</summary>
+        internal ContentMetadataRecordingMediaDownloader(IClientService service) : base(service)
+        {
+        }
+
+        protected override void OnResponseReceived(HttpResponseMessage response)
+        {
+            base.OnResponseReceived(response);
+            ContentMetadata = FromHttpResponseHeaders(response.Headers);
+        }
+
+        internal static ContentMetadata FromHttpResponseHeaders(HttpResponseHeaders headers)
+        {
+            long? generation = MaybeParse(GetFirstHeaderOrNull(GenerationHeader));
+            long? metageneration = MaybeParse(GetFirstHeaderOrNull(MetagenerationHeader));
+            string hash = GetFirstHeaderOrNull(HashHeader);
+            return new ContentMetadata(generation, metageneration, hash);
+
+            string GetFirstHeaderOrNull (string headerName) =>
+                headers.TryGetValues(headerName, out var values) ? values.FirstOrDefault() : null;
+
+            long? MaybeParse(string text) =>
+                text is null || !long.TryParse(text, NumberStyles.None, CultureInfo.InvariantCulture, out var value)
+                ? (long?) null
+                : value;
+        }
+    }
+}

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/HashValidatingDownloader.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/HashValidatingDownloader.cs
@@ -27,7 +27,7 @@ namespace Google.Cloud.Storage.V1
     /// Subclass of <see cref="MediaDownloader"/> which validates the data it receives
     /// against a CRC32c hash set in the header.
     /// </summary>
-    internal sealed class HashValidatingDownloader : MediaDownloader
+    internal sealed class HashValidatingDownloader : ContentMetadataRecordingMediaDownloader
     {
         private string crc32cHashBase64;
         private Crc32c hasher;

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClient.DownloadObject.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClient.DownloadObject.cs
@@ -32,7 +32,8 @@ namespace Google.Cloud.Storage.V1
         /// <param name="options">Additional options for the download. May be null, in which case appropriate
         /// defaults will be used.</param>
         /// <param name="progress">Progress reporter for the download. May be null.</param>
-        public virtual void DownloadObject(
+        /// <returns>FIXME</returns>
+        public virtual ContentMetadata DownloadObject(
             string bucket,
             string objectName,
             Stream destination,
@@ -53,7 +54,7 @@ namespace Google.Cloud.Storage.V1
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <param name="progress">Progress reporter for the download. May be null.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
-        public virtual Task DownloadObjectAsync(
+        public virtual Task<ContentMetadata> DownloadObjectAsync(
             string bucket,
             string objectName,
             Stream destination,
@@ -75,7 +76,7 @@ namespace Google.Cloud.Storage.V1
         /// <param name="options">Additional options for the download. May be null, in which case appropriate
         /// defaults will be used.</param>
         /// <param name="progress">Progress reporter for the download. May be null.</param>
-        public virtual void DownloadObject(
+        public virtual ContentMetadata DownloadObject(
             Object source,
             Stream destination,
             DownloadObjectOptions options = null,
@@ -97,7 +98,7 @@ namespace Google.Cloud.Storage.V1
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <param name="progress">Progress reporter for the download. May be null.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
-        public virtual Task DownloadObjectAsync(
+        public virtual Task<ContentMetadata> DownloadObjectAsync(
             Object source,
             Stream destination,
             DownloadObjectOptions options = null,


### PR DESCRIPTION
We won't do this until the next major version (as it's a breaking change) but this would address #7897.

This is really just a prototype to:

- Check that it's feasible (looks like it is)
- Provide a straw man of the general design to discuss