### PR TITLE
Release Google.Cloud.Channel.V1 version 1.7.0

### DIFF
--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.csproj
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.6.0</Version>
+    <Version>1.7.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Channel API, which enables Google Cloud resellers and distributors to manage their customers, channel partners, entitlements and reports.</Description>

--- a/apis/Google.Cloud.Channel.V1/docs/history.md
+++ b/apis/Google.Cloud.Channel.V1/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 1.7.0, released 2022-04-26
+
+### New features
+
+- Add API definitions for Cloud Channel Repricing APIs ([commit d654082](https://github.com/googleapis/google-cloud-dotnet/commit/d6540821516272203d41affeda5df0ef4eae31bc))
+- Add new enum value, new filter in ListCustomersRequest of Cloud Channel API ([commit dfdc095](https://github.com/googleapis/google-cloud-dotnet/commit/dfdc095dd2ee4c8a91cd9c8dd1960906052033f8))
+
+### Documentation improvements
+
+- Clarify language ([commit 1641322](https://github.com/googleapis/google-cloud-dotnet/commit/1641322b44efbd08a2d62b67468029b1ae0e565c))
+- Change description for enum default value ([commit 5a4f37b](https://github.com/googleapis/google-cloud-dotnet/commit/5a4f37bacef8f0b3cb22d9ebf466fc0ab1e50eca))
+- Change description for GCP ProvisionedService.provisioning_id value ([commit b30248e](https://github.com/googleapis/google-cloud-dotnet/commit/b30248ea2a0cc0066becda3f56eaa33fed29e157))
 ## Version 1.6.0, released 2021-12-07
 
 - [Commit 2382311](https://github.com/googleapis/google-cloud-dotnet/commit/2382311): docs: Small clarification

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -643,7 +643,7 @@
     },
     {
       "id": "Google.Cloud.Channel.V1",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "type": "grpc",
       "productName": "Cloud Channel",
       "productUrl": "https://cloud.google.com/channel/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add API definitions for Cloud Channel Repricing APIs ([commit d654082](https://github.com/googleapis/google-cloud-dotnet/commit/d6540821516272203d41affeda5df0ef4eae31bc))
- Add new enum value, new filter in ListCustomersRequest of Cloud Channel API ([commit dfdc095](https://github.com/googleapis/google-cloud-dotnet/commit/dfdc095dd2ee4c8a91cd9c8dd1960906052033f8))

### Documentation improvements

- Clarify language ([commit 1641322](https://github.com/googleapis/google-cloud-dotnet/commit/1641322b44efbd08a2d62b67468029b1ae0e565c))
- Change description for enum default value ([commit 5a4f37b](https://github.com/googleapis/google-cloud-dotnet/commit/5a4f37bacef8f0b3cb22d9ebf466fc0ab1e50eca))
- Change description for GCP ProvisionedService.provisioning_id value ([commit b30248e](https://github.com/googleapis/google-cloud-dotnet/commit/b30248ea2a0cc0066becda3f56eaa33fed29e157))
