### PR TITLE
fix: Specify switch for netcoreapp3.1 to fix testing against emulators

### DIFF
--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.IntegrationTests/BigtableFixtureBase.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.IntegrationTests/BigtableFixtureBase.cs
@@ -52,9 +52,13 @@ namespace Google.Cloud.Bigtable.V2.IntegrationTests
             string instanceId;
             if (RunningAgainstEmulator)
             {
-                // TODO: Use BigtableClientBuilder emulator support to when it exists...
                 projectId = "emulator-test-project";
                 instanceId = "doesnt-matter";
+#if NETCOREAPP3_1
+                // On .NET Core 3.1 (but not .NET 6) Grpc.Net.Client needs an additional switch
+                // to allow an insecure channel in HTTP/2.
+                AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
+#endif
             }
             else
             {

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/DatastoreFixture.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/DatastoreFixture.cs
@@ -90,6 +90,14 @@ namespace Google.Cloud.Datastore.V1.IntegrationTests
 
         public DatastoreDb CreateDatastoreDb(string namespaceId = null)
         {
+#if NETCOREAPP3_1
+            // On .NET Core 3.1 (but not .NET 6) Grpc.Net.Client needs an additional switch
+            // to allow an insecure channel in HTTP/2.
+            // We can't trivially tell whether we're running on the emulator or not, but it doesn't
+            // really matter as we won't be trying to use an unencrypted channel in production.
+            AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
+#endif
+
             string effectiveNamespace = namespaceId ?? NamespaceId;
             var builder = new DatastoreDbBuilder
             {

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/FirestoreFixture.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/FirestoreFixture.cs
@@ -64,6 +64,13 @@ namespace Google.Cloud.Firestore.IntegrationTests
 
         public FirestoreFixture() : base(ProjectEnvironmentVariable)
         {
+#if NETCOREAPP3_1
+            // On .NET Core 3.1 (but not .NET 6) Grpc.Net.Client needs an additional switch
+            // to allow an insecure channel in HTTP/2.
+            // We can't trivially tell whether we're running on the emulator or not, but it doesn't
+            // really matter as we won't be trying to use an unencrypted channel in production.
+            AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
+#endif
             // Currently, only the default database is supported... so we create all our collections with a randomly-generated prefix.
             // When multiple databases are supported, we'll create a new one per test run.
             CollectionPrefix = IdGenerator.FromGuid(prefix: "test-");

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.IntegrationTests/PubSubClientTest.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.IntegrationTests/PubSubClientTest.cs
@@ -44,6 +44,17 @@ namespace Google.Cloud.PubSub.V1.IntegrationTests
 
         private readonly PubsubFixture _fixture;
 
+#if NETCOREAPP3_1
+        static PubSubClientTest()
+        {
+            // On .NET Core 3.1 (but not .NET 6) Grpc.Net.Client needs an additional switch
+            // to allow an insecure channel in HTTP/2.
+            // We can't trivially tell whether we're running on the emulator or not, but it doesn't
+            // really matter as we won't be trying to use an unencrypted channel in production.
+            AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
+        }
+#endif
+
         // Factory methods for clients, as a centralized place to apply default settings.
         private static Task<PublisherServiceApiClient> CreatePublisherServiceApiClientAsync() =>
             new PublisherServiceApiClientBuilder { EmulatorDetection = EmulatorDetection.EmulatorOrProduction }.BuildAsync();


### PR DESCRIPTION
The tests still don't all pass, but that's expected due to
differences between production and the emulators, and happens with
Grpc.Core as well. We need to document the switch in the emulators
page.