### PR TITLE
Release Google.Cloud.Datastore.V1 version 3.5.0

### DIFF
--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.4.0</Version>
+    <Version>3.5.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Datastore API, which accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.</Description>

--- a/apis/Google.Cloud.Datastore.V1/docs/history.md
+++ b/apis/Google.Cloud.Datastore.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.5.0, released 2022-04-26
+
+### New features
+
+- Expose new read_time API fields, currently only available in private preview ([commit 4bc260c](https://github.com/googleapis/google-cloud-dotnet/commit/4bc260c0f34a5f5296badaefa4e6d962499cc225))
+
 ## Version 3.4.0, released 2022-04-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -940,7 +940,7 @@
       "protoPath": "google/datastore/v1",
       "productName": "Google Cloud Datastore",
       "productUrl": "https://cloud.google.com/datastore/docs/concepts/overview",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Datastore API, which accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.",


### PR DESCRIPTION

Changes in this release:

### New features

- Expose new read_time API fields, currently only available in private preview ([commit 4bc260c](https://github.com/googleapis/google-cloud-dotnet/commit/4bc260c0f34a5f5296badaefa4e6d962499cc225))
