### PR TITLE
Release Google.Cloud.Speech.V1P1Beta1 version 2.0.0-beta08

### DIFF
--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.csproj
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta07</Version>
+    <Version>2.0.0-beta08</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google client library to access the Google Cloud Speech API version v1p1beta1 with upcoming features.</Description>

--- a/apis/Google.Cloud.Speech.V1P1Beta1/docs/history.md
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.0.0-beta08, released 2022-04-26
+
+### Documentation improvements
+
+- Use full link in comment ([commit dc5c9ea](https://github.com/googleapis/google-cloud-dotnet/commit/dc5c9ea1f05e2b62e62ab9e63ca82e66a4118f97))
+
 ## Version 2.0.0-beta07, released 2021-12-07
 
 - [Commit bc7d94d](https://github.com/googleapis/google-cloud-dotnet/commit/bc7d94d): feat: add result_end_time to SpeechRecognitionResult

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3166,7 +3166,7 @@
       "protoPath": "google/cloud/speech/v1p1beta1",
       "productName": "Google Cloud Speech",
       "productUrl": "https://cloud.google.com/speech",
-      "version": "2.0.0-beta07",
+      "version": "2.0.0-beta08",
       "releaseLevelOverride": "preview",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",


### PR DESCRIPTION

Changes in this release:

### Documentation improvements

- Use full link in comment ([commit dc5c9ea](https://github.com/googleapis/google-cloud-dotnet/commit/dc5c9ea1f05e2b62e62ab9e63ca82e66a4118f97))
