### PR TITLE
chore: Install .NET Core 2.1 for testing

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -17,6 +17,18 @@ jobs:
       with:
         submodules: true
         fetch-depth: 100
+        
+    # We need just the .NET Core 2.1 runtime for testing    
+    - name: Setup .NET Core 2.1
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 2.1.x
+
+    # Install .NET Core 3.1 for building
+    - name: Setup .NET Core 3.1
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.x
 
     # The GitHub checkout action leaves the repo in a slightly awkward
     # state. This tidies it up.

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -17,6 +17,18 @@ jobs:
       with:
         submodules: true
 
+    # We need just the .NET Core 2.1 runtime for testing    
+    - name: Setup .NET Core 2.1
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 2.1.x
+
+    # Install .NET Core 3.1 for building
+    - name: Setup .NET Core 3.1
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.x
+
     - name: Build and test
       run: |
         dotnet --info

--- a/.github/workflows/spanner-emulator-pr-push.yml
+++ b/.github/workflows/spanner-emulator-pr-push.yml
@@ -27,6 +27,18 @@ jobs:
       with:
         submodules: true
 
+    # We need just the .NET Core 2.1 runtime for testing    
+    - name: Setup .NET Core 2.1
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 2.1.x
+
+    # Install .NET Core 3.1 for building
+    - name: Setup .NET Core 3.1
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.x
+
     - name: Spanner Emulator
       env:
           SPANNER_EMULATOR_HOST: localhost:9010


### PR DESCRIPTION
This used to be included by default, but isn't any more. We will
remove this in the next major version, when we can start testing
against .NET Core 3.1 as the lower bound.