### PR TITLE
Release Google.Cloud.StorageTransfer.V1 version 1.2.0

### DIFF
--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.csproj
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Transfers data from external data sources to a Google Cloud Storage bucket or between Google Cloud Storage buckets.</Description>

--- a/apis/Google.Cloud.StorageTransfer.V1/docs/history.md
+++ b/apis/Google.Cloud.StorageTransfer.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 1.2.0, released 2022-04-26
+
+### New features
+
+- Add support for Agent Pools ([commit 28de985](https://github.com/googleapis/google-cloud-dotnet/commit/28de9858c6895e242f93b915e5a51637b8d1fdf5))
+- Add support for transfers between file systems ([commit 28de985](https://github.com/googleapis/google-cloud-dotnet/commit/28de9858c6895e242f93b915e5a51637b8d1fdf5))
+- Add support for metadata preservation ([commit 28de985](https://github.com/googleapis/google-cloud-dotnet/commit/28de9858c6895e242f93b915e5a51637b8d1fdf5))
+- Add support for transferring a specific list of objects (manifest) ([commit 28de985](https://github.com/googleapis/google-cloud-dotnet/commit/28de9858c6895e242f93b915e5a51637b8d1fdf5))
+- Add support for Cloud Logging ([commit 28de985](https://github.com/googleapis/google-cloud-dotnet/commit/28de9858c6895e242f93b915e5a51637b8d1fdf5))
+
 ## Version 1.1.0, released 2021-09-06
 
 - [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3203,7 +3203,7 @@
     },
     {
       "id": "Google.Cloud.StorageTransfer.V1",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "type": "grpc",
       "productName": "Storage Transfer",
       "productUrl": "https://cloud.google.com/storage-transfer-service",


### PR DESCRIPTION

Changes in this release:

### New features

- Add support for Agent Pools ([commit 28de985](https://github.com/googleapis/google-cloud-dotnet/commit/28de9858c6895e242f93b915e5a51637b8d1fdf5))
- Add support for transfers between file systems ([commit 28de985](https://github.com/googleapis/google-cloud-dotnet/commit/28de9858c6895e242f93b915e5a51637b8d1fdf5))
- Add support for metadata preservation ([commit 28de985](https://github.com/googleapis/google-cloud-dotnet/commit/28de9858c6895e242f93b915e5a51637b8d1fdf5))
- Add support for transferring a specific list of objects (manifest) ([commit 28de985](https://github.com/googleapis/google-cloud-dotnet/commit/28de9858c6895e242f93b915e5a51637b8d1fdf5))
- Add support for Cloud Logging ([commit 28de985](https://github.com/googleapis/google-cloud-dotnet/commit/28de9858c6895e242f93b915e5a51637b8d1fdf5))
