### PR TITLE
Release Google.Cloud.Dataplex.V1 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.Dataplex.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.Dataplex.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.Dataplex.V1",
-  "release_level": "preview",
+  "release_level": "stable",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Dataplex.V1/latest",
   "library_type": "GAPIC_AUTO",
   "api_shortname": "dataplex"

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.csproj
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Dataplex API, which is used to manage the lifecycle of data lakes.</Description>

--- a/apis/Google.Cloud.Dataplex.V1/docs/history.md
+++ b/apis/Google.Cloud.Dataplex.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0, released 2022-03-14
+
+No API surface changes; just dependency updates and promotion to GA.
+
 ## Version 1.0.0-beta02, released 2022-02-22
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -838,7 +838,7 @@
     },
     {
       "id": "Google.Cloud.Dataplex.V1",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Cloud Dataplex",
       "productUrl": "https://cloud.google.com/dataplex/docs",
@@ -848,7 +848,9 @@
         "dataplex"
       ],
       "dependencies": {
-        "Google.LongRunning": "2.3.0"
+        "Google.Api.Gax.Grpc.GrpcCore": "3.7.0",
+        "Google.LongRunning": "2.3.0",
+        "Grpc.Core": "2.41.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/dataplex/v1",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates and promotion to GA.
