### PR TITLE
Release Google.Cloud.BigQuery.Reservation.V1 version 1.6.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.5.0</Version>
+    <Version>1.6.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery Reservation API, which allows you to modify your BigQuery flat-rate reservations.</Description>

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 1.6.0, released 2022-04-26
+
+### New features
+
+- Add UpdateAssignment method ([commit 9b9e9d1](https://github.com/googleapis/google-cloud-dotnet/commit/9b9e9d197d95d59a3e88b213a2511c22683247c0))
+- Add "concurrency" and "multi_region_auxiliary" in reservation ([commit 9b9e9d1](https://github.com/googleapis/google-cloud-dotnet/commit/9b9e9d197d95d59a3e88b213a2511c22683247c0))
+- Add preferred table. ([commit 9b9e9d1](https://github.com/googleapis/google-cloud-dotnet/commit/9b9e9d197d95d59a3e88b213a2511c22683247c0))
+
+### Documentation improvements
+
+- Cleanup and clarifications ([commit 9b9e9d1](https://github.com/googleapis/google-cloud-dotnet/commit/9b9e9d197d95d59a3e88b213a2511c22683247c0))
+
 ## Version 1.5.0, released 2022-01-17
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -394,7 +394,7 @@
     },
     {
       "id": "Google.Cloud.BigQuery.Reservation.V1",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "type": "grpc",
       "productName": "BigQuery Reservation",
       "productUrl": "https://cloud.google.com/bigquery/docs/reference/reservations",


### PR DESCRIPTION

Changes in this release:

### New features

- Add UpdateAssignment method ([commit 9b9e9d1](https://github.com/googleapis/google-cloud-dotnet/commit/9b9e9d197d95d59a3e88b213a2511c22683247c0))
- Add "concurrency" and "multi_region_auxiliary" in reservation ([commit 9b9e9d1](https://github.com/googleapis/google-cloud-dotnet/commit/9b9e9d197d95d59a3e88b213a2511c22683247c0))
- Add preferred table. ([commit 9b9e9d1](https://github.com/googleapis/google-cloud-dotnet/commit/9b9e9d197d95d59a3e88b213a2511c22683247c0))

### Documentation improvements

- Cleanup and clarifications ([commit 9b9e9d1](https://github.com/googleapis/google-cloud-dotnet/commit/9b9e9d197d95d59a3e88b213a2511c22683247c0))
