### PR TITLE
Release Google.Cloud.Dataproc.V1 version 4.0.0

### DIFF
--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.csproj
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.4.0</Version>
+    <Version>4.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Dataproc API, which manages Hadoop-based clusters and jobs on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Dataproc.V1/docs/history.md
+++ b/apis/Google.Cloud.Dataproc.V1/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 4.0.0, released 2022-02-17
+
+### New features
+
+- Add support for Virtual Dataproc cluster running on GKE cluster ([commit 462556b](https://github.com/googleapis/google-cloud-dotnet/commit/462556ba2b46bd840da1198fe0bd4bfba6b13af1))
+
+### Breaking changes
+
+- ClusterConfig.GkeClusterConfig has been removed
+- GkeClusterConfig.NamespacedGkeDeploymentTarget has been removed
+  (along with the corresponding nested type)
+
 ## Version 3.4.0, released 2022-01-17
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -861,7 +861,7 @@
       "protoPath": "google/cloud/dataproc/v1",
       "productName": "Google Cloud Dataproc",
       "productUrl": "https://cloud.google.com/dataproc/docs/concepts/overview",
-      "version": "3.4.0",
+      "version": "4.0.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Dataproc API, which manages Hadoop-based clusters and jobs on Google Cloud Platform.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- Add support for Virtual Dataproc cluster running on GKE cluster ([commit 462556b](https://github.com/googleapis/google-cloud-dotnet/commit/462556ba2b46bd840da1198fe0bd4bfba6b13af1))

### Breaking changes

- ClusterConfig.GkeClusterConfig has been removed
- GkeClusterConfig.NamespacedGkeDeploymentTarget has been removed
  (along with the corresponding nested type)
