### PR TITLE
chore: Fix OSConfig generation, in terms of gRPC generated code

### DIFF
--- a/apis/Google.Cloud.OsConfig.V1Alpha/postgeneration.sh
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/postgeneration.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+# Suppress deprecation warnings in generated gRPC code.
+# (If this becomes a common problem, we'll want a more robust fix.
+# It'll do for now.)
+
+sed -i 's/^#pragma warning disable 0414, 1591$/#pragma warning disable 0414, 1591, 0612/g' Google.Cloud.OsConfig.V1Alpha/OsconfigZonalServiceGrpc.g.cs


### PR DESCRIPTION
This just suppresses warnings around obsolete types.