### PR TITLE
Release Google.Cloud.OsConfig.V1 version 1.8.0

### DIFF
--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.csproj
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.7.0</Version>
+    <Version>1.8.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library for the Cloud OS Config API (v1). These are OS management tools that can be used for patch management, patch compliance, and configuration management on VM instances.</Description>

--- a/apis/Google.Cloud.OsConfig.V1/docs/history.md
+++ b/apis/Google.Cloud.OsConfig.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 1.8.0, released 2022-02-14
+
+### Bug fixes
+
+- Fix description of an interpreter field, validate if the field is not unspecified ([commit ddc399b](https://github.com/googleapis/google-cloud-dotnet/commit/ddc399bcb2411cb5629f49a669b638570574603c))
+
+### New features
+
+- Update osconfig v1 protos ([commit 3bac0d0](https://github.com/googleapis/google-cloud-dotnet/commit/3bac0d0f26d4aa438afdf9e28d71f4e2271ff08f))
+
 ## Version 1.7.0, released 2021-11-18
 
 - [Commit aaeed36](https://github.com/googleapis/google-cloud-dotnet/commit/aaeed36): feat: Add details of items affected by a vulnerability

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2263,7 +2263,7 @@
       "protoPath": "google/cloud/osconfig/v1",
       "productName": "Google Cloud OS Config",
       "productUrl": "https://cloud.google.com/compute/docs/osconfig/rest",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "type": "grpc",
       "description": "Recommended Google client library for the Cloud OS Config API (v1). These are OS management tools that can be used for patch management, patch compliance, and configuration management on VM instances.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Fix description of an interpreter field, validate if the field is not unspecified ([commit ddc399b](https://github.com/googleapis/google-cloud-dotnet/commit/ddc399bcb2411cb5629f49a669b638570574603c))

### New features

- Update osconfig v1 protos ([commit 3bac0d0](https://github.com/googleapis/google-cloud-dotnet/commit/3bac0d0f26d4aa438afdf9e28d71f4e2271ff08f))
