### PR TITLE
Release Google.Cloud.SecurityCenter.V1 version 2.11.0

### DIFF
--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.csproj
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.10.0</Version>
+    <Version>2.11.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Security Command Center API, which helps security teams gather data, identify threats, and act on them before they result in business damage or loss.</Description>
@@ -10,10 +10,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.6.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.3.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.3.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None" />
+    <PackageReference Include="Grpc.Core" Version="[2.41.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <Analyzer Condition="Exists('..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll')" Include="..\..\..\tools\Google.Cloud.Tools.Analyzers\bin\$(Configuration)\netstandard1.3\publish\Google.Cloud.Tools.Analyzers.dll" />

--- a/apis/Google.Cloud.SecurityCenter.V1/docs/history.md
+++ b/apis/Google.Cloud.SecurityCenter.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 2.11.0, released 2022-02-07
+
+### New features
+
+- Release the access field in the v1 finding proto, which represents an access event tied to the finding ([commit 7013d13](https://github.com/googleapis/google-cloud-dotnet/commit/7013d136ade920bdd69f1ad05213441ca2bc3810))
+
+### Documentation improvements
+
+- Added more clarification around what event_time means on a v1 finding ([commit 7013d13](https://github.com/googleapis/google-cloud-dotnet/commit/7013d136ade920bdd69f1ad05213441ca2bc3810))
+
 ## Version 2.10.0, released 2021-12-07
 
 - [Commit 1cda659](https://github.com/googleapis/google-cloud-dotnet/commit/1cda659): feat: Added a new API method UpdateExternalSystem, which enables updating a finding w/ external system metadata. External systems are a child resource under finding, and are housed on the finding itself, and can also be filtered on in Notifications, the ListFindings and GroupFindings API

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2741,14 +2741,14 @@
       "protoPath": "google/cloud/securitycenter/v1",
       "productName": "Google Cloud Security Command Center",
       "productUrl": "https://cloud.google.com/security-command-center/",
-      "version": "2.10.0",
+      "version": "2.11.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Security Command Center API, which helps security teams gather data, identify threats, and act on them before they result in business damage or loss.",
       "dependencies": {
-        "Google.Api.Gax.Grpc.GrpcCore": "3.5.0",
+        "Google.Api.Gax.Grpc.GrpcCore": "3.6.0",
         "Google.Cloud.Iam.V1": "2.3.0",
         "Google.LongRunning": "2.3.0",
-        "Grpc.Core": "2.38.1"
+        "Grpc.Core": "2.41.0"
       },
       "tags": [
         "security",


### PR DESCRIPTION

Changes in this release:

### New features

- Release the access field in the v1 finding proto, which represents an access event tied to the finding ([commit 7013d13](https://github.com/googleapis/google-cloud-dotnet/commit/7013d136ade920bdd69f1ad05213441ca2bc3810))

### Documentation improvements

- Added more clarification around what event_time means on a v1 finding ([commit 7013d13](https://github.com/googleapis/google-cloud-dotnet/commit/7013d136ade920bdd69f1ad05213441ca2bc3810))
