### PR TITLE
Release Google.Cloud.Tasks.V2 version 2.5.0

### DIFF
--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.csproj
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.4.0</Version>
+    <Version>2.5.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Tasks API (v2), which manages the execution of large numbers of distributed requests.</Description>

--- a/apis/Google.Cloud.Tasks.V2/docs/history.md
+++ b/apis/Google.Cloud.Tasks.V2/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 2.5.0, released 2022-04-26
+
+No API surface changes; just dependency updates.
+
 ## Version 2.4.0, released 2021-12-07
 
 - [Commit bb10aef](https://github.com/googleapis/google-cloud-dotnet/commit/bb10aef): docs: fix docstring formatting

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3272,7 +3272,7 @@
       "protoPath": "google/cloud/tasks/v2",
       "productName": "Google Cloud Tasks",
       "productUrl": "https://cloud.google.com/tasks/",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Tasks API (v2), which manages the execution of large numbers of distributed requests.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
