### PR TITLE
Release Google.Cloud.Redis.V1Beta1 version 2.0.0-beta08

### DIFF
--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.csproj
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta07</Version>
+    <Version>2.0.0-beta08</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to administer Cloud Memorystore for Redis (V1 Beta 1 API).</Description>

--- a/apis/Google.Cloud.Redis.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.Redis.V1Beta1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.0.0-beta08, released 2022-02-07
+
+### New features
+
+- Add automated RDB (AKA persistence) ([commit 6e089e6](https://github.com/googleapis/google-cloud-dotnet/commit/6e089e6d230539017573c479183e8e710c81ac4e))
+
 ## Version 2.0.0-beta07, released 2022-01-17
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2532,7 +2532,7 @@
       "protoPath": "google/cloud/redis/v1beta1",
       "productName": "Google Cloud Memorystore for Redis",
       "productUrl": "https://cloud.google.com/memorystore/",
-      "version": "2.0.0-beta07",
+      "version": "2.0.0-beta08",
       "releaseLevelOverride": "preview",
       "type": "grpc",
       "description": "Recommended Google client library to administer Cloud Memorystore for Redis (V1 Beta 1 API).",


### PR DESCRIPTION

Changes in this release:

### New features

- Add automated RDB (AKA persistence) ([commit 6e089e6](https://github.com/googleapis/google-cloud-dotnet/commit/6e089e6d230539017573c479183e8e710c81ac4e))
