### PR TITLE
Release Google.Cloud.Bigtable.Admin.V2 version 2.8.0

### DIFF
--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.csproj
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.7.0</Version>
+    <Version>2.8.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Bigtable Instance and Table Admin APIs.</Description>

--- a/apis/Google.Cloud.Bigtable.Admin.V2/docs/history.md
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 2.8.0, released 2022-04-04
+
+### New features
+
+- Add ListHotTablets API method and protobufs ([commit 56eea19](https://github.com/googleapis/google-cloud-dotnet/commit/56eea199afd45dcb1cef9179910e0b6307959fe0))
+
+### Documentation improvements
+
+- Update `cpu_utilization_percent` limit ([commit 01b008d](https://github.com/googleapis/google-cloud-dotnet/commit/01b008ddedb11234ef3452ef3da85d92b69fd86a))
+- Remove the limitation of all clusters in a CMEK instance must use the same key ([commit 01b008d](https://github.com/googleapis/google-cloud-dotnet/commit/01b008ddedb11234ef3452ef3da85d92b69fd86a))
+
 ## Version 2.7.0, released 2021-12-07
 
 - [Commit c8a3a3e](https://github.com/googleapis/google-cloud-dotnet/commit/c8a3a3e): feat: add Autoscaling API

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -457,7 +457,7 @@
       "protoPath": "google/bigtable/admin/v2",
       "productName": "Google Cloud Bigtable Administration",
       "productUrl": "https://cloud.google.com/bigtable/",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "commonResourcesConfig": "apis/Google.Cloud.Bigtable.Common.V2/CommonResourcesConfig.json",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Bigtable Instance and Table Admin APIs.",


### PR DESCRIPTION

Changes in this release:

### New features

- Add ListHotTablets API method and protobufs ([commit 56eea19](https://github.com/googleapis/google-cloud-dotnet/commit/56eea199afd45dcb1cef9179910e0b6307959fe0))

### Documentation improvements

- Update `cpu_utilization_percent` limit ([commit 01b008d](https://github.com/googleapis/google-cloud-dotnet/commit/01b008ddedb11234ef3452ef3da85d92b69fd86a))
- Remove the limitation of all clusters in a CMEK instance must use the same key ([commit 01b008d](https://github.com/googleapis/google-cloud-dotnet/commit/01b008ddedb11234ef3452ef3da85d92b69fd86a))
