### PR TITLE
feat: Add an adapter for an ILogger to a Spanner Logger

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/Internal/Logging/MsLoggerTest.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/Internal/Logging/MsLoggerTest.cs
@@ -1,0 +1,84 @@
+﻿// Copyright 2022 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Google.Cloud.Spanner.V1.Internal.Logging.Tests;
+
+public class MsLoggerTest
+{
+    [Fact]
+    public void LogLevelMapping()
+    {
+        var fake = new FakeLogger();
+        var logger = Logger.ForILogger(fake);
+        logger.LogLevel = LogLevel.Debug;
+        logger.Log(LogLevel.Debug, "Debug message", null);
+        logger.Log(LogLevel.Info, "Info message", null);
+        logger.Log(LogLevel.Warn, "Warn message", null);
+        logger.Log(LogLevel.Error, "Error message", null);
+
+        var expected = new List<string>
+        {
+            "Debug: Debug message",
+            "Information: Info message",
+            "Warning: Warn message",
+            "Error: Error message"
+        };
+        Assert.Equal(expected, fake.Entries);
+    }
+
+    [Fact]
+    public void WithException()
+    {
+        var fake = new FakeLogger();
+        var logger = Logger.ForILogger(fake);
+        logger.LogLevel = LogLevel.Debug;
+        logger.Log(LogLevel.Error, "Error message", new Exception("Bang"));
+        var entry = Assert.Single(fake.Entries);
+        Assert.Contains("Error message", entry);
+        Assert.Contains("Exception: Bang", entry);
+    }
+
+    [Fact]
+    public void Performance()
+    {
+        var fake = new FakeLogger();
+        var logger = Logger.ForILogger(fake);
+        logger.LogPerformanceTraces = true;
+        logger.LogPerformanceCounter("counter", 10.0);
+        logger.LogPerformanceData();
+        var entry = Assert.Single(fake.Entries);
+        Assert.StartsWith("Trace", entry);
+        Assert.Contains("counter", entry);
+        Assert.Contains("last=10", entry);
+    }
+
+    private class FakeLogger : ILogger
+    {
+        public List<string> Entries { get; } = new List<string>();
+
+        public IDisposable BeginScope<TState>(TState state) =>
+            throw new NotImplementedException();
+
+        public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel) =>
+            throw new NotImplementedException();
+
+        public void Log<TState>(Microsoft.Extensions.Logging.LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter) =>
+            Entries.Add(exception is null ? $"{logLevel}: {formatter(state, exception)}": $"{logLevel}: Exception: {exception.Message}, {formatter(state, exception)}");
+    }
+}

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Internal/Logging/Logger.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Internal/Logging/Logger.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Google.Api.Gax;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -50,6 +51,14 @@ namespace Google.Cloud.Spanner.V1.Internal.Logging
             GaxPreconditions.CheckNotNull(instance, nameof(instance));
             Interlocked.Exchange(ref s_defaultLogger, instance);
         }
+
+        /// <summary>
+        /// Creates a <see cref="Logger"/> instance that delegates all logging requests to
+        /// <paramref name="logger"/>.
+        /// </summary>
+        /// <param name="logger">The logger to delegate to. Must not be null.</param>
+        /// <returns>A Spanner logger that delegates to <paramref name="logger"/>.</returns>
+        public static Logger ForILogger(ILogger logger) => new MsLogger(logger);
 
         /// <summary>
         /// The level of logging this logger should perform. For example, if this is set to

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Internal/Logging/MsLogger.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Internal/Logging/MsLogger.cs
@@ -1,0 +1,56 @@
+﻿// Copyright 2022 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using MsLogLevel = Microsoft.Extensions.Logging.LogLevel;
+
+namespace Google.Cloud.Spanner.V1.Internal.Logging;
+
+/// <summary>
+/// Implementation of Logger that adapts a Microsoft.Extensions.Logging.ILogger.
+/// This allows users to unify their logs without a very disruptive change, before
+/// we eventually remove Spanner internal logging entirely.
+/// </summary>
+internal sealed class MsLogger : Logger
+{
+    private readonly ILogger _logger;
+
+    internal MsLogger(ILogger logger) =>
+        _logger = GaxPreconditions.CheckNotNull(logger, nameof(logger));
+
+    protected override void LogPerformanceEntries(IEnumerable<string> entries)
+    {
+        foreach (var entry in entries)
+        {
+            _logger.Log(MsLogLevel.Trace, entry);
+        }
+    }
+
+    protected override void LogImpl(LogLevel level, string message, Exception exception)
+    {
+        var msLogLevel = level switch
+        {
+            LogLevel.None => MsLogLevel.None,
+            LogLevel.Debug => MsLogLevel.Debug,
+            LogLevel.Info => MsLogLevel.Information,
+            LogLevel.Error => MsLogLevel.Error,
+            LogLevel.Warn => MsLogLevel.Warning,
+            _ => MsLogLevel.Debug
+        };
+        _logger.Log(msLogLevel, exception, message);
+    }
+}


### PR DESCRIPTION
This is an interim step to allow logs to be easily unified (to
ILogger) before we eventually remove the Spanner internal logging
system entirely.