### PR TITLE
Release Google.Cloud.ServiceManagement.V1 version 1.5.0

### DIFF
--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.csproj
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.4.0</Version>
+    <Version>1.5.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Service Management API, which allows service producers to publish their services on Google Cloud Platform so that they can be discovered and used by service consumers.</Description>

--- a/apis/Google.Cloud.ServiceManagement.V1/docs/history.md
+++ b/apis/Google.Cloud.ServiceManagement.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.5.0, released 2022-04-26
+
+### Documentation improvements
+
+- Fix broken links ([commit c6cef48](https://github.com/googleapis/google-cloud-dotnet/commit/c6cef48acd6124c4a724695e501f2b6943233021))
+- Fix remaining broken links ([commit 129c7cb](https://github.com/googleapis/google-cloud-dotnet/commit/129c7cbad009a12a5fc9273d6bb9e34e280c0dd7))
 ## Version 1.4.0, released 2022-02-15
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2963,7 +2963,7 @@
     },
     {
       "id": "Google.Cloud.ServiceManagement.V1",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "type": "grpc",
       "productName": "Service Management",
       "productUrl": "https://cloud.google.com/service-infrastructure/docs/service-management/reference/rpc",


### PR DESCRIPTION

Changes in this release:

### Documentation improvements

- Fix broken links ([commit c6cef48](https://github.com/googleapis/google-cloud-dotnet/commit/c6cef48acd6124c4a724695e501f2b6943233021))
- Fix remaining broken links ([commit 129c7cb](https://github.com/googleapis/google-cloud-dotnet/commit/129c7cbad009a12a5fc9273d6bb9e34e280c0dd7))
