### PR TITLE
fix(PubSub): Increased grpc.max_metadata_size value to 4 M.B.

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/PublisherClient.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/PublisherClient.cs
@@ -40,7 +40,9 @@ namespace Google.Cloud.PubSub.V1
     {
         private static readonly GrpcChannelOptions s_unlimitedSendReceiveChannelOptions = GrpcChannelOptions.Empty
             .WithMaxReceiveMessageSize(-1)
-            .WithMaxSendMessageSize(-1);
+            .WithMaxSendMessageSize(-1)
+            // Set max metadata size to 4 MB i.e., 4194304 bytes.
+            .WithCustomOption("grpc.max_metadata_size", 4194304);
 
         // TODO: Logging
 


### PR DESCRIPTION
Contains changes in PublisherClient to increase grpc.max_metadata_size value to 4 M.B. SubscriberClient changes were done in  #8269  This change is done to maintain consistency with other language libraries.  