### PR TITLE
Release Google.Cloud.SecretManager.V1 version 1.9.0

### DIFF
--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.csproj
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.8.0</Version>
+    <Version>1.9.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Secret Manager API.</Description>

--- a/apis/Google.Cloud.SecretManager.V1/docs/history.md
+++ b/apis/Google.Cloud.SecretManager.V1/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+## Version 1.9.0, released 2022-04-26
+
+### New features
+
+- Added support for accessing secret versions by alias ([commit 5102b66](https://github.com/googleapis/google-cloud-dotnet/commit/5102b66e3843295b60aa3c89e74999da46bd8e15))
 ## Version 1.8.0, released 2022-02-07
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2754,7 +2754,7 @@
       "protoPath": "google/cloud/secretmanager/v1",
       "productName": "Secret Manager",
       "productUrl": "https://cloud.google.com/secret-manager",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Secret Manager API.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Added support for accessing secret versions by alias ([commit 5102b66](https://github.com/googleapis/google-cloud-dotnet/commit/5102b66e3843295b60aa3c89e74999da46bd8e15))
