### PR TITLE
Release Google.Cloud.Compute.V1 version 1.4.0

### DIFF
--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Compute Engine API.</Description>

--- a/apis/Google.Cloud.Compute.V1/docs/history.md
+++ b/apis/Google.Cloud.Compute.V1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 1.4.0, released 2022-04-21
+
+### Bug fixes
+
+- Revert proto3_optional, required removal on parent_id ([issue 714](https://github.com/googleapis/google-cloud-dotnet/issues/714)) ([commit a6d7f74](https://github.com/googleapis/google-cloud-dotnet/commit/a6d7f74ce3b8d0e15c5965a6afdf64355cb59942))
+
+BREAKING CHANGE: The above change is breaking, in terms of
+removing the `HasParentId` and `ClearParentId()` members. We are
+releasing as a minor version as these members were only introduced
+recently, and the change will definitely be needed long-term.
+
 ## Version 1.3.0, released 2022-04-13
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -719,7 +719,7 @@
     },
     {
       "id": "Google.Cloud.Compute.V1",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "type": "regapic",
       "productName": "Compute Engine",
       "productUrl": "https://cloud.google.com/compute",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Revert proto3_optional, required removal on parent_id ([issue 714](https://github.com/googleapis/google-cloud-dotnet/issues/714)) ([commit a6d7f74](https://github.com/googleapis/google-cloud-dotnet/commit/a6d7f74ce3b8d0e15c5965a6afdf64355cb59942))

BREAKING CHANGE: The above change is breaking, in terms of removing the `HasParentId` and `ClearParentId()` members. We are releasing as a minor version as these members were only introduced recently, and the change will definitely be needed long-term.
