### PR TITLE
Release Google.Cloud.Datastream.V1 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.csproj
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Datastream API (v1), which allows you to synchronize data across heterogeneous databases and applications reliably, and with minimal latency and downtime.</Description>

--- a/apis/Google.Cloud.Datastream.V1/docs/history.md
+++ b/apis/Google.Cloud.Datastream.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2022-02-22
+
+### New features
+
+- Add Location mixin to Google.Cloud.Datastream.V1 ([commit 26dccaf](https://github.com/googleapis/google-cloud-dotnet/commit/26dccafc5c62d97d72e428b324d32727e6056327))
+
 ## Version 1.0.0-beta01, released 2022-02-07
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -922,7 +922,7 @@
     },
     {
       "id": "Google.Cloud.Datastream.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "DataStream",
       "productUrl": "https://cloud.google.com/datastream/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Add Location mixin to Google.Cloud.Datastream.V1 ([commit 26dccaf](https://github.com/googleapis/google-cloud-dotnet/commit/26dccafc5c62d97d72e428b324d32727e6056327))
