### PR TITLE
Release Google.Cloud.Bigtable.V2 version 2.6.0

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -17,6 +17,18 @@ jobs:
       with:
         submodules: true
         fetch-depth: 100
+        
+    # We need just the .NET Core 2.1 runtime for testing    
+    - name: Setup .NET Core 2.1
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 2.1.x
+
+    # Install .NET Core 3.1 for building
+    - name: Setup .NET Core 3.1
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.x
 
     # The GitHub checkout action leaves the repo in a slightly awkward
     # state. This tidies it up.

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -17,6 +17,18 @@ jobs:
       with:
         submodules: true
 
+    # We need just the .NET Core 2.1 runtime for testing    
+    - name: Setup .NET Core 2.1
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 2.1.x
+
+    # Install .NET Core 3.1 for building
+    - name: Setup .NET Core 3.1
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.x
+
     - name: Build and test
       run: |
         dotnet --info

--- a/.github/workflows/spanner-emulator-pr-push.yml
+++ b/.github/workflows/spanner-emulator-pr-push.yml
@@ -27,6 +27,18 @@ jobs:
       with:
         submodules: true
 
+    # We need just the .NET Core 2.1 runtime for testing    
+    - name: Setup .NET Core 2.1
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 2.1.x
+
+    # Install .NET Core 3.1 for building
+    - name: Setup .NET Core 3.1
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.x
+
     - name: Spanner Emulator
       env:
           SPANNER_EMULATOR_HOST: localhost:9010

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.5.0</Version>
+    <Version>2.6.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Bigtable API.</Description>

--- a/apis/Google.Cloud.Bigtable.V2/docs/history.md
+++ b/apis/Google.Cloud.Bigtable.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.6.0, released 2022-02-22
+
+### New features
+
+- Add WarmAndPing request for channel priming ([commit 263af4c](https://github.com/googleapis/google-cloud-dotnet/commit/263af4c4f666ebbe9e4e183fe4fb9616029bdaed))
+- Add explicit routing header annotations for bigtable/v2 ([commit 53d712e](https://github.com/googleapis/google-cloud-dotnet/commit/53d712e19ed4fc727b47534fc771363fc901f9ab))
 ## Version 2.5.0, released 2022-01-18
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -461,7 +461,7 @@
       "protoPath": "google/bigtable/v2",
       "productName": "Google Bigtable",
       "productUrl": "https://cloud.google.com/bigtable/",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "commonResourcesConfig": "apis/Google.Cloud.Bigtable.Common.V2/CommonResourcesConfig.json",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",


### PR DESCRIPTION

Changes in this release:

### New features

- Add WarmAndPing request for channel priming ([commit 263af4c](https://github.com/googleapis/google-cloud-dotnet/commit/263af4c4f666ebbe9e4e183fe4fb9616029bdaed))
- Add explicit routing header annotations for bigtable/v2 ([commit 53d712e](https://github.com/googleapis/google-cloud-dotnet/commit/53d712e19ed4fc727b47534fc771363fc901f9ab))
