### PR TITLE
Release Google.Cloud.AppEngine.V1 version 1.4.0

### DIFF
--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.csproj
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the App Engine API, which provisions and manages developers' App Engine applications.</Description>

--- a/apis/Google.Cloud.AppEngine.V1/docs/history.md
+++ b/apis/Google.Cloud.AppEngine.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 1.4.0, released 2022-05-05
+
+### New features
+
+- Add Application.service_account ([commit 523e2d2](https://github.com/googleapis/google-cloud-dotnet/commit/523e2d23624e0ed8565027843f2e7e48c2e76f5c))
+- Add client library method signature to retrieve Application by name ([commit 523e2d2](https://github.com/googleapis/google-cloud-dotnet/commit/523e2d23624e0ed8565027843f2e7e48c2e76f5c))
+- Add Service.labels ([commit 523e2d2](https://github.com/googleapis/google-cloud-dotnet/commit/523e2d23624e0ed8565027843f2e7e48c2e76f5c))
+- Add Version.app_engine_apis ([commit 523e2d2](https://github.com/googleapis/google-cloud-dotnet/commit/523e2d23624e0ed8565027843f2e7e48c2e76f5c))
+- Add VpcAccessConnector.egress_setting ([commit 523e2d2](https://github.com/googleapis/google-cloud-dotnet/commit/523e2d23624e0ed8565027843f2e7e48c2e76f5c))
+
 ## Version 1.3.0, released 2022-04-26
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -147,7 +147,7 @@
     },
     {
       "id": "Google.Cloud.AppEngine.V1",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "type": "grpc",
       "productName": "App Engine Audit Data",
       "productUrl": "https://cloud.google.com/appengine",


### PR DESCRIPTION

Changes in this release:

### New features

- Add Application.service_account ([commit 523e2d2](https://github.com/googleapis/google-cloud-dotnet/commit/523e2d23624e0ed8565027843f2e7e48c2e76f5c))
- Add client library method signature to retrieve Application by name ([commit 523e2d2](https://github.com/googleapis/google-cloud-dotnet/commit/523e2d23624e0ed8565027843f2e7e48c2e76f5c))
- Add Service.labels ([commit 523e2d2](https://github.com/googleapis/google-cloud-dotnet/commit/523e2d23624e0ed8565027843f2e7e48c2e76f5c))
- Add Version.app_engine_apis ([commit 523e2d2](https://github.com/googleapis/google-cloud-dotnet/commit/523e2d23624e0ed8565027843f2e7e48c2e76f5c))
- Add VpcAccessConnector.egress_setting ([commit 523e2d2](https://github.com/googleapis/google-cloud-dotnet/commit/523e2d23624e0ed8565027843f2e7e48c2e76f5c))
