### PR TITLE
[Bugfix] Allow to read data from big query table with connected google sheet

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClient.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClient.cs
@@ -49,11 +49,17 @@ namespace Google.Cloud.BigQuery.V2
     /// </remarks>
     public abstract partial class BigQueryClient : IDisposable
     {
+        /// <summary>
+        /// Google Drive Scope is required when Big Query Table has Google Sheet as a data source.
+        /// </summary>
+        private const string GoogleDriveScope = "https://www.googleapis.com/auth/drive";
+
         private static readonly string[] s_scopes = new[] {
                 BigqueryService.Scope.Bigquery,
                 BigqueryService.Scope.BigqueryInsertdata,
                 BigqueryService.Scope.DevstorageFullControl,
-                BigqueryService.Scope.CloudPlatform
+                BigqueryService.Scope.CloudPlatform,
+                GoogleDriveScope
             };
 
         internal static ScopedCredentialProvider ScopedCredentialProvider { get; } =


### PR DESCRIPTION
Hi everyone,

I would like to propose the code change to include "Drive" scope in BigQueryClient.
Currently when big query table is connected with google sheet the client library is not able to read data from it.
The library throws "Access Denied: BigQuery BigQuery: Permission denied while getting Drive credentials." even when service account has all required privileges (access to the sheet, access to the dataset/table etc...).

By adding these 2 lines of code everything starts to work without any problems.