### PR TITLE
chore: Use "transports" generator option

### DIFF
--- a/apis/Google.Cloud.Compute.V1/postgeneration.sh
+++ b/apis/Google.Cloud.Compute.V1/postgeneration.sh
@@ -2,9 +2,6 @@
 
 set -e
 
-# Until we have transports in the generator itself, manually fix this up.
-sed -i 's/ApiTransports.Grpc/ApiTransports.Rest/g' Google.Cloud.Compute.V1/*.g.cs
-
 # Generate enum constants
 dotnet build Google.Cloud.Compute.V1.EnumConstantGenerator
 dotnet run --no-build --project Google.Cloud.Compute.V1.EnumConstantGenerator > Google.Cloud.Compute.V1/ComputeEnumConstants.g.cs

--- a/apis/README.md
+++ b/apis/README.md
@@ -41,3 +41,4 @@ Fields:
   automatically.)
 - `shortName`: the value of the `name` field in the corresponding service config, if any
 - `serviceConfigFile`: the path the service config YAML file, relative to `protoPath`
+- `transport`: the value passed into the microgenerator `transport` option; defaults to "grpc"

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -735,7 +735,8 @@
       "generator": "micro",
       "protoPath": "google/cloud/compute/v1",
       "shortName": "compute",
-      "serviceConfigFile": "compute_v1.yaml"
+      "serviceConfigFile": "compute_v1.yaml",
+      "transport": "rest"
     },
     {
       "id": "Google.Cloud.ContactCenterInsights.V1",

--- a/generateapis.sh
+++ b/generateapis.sh
@@ -76,6 +76,7 @@ generate_microgenerator() {
     COMMON_RESOURCES_CONFIG=$COMMON_RESOURCES_CONFIG,common-resources-config=$API_COMMON_RESOURCES_CONFIG
   fi
   COMMON_RESOURCES_OPTION=--gapic_opt=$COMMON_RESOURCES_CONFIG
+  TRANSPORT_OPTION=--gapic_opt=transport=$($PYTHON3 tools/getapifield.py apis/apis.json $PACKAGE transport --default=grpc)
 
   # All APIs should have a service config specified, but it might be deliberately "none" to mean
   # "there are no services for this API directory" e.g. for oslogin/common
@@ -127,6 +128,7 @@ generate_microgenerator() {
     $GRPC_SERVICE_CONFIG_OPTION \
     $SERVICE_CONFIG_OPTION \
     $COMMON_RESOURCES_OPTION \
+    $TRANSPORT_OPTION \
     --plugin=protoc-gen-gapic=$GAPIC_PLUGIN \
     -I $GOOGLEAPIS \
     -I $CORE_PROTOS_ROOT \

--- a/tools/Google.Cloud.Tools.Common/ApiMetadata.cs
+++ b/tools/Google.Cloud.Tools.Common/ApiMetadata.cs
@@ -252,5 +252,13 @@ namespace Google.Cloud.Tools.Common
         /// for GAPIC APIs, and is usually copied from the API index when an API is added.
         /// </summary>
         public string ServiceConfigFile { get; set; }
+
+        /// <summary>
+        /// The option to pass to protoc for API transports. (Note that this is singular
+        /// to conform with the existing option in other languages.) Values are expected to
+        /// be semi-colon-separated, e.g. "grpc", "rest" or "grpc;rest". Defaults to "grpc"
+        /// during generation.
+        /// </summary>
+        public string Transport { get; set; }
     }
 }


### PR DESCRIPTION
This allows us to remove one piece of special-casing for Compute

We could potentially remove the "regapic" type at some point, but that can come later.