### PR TITLE
Release Google.Cloud.Compute.V1 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Compute Engine API.</Description>

--- a/apis/Google.Cloud.Compute.V1/docs/history.md
+++ b/apis/Google.Cloud.Compute.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 1.1.0, released 2022-02-14
+
+### New features
+
+- Update compute API to revision 20220112 ([issue 700](https://github.com/googleapis/google-cloud-dotnet/issues/700)) ([commit ebe518a](https://github.com/googleapis/google-cloud-dotnet/commit/ebe518afb1f06c38fc5162c04ed1f7650e52fd14))
+  - The original commit contained breaking changes, but they were reverted in [commit 50ea200](https://github.com/googleapis/google-cloud-dotnet/commit/50ea200dc05ed5001cb7dca99c5f8203eb4ca6c7)
+
 ## Version 1.0.0, released 2022-01-11
 
 No API surface changes; just dependency updates for first GA release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -682,7 +682,7 @@
     },
     {
       "id": "Google.Cloud.Compute.V1",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "regapic",
       "productName": "Compute Engine",
       "productUrl": "https://cloud.google.com/compute",


### PR DESCRIPTION

Changes in this release:

### New features

- Update compute API to revision 20220112 ([issue 700](https://github.com/googleapis/google-cloud-dotnet/issues/700)) ([commit ebe518a](https://github.com/googleapis/google-cloud-dotnet/commit/ebe518afb1f06c38fc5162c04ed1f7650e52fd14))
  - The original commit contained breaking changes, but they were reverted in [commit 50ea200](https://github.com/googleapis/google-cloud-dotnet/commit/50ea200dc05ed5001cb7dca99c5f8203eb4ca6c7)
