### PR TITLE
Release Google.Cloud.Dlp.V2 version 3.5.0

### DIFF
--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.csproj
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.4.0</Version>
+    <Version>3.5.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Data Loss Prevention API, which provides methods for detection of privacy-sensitive fragments in text, images, and Google Cloud Platform storage repositories.</Description>

--- a/apis/Google.Cloud.Dlp.V2/docs/history.md
+++ b/apis/Google.Cloud.Dlp.V2/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 3.5.0, released 2022-04-04
+
+### New features
+
+- Add DataProfilePubSubMessage supporting pub/sub integration ([commit 5d46153](https://github.com/googleapis/google-cloud-dotnet/commit/5d461532af7674d5494ee29dfb9867897910b347))
+- New Bytes and File types: POWERPOINT and EXCEL ([commit 114219d](https://github.com/googleapis/google-cloud-dotnet/commit/114219d198dc22acfd4fdf2839e3bda6bc7f17af))
+
 ## Version 3.4.0, released 2021-12-07
 
 - [Commit 4ccc8e5](https://github.com/googleapis/google-cloud-dotnet/commit/4ccc8e5):

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1217,7 +1217,7 @@
       "protoPath": "google/privacy/dlp/v2",
       "productName": "Google Cloud Data Loss Prevention",
       "productUrl": "https://cloud.google.com/dlp/",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Data Loss Prevention API, which provides methods for detection of privacy-sensitive fragments in text, images, and Google Cloud Platform storage repositories.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Add DataProfilePubSubMessage supporting pub/sub integration ([commit 5d46153](https://github.com/googleapis/google-cloud-dotnet/commit/5d461532af7674d5494ee29dfb9867897910b347))
- New Bytes and File types: POWERPOINT and EXCEL ([commit 114219d](https://github.com/googleapis/google-cloud-dotnet/commit/114219d198dc22acfd4fdf2839e3bda6bc7f17af))
