### PR TITLE
Release Google.Cloud.Redis.V1 version 2.5.0

### DIFF
--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.csproj
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.4.0</Version>
+    <Version>2.5.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to administer Cloud Memorystore for Redis.</Description>

--- a/apis/Google.Cloud.Redis.V1/docs/history.md
+++ b/apis/Google.Cloud.Redis.V1/docs/history.md
@@ -1,5 +1,14 @@
 # Version history
 
+## Version 2.5.0, released 2022-04-04
+
+### New features
+
+- Add support for Maintenance Window ([commit fa2f5e9](https://github.com/googleapis/google-cloud-dotnet/commit/fa2f5e95b580a0aa03618408b09d798c9e6d82d8))
+- Add support for AUTH functionality ([commit bed04f2](https://github.com/googleapis/google-cloud-dotnet/commit/bed04f2667156b728fe42c748f71fddf613c02e7))
+- Add support for TLS functionality ([commit bed04f2](https://github.com/googleapis/google-cloud-dotnet/commit/bed04f2667156b728fe42c748f71fddf613c02e7))
+- Add secondary_ip_range field ([commit bed04f2](https://github.com/googleapis/google-cloud-dotnet/commit/bed04f2667156b728fe42c748f71fddf613c02e7))
+
 ## Version 2.4.0, released 2021-11-10
 
 - [Commit a7e87ee](https://github.com/googleapis/google-cloud-dotnet/commit/a7e87ee): feat: Support Multiple Read Replicas when creating Instance

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2612,7 +2612,7 @@
       "protoPath": "google/cloud/redis/v1",
       "productName": "Google Cloud Memorystore for Redis",
       "productUrl": "https://cloud.google.com/memorystore/",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "type": "grpc",
       "description": "Recommended Google client library to administer Cloud Memorystore for Redis.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Add support for Maintenance Window ([commit fa2f5e9](https://github.com/googleapis/google-cloud-dotnet/commit/fa2f5e95b580a0aa03618408b09d798c9e6d82d8))
- Add support for AUTH functionality ([commit bed04f2](https://github.com/googleapis/google-cloud-dotnet/commit/bed04f2667156b728fe42c748f71fddf613c02e7))
- Add support for TLS functionality ([commit bed04f2](https://github.com/googleapis/google-cloud-dotnet/commit/bed04f2667156b728fe42c748f71fddf613c02e7))
- Add secondary_ip_range field ([commit bed04f2](https://github.com/googleapis/google-cloud-dotnet/commit/bed04f2667156b728fe42c748f71fddf613c02e7))
