### PR TITLE
Add smoke tests for Google.Cloud.Dataplex.V1

### DIFF
--- a/apis/Google.Cloud.Dataplex.V1/smoketests.json
+++ b/apis/Google.Cloud.Dataplex.V1/smoketests.json
@@ -1,0 +1,9 @@
+[
+  {
+    "method": "ListLakes",
+    "client": "DataplexServiceClient",
+    "arguments": {
+      "parent": "projects/${PROJECT_ID}/locations/us-east1"
+    }
+  }
+]


### PR DESCRIPTION
(We're still not ready for a release of this, but the smoke test should pass in CI.)