### PR TITLE
Release Google.Cloud.Billing.Budgets.V1Beta1 version 1.0.0-beta05

### DIFF
--- a/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1.csproj
+++ b/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta04</Version>
+    <Version>1.0.0-beta05</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Cloud Billing Budget API v1beta1. This API stores Cloud Billing budgets, which define a budget plan and the rules to execute as spend is tracked against that plan.</Description>

--- a/apis/Google.Cloud.Billing.Budgets.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.Billing.Budgets.V1Beta1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta05, released 2022-02-11
+
+### Documentation improvements
+
+- Formatting change from HTML to markdown; Additional clarifications ([commit f022157](https://github.com/googleapis/google-cloud-dotnet/commit/f022157db890a54b9c1c1d1d3fba38ef930b4d8d))
+
 ## Version 1.0.0-beta04, released 2021-08-19
 
 - [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -504,7 +504,7 @@
     },
     {
       "id": "Google.Cloud.Billing.Budgets.V1Beta1",
-      "version": "1.0.0-beta04",
+      "version": "1.0.0-beta05",
       "type": "grpc",
       "productName": "Cloud Billing Budget",
       "productUrl": "https://cloud.google.com/billing/docs/how-to/budget-api-overview",


### PR DESCRIPTION

Changes in this release:

### Documentation improvements

- Formatting change from HTML to markdown; Additional clarifications ([commit f022157](https://github.com/googleapis/google-cloud-dotnet/commit/f022157db890a54b9c1c1d1d3fba38ef930b4d8d))
