### PR TITLE
Release Google.Cloud.Compute.V1 version 1.2.0

### DIFF
--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Compute Engine API.</Description>

--- a/apis/Google.Cloud.Compute.V1/docs/history.md
+++ b/apis/Google.Cloud.Compute.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.2.0, released 2022-04-08
+
+### New features
+
+- Update compute API to revision 20220322 ([issue 710](https://github.com/googleapis/google-cloud-dotnet/issues/710)) ([commit 282c421](https://github.com/googleapis/google-cloud-dotnet/commit/282c421c1e5a76ed5734d9e7bf6440610e27db0c))
+
 ## Version 1.1.0, released 2022-02-14
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -719,7 +719,7 @@
     },
     {
       "id": "Google.Cloud.Compute.V1",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "type": "regapic",
       "productName": "Compute Engine",
       "productUrl": "https://cloud.google.com/compute",


### PR DESCRIPTION

Changes in this release:

### New features

- Update compute API to revision 20220322 ([issue 710](https://github.com/googleapis/google-cloud-dotnet/issues/710)) ([commit 282c421](https://github.com/googleapis/google-cloud-dotnet/commit/282c421c1e5a76ed5734d9e7bf6440610e27db0c))
