### PR TITLE
Release Google.Cloud.BigQuery.Storage.V1 version 2.7.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery Storage API.</Description>

--- a/apis/Google.Cloud.BigQuery.Storage.V1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/docs/history.md
@@ -1,5 +1,18 @@
 # Version history
 
+## Version 2.7.0, released 2022-02-22
+
+### New features
+
+- Add trace_id for Read API ([commit 2cac347](https://github.com/googleapis/google-cloud-dotnet/commit/2cac34761c11e939b6150fb70fd4409f40c7edb8))
+
+### Additional notes
+
+The `bigquery.readonly` has been removed ([commit
+f691c91](https://github.com/googleapis/google-cloud-dotnet/commit/f691c9119d6b00f1c0629a5d5bc65c7b6ee8ed12)).
+We don't expect that to break any users, but please be aware of the
+change.
+
 ## Version 2.6.0, released 2022-01-17
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -402,7 +402,7 @@
       "protoPath": "google/cloud/bigquery/storage/v1",
       "productName": "Google BigQuery Storage",
       "productUrl": "https://cloud.google.com/bigquery/docs/reference/storage/",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the BigQuery Storage API.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Add trace_id for Read API ([commit 2cac347](https://github.com/googleapis/google-cloud-dotnet/commit/2cac34761c11e939b6150fb70fd4409f40c7edb8))

### Additional notes

The `bigquery.readonly` has been removed ([commit f691c91](https://github.com/googleapis/google-cloud-dotnet/commit/f691c9119d6b00f1c0629a5d5bc65c7b6ee8ed12)). We don't expect that to break any users, but please be aware of the change.
