### PR TITLE
Release Google.Cloud.BigQuery.Storage.V1 version 2.9.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.8.0</Version>
+    <Version>2.9.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery Storage API.</Description>

--- a/apis/Google.Cloud.BigQuery.Storage.V1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.9.0, released 2022-04-04
+
+### New features
+
+- Deprecate format specific `row_count` field in Read API ([commit 682ee9e](https://github.com/googleapis/google-cloud-dotnet/commit/682ee9e031905a71c664234e6901de88438d7556))
+
 ## Version 2.8.0, released 2022-03-14
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -438,7 +438,7 @@
       "protoPath": "google/cloud/bigquery/storage/v1",
       "productName": "Google BigQuery Storage",
       "productUrl": "https://cloud.google.com/bigquery/docs/reference/storage/",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the BigQuery Storage API.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Deprecate format specific `row_count` field in Read API ([commit 682ee9e](https://github.com/googleapis/google-cloud-dotnet/commit/682ee9e031905a71c664234e6901de88438d7556))
