### PR TITLE
Release Google.Cloud.OsConfig.V1Alpha version 1.0.0-alpha04

### DIFF
--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.csproj
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha03</Version>
+    <Version>1.0.0-alpha04</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library for the Cloud OS Config API (v1 alpha). These are OS management tools that can be used for patch management, patch compliance, and configuration management on VM instances.</Description>

--- a/apis/Google.Cloud.OsConfig.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+## Version 1.0.0-alpha04, released 2022-02-14
+
+### Bug fixes
+
+- Fix description of an interpreter field, validate if the field is not unspecified ([commit 5383e6f](https://github.com/googleapis/google-cloud-dotnet/commit/5383e6fac5edde770d475cabd458b3ae89689524))
 ## Version 1.0.0-alpha03, released 2021-09-24
 
 - [Commit c38ba1f](https://github.com/googleapis/google-cloud-dotnet/commit/c38ba1f): feat: Update osconfig v1 and v1alpha with WindowsApplication

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2283,7 +2283,7 @@
     },
     {
       "id": "Google.Cloud.OsConfig.V1Alpha",
-      "version": "1.0.0-alpha03",
+      "version": "1.0.0-alpha04",
       "type": "grpc",
       "productName": "Google Cloud OS Config",
       "productUrl": "https://cloud.google.com/compute/docs/osconfig/rest",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Fix description of an interpreter field, validate if the field is not unspecified ([commit 5383e6f](https://github.com/googleapis/google-cloud-dotnet/commit/5383e6fac5edde770d475cabd458b3ae89689524))
