### PR TITLE
chore: Regenerate mixins with GAX-v4-compliant generator

### DIFF
--- a/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/IAMPolicyClient.g.cs
+++ b/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/IAMPolicyClient.g.cs
@@ -183,6 +183,7 @@ namespace Google.Cloud.Iam.V1
         /// <remarks>The default IAMPolicy scopes are:<list type="bullet"></list></remarks>
         public static scg::IReadOnlyList<string> DefaultScopes { get; } = new sco::ReadOnlyCollection<string>(new string[] { });
 
+        /// <summary>The service metadata associated with this client type.</summary>
         internal static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(IAMPolicy.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);

--- a/apis/Google.Cloud.Location/Google.Cloud.Location/LocationsClient.g.cs
+++ b/apis/Google.Cloud.Location/Google.Cloud.Location/LocationsClient.g.cs
@@ -155,6 +155,7 @@ namespace Google.Cloud.Location
             "https://www.googleapis.com/auth/cloud-platform",
         });
 
+        /// <summary>The service metadata associated with this client type.</summary>
         internal static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Locations.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);

--- a/apis/Google.LongRunning/Google.LongRunning/OperationsClient.g.cs
+++ b/apis/Google.LongRunning/Google.LongRunning/OperationsClient.g.cs
@@ -218,6 +218,7 @@ namespace Google.LongRunning
         /// <remarks>The default Operations scopes are:<list type="bullet"></list></remarks>
         public static scg::IReadOnlyList<string> DefaultScopes { get; } = new sco::ReadOnlyCollection<string>(new string[] { });
 
+        /// <summary>The service metadata associated with this client type.</summary>
         internal static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Operations.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);

--- a/apis/Google.LongRunning/Google.LongRunning/PackageApiMetadata.g.cs
+++ b/apis/Google.LongRunning/Google.LongRunning/PackageApiMetadata.g.cs
@@ -24,7 +24,7 @@ namespace Google.LongRunning
     internal static class PackageApiMetadata
     {
         /// <summary>The <see cref="gaxgrpc::ApiMetadata"/> for services in this package.</summary>
-        internal static gaxgrpc::ApiMetadata ApiMetadata { get; } = new gaxgrpc::ApiMetadata("Google.Cloud.Iam.V1", GetFileDescriptors);
+        internal static gaxgrpc::ApiMetadata ApiMetadata { get; } = new gaxgrpc::ApiMetadata("Google.LongRunning", GetFileDescriptors);
 
         private static scg::IEnumerable<gpr::FileDescriptor> GetFileDescriptors()
         {


### PR DESCRIPTION
The generator in https://github.com/googleapis/gapic-generator-csharp/pull/462 was used for this.

The changes are just minor.