### PR TITLE
Release Google.Cloud.ServiceManagement.V1 version 1.4.0

### DIFF
--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.csproj
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Service Management API, which allows service producers to publish their services on Google Cloud Platform so that they can be discovered and used by service consumers.</Description>

--- a/apis/Google.Cloud.ServiceManagement.V1/docs/history.md
+++ b/apis/Google.Cloud.ServiceManagement.V1/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 1.4.0, released 2022-02-15
+
+### Bug fixes
+
+- **BREAKING CHANGE** Remove EnableService and DisableService RPC methods and related protos from service management API ([commit d5cb1ab](https://github.com/googleapis/google-cloud-dotnet/commit/d5cb1abcd3ed51c1b1d22b622900fac9caf727ca))
+
+The breaking change here reflects the actual API; the `EnableService` and `DisableService` RPCs have not been available for some time. In other words, this change will not break any customer who isn't already broken in terms of making RPCs. (It may break mock/fake test code which expects those RPCs to still be available, however.)
+
 ## Version 1.3.0, released 2021-09-06
 
 - [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2877,7 +2877,7 @@
     },
     {
       "id": "Google.Cloud.ServiceManagement.V1",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "type": "grpc",
       "productName": "Service Management",
       "productUrl": "https://cloud.google.com/service-infrastructure/docs/service-management/reference/rpc",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- **BREAKING CHANGE** Remove EnableService and DisableService RPC methods and related protos from service management API ([commit d5cb1ab](https://github.com/googleapis/google-cloud-dotnet/commit/d5cb1abcd3ed51c1b1d22b622900fac9caf727ca))

The breaking change here reflects the actual API; the `EnableService` and `DisableService` RPCs have not been available for some time. In other words, this change will not break any customer who isn't already broken in terms of making RPCs. (It may break mock/fake test code which expects those RPCs to still be available, however.)
