### PR TITLE
Release Google.Cloud.Logging.V2 version 3.5.0

### DIFF
--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.csproj
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.4.0</Version>
+    <Version>3.5.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Logging API, which writes log entries and manages your logs, log sinks, and logs-based metrics.</Description>
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.7.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Logging.Type" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Logging.Type" Version="[3.4.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[2.3.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.41.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />

--- a/apis/Google.Cloud.Logging.V2/docs/history.md
+++ b/apis/Google.Cloud.Logging.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.5.0, released 2022-02-22
+
+### New features
+
+- Update Logging API with latest changes ([commit 644279c](https://github.com/googleapis/google-cloud-dotnet/commit/644279c4e5b4725b6fada108667372b39f52f83e))
+
 ## Version 3.4.0, released 2021-09-06
 
 - [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1900,7 +1900,7 @@
       "protoPath": "google/logging/v2",
       "productName": "Google Cloud Logging",
       "productUrl": "https://cloud.google.com/logging/",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Logging API, which writes log entries and manages your logs, log sinks, and logs-based metrics.",
       "tags": [
@@ -1909,7 +1909,7 @@
       ],
       "dependencies": {
         "Google.Api.Gax.Grpc.GrpcCore": "3.7.0",
-        "Google.Cloud.Logging.Type": "3.3.0",
+        "Google.Cloud.Logging.Type": "3.4.0",
         "Google.LongRunning": "2.3.0",
         "Grpc.Core": "2.41.0"
       },


### PR DESCRIPTION

Changes in this release:

### New features

- Update Logging API with latest changes ([commit 644279c](https://github.com/googleapis/google-cloud-dotnet/commit/644279c4e5b4725b6fada108667372b39f52f83e))
