### PR TITLE
Release Google.Cloud.ArtifactRegistry.V1 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.csproj
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Artifact Registry API v1, which stores and manages build artifacts in a scalable and integrated service built on Google infrastructure.</Description>

--- a/apis/Google.Cloud.ArtifactRegistry.V1/docs/history.md
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.1.0, released 2022-04-04
+
+### New features
+
+- Promote v1beta2 features to v1 ([commit 5c5d56f](https://github.com/googleapis/google-cloud-dotnet/commit/5c5d56f989536b2764bf777e6db6a3a98da6ab27))
+
 ## Version 1.0.0, released 2021-11-10
 
 - [Commit a21c747](https://github.com/googleapis/google-cloud-dotnet/commit/a21c747): docs: fix docstring formatting

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -169,7 +169,7 @@
     },
     {
       "id": "Google.Cloud.ArtifactRegistry.V1",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "grpc",
       "productName": "Artifact Registry",
       "productUrl": "https://cloud.google.com/artifact-registry",


### PR DESCRIPTION

Changes in this release:

### New features

- Promote v1beta2 features to v1 ([commit 5c5d56f](https://github.com/googleapis/google-cloud-dotnet/commit/5c5d56f989536b2764bf777e6db6a3a98da6ab27))
