### PR TITLE
Release Google.Cloud.Dataflow.V1Beta3 version 1.0.0-beta03

### DIFF
--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.csproj
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Dataflow API (v1beta3) which manages Google Cloud Dataflow projects on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Dataflow.V1Beta3/docs/history.md
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 1.0.0-beta03, released 2022-03-28
+
+### Bug fixes
+
+- Added google.api.http annotations to RPCs. Fixes [issue 7038](https://github.com/googleapis/google-cloud-dotnet/issues/7038). ([commit 7e6edad](https://github.com/googleapis/google-cloud-dotnet/commit/7e6edad1653324684e07186c859ee4b7c41ebea5))
+
+### New features
+
+- Add the ability to plumb environment capabilities through v1beta3 protos. ([commit f703fba](https://github.com/googleapis/google-cloud-dotnet/commit/f703fba5ac47cef0badc2248c5a41088ca49dd5e))
+- New parameters in FlexTemplateRuntimeEnvironment ([commit 7e6edad](https://github.com/googleapis/google-cloud-dotnet/commit/7e6edad1653324684e07186c859ee4b7c41ebea5))
+
 ## Version 1.0.0-beta02, released 2021-08-19
 
 - [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -823,7 +823,7 @@
     },
     {
       "id": "Google.Cloud.Dataflow.V1Beta3",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0-beta03",
       "type": "grpc",
       "productName": "Dataflow",
       "productUrl": "https://cloud.google.com/dataflow/docs/",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Added google.api.http annotations to RPCs. Fixes [issue 7038](https://github.com/googleapis/google-cloud-dotnet/issues/7038). ([commit 7e6edad](https://github.com/googleapis/google-cloud-dotnet/commit/7e6edad1653324684e07186c859ee4b7c41ebea5))

### New features

- Add the ability to plumb environment capabilities through v1beta3 protos. ([commit f703fba](https://github.com/googleapis/google-cloud-dotnet/commit/f703fba5ac47cef0badc2248c5a41088ca49dd5e))
- New parameters in FlexTemplateRuntimeEnvironment ([commit 7e6edad](https://github.com/googleapis/google-cloud-dotnet/commit/7e6edad1653324684e07186c859ee4b7c41ebea5))
