### PR TITLE
Release Google.Analytics.Admin.V1Alpha version 1.0.0-alpha11

### DIFF
--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha10</Version>
+    <Version>1.0.0-alpha11</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Analytics Admin API (v1alpha)</Description>

--- a/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
+++ b/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 1.0.0-alpha11, released 2022-03-14
+
+### New features
+
+- **BREAKING CHANGE** Remove `WebDataStream`, `IosAppDataStream`, `AndroidAppDataStream` resources, and corresponding operations, as they are replaced by the `DataStream` resource ([commit 9f989fd](https://github.com/googleapis/google-cloud-dotnet/commit/9f989fd74cd939ea7b6e08cb95f3aa8d567464ce))
+- Add `restricted_metric_type` field to the `CustomMetric` resource ([commit 9f989fd](https://github.com/googleapis/google-cloud-dotnet/commit/9f989fd74cd939ea7b6e08cb95f3aa8d567464ce))
+- **BREAKING CHANGE** Move the `GlobalSiteTag` resource from the property level to the data stream level ([commit 9f989fd](https://github.com/googleapis/google-cloud-dotnet/commit/9f989fd74cd939ea7b6e08cb95f3aa8d567464ce))
 ## Version 1.0.0-alpha10, released 2022-01-17
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2,7 +2,7 @@
   "apis": [
     {
       "id": "Google.Analytics.Admin.V1Alpha",
-      "version": "1.0.0-alpha10",
+      "version": "1.0.0-alpha11",
       "type": "grpc",
       "productName": "Analytics Admin",
       "productUrl": "https://developers.google.com/analytics",


### PR DESCRIPTION

Changes in this release:

### New features

- **BREAKING CHANGE** Remove `WebDataStream`, `IosAppDataStream`, `AndroidAppDataStream` resources, and corresponding operations, as they are replaced by the `DataStream` resource ([commit 9f989fd](https://github.com/googleapis/google-cloud-dotnet/commit/9f989fd74cd939ea7b6e08cb95f3aa8d567464ce))
- Add `restricted_metric_type` field to the `CustomMetric` resource ([commit 9f989fd](https://github.com/googleapis/google-cloud-dotnet/commit/9f989fd74cd939ea7b6e08cb95f3aa8d567464ce))
- **BREAKING CHANGE** Move the `GlobalSiteTag` resource from the property level to the data stream level ([commit 9f989fd](https://github.com/googleapis/google-cloud-dotnet/commit/9f989fd74cd939ea7b6e08cb95f3aa8d567464ce))
