### PR TITLE
Release Google.Cloud.DataCatalog.V1 version 1.8.0

### DIFF
--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.csproj
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.7.0</Version>
+    <Version>1.8.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Data Catalog API. Data Catalog is a fully managed and highly scalable data discovery and metadata management service.</Description>

--- a/apis/Google.Cloud.DataCatalog.V1/docs/history.md
+++ b/apis/Google.Cloud.DataCatalog.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 1.8.0, released 2022-04-26
+
+### New features
+
+- Added Dataplex specific fields ([commit f445d27](https://github.com/googleapis/google-cloud-dotnet/commit/f445d27d4a4171c8149ed4d930594ffae8b427c4))
+
+### Documentation improvements
+
+- Update taxonomy display_name comment ([commit f445d27](https://github.com/googleapis/google-cloud-dotnet/commit/f445d27d4a4171c8149ed4d930594ffae8b427c4))
+
 ## Version 1.7.0, released 2022-02-14
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -783,7 +783,7 @@
       "protoPath": "google/cloud/datacatalog/v1",
       "productName": "Data Catalog",
       "productUrl": "https://cloud.google.com/data-catalog/docs",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Data Catalog API. Data Catalog is a fully managed and highly scalable data discovery and metadata management service.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- Added Dataplex specific fields ([commit f445d27](https://github.com/googleapis/google-cloud-dotnet/commit/f445d27d4a4171c8149ed4d930594ffae8b427c4))

### Documentation improvements

- Update taxonomy display_name comment ([commit f445d27](https://github.com/googleapis/google-cloud-dotnet/commit/f445d27d4a4171c8149ed4d930594ffae8b427c4))
