### PR TITLE
fix: VideoIntelligence snippets are sensitive to precise words

### DIFF
--- a/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1.Snippets/VideoIntelligenceServiceClientSnippets.cs
+++ b/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1.Snippets/VideoIntelligenceServiceClientSnippets.cs
@@ -86,7 +86,8 @@ namespace Google.Cloud.VideoIntelligence.V1.Snippets
             IEnumerable<string> allTranscripts = result.SpeechTranscriptions
                 .SelectMany(st => st.Alternatives)
                 .Select(alt => alt.Transcript);
-            Assert.Contains(allTranscripts, t => t.Contains("Paris is special because"));
+            
+            Assert.Contains(allTranscripts, t => t.Contains("shows the will of Google to invest for long-term in France"));
         }
     }
 }


### PR DESCRIPTION
This change seems to be okay and corresponds to fairly clear text.
We can make it looser later if we need to.