### PR TITLE
Release Google.Cloud.AppEngine.V1 version 1.3.0

### DIFF
--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.csproj
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the App Engine API, which provisions and manages developers' App Engine applications.</Description>
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.7.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[2.3.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.41.0, 3.0.0)" PrivateAssets="None" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />

--- a/apis/Google.Cloud.AppEngine.V1/docs/history.md
+++ b/apis/Google.Cloud.AppEngine.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.3.0, released 2022-04-26
+
+No API surface changes; just dependency updates.
+
 ## Version 1.2.0, released 2021-08-19
 
 - [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -147,7 +147,7 @@
     },
     {
       "id": "Google.Cloud.AppEngine.V1",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "type": "grpc",
       "productName": "App Engine Audit Data",
       "productUrl": "https://cloud.google.com/appengine",
@@ -159,7 +159,7 @@
       ],
       "dependencies": {
         "Google.Api.Gax.Grpc.GrpcCore": "3.7.0",
-        "Google.LongRunning": "2.2.0",
+        "Google.LongRunning": "2.3.0",
         "Grpc.Core": "2.41.0"
       },
       "generator": "micro",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
