### PR TITLE
Release Google.Cloud.BigQuery.V2 version 2.4.0-beta01

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.3.0</Version>
+    <Version>2.4.0-beta01</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery API. It wraps the Google.Apis.Bigquery.v2 client library, making common operations simpler in client code. BigQuery is a data platform for customers to create, manage, share and query data.</Description>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Rest" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Rest" Version="[3.6.0, 4.0.0)" />
     <PackageReference Include="Google.Apis.Bigquery.v2" Version="[1.54.0.2397, 2.0.0.0)" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.BigQuery.V2/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.4.0-beta01, released 2022-02-07
+
+### New features
+
+- Add support for BigNumeric. ([commit 4dc2e9b](https://github.com/googleapis/google-cloud-dotnet/commit/4dc2e9bc641e629838a909c49e691bbadd1d6ab6))
+
 ## Version 2.3.0, released 2021-08-10
 
 - [Commit d51544c](https://github.com/googleapis/google-cloud-dotnet/commit/d51544c): In GetOrCreate methods, retry "get" operation if "create" fails due to conflict. Fixes [issue 6902](https://github.com/googleapis/google-cloud-dotnet/issues/6902)

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -379,11 +379,11 @@
       "id": "Google.Cloud.BigQuery.V2",
       "productName": "Google BigQuery",
       "productUrl": "https://cloud.google.com/bigquery/",
-      "version": "2.3.0",
+      "version": "2.4.0-beta01",
       "type": "rest",
       "description": "Recommended Google client library to access the BigQuery API. It wraps the Google.Apis.Bigquery.v2 client library, making common operations simpler in client code. BigQuery is a data platform for customers to create, manage, share and query data.",
       "dependencies": {
-        "Google.Api.Gax.Rest": "3.5.0",
+        "Google.Api.Gax.Rest": "3.6.0",
         "Google.Apis.Bigquery.v2": "1.54.0.2397"
       },
       "testDependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Add support for BigNumeric. ([commit 4dc2e9b](https://github.com/googleapis/google-cloud-dotnet/commit/4dc2e9bc641e629838a909c49e691bbadd1d6ab6))
