### PR TITLE
Release Google.Cloud.BigQuery.DataTransfer.V1 version 3.3.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.2.0</Version>
+    <Version>3.3.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery Data Transfer API, which transfers data from partner SaaS applications to Google BigQuery on a scheduled, managed basis.</Description>
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.6.0, 4.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.41.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 3.3.0, released 2022-02-07
+
+### New features
+
+- Add owner email to TransferConfig message ([commit 5939502](https://github.com/googleapis/google-cloud-dotnet/commit/593950270001c126abccb139dd1268997996ac10))
+- Allow customer to enroll a datasource programmatically ([commit 5939502](https://github.com/googleapis/google-cloud-dotnet/commit/593950270001c126abccb139dd1268997996ac10))
+
+### Documentation improvements
+
+- Improvements to various message and field descriptions ([commit 5939502](https://github.com/googleapis/google-cloud-dotnet/commit/593950270001c126abccb139dd1268997996ac10))
+
 ## Version 3.2.0, released 2021-09-23
 
 - [Commit edaadae](https://github.com/googleapis/google-cloud-dotnet/commit/edaadae): docs: Improvements to various message and field descriptions

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -341,12 +341,12 @@
       "protoPath": "google/cloud/bigquery/datatransfer/v1",
       "productName": "Google BigQuery Data Transfer",
       "productUrl": "https://cloud.google.com/bigquery/transfer/",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the BigQuery Data Transfer API, which transfers data from partner SaaS applications to Google BigQuery on a scheduled, managed basis.",
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
-        "Grpc.Core": "2.38.1"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.6.0",
+        "Grpc.Core": "2.41.0"
       },
       "tags": [
         "BigQuery",


### PR DESCRIPTION

Changes in this release:

### New features

- Add owner email to TransferConfig message ([commit 5939502](https://github.com/googleapis/google-cloud-dotnet/commit/593950270001c126abccb139dd1268997996ac10))
- Allow customer to enroll a datasource programmatically ([commit 5939502](https://github.com/googleapis/google-cloud-dotnet/commit/593950270001c126abccb139dd1268997996ac10))

### Documentation improvements

- Improvements to various message and field descriptions ([commit 5939502](https://github.com/googleapis/google-cloud-dotnet/commit/593950270001c126abccb139dd1268997996ac10))
