### PR TITLE
Release Google.Cloud.BigQuery.Storage.V1 version 2.8.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.7.0</Version>
+    <Version>2.8.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery Storage API.</Description>

--- a/apis/Google.Cloud.BigQuery.Storage.V1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 2.8.0, released 2022-03-14
+
+### New features
+
+- Update default timeout/retry information ([commit e64637d](https://github.com/googleapis/google-cloud-dotnet/commit/e64637d6ed0544c3fe2981560a8ea8c8a5532364))
+- Update parent annotation for BatchCommitWriteStreamsRequest ([commit e64637d](https://github.com/googleapis/google-cloud-dotnet/commit/e64637d6ed0544c3fe2981560a8ea8c8a5532364))
+- Expose additional StorageError enum values ([commit e64637d](https://github.com/googleapis/google-cloud-dotnet/commit/e64637d6ed0544c3fe2981560a8ea8c8a5532364))
+
+### Documentation improvements
+
+- Improve documentation for write client ([commit e64637d](https://github.com/googleapis/google-cloud-dotnet/commit/e64637d6ed0544c3fe2981560a8ea8c8a5532364))
+
 ## Version 2.7.0, released 2022-02-22
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -402,7 +402,7 @@
       "protoPath": "google/cloud/bigquery/storage/v1",
       "productName": "Google BigQuery Storage",
       "productUrl": "https://cloud.google.com/bigquery/docs/reference/storage/",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the BigQuery Storage API.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Update default timeout/retry information ([commit e64637d](https://github.com/googleapis/google-cloud-dotnet/commit/e64637d6ed0544c3fe2981560a8ea8c8a5532364))
- Update parent annotation for BatchCommitWriteStreamsRequest ([commit e64637d](https://github.com/googleapis/google-cloud-dotnet/commit/e64637d6ed0544c3fe2981560a8ea8c8a5532364))
- Expose additional StorageError enum values ([commit e64637d](https://github.com/googleapis/google-cloud-dotnet/commit/e64637d6ed0544c3fe2981560a8ea8c8a5532364))

### Documentation improvements

- Improve documentation for write client ([commit e64637d](https://github.com/googleapis/google-cloud-dotnet/commit/e64637d6ed0544c3fe2981560a8ea8c8a5532364))
