### PR TITLE
chore: Set up submodules when building docs

### DIFF
--- a/.kokoro/builddocs.sh
+++ b/.kokoro/builddocs.sh
@@ -8,6 +8,10 @@ SCRIPT_DIR=$(dirname "$SCRIPT")
 cd $SCRIPT_DIR
 cd ..
 
+echo "Cloning submodules"
+git submodule init
+git submodule update
+
 # Build the libraries w/o running unit tests.
 ./build.sh --notests
 


### PR DESCRIPTION
This avoids a lot of pointless warnings in logs