### PR TITLE
tools: Fix version compatibility detection across TFMs

### DIFF
--- a/detect-pr-changes.sh
+++ b/detect-pr-changes.sh
@@ -47,7 +47,10 @@ for api in $apis
 do  
   if [[ -d tmpgit/apis/$api/$api && -d apis/$api/$api ]]
   then
-    targetVersion="netstandard2.0"
+    # We expect almost all libraries to support netstandard2.1.
+    # When moving from GAX v3 to GAX v4 this will fail as we used to target
+    # netstandard2.0, but that's a single PR (which we expect to have breaking changes anyway).
+    targetVersion="netstandard2.1"
     if [[ $api == "Google.Cloud.Diagnostics.AspNetCore3" ]]
     then
       targetVersion="netcoreapp3.1"

--- a/tools/Google.Cloud.Tools.ReleaseManager/CheckVersionCompatibilityCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/CheckVersionCompatibilityCommand.cs
@@ -120,7 +120,7 @@ namespace Google.Cloud.Tools.ReleaseManager
         {
             Console.WriteLine($"Differences from {version}");
 
-            // TODO: Remove this try/catch when *everything* has a previous minor version on netstandard2.0.
+            // TODO: Remove this try/catch when we can detect that a package has never been pushed.
             AssemblyDefinition oldMetadata;
             try
             {
@@ -136,7 +136,7 @@ namespace Google.Cloud.Tools.ReleaseManager
                 Console.WriteLine($"Returning 'identical' as the change level; please check carefully before release.");
                 return Level.Identical;
             }
-            var sourceAssembly = Path.Combine(DirectoryLayout.ForApi(api.Id).SourceDirectory, api.Id, "bin", "Release", "netstandard2.0", $"{api.Id}.dll");
+            var sourceAssembly = Path.Combine(DirectoryLayout.ForApi(api.Id).SourceDirectory, api.Id, "bin", "Release", "netstandard2.1", $"{api.Id}.dll");
             var newMetadata = Assemblies.LoadFile(sourceAssembly);
 
             var diff = Assemblies.Compare(oldMetadata, newMetadata, null);


### PR DESCRIPTION
- In the detect-pr-changes.sh script, we expect new code to build with a netstandard2.1 target (at least)
- In the compatibility checker, we check against multiple TFMs if no TFM is specified