### PR TITLE
fix(PubSub): Increased grpc.max_metadata_size value to 4 M.B. 

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberClient.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberClient.cs
@@ -48,7 +48,9 @@ namespace Google.Cloud.PubSub.V1
     {
         private static readonly GrpcChannelOptions s_unlimitedSendReceiveChannelOptions = GrpcChannelOptions.Empty
             .WithMaxReceiveMessageSize(-1)
-            .WithMaxSendMessageSize(-1);
+            .WithMaxSendMessageSize(-1)            
+            // Set max metadata size to 4 MB i.e., 4194304 bytes.
+            .WithCustomOption("grpc.max_metadata_size", "4194304");
 
         /// <summary>
         /// Reply from a message handler; whether to <see cref="Ack"/>


### PR DESCRIPTION
Increased GRPC Max metadata size value to 4 M.B in GrpcChannelOptions for Subscriber client