### PR TITLE
Release Google.Cloud.TextToSpeech.V1 version 2.5.0

### DIFF
--- a/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.csproj
+++ b/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.4.0</Version>
+    <Version>2.5.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Text-to-Speech API v1, synthesizes natural-sounding speech by applying powerful neural network models.</Description>

--- a/apis/Google.Cloud.TextToSpeech.V1/docs/history.md
+++ b/apis/Google.Cloud.TextToSpeech.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 2.5.0, released 2022-03-14
+
+### New features
+
+- Promote CustomVoiceParams to v1 ([commit ba7f867](https://github.com/googleapis/google-cloud-dotnet/commit/ba7f867b223b52cbbf0d742fd603e3f99cc52c99))
+
+### Documentation improvements
+
+- Update comments for ListVoicesRequest ([commit 479ddef](https://github.com/googleapis/google-cloud-dotnet/commit/479ddef27f04eb184c2c2cdb621fe5caf6a4118b))
+
 ## Version 2.4.0, released 2021-11-18
 
 - [Commit fc5df69](https://github.com/googleapis/google-cloud-dotnet/commit/fc5df69):

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3238,7 +3238,7 @@
       "protoPath": "google/cloud/texttospeech/v1",
       "productName": "Google Cloud Text-to-Speech",
       "productUrl": "https://cloud.google.com/text-to-speech",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Text-to-Speech API v1, synthesizes natural-sounding speech by applying powerful neural network models.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Promote CustomVoiceParams to v1 ([commit ba7f867](https://github.com/googleapis/google-cloud-dotnet/commit/ba7f867b223b52cbbf0d742fd603e3f99cc52c99))

### Documentation improvements

- Update comments for ListVoicesRequest ([commit 479ddef](https://github.com/googleapis/google-cloud-dotnet/commit/479ddef27f04eb184c2c2cdb621fe5caf6a4118b))
