### PR TITLE
Release Google.Cloud.ServiceDirectory.V1 version 1.4.0

### DIFF
--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.csproj
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Service Directory API version v1, which provides a platform for discovering, publishing, and connecting services.</Description>

--- a/apis/Google.Cloud.ServiceDirectory.V1/docs/history.md
+++ b/apis/Google.Cloud.ServiceDirectory.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.4.0, released 2022-04-26
+
+No API surface changes; just dependency updates.
+
 ## Version 1.3.0, released 2021-12-07
 
 - [Commit 7c9d9f0](https://github.com/googleapis/google-cloud-dotnet/commit/7c9d9f0): docs: fix docstring formatting

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2925,7 +2925,7 @@
     },
     {
       "id": "Google.Cloud.ServiceDirectory.V1",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "type": "grpc",
       "productName": "Service Directory",
       "productUrl": "https://cloud.google.com/service-directory/",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
