### PR TITLE
Release Google.Cloud.BigQuery.V2 version 2.4.0-beta02

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.4.0-beta01</Version>
+    <Version>2.4.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery API. It wraps the Google.Apis.Bigquery.v2 client library, making common operations simpler in client code. BigQuery is a data platform for customers to create, manage, share and query data.</Description>

--- a/apis/Google.Cloud.BigQuery.V2/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.V2/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 2.4.0-beta02, released 2022-04-26
+
+### New features
+
+- Include more information on GoogleApiException.Message when possible. ([commit 2057c2e](https://github.com/googleapis/google-cloud-dotnet/commit/2057c2eea72f205fd79860094d7d28a4ae056eac))
+
+BREAKING CHANGE: If calling code depended on the exact exception message, it could be broken by this change. Customers are strongly encouraged not to depend on error message text.
 ## Version 2.4.0-beta01, released 2022-02-07
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -416,7 +416,7 @@
       "id": "Google.Cloud.BigQuery.V2",
       "productName": "Google BigQuery",
       "productUrl": "https://cloud.google.com/bigquery/",
-      "version": "2.4.0-beta01",
+      "version": "2.4.0-beta02",
       "type": "rest",
       "description": "Recommended Google client library to access the BigQuery API. It wraps the Google.Apis.Bigquery.v2 client library, making common operations simpler in client code. BigQuery is a data platform for customers to create, manage, share and query data.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Include more information on GoogleApiException.Message when possible. ([commit 2057c2e](https://github.com/googleapis/google-cloud-dotnet/commit/2057c2eea72f205fd79860094d7d28a4ae056eac))

BREAKING CHANGE: If calling code depended on the exact exception message, it could be broken by this change. Customers are strongly encouraged not to depend on error message text.
