### PR TITLE
Release Google.Cloud.GkeHub.V1Beta1 version 1.0.0-beta04

### DIFF
--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.csproj
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta03</Version>
+    <Version>1.0.0-beta04</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the GKE Hub API, version v1beta1.</Description>

--- a/apis/Google.Cloud.GkeHub.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/docs/history.md
@@ -1,5 +1,14 @@
 # Version history
 
+## Version 1.0.0-beta04, released 2022-02-28
+
+### New features
+
+- Added support for k8s_version field ([commit 38e1e18](https://github.com/googleapis/google-cloud-dotnet/commit/38e1e18e562490fc3b68d55f64c816421ed40a5c))
+
+### Documentation improvements
+
+- K8s_version field is not part of resource_options struct ([commit 38e1e18](https://github.com/googleapis/google-cloud-dotnet/commit/38e1e18e562490fc3b68d55f64c816421ed40a5c))
 ## Version 1.0.0-beta03, released 2021-09-23
 
 - [Commit 1d19cbd](https://github.com/googleapis/google-cloud-dotnet/commit/1d19cbd):

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1558,7 +1558,7 @@
     },
     {
       "id": "Google.Cloud.GkeHub.V1Beta1",
-      "version": "1.0.0-beta03",
+      "version": "1.0.0-beta04",
       "type": "grpc",
       "productName": "GKE Hub",
       "productUrl": "https://cloud.google.com/anthos/multicluster-management/connect/registering-a-cluster",


### PR DESCRIPTION

Changes in this release:

### New features

- Added support for k8s_version field ([commit 38e1e18](https://github.com/googleapis/google-cloud-dotnet/commit/38e1e18e562490fc3b68d55f64c816421ed40a5c))

### Documentation improvements

- K8s_version field is not part of resource_options struct ([commit 38e1e18](https://github.com/googleapis/google-cloud-dotnet/commit/38e1e18e562490fc3b68d55f64c816421ed40a5c))
