### PR TITLE
chore: Add smoke tests for Google.Cloud.Video.Stitcher.V1

### DIFF
--- a/apis/Google.Cloud.Video.Stitcher.V1/smoketests.json
+++ b/apis/Google.Cloud.Video.Stitcher.V1/smoketests.json
@@ -1,0 +1,16 @@
+[
+  {
+    "method": "ListSlates",
+    "client": "VideoStitcherServiceClient",
+    "arguments": {
+      "parent": "projects/${PROJECT_ID}/locations/us-east1"
+    }
+  },
+  {
+    "method": "ListCdnKeys",
+    "client": "VideoStitcherServiceClient",
+    "arguments": {
+      "parent": "projects/${PROJECT_ID}/locations/us-east1"
+    }
+  }
+]


### PR DESCRIPTION
The CI project has now been allow-listed - but we shouldn't release the library until the allow-list has been removed entirely.