### PR TITLE
Release Google.Cloud.Security.PrivateCA.V1 version 2.2.0

### DIFF
--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.csproj
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Certificate Authority Service API version v1. The Certificate Authority Service API is a highly-available, scalable service that enables you to simplify and automate the management of private certificate authorities (CAs) while staying in control of your private keys.</Description>
@@ -13,7 +13,7 @@
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.7.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[2.3.0, 3.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[1.0.0, 2.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.3.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.41.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.Security.PrivateCA.V1/docs/history.md
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 2.2.0, released 2022-02-22
+
+### New features
+
+- Add IAM and Location mixins to Google.Cloud.Security.PrivateCA.V1 ([commit d2ea336](https://github.com/googleapis/google-cloud-dotnet/commit/d2ea3361882a5be55cccde97fba443490b8052dd))
+
+### Documentation improvements
+
+- Mark CaPool.lifetime as IMMUTABLE ([commit 0139338](https://github.com/googleapis/google-cloud-dotnet/commit/01393381b9badc4e9e6c36bbe85dc8c74a9c2fdf))
+- Add format requirements on `custom_sans` ([commit 0139338](https://github.com/googleapis/google-cloud-dotnet/commit/01393381b9badc4e9e6c36bbe85dc8c74a9c2fdf))
+
 ## Version 2.1.0, released 2021-09-01
 
 - [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2716,7 +2716,7 @@
     },
     {
       "id": "Google.Cloud.Security.PrivateCA.V1",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "type": "grpc",
       "productName": "Certificate Authority",
       "productUrl": "https://cloud.google.com/certificate-authority-service/",
@@ -2730,7 +2730,7 @@
         "Google.Api.Gax.Grpc.GrpcCore": "3.7.0",
         "Google.Cloud.Iam.V1": "2.3.0",
         "Google.Cloud.Location": "1.0.0",
-        "Google.LongRunning": "2.2.0",
+        "Google.LongRunning": "2.3.0",
         "Grpc.Core": "2.41.0"
       },
       "generator": "micro",


### PR DESCRIPTION

Changes in this release:

### New features

- Add IAM and Location mixins to Google.Cloud.Security.PrivateCA.V1 ([commit d2ea336](https://github.com/googleapis/google-cloud-dotnet/commit/d2ea3361882a5be55cccde97fba443490b8052dd))

### Documentation improvements

- Mark CaPool.lifetime as IMMUTABLE ([commit 0139338](https://github.com/googleapis/google-cloud-dotnet/commit/01393381b9badc4e9e6c36bbe85dc8c74a9c2fdf))
- Add format requirements on `custom_sans` ([commit 0139338](https://github.com/googleapis/google-cloud-dotnet/commit/01393381b9badc4e9e6c36bbe85dc8c74a9c2fdf))
