### PR TITLE
Release Google.Cloud.PubSub.V1 version 2.9.0

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.8.0</Version>
+    <Version>2.9.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.</Description>

--- a/apis/Google.Cloud.PubSub.V1/docs/history.md
+++ b/apis/Google.Cloud.PubSub.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 2.9.0, released 2022-04-04
+
+### Bug fixes
+
+- Increased grpc.max_metadata_size value to 4 M.B. in PublisherClient ([commit a29a5f3](https://github.com/googleapis/google-cloud-dotnet/commit/a29a5f3e89b3be037c64ab2b74ff44199d88cff5))
+- Ignore exceptions during Ack/ModifyAckDeadline in SubscriberClient ([commit f36fd61](https://github.com/googleapis/google-cloud-dotnet/commit/f36fd619f2ce50425fda5fb9f19f6ada48fb6f40))
+
 ## Version 2.8.0, released 2022-03-22
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2513,7 +2513,7 @@
       "protoPath": "google/pubsub/v1",
       "productName": "Cloud Pub/Sub",
       "productUrl": "https://cloud.google.com/pubsub/",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Increased grpc.max_metadata_size value to 4 M.B. in PublisherClient ([commit a29a5f3](https://github.com/googleapis/google-cloud-dotnet/commit/a29a5f3e89b3be037c64ab2b74ff44199d88cff5))
- Ignore exceptions during Ack/ModifyAckDeadline in SubscriberClient ([commit f36fd61](https://github.com/googleapis/google-cloud-dotnet/commit/f36fd619f2ce50425fda5fb9f19f6ada48fb6f40))
