### PR TITLE
Release Google.Cloud.Dialogflow.Cx.V3 version 1.11.0

### DIFF
--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.csproj
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.10.0</Version>
+    <Version>1.11.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Builds conversational interfaces (for example, chatbots, and voice-powered apps and devices).</Description>

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/docs/history.md
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 1.11.0, released 2022-04-04
+
+### New features
+
+- Added support for locking an agent for changes ([commit 7afeda7](https://github.com/googleapis/google-cloud-dotnet/commit/7afeda772cb17f1bd039bd53554df68e67cff1b9))
+- Added data format specification for export agent ([commit 7afeda7](https://github.com/googleapis/google-cloud-dotnet/commit/7afeda772cb17f1bd039bd53554df68e67cff1b9))
+
+### Documentation improvements
+
+- Improved docs format ([commit 034e33b](https://github.com/googleapis/google-cloud-dotnet/commit/034e33b72ef0ad4e40cbc6fe3838b30fbde59e57))
+
 ## Version 1.10.0, released 2022-03-14
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1167,7 +1167,7 @@
     },
     {
       "id": "Google.Cloud.Dialogflow.Cx.V3",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "type": "grpc",
       "productName": "Dialogflow",
       "productUrl": "https://cloud.google.com/dialogflow/cx/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Added support for locking an agent for changes ([commit 7afeda7](https://github.com/googleapis/google-cloud-dotnet/commit/7afeda772cb17f1bd039bd53554df68e67cff1b9))
- Added data format specification for export agent ([commit 7afeda7](https://github.com/googleapis/google-cloud-dotnet/commit/7afeda772cb17f1bd039bd53554df68e67cff1b9))

### Documentation improvements

- Improved docs format ([commit 034e33b](https://github.com/googleapis/google-cloud-dotnet/commit/034e33b72ef0ad4e40cbc6fe3838b30fbde59e57))
