### PR TITLE
Release Google.Cloud.Eventarc.Publishing.V1 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1.csproj
+++ b/apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Eventarc Publishing API</Description>

--- a/apis/Google.Cloud.Eventarc.Publishing.V1/docs/history.md
+++ b/apis/Google.Cloud.Eventarc.Publishing.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2022-04-21
+
+### New features
+
+- Add publishing methods for channel resources ([commit b5ef156](https://github.com/googleapis/google-cloud-dotnet/commit/b5ef156498297f70af0d736dbbe170ccb4a3365c))
+
 ## Version 1.0.0-beta01, released 2022-01-10
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1359,7 +1359,7 @@
     },
     {
       "id": "Google.Cloud.Eventarc.Publishing.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Eventarc Publishing",
       "productUrl": "https://cloud.google.com/eventarc/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Add publishing methods for channel resources ([commit b5ef156](https://github.com/googleapis/google-cloud-dotnet/commit/b5ef156498297f70af0d736dbbe170ccb4a3365c))
