### PR TITLE
docs: Add Google.Apis.Auth.AspNetCore3 for Cloud docs

### DIFF
--- a/docs/generate-devsite-utilities.sh
+++ b/docs/generate-devsite-utilities.sh
@@ -56,9 +56,10 @@ case $1 in
     declare -a PROJECTS=(
       'Src/Support/Google.Apis'
       'Src/Support/Google.Apis.Auth'
+      'Src/Support/Google.Apis.Auth.AspNetCore3'
       'Src/Support/Google.Apis.Core'
     )
-    declare -r TARGET_FRAMEWORK=netstandard2.0
+    declare -r TARGET_FRAMEWORK=netcoreapp3.1
     declare -a XREFS=(
     )
     ;;


### PR DESCRIPTION
As far as I can tell, it looks like using netcoreapp3.1 should be okay for generating docs. (It appears to work...)