### PR TITLE
fix: Fix emulator tests running on Grpc.Net.Client on .NET Core 3.1

### DIFF
--- a/.github/workflows/spanner-emulator-pr-push.yml
+++ b/.github/workflows/spanner-emulator-pr-push.yml
@@ -43,8 +43,6 @@ jobs:
       env:
           SPANNER_EMULATOR_HOST: localhost:9010
           TEST_PROJECT: emulator-test-project
-          # Temporary measure until we can get Grpc.Net.Client working with the emulator
-          GRPC_DEFAULT_ADAPTER_OVERRIDE: Grpc.Core
       run: |
         dotnet test -c Release ./apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests
         dotnet test -c Release ./apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.CommonTesting/SpannerTestDatabase.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.CommonTesting/SpannerTestDatabase.cs
@@ -124,6 +124,11 @@ namespace Google.Cloud.Spanner.Data.CommonTesting
         {
             if (SpannerClientCreationOptions.UsesEmulator)
             {
+#if NETSTANDARD2_1
+                // On .NET Core 3.1 (but not .NET 6) Grpc.Net.Client needs an additional switch
+                // to allow an insecure channel in HTTP/2.
+                AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
+#endif
                 // Try to create an instance on the emulator and ignore any AlreadyExists error.
                 var adminClientBuilder = new InstanceAdminClientBuilder
                 {

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/Google.Cloud.Spanner.Data.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/Google.Cloud.Spanner.Data.IntegrationTests.csproj
@@ -33,7 +33,5 @@
   <ItemGroup>
     <ProjectReference Include="..\Google.Cloud.Spanner.Data.CommonTesting\Google.Cloud.Spanner.Data.CommonTesting.csproj" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <!-- Temporary measure until we can get Grpc.Net.Client working with the emulator -->
-    <PackageReference Include="Grpc.Core" Version="2.41.0" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/Google.Cloud.Spanner.Data.Snippets.csproj
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/Google.Cloud.Spanner.Data.Snippets.csproj
@@ -28,7 +28,5 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Google.Cloud.Spanner.Data.CommonTesting\Google.Cloud.Spanner.Data.CommonTesting.csproj" />
-    <!-- Temporary measure until we can get Grpc.Net.Client working with the emulator -->
-    <PackageReference Include="Grpc.Core" Version="2.41.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
We need to document this as something that users will need to do
when using the emulator.