### PR TITLE
Release Google.Cloud.ArtifactRegistry.V1Beta2 version 1.0.0-beta05

### DIFF
--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.csproj
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta04</Version>
+    <Version>1.0.0-beta05</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Artifact Registry API v1beta2, which stores and manages build artifacts in a scalable and integrated service built on Google infrastructure.</Description>

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/docs/history.md
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 1.0.0-beta05, released 2022-02-07
+
+### New features
+
+- Add APIs for importing and uploading Apt and Yum artifacts ([commit 14bc6ed](https://github.com/googleapis/google-cloud-dotnet/commit/14bc6edc0e67a2a0809486c66ce901e63b07a42f))
+- Add version policy support for Maven repositories ([commit 14bc6ed](https://github.com/googleapis/google-cloud-dotnet/commit/14bc6edc0e67a2a0809486c66ce901e63b07a42f))
+- Add order_by support for listing versions ([commit 14bc6ed](https://github.com/googleapis/google-cloud-dotnet/commit/14bc6edc0e67a2a0809486c66ce901e63b07a42f))
+
 ## Version 1.0.0-beta04, released 2022-01-17
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -190,7 +190,7 @@
     },
     {
       "id": "Google.Cloud.ArtifactRegistry.V1Beta2",
-      "version": "1.0.0-beta04",
+      "version": "1.0.0-beta05",
       "type": "grpc",
       "productName": "Artifact Registry",
       "productUrl": "https://cloud.google.com/artifact-registry",


### PR DESCRIPTION

Changes in this release:

### New features

- Add APIs for importing and uploading Apt and Yum artifacts ([commit 14bc6ed](https://github.com/googleapis/google-cloud-dotnet/commit/14bc6edc0e67a2a0809486c66ce901e63b07a42f))
- Add version policy support for Maven repositories ([commit 14bc6ed](https://github.com/googleapis/google-cloud-dotnet/commit/14bc6edc0e67a2a0809486c66ce901e63b07a42f))
- Add order_by support for listing versions ([commit 14bc6ed](https://github.com/googleapis/google-cloud-dotnet/commit/14bc6edc0e67a2a0809486c66ce901e63b07a42f))
