### PR TITLE
Release Google.Cloud.Compute.V1 version 1.3.0

### DIFF
--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Compute Engine API.</Description>

--- a/apis/Google.Cloud.Compute.V1/docs/history.md
+++ b/apis/Google.Cloud.Compute.V1/docs/history.md
@@ -1,5 +1,18 @@
 # Version history
 
+## Version 1.3.0, released 2022-04-13
+
+### Bug fixes
+
+- Remove proto3_optional from parent_id ([issue 712](https://github.com/googleapis/google-cloud-dotnet/issues/712)) ([commit eabc9ef](https://github.com/googleapis/google-cloud-dotnet/commit/eabc9efd1841d18c0637650905c7276865c8b56a))
+- Replace missing REQUIRED for parent_id ([issue 711](https://github.com/googleapis/google-cloud-dotnet/issues/711)) ([commit d2b3623](https://github.com/googleapis/google-cloud-dotnet/commit/d2b362398918387d2586c26c240d5e05b16b4b08))
+
+BREAKING CHANGES: The above changes are breaking, in terms of
+removing the `HasParentId` and `ClearParentId()` members. We are
+releasing as a minor version as these members were only introduced
+less than a week ago, and the change will definitely be needed
+long-term.
+
 ## Version 1.2.0, released 2022-04-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -719,7 +719,7 @@
     },
     {
       "id": "Google.Cloud.Compute.V1",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "type": "regapic",
       "productName": "Compute Engine",
       "productUrl": "https://cloud.google.com/compute",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Remove proto3_optional from parent_id ([issue 712](https://github.com/googleapis/google-cloud-dotnet/issues/712)) ([commit eabc9ef](https://github.com/googleapis/google-cloud-dotnet/commit/eabc9efd1841d18c0637650905c7276865c8b56a))
- Replace missing REQUIRED for parent_id ([issue 711](https://github.com/googleapis/google-cloud-dotnet/issues/711)) ([commit d2b3623](https://github.com/googleapis/google-cloud-dotnet/commit/d2b362398918387d2586c26c240d5e05b16b4b08))

BREAKING CHANGES: The above changes are breaking, in terms of removing the `HasParentId` and `ClearParentId()` members. We are releasing as a minor version as these members were only introduced less than a week ago, and the change will definitely be needed long-term.
