### PR TITLE
feat(Spanner): SpannerDate and its unit tests

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SpannerDateTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SpannerDateTests.cs
@@ -1,0 +1,160 @@
+﻿// Copyright 2022 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Xunit;
+
+namespace Google.Cloud.Spanner.V1.Tests
+{
+    public class SpannerDateTests
+    {
+        public static IEnumerable<object[]> FromDateTimeData()
+        {
+            // Input: DateTime values.
+            yield return new object[] { new DateTime(2022, 4, 18, 0, 0, 0, DateTimeKind.Utc) };
+            yield return new object[] { new DateTime(2022, 4, 18, 1, 0, 0, DateTimeKind.Utc) };
+            yield return new object[] { new DateTime(2022, 4, 18, 0, 0, 0, DateTimeKind.Local) };
+            yield return new object[] { new DateTime(2022, 4, 18, 1, 0, 0, DateTimeKind.Local) };
+            yield return new object[] { new DateTime(2022, 4, 18, 23, 59, 59, DateTimeKind.Utc) };
+            yield return new object[] { new DateTime(2022, 4, 18, 23, 59, 59, DateTimeKind.Local) };
+            yield return new object[] { new DateTime(2022, 4, 18, 23, 59, 59, DateTimeKind.Unspecified) };
+            yield return new object[] { new DateTime(0001, 01, 01, 0, 0, 0, DateTimeKind.Utc) };
+            yield return new object[] { new DateTime(9999, 12, 31, 23, 59, 59, DateTimeKind.Utc) };
+            yield return new object[] { new DateTime(2000, 12, 31, 23, 59, 59, DateTimeKind.Unspecified) };
+        }
+
+        [Theory]
+        [InlineData("0001-01-01")]
+        [InlineData("9999-12-31")]
+        [InlineData("2022-04-18")]
+        [InlineData("2020-02-29")]
+        public void ParseToStringRoundTrip(string input)
+        {
+            SpannerDate date = SpannerDate.Parse(input);
+            Assert.Equal(input, date.ToString());
+
+            // Check that TryParse works too.
+            Assert.True(SpannerDate.TryParse(input, out var date2));
+            Assert.Equal(date, date2);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("       ")]
+        [InlineData("ABCDEFGH")]
+        [InlineData("pp/qq/rrss")]
+        [InlineData("12-34-5678")]
+        [InlineData("0000-01-01")]
+        [InlineData("9999-12-32")]
+        [InlineData("0000/01/01")]
+        [InlineData("9999/12/32")]
+        [InlineData("2020-00-01")]
+        [InlineData("2020-13-13")]
+        [InlineData("2020-01-00")]
+        [InlineData("2020-01-32")]
+        [InlineData("2020-02-30")]
+        [InlineData("12/31/9999")]
+        [InlineData("0001/01/01")]
+        [InlineData("2022/04/20")]
+        [InlineData("31/12/9999")]
+        public void Parse_Invalid(string input)
+        {
+            Assert.Throws<FormatException>(() => SpannerDate.Parse(input));
+            bool success = SpannerDate.TryParse(input, out SpannerDate date2);
+            Assert.Equal(default(SpannerDate), date2);
+            Assert.False(success);
+        }
+
+        [Theory]
+        [InlineData("0001-01-01","0001-01-02")]
+        [InlineData("9999-12-30", "9999-12-31")]
+        [InlineData("0001-01-01", "2022-04-18")]
+        [InlineData("2022-04-18", "9999-12-31")]
+        public void Inequality(string input1, string input2)
+        {
+            var date1 = SpannerDate.Parse(input1);
+            var date2 = SpannerDate.Parse(input2);
+            // Value of input1 is always less than input2.
+            // So, we assert that input1 is not equal to input2 and
+            // input1 is less than input2 and input2 is greater than input1.
+            // In addition to inequality, we assert that first date
+            // is less than second date using Assert.True.
+            Assert.NotEqual(date1, date2);
+            Assert.False(date1 == date2);
+            Assert.NotEqual(date1.GetHashCode(), date2.GetHashCode());
+            Assert.False(date1.GetHashCode() == date2.GetHashCode());
+            Assert.True(date1 != date2);
+            Assert.True(!date1.Equals(date2));
+            Assert.True(!date2.Equals(date1));
+            Assert.True(date1 < date2);
+            Assert.True(date1 <= date2);
+            Assert.True(date1.CompareTo(date2) < 0);
+            Assert.True(date2 > date1);
+            Assert.True(date2 >= date1);
+            Assert.True(date2.CompareTo(date1) > 0);
+        }
+
+        [Theory]
+        [InlineData("0001-01-01")]
+        [InlineData("9999-12-31")]
+        [InlineData("2022-04-18")]
+        [InlineData("2000-02-28")]
+        public void Equality(string input1)
+        {
+            var date1 = SpannerDate.Parse(input1);
+            var date2 = SpannerDate.Parse(input1);
+            var hashCode1 = date1.GetHashCode();
+            var hashCode2 = date2.GetHashCode();
+            Assert.True(date1.Equals(date2));
+            Assert.True(date2.Equals(date1));
+            Assert.Equal(0, date1.CompareTo(date2));
+            Assert.Equal(0, date2.CompareTo(date1));
+            Assert.Equal(hashCode1, hashCode2);
+        }
+
+        [Theory]
+        [MemberData(nameof(FromDateTimeData))]
+        public void FromDateTime(DateTime input)
+        {
+            SpannerDate spannerDate = SpannerDate.FromDateTime(input);
+            Assert.Equal(input.Date.Year, spannerDate.Year);
+            Assert.Equal(input.Date.Month, spannerDate.Month);
+            Assert.Equal(input.Date.Day, spannerDate.Day);
+        }
+
+        [Theory]
+        [InlineData("9999-12-31")]
+        [InlineData("0001-01-01")]
+        [InlineData("2022-04-18")]
+        [InlineData("2000-12-31")]
+        public void ToDateTime(string input)
+        {
+            SpannerDate spannerDate = SpannerDate.Parse(input);
+            var expectedDateTime = DateTime.Parse(input, CultureInfo.InvariantCulture);
+            var result = spannerDate.ToDateTime();
+            Assert.Equal(expectedDateTime, result);
+            Assert.Equal(DateTimeKind.Unspecified, result.Kind);
+        }
+
+        [Fact]
+        public void Constants()
+        {
+            Assert.Equal(SpannerDate.FromDateTime(DateTime.MaxValue), SpannerDate.MaxDate);
+            Assert.Equal(SpannerDate.FromDateTime(DateTime.MinValue), SpannerDate.MinDate);
+            Assert.Equal(default(SpannerDate), SpannerDate.Parse("0001-01-01"));
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDataReader.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDataReader.cs
@@ -236,6 +236,13 @@ namespace Google.Cloud.Spanner.Data
         /// <returns>The value converted to a <see cref="PgNumeric"/>.</returns>
         public PgNumeric GetPgNumeric(int i) => GetFieldValue<PgNumeric>(i);
 
+        /// <summary>
+        /// Gets the value of the specified column as type <see cref="SpannerDate"/>.
+        /// </summary>
+        /// <param name="i">The index of the column to retrieve.</param>
+        /// <returns>The value converted to a <see cref="SpannerDate"/>.</returns>
+        public SpannerDate GetSpannerDate(int i) => GetFieldValue<SpannerDate>(i);
+
         /// <inheritdoc />
         public override object GetValue(int i) => this[i];
 

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDbType.ValueConversion.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDbType.ValueConversion.cs
@@ -179,6 +179,10 @@ namespace Google.Cloud.Spanner.Data
                         StringValue = XmlConvert.ToString(Convert.ToDateTime(value, InvariantCulture), XmlDateTimeSerializationMode.Utc)
                     };
                 case TypeCode.Date:
+                    if(value is SpannerDate spannerDate)
+                    {
+                        return new Value { StringValue = spannerDate.ToString() };
+                    }
                     if (value is DateTime date && date.Kind == DateTimeKind.Local)
                     {
                         // If the DateTime is local the value should be changed to unspecified
@@ -432,6 +436,20 @@ namespace Google.Cloud.Spanner.Data
                         return null;
                     case Value.KindOneofCase.StringValue:
                         return XmlConvert.ToDateTime(wireValue.StringValue, XmlDateTimeSerializationMode.Utc);
+                    default:
+                        throw new InvalidOperationException(
+                            $"Invalid Type conversion from {wireValue.KindCase} to {targetClrType.FullName}");
+                }
+            }
+
+            if (targetClrType == typeof(SpannerDate))
+            {
+                switch (wireValue.KindCase)
+                {
+                    case Value.KindOneofCase.NullValue:
+                        return null;
+                    case Value.KindOneofCase.StringValue:
+                        return SpannerDate.Parse(wireValue.StringValue);
                     default:
                         throw new InvalidOperationException(
                             $"Invalid Type conversion from {wireValue.KindCase} to {targetClrType.FullName}");

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SpannerDate.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SpannerDate.cs
@@ -1,0 +1,260 @@
+﻿// Copyright 2022 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using System;
+using System.Globalization;
+
+namespace Google.Cloud.Spanner.V1
+{
+    /// <summary>
+    /// The SpannerDate type represents a logical calendar date, independent of time zone.
+    /// Represents dates with values ranging from January 1, 0001 A.D through December 31, 9999 A.D. in the Gregorian calendar.
+    /// </summary>
+    public readonly struct SpannerDate : IEquatable<SpannerDate>, IComparable<SpannerDate>, IComparable
+    {
+        // TODO : Once upgraded to .NET 6, have an operator for converting DateOnly to SpannerDate and vice versa.
+
+        // The latest possible date is 9999/12/31 (DateTime.MaxValue) and the earliest possible date is 0001/01/01 (DateTime.MinValue).
+        // The days between maximum and minimum date is MaxNumberOfDays.
+        private const int MaxNumberOfDays = 3652058;
+
+        /// <summary>
+        /// Gets the latest possible date that can be represented by <see cref="SpannerDate"/>.
+        /// </summary>
+        public static SpannerDate MaxDate => new SpannerDate(DateTime.MaxValue);
+
+        /// <summary>
+        /// Gets the earliest possible date that can be represented by <see cref="SpannerDate"/>.
+        /// </summary>
+        public static SpannerDate MinDate => new SpannerDate(DateTime.MinValue);
+
+        // The value of SpannerDate stored as the number of days since the DateTime.MinValue day i.e., 0001/01/01.
+        private readonly int _days;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SpannerDate"/> structure to the specified DateTime.
+        /// </summary>
+        /// <remarks>No time zone conversions are performed.</remarks>
+        /// <param name="dateTime">The dateTime as <see cref="DateTime"/>.</param>
+        private SpannerDate(DateTime dateTime) : this(dateTime.Subtract(DateTime.MinValue).Days)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SpannerDate"/> structure to the specified year, month, and day in the Gregorian calendar.
+        /// </summary>
+        /// <param name="year">The year (in the range 1-9999 inclusive).</param>
+        /// <param name="month">The month (in the range 1-12 inclusive).</param>
+        /// <param name="day">The day (1 through the number of days in <paramref name="month"/>).</param>
+        public SpannerDate(int year, int month, int day) : this(new DateTime(year, month, day))
+        {
+        }
+
+        private SpannerDate(int days) => _days = GaxPreconditions.CheckArgumentRange(days, nameof(days), 0, MaxNumberOfDays);
+
+        /// <inheritdoc/>
+        public int CompareTo(SpannerDate other) => _days.CompareTo(other._days);
+
+        /// <summary>
+        /// Implementation of <see cref="IComparable.CompareTo"/> to compare two <see cref="SpannerDate"/> values.
+        /// </summary>
+        /// <remarks>
+        /// This uses explicit interface implementation to avoid it being called accidentally. The generic implementation should usually be preferred.
+        /// </remarks>
+        /// <exception cref="ArgumentException"><paramref name="obj"/> is non-null but does not refer to an instance of <see cref="SpannerDate"/>.</exception>
+        /// <param name="obj">The object to compare this value with.</param>
+        /// <returns>The result of comparing this value with <paramref name="obj"/>. <paramref name="obj"/> is null, this method returns a value greater than 0.
+        /// </returns>
+        int IComparable.CompareTo(object obj)
+        {
+            if (obj == null)
+            {
+                return 1;
+            }
+            return obj is SpannerDate date
+                ? CompareTo(date)
+                : throw new ArgumentException($"Object must be of type {nameof(SpannerDate)}", nameof(obj));
+        }
+
+        /// <inheritdoc/>
+        public bool Equals(SpannerDate other) => CompareTo(other) == 0;
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj) => obj is SpannerDate other && Equals(other);
+
+        /// <inheritdoc/>
+        public override int GetHashCode() => _days;
+
+        /// <summary>
+        /// Parses a textual representation in yyyy-MM-dd format as a <see cref="SpannerDate"/>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <paramref name="text"/> must be a representation of a date value in yyyy-MM-dd format which can be represented by <see cref="SpannerDate"/>.
+        /// </para>
+        /// </remarks>
+        /// <param name="text">The text to parse. Must not be null. Must be in yyyy-MM-dd format only.</param>
+        /// <returns>The parsed value.</returns>
+        /// <exception cref="FormatException">The value could not be parsed as a <see cref="SpannerDate"/>.</exception>
+        public static SpannerDate Parse(string text)
+        {
+            string message = TryParseImpl(text, out var value);
+            return message is null ? value : throw new FormatException(message);
+        }
+
+        /// <summary>
+        /// Attempts to parse a textual representation of date in yyyy-MM-dd format as <see cref="SpannerDate"/>.
+        /// </summary>
+        /// <remarks>
+        /// See <see cref="Parse(string)"/> for format details. This method will return <c>true</c> if and only if
+        /// <see cref="Parse(string)"/> would return without an exception.
+        /// </remarks>
+        /// <param name="text">The text to parse. Must not be null. Must be in yyyy-MM-dd format only.</param>
+        /// <param name="value">The parsed value, or 0 on failure.</param>
+        /// <returns><c>true</c> if <paramref name="text"/> was parsed successfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string text, out SpannerDate value)
+        {
+            string message = TryParseImpl(text, out value);
+            return message is null;
+        }
+
+        /// <summary>
+        /// Returns the error message for a FormatException if parsing fails, or null for success.
+        /// </summary>
+        private static string TryParseImpl(string text, out SpannerDate value)
+        {
+            GaxPreconditions.CheckNotNull(text, nameof(text));
+
+            if (DateTime.TryParseExact(text, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime dateTime))
+            {
+                value = new SpannerDate(dateTime);
+                return null;
+            }
+            else
+            {
+                value = default;
+                return "Text representation must be a valid date.";
+            }
+        }
+
+        /// <summary>
+        /// Returns the ISO 8601 representation (yyyy-MM-dd) of the date represented by this instance.
+        /// </summary>
+        /// <returns>The ISO 8601 string representation of the date represented by this instance.</returns>
+        public override string ToString() => ToDateTime().ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+        /// <summary>
+        /// Returns a SpannerDate instance that is set to the date part of the specified DateTime.
+        /// </summary>
+        /// <param name="dateTime">The DateTime value.</param>
+        /// <returns>The SpannerDate instance</returns>
+        public static SpannerDate FromDateTime(DateTime dateTime) => new SpannerDate(dateTime);
+
+        /// <summary>
+        /// Converts the value of this SpannerDate instance to the <see cref="DateTime"/> of kind <see cref="DateTimeKind.Unspecified"/>.
+        /// </summary>
+        /// <returns>The DateTime value.</returns>
+        public DateTime ToDateTime() => DateTime.MinValue.AddDays(_days);
+
+        /// <summary>
+        /// Returns a new instance of the <see cref="SpannerDate"/> that adds the specified number of days to the value of this instance.
+        /// </summary>
+        /// <param name="days">The number of days to be added.</param>
+        /// <returns>A new instance of the SpannerDate value that is the sum of the date represented by this instance and the number of 
+        /// days represented by <paramref name="days"/>.</returns>
+        public SpannerDate AddDays(int days) => new SpannerDate(_days + days);
+
+        // DateTime Properties.
+
+        /// <summary>
+        /// Gets the day of the month of the date represented by this instance.
+        /// </summary>
+        public int Day => ToDateTime().Day;
+
+        /// <summary>
+        /// Gets the month component of the date represented by this instance.
+        /// </summary>
+        public int Month => ToDateTime().Month;
+
+        /// <summary>
+        /// Gets the year component of the date represented by this instance.
+        /// </summary>
+        public int Year => ToDateTime().Year;
+
+        // Operators.
+
+        /// <summary>
+        /// Returns a value that indicates whether the values of two <see cref="SpannerDate"/> objects are equal.
+        /// </summary>
+        /// <param name="lhs">The first value to compare.</param>
+        /// <param name="rhs">The second value to compare.</param>
+        /// <returns><c>true</c> if the two arguments are equal; <c>false</c> otherwise.</returns>
+        public static bool operator ==(SpannerDate lhs, SpannerDate rhs) => lhs.Equals(rhs);
+
+        /// <summary>
+        /// Returns a value that indicates whether the two <see cref="SpannerDate"/> objects have unequal values.
+        /// </summary>
+        /// <param name="lhs">The first value to compare.</param>
+        /// <param name="rhs">The second value to compare.</param>
+        /// <returns><c>false</c> if the two arguments are equal; <c>true</c> otherwise.</returns>
+        public static bool operator !=(SpannerDate lhs, SpannerDate rhs) => !lhs.Equals(rhs);
+
+        /// <summary>Returns a value that indicates whether a <see cref="SpannerDate"/> value is less than another <see cref="SpannerDate"/>.</summary>
+        /// <param name="lhs">The value to compare with <paramref name="rhs" />.</param>
+        /// <param name="rhs">The value to compare with <paramref name="lhs" />.</param>
+        /// <returns><c>true</c> if <paramref name="lhs" /> is less than <paramref name="rhs" />; otherwise, <c>false</c>.</returns>
+        public static bool operator <(SpannerDate lhs, SpannerDate rhs) => lhs.CompareTo(rhs) < 0;
+
+        /// <summary>Returns a value that indicates whether a <see cref="SpannerDate"/> value is less than or equal to another <see cref="SpannerDate"/>.</summary>
+        /// <param name="lhs">The value to compare with <paramref name="rhs" />.</param>
+        /// <param name="rhs">The value to compare with <paramref name="lhs" />.</param>
+        /// <returns><c>true</c> if <paramref name="lhs" /> is less than or equal to <paramref name="rhs" />; otherwise, <c>false</c>.</returns>
+        public static bool operator <=(SpannerDate lhs, SpannerDate rhs) => lhs.CompareTo(rhs) <= 0;
+
+        /// <summary>Returns a value that indicates whether a <see cref="SpannerDate"/> value is greater than another <see cref="SpannerDate"/>.</summary>
+        /// <param name="lhs">The value to compare with <paramref name="rhs" />.</param>
+        /// <param name="rhs">The value to compare with <paramref name="lhs" />.</param>
+        /// <returns><c>true</c> if <paramref name="lhs" /> is greater than <paramref name="rhs" />; otherwise, <c>false</c>.</returns>
+        public static bool operator >(SpannerDate lhs, SpannerDate rhs) => lhs.CompareTo(rhs) > 0;
+
+        /// <summary>Returns a value that indicates whether a <see cref="SpannerDate"/> value is greater than or equal to another <see cref="SpannerDate"/>.</summary>
+        /// <param name="lhs">The value to compare with <paramref name="rhs" />.</param>
+        /// <param name="rhs">The value to compare with <paramref name="lhs" />.</param>
+        /// <returns><c>true</c> if <paramref name="lhs" /> is greater than or equal to <paramref name="rhs" />; otherwise, <c>false</c>.</returns>
+        public static bool operator >=(SpannerDate lhs, SpannerDate rhs) => lhs.CompareTo(rhs) >= 0;
+
+        /// <summary>
+        /// Performs an explicit conversion from <see cref="DateTime"/> to <see cref="SpannerDate"/>.
+        /// </summary>
+        /// <param name="value">The DateTime value.</param>
+        /// <returns>
+        /// The result of the conversion.
+        /// </returns>
+        public static explicit operator SpannerDate(DateTime value) => new SpannerDate(value);
+
+        /// <summary>
+        /// Performs an explicit conversion from <see cref="SpannerDate"/> to <see cref="DateTime"/>.
+        /// </summary>
+        /// <param name="value">The SpannerDate value.</param>
+        /// <returns>
+        /// The result of the conversion.
+        /// </returns>
+        public static explicit operator DateTime(SpannerDate value) => value.ToDateTime();
+
+#if NET6_0_OR_GREATER
+        // TODO: Create Operators for conversion to DateOnly and vice versa.
+#endif
+    }
+}


### PR DESCRIPTION
SpannerDate and its unit tests (and integration test)
The changes are backward compatible so using DateTime for Date will continue to work.