### PR TITLE
Release Google.Cloud.CertificateManager.V1 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.csproj
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Certificate Manager API, which lets you acquire and manage TLS (SSL) certificates for use with Cloud Load Balancing</Description>

--- a/apis/Google.Cloud.CertificateManager.V1/docs/history.md
+++ b/apis/Google.Cloud.CertificateManager.V1/docs/history.md
@@ -1,5 +1,14 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2022-04-26
+
+### Bug fixes
+
+- **BREAKING CHANGE** Updated resource patterns to comply with https://google.aip.dev/123#annotating-resource-types ([commit 9f116f5](https://github.com/googleapis/google-cloud-dotnet/commit/9f116f5f55837084d0f197c1f90e6b42e86c7848))
+
+### Documentation improvements
+
+- Fix docstring formatting ([commit 3fa70c6](https://github.com/googleapis/google-cloud-dotnet/commit/3fa70c68e03ef44c94748a31ef4d2f1e37a33ddd))
 ## Version 1.0.0-beta01, released 2022-02-09
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -623,7 +623,7 @@
     },
     {
       "id": "Google.Cloud.CertificateManager.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Certificate Manager",
       "productUrl": "https://cloud.google.com/certificate-manager/docs",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- **BREAKING CHANGE** Updated resource patterns to comply with https://google.aip.dev/123#annotating-resource-types ([commit 9f116f5](https://github.com/googleapis/google-cloud-dotnet/commit/9f116f5f55837084d0f197c1f90e6b42e86c7848))

### Documentation improvements

- Fix docstring formatting ([commit 3fa70c6](https://github.com/googleapis/google-cloud-dotnet/commit/3fa70c68e03ef44c94748a31ef4d2f1e37a33ddd))
