### PR TITLE
Release Google.Cloud.NetworkConnectivity.V1 version 1.2.0

### DIFF
--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.csproj
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Network Connectivity API, which provides access to Network Connectivity Center.</Description>

--- a/apis/Google.Cloud.NetworkConnectivity.V1/docs/history.md
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 1.2.0, released 2022-02-14
+
+### New features
+
+- Add LocationMetadata message ([commit b6edefb](https://github.com/googleapis/google-cloud-dotnet/commit/b6edefb793651dc0f1a07349852f381e56139b9a))
+- Add RoutingVPC.required_for_new_site_to_site_data_transfer_spokes field ([commit b6edefb](https://github.com/googleapis/google-cloud-dotnet/commit/b6edefb793651dc0f1a07349852f381e56139b9a))
+
+### Documentation improvements
+
+- Update comments to reflect that spokes can now be created with data transfer disabled ([commit b6edefb](https://github.com/googleapis/google-cloud-dotnet/commit/b6edefb793651dc0f1a07349852f381e56139b9a))
+
 ## Version 1.1.0, released 2021-12-07
 
 - [Commit 10e499d](https://github.com/googleapis/google-cloud-dotnet/commit/10e499d): fix!: Mark a couple networkconnectivity API fields as required, to match implemented behavior

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2074,7 +2074,7 @@
     },
     {
       "id": "Google.Cloud.NetworkConnectivity.V1",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "type": "grpc",
       "productName": "Network Connectivity",
       "productUrl": "https://cloud.google.com/network-connectivity/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add LocationMetadata message ([commit b6edefb](https://github.com/googleapis/google-cloud-dotnet/commit/b6edefb793651dc0f1a07349852f381e56139b9a))
- Add RoutingVPC.required_for_new_site_to_site_data_transfer_spokes field ([commit b6edefb](https://github.com/googleapis/google-cloud-dotnet/commit/b6edefb793651dc0f1a07349852f381e56139b9a))

### Documentation improvements

- Update comments to reflect that spokes can now be created with data transfer disabled ([commit b6edefb](https://github.com/googleapis/google-cloud-dotnet/commit/b6edefb793651dc0f1a07349852f381e56139b9a))
