### PR TITLE
Release Google.Cloud.Recommender.V1 version 2.8.0

### DIFF
--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.csproj
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.7.0</Version>
+    <Version>2.8.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library for the Recommender API, which provides usage recommendations for Cloud products and services.</Description>
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.6.0, 4.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.41.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.Recommender.V1/docs/history.md
+++ b/apis/Google.Cloud.Recommender.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 2.8.0, released 2022-02-07
+
+### New features
+
+- Recommendation Priority / Insight Severity ([commit 48d865e](https://github.com/googleapis/google-cloud-dotnet/commit/48d865e3f409f641d5bc628c5b00eb83f0d4b21a))
+- Recommendation xor_group_id ([commit 48d865e](https://github.com/googleapis/google-cloud-dotnet/commit/48d865e3f409f641d5bc628c5b00eb83f0d4b21a))
+- Recommendation security projection ([commit 48d865e](https://github.com/googleapis/google-cloud-dotnet/commit/48d865e3f409f641d5bc628c5b00eb83f0d4b21a))
 ## Version 2.7.0, released 2021-12-07
 
 - [Commit 35a1949](https://github.com/googleapis/google-cloud-dotnet/commit/35a1949): docs: fix docstring formatting

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2492,12 +2492,12 @@
       "protoPath": "google/cloud/recommender/v1",
       "productName": "Google Cloud Recommender",
       "productUrl": "https://cloud.google.com/recommender/",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "type": "grpc",
       "description": "Recommended Google client library for the Recommender API, which provides usage recommendations for Cloud products and services.",
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
-        "Grpc.Core": "2.38.1"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.6.0",
+        "Grpc.Core": "2.41.0"
       },
       "tags": [
         "Recommender"


### PR DESCRIPTION

Changes in this release:

### New features

- Recommendation Priority / Insight Severity ([commit 48d865e](https://github.com/googleapis/google-cloud-dotnet/commit/48d865e3f409f641d5bc628c5b00eb83f0d4b21a))
- Recommendation xor_group_id ([commit 48d865e](https://github.com/googleapis/google-cloud-dotnet/commit/48d865e3f409f641d5bc628c5b00eb83f0d4b21a))
- Recommendation security projection ([commit 48d865e](https://github.com/googleapis/google-cloud-dotnet/commit/48d865e3f409f641d5bc628c5b00eb83f0d4b21a))
