### PR TITLE
feat: SpannerConversionOptions infrastructure changes, decimal handling with options, Date handling with options.

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.CommonTesting/SpannerFixtureBasePostgre.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.CommonTesting/SpannerFixtureBasePostgre.cs
@@ -1,0 +1,41 @@
+﻿// Copyright 2022 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.ClientTesting;
+using Google.Cloud.Spanner.Common.V1;
+using Google.Cloud.Spanner.V1.Internal.Logging;
+
+namespace Google.Cloud.Spanner.Data.CommonTesting
+{
+    /// <summary>
+    /// Base classes for test fixtures for Spanner PostgreSQL database.
+    /// </summary>
+    public abstract class SpannerFixtureBasePostgre : CloudProjectFixtureBase
+    {
+        public SpannerTestDatabasePostgre Database { get; }
+
+        public SpannerFixtureBasePostgre()
+        {
+            GrpcInfo.EnableSubchannelCounting();
+            Database = SpannerTestDatabasePostgre.GetInstance(ProjectId);
+        }
+
+        public DatabaseName DatabaseName => Database.DatabaseName;
+        public SpannerConnection GetConnection() => Database.GetConnection();
+        public string ConnectionString => Database.ConnectionString;
+        public SpannerConnection GetConnection(Logger logger, bool logCommitStats = false) => Database.GetConnection(logger, logCommitStats);
+        public bool RunningOnEmulator => SpannerClientCreationOptions.UsesEmulator;
+        internal SpannerClientCreationOptions SpannerClientCreationOptions => Database.SpannerClientCreationOptions;
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.CommonTesting/SpannerTableFixturePostgre.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.CommonTesting/SpannerTableFixturePostgre.cs
@@ -1,0 +1,75 @@
+﻿// Copyright 2022 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Spanner.V1.Internal.Logging;
+
+namespace Google.Cloud.Spanner.Data.CommonTesting
+{
+    /// <summary>
+    /// Base class for test fixtures for PostgreSQL tables.
+    /// </summary>
+    public abstract class SpannerTableFixturePostgre : SpannerFixtureBasePostgre
+    {
+        public string TableName { get; }
+
+        public SpannerTableFixturePostgre(string tableName)
+        {
+            // Emulator doesn't support PostgreSQL, so just return.
+            if (RunningOnEmulator)
+            {
+                return;
+            }
+
+            TableName = tableName;
+            if (Database.Fresh)
+            {
+                Logger.DefaultLogger.Debug($"Creating PostgreSQL table {TableName}");
+                CreateTable();
+            }
+            RetryHelpers.ResetStats();
+            Logger.DefaultLogger.Debug($"Populating PostgreSQL table {TableName}");
+            PopulateTable(Database.Fresh);
+            Logger.DefaultLogger.Debug($"Ready to run PostgreSQL tests");
+            RetryHelpers.MaybeLogStats($"Population of PostgreSQL table {TableName}");
+            RetryHelpers.ResetStats();
+        }
+
+        /// <summary>
+        /// Creates the table. This method is only called when a new database has been created.
+        /// </summary>
+        protected abstract void CreateTable();
+
+        /// <summary>
+        /// Optional operation; populates the table, potentially doing different things based on whether
+        /// the database is new or not.
+        /// </summary>
+        protected virtual void PopulateTable(bool fresh)
+        {
+        }
+
+        protected void ExecuteDdl(string ddl)
+        {
+            using (var connection = GetConnection())
+            {
+                connection.CreateDdlCommand(ddl).ExecuteNonQuery();
+            }
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
+            RetryHelpers.MaybeLogStats($"Disposal of fixture for PostgreSQL table {TableName}");
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.CommonTesting/SpannerTestDatabasePostgre.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.CommonTesting/SpannerTestDatabasePostgre.cs
@@ -1,0 +1,198 @@
+﻿// Copyright 2022 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using Google.Api.Gax.ResourceNames;
+using Google.Cloud.ClientTesting;
+using Google.Cloud.Spanner.Admin.Database.V1;
+using Google.Cloud.Spanner.Admin.Instance.V1;
+using Google.Cloud.Spanner.Common.V1;
+using Google.Cloud.Spanner.V1.Internal.Logging;
+using Grpc.Core;
+using System;
+
+namespace Google.Cloud.Spanner.Data.CommonTesting
+{
+    /// <summary>
+    /// A database with PostgreSQL dialect created on-demand for testing. This is never dropped, partly as it's hard to know when to do so.
+    /// (This may be used by multiple fixtures, each created and then disposed, within the same test run.) 
+    /// </summary>
+    public class SpannerTestDatabasePostgre
+    {
+        private static readonly object s_lock = new object();
+        private static SpannerTestDatabasePostgre s_instance = null;
+
+        /// <summary>
+        /// Fetches the PostgreSQL database, creating it if necessary.
+        /// </summary>
+        /// <param name="projectId">The project ID to use, typically from a fixture.</param>
+        public static SpannerTestDatabasePostgre GetInstance(string projectId)
+        {
+            if (s_instance == null)
+            {
+                lock (s_lock)
+                {
+                    if (s_instance == null)
+                    {
+                        s_instance = new SpannerTestDatabasePostgre(projectId);
+                    }
+                    else if (s_instance.ProjectId != projectId)
+                    {
+                        throw new ArgumentException($"A PostgreSQL database for project ID {s_instance.ProjectId} has already been created; this test requested {projectId}");
+                    }
+                    return s_instance;
+                }
+            }
+            return s_instance;
+        }
+
+        private static readonly string s_generatedDatabaseName = IdGenerator.FromDateTime(prefix: "testdb_pg_", pattern: "yyyyMMdd't'HHmmss");
+
+        public string SpannerHost { get; } = GetEnvironmentVariableOrDefault("TEST_SPANNER_HOST", null);
+        public string SpannerPort { get; } = GetEnvironmentVariableOrDefault("TEST_SPANNER_PORT", null);
+        public string SpannerInstance { get; } = GetEnvironmentVariableOrDefault("TEST_SPANNER_INSTANCE", "spannerintegration");
+        public string SpannerDatabase { get; } = GetEnvironmentVariableOrDefault("TEST_SPANNER_POSTGRESQL_DATABASE", s_generatedDatabaseName);
+
+        // This is the simplest way of checking whether the environment variable was specified or not.
+        // It's a little ugly, but simpler than the alternatives.
+
+        /// <summary>
+        /// Returns true if the database was created just for this test, or false if the database was an existing one
+        /// specified through an environment variable.
+        /// </summary>
+        public bool Fresh => SpannerDatabase == s_generatedDatabaseName;
+
+        // Connection string including database, generated from the above properties
+        public string ConnectionString { get; }
+        // Connection string without the database, generated from the above properties
+        public string NoDbConnectionString { get; }
+        public string ProjectId { get; }
+        public DatabaseName DatabaseName { get; }
+        internal SpannerClientCreationOptions SpannerClientCreationOptions { get; }
+
+        private SpannerTestDatabasePostgre(string projectId)
+        {
+            TestLogger.Install();
+
+            ProjectId = projectId;
+            var builder = new SpannerConnectionStringBuilder
+            {
+                Host = SpannerHost,
+                DataSource = $"projects/{ProjectId}/instances/{SpannerInstance}",
+                EmulatorDetection = EmulatorDetection.EmulatorOrProduction
+            };
+            if (SpannerPort != null)
+            {
+                builder.Port = int.Parse(SpannerPort);
+            }
+            NoDbConnectionString = builder.ConnectionString;
+            SpannerClientCreationOptions = new SpannerClientCreationOptions(builder);
+            var databaseBuilder = builder.WithDatabase(SpannerDatabase);
+            ConnectionString = databaseBuilder.ConnectionString;
+            DatabaseName = databaseBuilder.DatabaseName;
+
+            MaybeCreateInstanceOnEmulator(projectId);
+            if (Fresh)
+            {
+                // Skip creating database in Emulator, as it would fail.
+                if (!SpannerClientCreationOptions.UsesEmulator)
+                {
+                    CreatePostgreSqlDatabase();
+                    Logger.DefaultLogger.Debug($"Created database {SpannerDatabase} with PostgreSql dialect.");
+                }
+            }
+            else
+            {
+                Logger.DefaultLogger.Debug($"Using existing PostgreSql database {SpannerDatabase}");
+            }
+        }
+
+        private static string GetEnvironmentVariableOrDefault(string name, string defaultValue)
+        {
+            string value = Environment.GetEnvironmentVariable(name);
+            return string.IsNullOrEmpty(value) ? defaultValue : value;
+        }
+
+        private void MaybeCreateInstanceOnEmulator(string projectId)
+        {
+            if (SpannerClientCreationOptions.UsesEmulator)
+            {
+                // Try to create an instance on the emulator and ignore any AlreadyExists error.
+                var adminClientBuilder = new InstanceAdminClientBuilder
+                {
+                    EmulatorDetection = EmulatorDetection.EmulatorOnly
+                };
+                var instanceAdminClient = adminClientBuilder.Build();
+
+                var instanceName = InstanceName.FromProjectInstance(projectId, SpannerInstance);
+                try
+                {
+                    instanceAdminClient.CreateInstance(new CreateInstanceRequest
+                    {
+                        InstanceId = instanceName.InstanceId,
+                        ParentAsProjectName = ProjectName.FromProject(projectId),
+                        Instance = new Instance
+                        {
+                            InstanceName = instanceName,
+                            ConfigAsInstanceConfigName = new InstanceConfigName(projectId, "emulator-config"),
+                            DisplayName = "Test Instance",
+                            NodeCount = 1,
+                        },
+                    }).PollUntilCompleted();
+                }
+                catch (RpcException e) when (e.StatusCode == StatusCode.AlreadyExists)
+                {
+                    // Ignore
+                }
+            }
+        }
+
+        private void CreatePostgreSqlDatabase()
+        {
+            DatabaseAdminClient databaseAdminClient = DatabaseAdminClient.Create();
+            CreateDatabaseRequest createDatabaseRequest = new CreateDatabaseRequest
+            {
+                CreateStatement = $"CREATE DATABASE {SpannerDatabase}",
+                DatabaseDialect = DatabaseDialect.Postgresql,
+                ParentAsInstanceName = InstanceName.FromProjectInstance(ProjectId, SpannerInstance)
+            };
+
+            try
+            {
+                var operation = databaseAdminClient.CreateDatabase(createDatabaseRequest);
+                var completedResponse = operation.PollUntilCompleted();
+                if (completedResponse.IsFaulted)
+                {
+                    Console.WriteLine($"Error while creating PostgreSQL database: {completedResponse.Exception}");
+                    throw completedResponse.Exception;
+                }
+            }
+            catch (RpcException e) when (e.StatusCode == StatusCode.AlreadyExists)
+            {
+                // Ignore.
+            }
+        }
+
+        public SpannerConnection GetConnection() => new SpannerConnection(ConnectionString);
+
+        // Creates a SpannerConnection with a specific logger.
+        public SpannerConnection GetConnection(Logger logger, bool logCommitStats = false) =>
+            new SpannerConnection(new SpannerConnectionStringBuilder(ConnectionString)
+            {
+                SessionPoolManager = SessionPoolManager.Create(new V1.SessionPoolOptions(), logger),
+                LogCommitStats = logCommitStats
+            });
+    }
+}
+

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/DateTimestampTableFixturePostgre.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/DateTimestampTableFixturePostgre.cs
@@ -1,0 +1,36 @@
+﻿// Copyright 2022 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Spanner.Data.CommonTesting;
+using Xunit;
+
+namespace Google.Cloud.Spanner.Data.IntegrationTests
+{
+    [CollectionDefinition(nameof(DateTimestampTableFixturePostgre))]
+    public class DateTimestampTableFixturePostgre : SpannerTableFixturePostgre, ICollectionFixture<DateTimestampTableFixturePostgre>
+    {
+        public DateTimestampTableFixturePostgre() : base("DateTimestampTest")
+        {
+        }
+
+        protected override void CreateTable()
+        {
+            ExecuteDdl($@"CREATE TABLE {TableName} (
+                            id BIGINT NOT NULL,
+                            datevalue DATE,
+                            timestampvalue TIMESTAMPTZ,
+                            PRIMARY KEY (id))");
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/DecimalReadTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/DecimalReadTests.cs
@@ -1,0 +1,214 @@
+﻿// Copyright 2022 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Google.Cloud.Spanner.V1;
+using Xunit;
+
+namespace Google.Cloud.Spanner.Data.IntegrationTests
+{
+    [Collection(nameof(DecimalTableFixture))]
+    public class DecimalReadTests
+    {
+        private readonly DecimalTableFixture _fixture;
+
+        public DecimalReadTests(DecimalTableFixture fixture) =>
+            _fixture = fixture;
+
+        public static IEnumerable<object[]> TestDecimals =>
+            new List<object[]>
+            {
+                new object[] { new decimal(1.23456789) },
+                new object[] { decimal.MinusOne },
+                new object[] { decimal.Zero },
+                new object[] { new decimal(123456789.0123456789012345678) },
+            };
+
+        public static IEnumerable<object[]> TestDecimalsWithNumeric =>
+            new List<object[]>
+            {
+                new object[] { new decimal(1.23456789) },
+                new object[] { decimal.MaxValue },
+                new object[] { decimal.MinValue },
+                new object[] { decimal.MinusOne },
+                new object[] { decimal.Zero },
+                new object[] { new decimal(123456789.0123456789012345678) },
+            };
+
+        // Test case: Simple case of using decimal value with Float64 column in database.
+        // SpannerDbType is explicitly set for the parameter.
+        [Theory]
+        [MemberData(nameof(TestDecimals))]
+        public async Task WriteThenRead_ShouldBeEqual(decimal expectedValue)
+        {
+            using var connection = _fixture.GetConnection();
+            // Write the decimal value and read it back.
+            await connection.CreateInsertOrUpdateCommand(_fixture.TableName,
+                new SpannerParameterCollection
+                {
+                    new SpannerParameter("DecimalValue", SpannerDbType.Float64, expectedValue),
+                }
+            ).ExecuteNonQueryAsync();
+            var decimalValue = await connection.CreateSelectCommand($"SELECT DecimalValue FROM {_fixture.TableName}").ExecuteScalarAsync<decimal>();
+            Assert.Equal(expectedValue, decimalValue);
+        }
+
+        // Test Case: Using decimal with Float64 column in database. SpannerConversionOptions set to use Numeric for decimal.
+        // SpannerDbType is explicitly set for the parameter.
+        // The configuration should be ignored in .NET to Spanner path, as SpannerDbType of parameter is specified.
+        // The configuration should be honored in Spanner to .NET path if ClrType isn't specified while reading.
+        [Theory]
+        [MemberData(nameof(TestDecimals))]
+        public async Task WriteThenRead_ShouldBeEqual_UseOptions(decimal expectedValue)
+        {
+            // Set the SpannerConversionOptions in the connection string.
+            using var connection = new SpannerConnection($"{_fixture.ConnectionString};UseSpannerNumericForDecimal=true");
+            // Write the decimal value and read it back.
+            await connection.CreateInsertOrUpdateCommand(_fixture.TableName,
+                new SpannerParameterCollection
+                {
+                    new SpannerParameter("DecimalValue", SpannerDbType.Float64, expectedValue),
+                }
+            ).ExecuteNonQueryAsync();
+            var decimalValue = await connection.CreateSelectCommand($"SELECT DecimalValue FROM {_fixture.TableName}").ExecuteScalarAsync<decimal>();
+            Assert.Equal(expectedValue, decimalValue);
+            var numericValue = await connection.CreateSelectCommand($"SELECT DecimalValue FROM {_fixture.TableName}").ExecuteScalarAsync<SpannerNumeric>();
+            Assert.Equal(SpannerNumeric.FromDecimal(expectedValue, LossOfPrecisionHandling.Truncate), numericValue);
+            // Explicitly test the scenario in which CLR Type is not specified.
+            var value = await connection.CreateSelectCommand($"SELECT DecimalValue FROM {_fixture.TableName}").ExecuteScalarAsync<object>();
+            Assert.True(value is SpannerNumeric);
+            Assert.Equal(SpannerNumeric.FromDecimal(expectedValue, LossOfPrecisionHandling.Truncate), (SpannerNumeric)value);
+        }
+
+        // Test Case: Using decimal with Float64 column in database without explicitly specifying SpannerDbType of parameter.
+        // SpannerConversionOptions is not explicitly set, so Default option would be used.
+        // Default type for decimal is Float64, so it will work with Float64 type column in database.
+        [Theory]
+        [MemberData(nameof(TestDecimals))]
+        public async Task WriteThenRead_ShouldBeEqual_WithoutSpannerDbType(decimal expectedValue)
+        {
+            using var connection = _fixture.GetConnection();
+            await connection.CreateInsertOrUpdateCommand(_fixture.TableName,
+                new SpannerParameterCollection
+                {
+                    // Without options, SpannerDbType of parameter will default to Float64.
+                    new SpannerParameter { ParameterName = "DecimalValue", Value = expectedValue },
+                }
+            ).ExecuteNonQueryAsync();
+            var decimalValue = await connection.CreateSelectCommand($"SELECT DecimalValue FROM {_fixture.TableName}").ExecuteScalarAsync<decimal>();
+            Assert.Equal(expectedValue, decimalValue);
+        }
+
+        // Test Case: Using decimal with Float64 column in database without passing SpannerDbType of the parameter.
+        // SpannerConversionOptions is set to use Numeric for decimal.
+        // This should throw SpannerException as Float64 column expects Float64 value but Numeric value is passed.
+        [Theory]
+        [MemberData(nameof(TestDecimals))]
+        public async Task WriteWithoutSpannerDbType_UseOptions(decimal expectedValue)
+        {
+            using var connection = new SpannerConnection($"{_fixture.ConnectionString};UseSpannerNumericForDecimal=true");
+            // Writing the decimal value as numeric to Float64 column should throw SpannerException.
+            await Assert.ThrowsAsync<SpannerException>(async () => 
+            await connection.CreateInsertOrUpdateCommand(_fixture.TableName,
+                new SpannerParameterCollection
+                {
+                    new SpannerParameter { ParameterName = "DecimalValue", Value = expectedValue },
+                }
+            ).ExecuteNonQueryAsync());
+        }
+
+        // Normal case of using decimal with Numeric column in database.
+        [Theory]
+        [MemberData(nameof(TestDecimalsWithNumeric))]
+        public async Task WriteThenRead_ShouldBeEqual_WithNumericColumn(decimal expectedValue)
+        {
+            using var connection = _fixture.GetConnection();
+            // Write the decimal value as Numeric and read it back.
+            await connection.CreateInsertOrUpdateCommand(_fixture.TableName,
+                new SpannerParameterCollection
+                {
+                    new SpannerParameter { ParameterName = "NumericValue", SpannerDbType = SpannerDbType.Numeric, Value = expectedValue },
+                }
+            ).ExecuteNonQueryAsync();
+            var decimalValue = await connection.CreateSelectCommand($"SELECT NumericValue FROM {_fixture.TableName}").ExecuteScalarAsync<SpannerNumeric>();
+            Assert.Equal(SpannerNumeric.FromDecimal(expectedValue, LossOfPrecisionHandling.Truncate), decimalValue);
+        }
+
+        // Case of using decimal with Numeric column in database.
+        // SpannerConversionOptions is set to use Numeric for decimal.
+        // The configuration should be ignored in .NET to Spanner path, as SpannerDbType of parameter is specified.
+        // The configuration should be honored in Spanner to .NET path if ClrType isn't specified while reading.
+        [Theory]
+        [MemberData(nameof(TestDecimalsWithNumeric))]
+        public async Task WriteThenRead_ShouldBeEqual_WithNumericColumn_UseOptions(decimal expectedValue)
+        {
+            using var connection = new SpannerConnection($"{_fixture.ConnectionString};UseSpannerNumericForDecimal=true");
+            // Write the decimal value and read it back.
+            await connection.CreateInsertOrUpdateCommand(_fixture.TableName,
+                new SpannerParameterCollection
+                {
+                    new SpannerParameter { ParameterName = "NumericValue", SpannerDbType = SpannerDbType.Numeric, Value = expectedValue },
+                }
+            ).ExecuteNonQueryAsync();
+            var numericValue = await connection.CreateSelectCommand($"SELECT NumericValue FROM {_fixture.TableName}").ExecuteScalarAsync<SpannerNumeric>();
+            Assert.Equal(SpannerNumeric.FromDecimal(expectedValue, LossOfPrecisionHandling.Truncate), numericValue);
+            // Explicitly test the scenario in which CLR Type is not specified.
+            var value = await connection.CreateSelectCommand($"SELECT NumericValue FROM {_fixture.TableName}").ExecuteScalarAsync<object>();
+            Assert.True(value is SpannerNumeric);
+            Assert.Equal(SpannerNumeric.FromDecimal(expectedValue, LossOfPrecisionHandling.Truncate), (SpannerNumeric)value);
+        }
+
+        // Case of using decimal with Numeric column in database without specifying SpannerDbType of parameter. 
+        // SpannerConversionOptions is not explicitly set, so Default of Float64 for decimal would be used.
+        // This should throw SpannerException as Float64 type value would be provided to a Numeric column.
+        [Theory]
+        [MemberData(nameof(TestDecimalsWithNumeric))]
+        public async Task WriteWithoutSpannerDbType_WithNumericColumn(decimal expectedValue)
+        {
+            using var connection = _fixture.GetConnection();
+            await Assert.ThrowsAsync<SpannerException>(async () =>
+            await connection.CreateInsertOrUpdateCommand(_fixture.TableName,
+                new SpannerParameterCollection
+                {
+                    new SpannerParameter { ParameterName = "NumericValue", Value = expectedValue },
+                }).ExecuteNonQueryAsync());
+        }
+
+        // Case of using decimal with Numeric column in database.
+        // SpannerConversionOptions is set to use Numeric for decimal.
+        // The configuration should be honored in .NET to Spanner path, as SpannerDbType of parameter isn't specified.
+        // The configuration should be honored in Spanner to .NET path if ClrType isn't specified while reading.
+        [Theory]
+        [MemberData(nameof(TestDecimalsWithNumeric))]
+        public async Task WriteThenReadWithoutSpannerDbType_ShouldBeEqual_WithNumericColumn_UseOptions(decimal expectedValue)
+        {
+            using var connection = new SpannerConnection($"{_fixture.ConnectionString};UseSpannerNumericForDecimal=true");
+            // Write the decimal value and read it back.
+            await connection.CreateInsertOrUpdateCommand(_fixture.TableName,
+                new SpannerParameterCollection
+                {
+                    // SpannerDbType of Numeric will be used based on option.
+                    new SpannerParameter { ParameterName = "NumericValue", Value = expectedValue },
+                }
+            ).ExecuteNonQueryAsync();
+            var numericValue = await connection.CreateSelectCommand($"SELECT NumericValue FROM {_fixture.TableName}").ExecuteScalarAsync<SpannerNumeric>();
+            Assert.Equal(SpannerNumeric.FromDecimal(expectedValue, LossOfPrecisionHandling.Truncate), numericValue);
+            // Explicitly test the scenario in which CLR Type is not specified.
+            var value = await connection.CreateSelectCommand($"SELECT NumericValue FROM {_fixture.TableName}").ExecuteScalarAsync<object>();
+            Assert.True(value is SpannerNumeric);
+            Assert.Equal(SpannerNumeric.FromDecimal(expectedValue, LossOfPrecisionHandling.Truncate), (SpannerNumeric)value);
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/DecimalReadTestsPostgre.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/DecimalReadTestsPostgre.cs
@@ -1,0 +1,229 @@
+﻿// Copyright 2022 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Google.Cloud.Spanner.V1;
+using Xunit;
+
+namespace Google.Cloud.Spanner.Data.IntegrationTests
+{
+    [Collection(nameof(DecimalTableFixturePostgre))]
+    public class DecimalReadTestsPostgre
+    {
+        private readonly DecimalTableFixturePostgre _fixture;
+
+        public DecimalReadTestsPostgre(DecimalTableFixturePostgre fixture) =>
+            _fixture = fixture;
+
+        public static IEnumerable<object[]> TestDecimals =>
+            new List<object[]>
+            {
+                new object[] { new decimal(1.23456789) },
+                new object[] { decimal.MinusOne },
+                new object[] { decimal.Zero },
+                new object[] { new decimal(123456789.0123456789012345678) },
+            };
+
+        public static IEnumerable<object[]> TestDecimalsWithPgNumeric =>
+            new List<object[]>
+            {
+                new object[] { new decimal(1.23456789) },
+                new object[] { decimal.MaxValue },
+                new object[] { decimal.MinValue },
+                new object[] { decimal.MinusOne },
+                new object[] { decimal.Zero },
+                new object[] { new decimal(123456789.0123456789012345678) },
+            };
+
+        // Test case: Simple case of using decimal value with Float8 column in database.
+        // SpannerDbType is explicitly set for the parameter.
+        [SkippableTheory]
+        [MemberData(nameof(TestDecimals))]
+        public async Task WriteThenRead_ShouldBeEqual(decimal expectedValue)
+        {
+            Skip.If(_fixture.RunningOnEmulator, "The emulator does not support PostgreSQL dialect.");
+            using var connection = _fixture.GetConnection();
+            // Write the decimal value and read it back.
+            await connection.CreateInsertOrUpdateCommand(_fixture.TableName,
+                new SpannerParameterCollection
+                {
+                    new SpannerParameter ("id", SpannerDbType.Int64, 1),
+                    // SpannerDbType Float64 maps to Float8 in Spanner PostgreSQL dialect.
+                    // Henceforth, both are used interchangeably.
+                    new SpannerParameter("decimalvalue", SpannerDbType.Float64, expectedValue),
+                }
+            ).ExecuteNonQueryAsync();
+            var decimalValue = await connection.CreateSelectCommand($"SELECT decimalvalue FROM {_fixture.TableName}").ExecuteScalarAsync<decimal>();
+            Assert.Equal(expectedValue, decimalValue);
+        }
+
+        // Test Case: Using decimal with Float8 column in database. SpannerConversionOptions set to use PgNumeric for decimal.
+        // SpannerDbType is explicitly set for the parameter.
+        // The configuration should be ignored in .NET to Spanner path, as SpannerDbType of parameter is specified.
+        // The configuration should be honored in Spanner to .NET path if ClrType isn't specified while reading.
+        [SkippableTheory]
+        [MemberData(nameof(TestDecimals))]
+        public async Task WriteThenRead_ShouldBeEqual_UseOptions(decimal expectedValue)
+        {
+            Skip.If(_fixture.RunningOnEmulator, "The emulator does not support PostgreSQL dialect.");
+            // Set the SpannerConversionOptions in the connection string.
+            using var connection = new SpannerConnection($"{_fixture.ConnectionString};UsePgNumericForDecimal=true");
+            // Write the decimal value and read it back.
+            await connection.CreateInsertOrUpdateCommand(_fixture.TableName,
+                new SpannerParameterCollection
+                {
+                    new SpannerParameter ("id", SpannerDbType.Int64, 1),
+                    new SpannerParameter("decimalvalue", SpannerDbType.Float64, expectedValue),
+                }
+            ).ExecuteNonQueryAsync();
+            var decimalValue = await connection.CreateSelectCommand($"SELECT decimalvalue FROM {_fixture.TableName}").ExecuteScalarAsync<decimal>();
+            Assert.Equal(expectedValue, decimalValue);
+            var numericValue = await connection.CreateSelectCommand($"SELECT decimalvalue FROM {_fixture.TableName}").ExecuteScalarAsync<PgNumeric>();
+            Assert.Equal(PgNumeric.FromDecimal(expectedValue), numericValue);
+            // Explicitly test the scenario in which CLR Type is not specified.
+            var value = await connection.CreateSelectCommand($"SELECT decimalValue FROM {_fixture.TableName}").ExecuteScalarAsync<object>();
+            Assert.True(value is PgNumeric);
+            Assert.Equal(PgNumeric.FromDecimal(expectedValue), (PgNumeric)value);
+        }
+
+        // Test Case: Using decimal with Float8 column in database without explicitly specifying SpannerDbType of parameter.
+        // SpannerConversionOptions is not explicitly set, so Default option would be used.
+        // Default SpannerDbType for decimal is Float64, so it will work with Float8 type column in database.
+        [SkippableTheory]
+        [MemberData(nameof(TestDecimals))]
+        public async Task WriteThenRead_ShouldBeEqual_WithoutSpannerDbType(decimal expectedValue)
+        {
+            Skip.If(_fixture.RunningOnEmulator, "The emulator does not support PostgreSQL dialect.");
+            using var connection = _fixture.GetConnection();
+            await connection.CreateInsertOrUpdateCommand(_fixture.TableName,
+                new SpannerParameterCollection
+                {
+                    // Without options, SpannerDbType of parameter will default to Float64.                    
+                    new SpannerParameter ("id", SpannerDbType.Int64, 1),
+                    new SpannerParameter { ParameterName = "decimalvalue", Value = expectedValue },
+                }
+            ).ExecuteNonQueryAsync();
+            var decimalValue = await connection.CreateSelectCommand($"SELECT decimalValue FROM {_fixture.TableName}").ExecuteScalarAsync<decimal>();
+            Assert.Equal(expectedValue, decimalValue);
+        }
+
+        // Test Case: Using decimal with Float8 column in database without passing SpannerDbType of the parameter.
+        // SpannerConversionOptions is set to use PgNumeric for decimal.
+        // This should throw SpannerException as Float8 column expects Float8 value but PgNumeric value is passed.
+        [SkippableTheory]
+        [MemberData(nameof(TestDecimals))]
+        public async Task WriteWithoutSpannerDbType_UseOptions(decimal expectedValue)
+        {
+            Skip.If(_fixture.RunningOnEmulator, "The emulator does not support PostgreSQL dialect.");
+            using var connection = new SpannerConnection($"{_fixture.ConnectionString};UsePgNumericForDecimal=true");
+            await Assert.ThrowsAsync<SpannerException>(async () =>
+            await connection.CreateInsertOrUpdateCommand(_fixture.TableName,
+                new SpannerParameterCollection
+                {
+                    new SpannerParameter { ParameterName = "id", SpannerDbType = SpannerDbType.Int64, Value = 1 },
+                    new SpannerParameter { ParameterName = "decimalvalue", Value = expectedValue },
+                }
+            ).ExecuteNonQueryAsync());
+        }
+
+        // Normal case of using decimal with PgNumeric column in database.
+        [SkippableTheory]
+        [MemberData(nameof(TestDecimalsWithPgNumeric))]
+        public async Task WriteThenRead_ShouldBeEqual_WithPgNumericColumn(decimal expectedValue)
+        {
+            Skip.If(_fixture.RunningOnEmulator, "The emulator does not support PostgreSQL dialect.");
+            using var connection = _fixture.GetConnection();
+            // Write the decimal value as PgNumeric and read it back.
+            await connection.CreateInsertOrUpdateCommand(_fixture.TableName,
+                new SpannerParameterCollection
+                {
+                    new SpannerParameter { ParameterName = "id", SpannerDbType = SpannerDbType.Int64, Value = 1 },
+                    new SpannerParameter { ParameterName = "numericvalue", SpannerDbType = SpannerDbType.PgNumeric, Value = expectedValue },
+                }
+            ).ExecuteNonQueryAsync();
+            var decimalValue = await connection.CreateSelectCommand($"SELECT numericvalue FROM {_fixture.TableName}").ExecuteScalarAsync<PgNumeric>();
+            Assert.Equal(PgNumeric.FromDecimal(expectedValue), decimalValue);
+        }
+
+        // Case of using decimal with PgNumeric column in database.
+        // SpannerConversionOptions is set to use PgNumeric for decimal.
+        // The configuration should be ignored in .NET to Spanner path, as SpannerDbType of parameter is specified.
+        // The configuration should be honored in Spanner to .NET path if ClrType isn't specified while reading.
+        [SkippableTheory]
+        [MemberData(nameof(TestDecimalsWithPgNumeric))]
+        public async Task WriteThenRead_ShouldBeEqual_WithPgNumericColumn_UseOptions(decimal expectedValue)
+        {
+            Skip.If(_fixture.RunningOnEmulator, "The emulator does not support PostgreSQL dialect.");
+            using var connection = new SpannerConnection($"{_fixture.ConnectionString};UsePgNumericForDecimal=true");
+            await connection.CreateInsertOrUpdateCommand(_fixture.TableName,
+                new SpannerParameterCollection
+                {
+                    new SpannerParameter { ParameterName = "id", SpannerDbType = SpannerDbType.Int64, Value = 1 },
+                    new SpannerParameter { ParameterName = "numericvalue", SpannerDbType = SpannerDbType.PgNumeric, Value = expectedValue },
+                }
+            ).ExecuteNonQueryAsync();
+            var numericValue = await connection.CreateSelectCommand($"SELECT numericvalue FROM {_fixture.TableName}").ExecuteScalarAsync<PgNumeric>();
+            Assert.Equal(PgNumeric.FromDecimal(expectedValue), numericValue);
+            // Explicitly test the scenario in which CLR Type is not specified.
+            var value = await connection.CreateSelectCommand($"SELECT numericvalue FROM {_fixture.TableName}").ExecuteScalarAsync<object>();
+            Assert.True(value is PgNumeric);
+            Assert.Equal(PgNumeric.FromDecimal(expectedValue), (PgNumeric)value);
+        }
+
+        // Case of using decimal with PgNumeric column in database without specifying SpannerDbType of parameter. 
+        // SpannerConversionOptions is not explicitly set, so Default of Float64 for decimal would be used.
+        // This should throw SpannerException as Float64 type value would be provided to a PgNumeric column.
+        [SkippableTheory]
+        [MemberData(nameof(TestDecimalsWithPgNumeric))]
+        public async Task WriteWithoutSpannerDbType_WithPgNumericColumn(decimal expectedValue)
+        {
+            Skip.If(_fixture.RunningOnEmulator, "The emulator does not support PostgreSQL dialect.");
+            using var connection = _fixture.GetConnection();
+            await Assert.ThrowsAsync<SpannerException>(async () =>
+            await connection.CreateInsertOrUpdateCommand(_fixture.TableName,
+                new SpannerParameterCollection
+                {
+                    new SpannerParameter { ParameterName = "id", SpannerDbType = SpannerDbType.Int64, Value = 1 },
+                    new SpannerParameter { ParameterName = "numericvalue", Value = expectedValue },
+                }).ExecuteNonQueryAsync());
+        }
+
+        // Case of using decimal with PgNumeric column in database.
+        // SpannerConversionOptions is set to use PgNumeric for decimal.
+        // The configuration should be honored in .NET to Spanner path, as SpannerDbType of parameter isn't specified.
+        // The configuration should be honored in Spanner to .NET path if ClrType isn't specified while reading.
+        [SkippableTheory]
+        [MemberData(nameof(TestDecimalsWithPgNumeric))]
+        public async Task WriteThenReadWithoutSpannerDbType_ShouldBeEqual_WithPgNumericColumn_UseOptions(decimal expectedValue)
+        {
+            Skip.If(_fixture.RunningOnEmulator, "The emulator does not support PostgreSQL dialect.");
+            using var connection = new SpannerConnection($"{_fixture.ConnectionString};UsePgNumericForDecimal=true");
+            await connection.CreateInsertOrUpdateCommand(_fixture.TableName,
+                new SpannerParameterCollection
+                {
+                    new SpannerParameter { ParameterName = "id", SpannerDbType = SpannerDbType.Int64, Value = 1 },
+                    // SpannerDbType of PgNumeric will be used.
+                    new SpannerParameter { ParameterName = "numericvalue", Value = expectedValue },
+                }
+            ).ExecuteNonQueryAsync();
+            var numericValue = await connection.CreateSelectCommand($"SELECT numericvalue FROM {_fixture.TableName}").ExecuteScalarAsync<PgNumeric>();
+            Assert.Equal(PgNumeric.FromDecimal(expectedValue), numericValue);
+            // Explicitly test the scenario in which CLR Type is not specified.
+            var value = await connection.CreateSelectCommand($"SELECT numericvalue FROM {_fixture.TableName}").ExecuteScalarAsync<object>();
+            Assert.True(value is PgNumeric);
+            Assert.Equal(PgNumeric.FromDecimal(expectedValue), (PgNumeric)value);
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/DecimalTableFixture.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/DecimalTableFixture.cs
@@ -1,0 +1,35 @@
+﻿// Copyright 2022 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Spanner.Data.CommonTesting;
+using Xunit;
+
+namespace Google.Cloud.Spanner.Data.IntegrationTests
+{
+    [CollectionDefinition(nameof(DecimalTableFixture))]
+    public class DecimalTableFixture : SpannerTableFixture, ICollectionFixture<DecimalTableFixture>
+    {
+        public DecimalTableFixture() : base("DecimalTest")
+        {
+        }
+
+        protected override void CreateTable()
+        {
+            ExecuteDdl($@"CREATE TABLE {TableName} (
+                          DecimalValue FLOAT64,
+                          NumericValue NUMERIC,
+                          ) PRIMARY KEY ()");
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/DecimalTableFixturePostgre.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/DecimalTableFixturePostgre.cs
@@ -1,0 +1,36 @@
+﻿// Copyright 2022 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Spanner.Data.CommonTesting;
+using Xunit;
+
+namespace Google.Cloud.Spanner.Data.IntegrationTests
+{
+    [CollectionDefinition(nameof(DecimalTableFixturePostgre))]
+    public class DecimalTableFixturePostgre : SpannerTableFixturePostgre, ICollectionFixture<DecimalTableFixturePostgre>
+    {
+        public DecimalTableFixturePostgre() : base("DecimalTest")
+        {
+        }
+
+        protected override void CreateTable()
+        {
+            ExecuteDdl($@"CREATE TABLE {TableName} (
+                            id BIGINT NOT NULL,
+                            decimalvalue FLOAT8,
+                            numericvalue NUMERIC,
+                            PRIMARY KEY (id))");
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerConnectionStringBuilderTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerConnectionStringBuilderTests.cs
@@ -187,6 +187,45 @@ namespace Google.Cloud.Spanner.Data.Tests
         }
 
         [Fact]
+        public void UseSpannerDateForDate()
+        {
+            var connectionStringBuilder = new SpannerConnectionStringBuilder("UseSpannerDateForDate=true");
+            Assert.True(connectionStringBuilder.UseSpannerDateForDate);
+            connectionStringBuilder.UseSpannerDateForDate = false;
+            Assert.False(connectionStringBuilder.UseSpannerDateForDate);
+            // DbConnectionStringBuilder lower-cases keywords, annoyingly.
+            Assert.Equal("usespannerdatefordate=False", connectionStringBuilder.ToString());
+            connectionStringBuilder = new SpannerConnectionStringBuilder("");
+            Assert.False(connectionStringBuilder.UseSpannerDateForDate);
+        }
+
+        [Fact]
+        public void UseSpannerNumericForDecimal()
+        {
+            var connectionStringBuilder = new SpannerConnectionStringBuilder("UseSpannerNumericForDecimal=true");
+            Assert.True(connectionStringBuilder.UseSpannerNumericForDecimal);
+            connectionStringBuilder.UseSpannerNumericForDecimal = false;
+            Assert.False(connectionStringBuilder.UseSpannerNumericForDecimal);
+            // DbConnectionStringBuilder lower-cases keywords, annoyingly.
+            Assert.Equal("usespannernumericfordecimal=False", connectionStringBuilder.ToString());
+            connectionStringBuilder = new SpannerConnectionStringBuilder("");
+            Assert.False(connectionStringBuilder.UseSpannerNumericForDecimal);
+        }
+
+        [Fact]
+        public void UsePgNumericForDecimal()
+        {
+            var connectionStringBuilder = new SpannerConnectionStringBuilder("UsePgNumericForDecimal=true");
+            Assert.True(connectionStringBuilder.UsePgNumericForDecimal);
+            connectionStringBuilder.UsePgNumericForDecimal = false;
+            Assert.False(connectionStringBuilder.UsePgNumericForDecimal);
+            // DbConnectionStringBuilder lower-cases keywords, annoyingly.
+            Assert.Equal("usepgnumericfordecimal=False", connectionStringBuilder.ToString());
+            connectionStringBuilder = new SpannerConnectionStringBuilder("");
+            Assert.False(connectionStringBuilder.UsePgNumericForDecimal);
+        }
+
+        [Fact]
         public void EmulatorDetectionProperty()
         {
             var connectionStringBuilder = new SpannerConnectionStringBuilder("EmulatorDetection=EmulatorOnly");

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerDbTypeTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerDbTypeTests.cs
@@ -257,6 +257,12 @@ namespace Google.Cloud.Spanner.Data.Tests
             yield return new object[] { SpannerDbType.Numeric, GetSpannerConversionOptions(true, false, false), typeof(SpannerNumeric) };
             yield return new object[] { SpannerDbType.PgNumeric, GetSpannerConversionOptions(false, false, false), typeof(PgNumeric) };
             yield return new object[] { SpannerDbType.PgNumeric, GetSpannerConversionOptions(false, true, false), typeof(PgNumeric) };
+
+            // Date, Timestamp.
+            yield return new object[] { SpannerDbType.Date, GetSpannerConversionOptions(false, false, false), typeof(DateTime) };
+            yield return new object[] { SpannerDbType.Date, GetSpannerConversionOptions(false, false, true), typeof(SpannerDate) };
+            yield return new object[] { SpannerDbType.Timestamp, GetSpannerConversionOptions(false, false, false), typeof(DateTime) };
+            yield return new object[] { SpannerDbType.Timestamp, GetSpannerConversionOptions(false, false, true), typeof(DateTime) };
         }
 
         [Theory]

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerParameterTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerParameterTests.cs
@@ -61,6 +61,7 @@ namespace Google.Cloud.Spanner.Data.Tests
             yield return new object[] { new List<byte> { 1 }, SpannerDbType.Bytes, DbType.Binary, typeof(byte[]) };
             yield return new object[] { true, SpannerDbType.Bool, DbType.Boolean, typeof(bool) };
             yield return new object[] { new DateTime(2021, 1, 13, 12, 3, 10), SpannerDbType.Timestamp, DbType.DateTime, typeof(DateTime) };
+            yield return new object[] { new SpannerDate(2021, 1, 13), SpannerDbType.Date, DbType.Date, typeof(DateTime) };
 
             yield return new object[] { 3.14f, SpannerDbType.Float64, DbType.Double, typeof(double) };
             yield return new object[] { 3.14d, SpannerDbType.Float64, DbType.Double, typeof(double) };
@@ -113,6 +114,25 @@ namespace Google.Cloud.Spanner.Data.Tests
                 SpannerDbType.PgNumeric, DbType.VarNumeric, typeof(PgNumeric) };
             yield return new object[] { (PgNumeric)3.14m, SpannerDbType.PgNumeric, GetSpannerConversionOptions(false, true, false),
                 SpannerDbType.PgNumeric, DbType.VarNumeric, typeof(PgNumeric) };
+
+            // DateTime and Timestamp.
+            yield return new object[] { new DateTime(2022, 5, 10, 12, 3, 10), SpannerDbType.Timestamp, GetSpannerConversionOptions(false, false, false),
+                SpannerDbType.Timestamp, DbType.DateTime, typeof(DateTime) };
+            yield return new object[] { new DateTime(2022, 5, 10, 12, 3, 10), SpannerDbType.Timestamp, GetSpannerConversionOptions(false, false, true),
+                SpannerDbType.Timestamp, DbType.DateTime, typeof(DateTime) };
+
+            // DateTime and Date.
+            // Demonstrates the issue with current defaults.
+            yield return new object[] { new DateTime(2022, 5, 10), SpannerDbType.Date, GetSpannerConversionOptions(false, false, false),
+                SpannerDbType.Timestamp, DbType.DateTime, typeof(DateTime) };  
+            yield return new object[] { new DateTime(2022, 5, 10), SpannerDbType.Date, GetSpannerConversionOptions(false, false, true),
+                SpannerDbType.Timestamp, DbType.DateTime, typeof(SpannerDate) };
+
+            // SpannerDate and Date.
+            yield return new object[] { new SpannerDate(2022, 5, 10), SpannerDbType.Date, GetSpannerConversionOptions(false, false, false),
+                SpannerDbType.Date, DbType.Date, typeof(DateTime) };
+            yield return new object[] { new SpannerDate(2022, 5, 10), SpannerDbType.Date, GetSpannerConversionOptions(false, false, true),
+                SpannerDbType.Date, DbType.Date, typeof(SpannerDate) };
         }
 
         [Theory]
@@ -245,6 +265,16 @@ namespace Google.Cloud.Spanner.Data.Tests
             yield return new object[] { new SpannerParameter { Value = 3.14M },
                 GetSpannerConversionOptions(false, true, false), SpannerDbType.PgNumeric };
 
+            // Date and Timestamp.
+            yield return new object[] { new SpannerParameter { Value = new SpannerDate(2022, 5, 10) },
+                GetSpannerConversionOptions(false, false, false), SpannerDbType.Date };
+            yield return new object[] { new SpannerParameter { Value = new SpannerDate(2022, 5, 10) },
+                GetSpannerConversionOptions(false, false, true), SpannerDbType.Date };
+            yield return new object[] { new SpannerParameter { Value = new DateTime(2022, 5, 10) },
+                GetSpannerConversionOptions(false, false, false), SpannerDbType.Timestamp };
+            yield return new object[] { new SpannerParameter { Value = new DateTime(2022, 5, 10) },
+                GetSpannerConversionOptions(false, false, true), SpannerDbType.Timestamp };
+
             // Cases where SpannerDbType is explicitly provided for SpannerParameter.
             // Options will be ignored.
 
@@ -261,6 +291,16 @@ namespace Google.Cloud.Spanner.Data.Tests
                 GetSpannerConversionOptions(false, false, false), SpannerDbType.PgNumeric };
             yield return new object[] { new SpannerParameter { Value = 3.14M, SpannerDbType = SpannerDbType.PgNumeric },
                 GetSpannerConversionOptions(false, true, false), SpannerDbType.PgNumeric };
+
+            // Date and Timestamp.
+            yield return new object[] { new SpannerParameter { Value = new SpannerDate(2022, 5, 10), SpannerDbType = SpannerDbType.Date },
+                GetSpannerConversionOptions(false, false, false), SpannerDbType.Date };
+            yield return new object[] { new SpannerParameter { Value = new SpannerDate(2022, 5, 10), SpannerDbType = SpannerDbType.Date },
+                GetSpannerConversionOptions(false, false, true), SpannerDbType.Date };
+            yield return new object[] { new SpannerParameter { Value = new DateTime(2022, 5, 10), SpannerDbType = SpannerDbType.Timestamp },
+                GetSpannerConversionOptions(false, false, false), SpannerDbType.Timestamp };
+            yield return new object[] { new SpannerParameter { Value = new DateTime(2022, 5, 10), SpannerDbType = SpannerDbType.Timestamp },
+                GetSpannerConversionOptions(false, false, true), SpannerDbType.Timestamp };
         }
 
         [Theory]

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerParameterTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerParameterTests.cs
@@ -31,6 +31,7 @@ namespace Google.Cloud.Spanner.Data.Tests
             yield return new object[] { SpannerDbType.Float64, DbType.Double, true };
             yield return new object[] { SpannerDbType.Int64, DbType.Int64, true };
             yield return new object[] { SpannerDbType.Numeric, DbType.VarNumeric, true };
+            yield return new object[] { SpannerDbType.PgNumeric, DbType.VarNumeric, false };
             yield return new object[] { SpannerDbType.Unspecified, DbType.Object, true };
             yield return new object[] { SpannerDbType.String, DbType.String, true };
             // There is no DbType that will map automatically to SpannerDbType.Json.
@@ -53,7 +54,7 @@ namespace Google.Cloud.Spanner.Data.Tests
             }
         }
 
-        // TODO: There are no values that will default to Spanner types DATE and JSON.
+        // TODO: There are no values that will default to Spanner type JSON.
         public static IEnumerable<object[]> GetValueConversions()
         {
             yield return new object[] { new byte[] { 1 }, SpannerDbType.Bytes, DbType.Binary, typeof(byte[]) };
@@ -73,6 +74,7 @@ namespace Google.Cloud.Spanner.Data.Tests
             yield return new object[] { 1uL, SpannerDbType.Int64, DbType.Int64, typeof(long) };
 
             yield return new object[] { (SpannerNumeric)3.14m, SpannerDbType.Numeric, DbType.VarNumeric, typeof(SpannerNumeric) };
+            yield return new object[] { (PgNumeric)3.14m, SpannerDbType.PgNumeric, DbType.VarNumeric, typeof(PgNumeric) };
             yield return new object[] { "test", SpannerDbType.String, DbType.String, typeof(string) };
         }
 
@@ -85,6 +87,44 @@ namespace Google.Cloud.Spanner.Data.Tests
             Assert.Equal(defaultClrType, spannerType.DefaultClrType);
             Assert.Equal(spannerType, parameter.SpannerDbType);
             Assert.Equal(adoType, parameter.DbType);
+        }
+
+        public static IEnumerable<object[]> GetConfiguredValueConversions()
+        {
+            // Format: parameter value, SpannerDbType, SpannerConversionOptions,
+            // Configured SpannerDbType, DbType, expected configured ClrType.
+
+            // Float64 for decimal.
+            yield return new object[] { 3.14m, SpannerDbType.Float64, GetSpannerConversionOptions(false, false, false),
+                SpannerDbType.Float64, DbType.Double, typeof(double) };
+            yield return new object[] { 3.14m, SpannerDbType.Float64, GetSpannerConversionOptions(true, false, false),
+                SpannerDbType.Numeric, DbType.VarNumeric, typeof(SpannerNumeric) };
+            yield return new object[] { 3.14m, SpannerDbType.Float64, GetSpannerConversionOptions(false, true, false),
+                SpannerDbType.PgNumeric, DbType.VarNumeric, typeof(PgNumeric) };
+
+            // Numeric for decimal.
+            yield return new object[] { (SpannerNumeric)3.14m, SpannerDbType.Numeric, GetSpannerConversionOptions(false, false, false),
+                SpannerDbType.Numeric, DbType.VarNumeric, typeof(SpannerNumeric) };
+            yield return new object[] { (SpannerNumeric)3.14m, SpannerDbType.Numeric, GetSpannerConversionOptions(true, false, false),
+                SpannerDbType.Numeric, DbType.VarNumeric, typeof(SpannerNumeric) };
+
+            // PgNumeric for decimal.
+            yield return new object[] { (PgNumeric)3.14m, SpannerDbType.PgNumeric, GetSpannerConversionOptions(false, false, false),
+                SpannerDbType.PgNumeric, DbType.VarNumeric, typeof(PgNumeric) };
+            yield return new object[] { (PgNumeric)3.14m, SpannerDbType.PgNumeric, GetSpannerConversionOptions(false, true, false),
+                SpannerDbType.PgNumeric, DbType.VarNumeric, typeof(PgNumeric) };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetConfiguredValueConversions))]
+        internal void ConfiguredValueMappings(object value, SpannerDbType spannerType, SpannerConversionOptions options,
+            SpannerDbType configuredSpannerType, DbType adoType, System.Type configuredClrType)
+        {
+            var parameter = new SpannerParameter { Value = value };
+
+            Assert.Equal(configuredClrType, spannerType.GetConfiguredClrType(options));
+            Assert.Equal(configuredSpannerType, parameter.GetConfiguredSpannerDbType(options));
+            Assert.Equal(adoType, configuredSpannerType.DbType);
         }
 
         public static IEnumerable<object[]> GetDbTypeSizes()
@@ -151,6 +191,7 @@ namespace Google.Cloud.Spanner.Data.Tests
             yield return new object[] { SpannerDbType.Float64 };
             yield return new object[] { SpannerDbType.Int64 };
             yield return new object[] { SpannerDbType.Numeric };
+            yield return new object[] { SpannerDbType.PgNumeric };
             yield return new object[] { SpannerDbType.Timestamp };
             yield return new object[] { SpannerDbType.Json };
             yield return new object[] { SpannerDbType.ArrayOf(SpannerDbType.Bytes) };
@@ -159,6 +200,7 @@ namespace Google.Cloud.Spanner.Data.Tests
             yield return new object[] { SpannerDbType.ArrayOf(SpannerDbType.Date) };
             yield return new object[] { SpannerDbType.ArrayOf(SpannerDbType.Float64) };
             yield return new object[] { SpannerDbType.ArrayOf(SpannerDbType.Int64) };
+            yield return new object[] { SpannerDbType.ArrayOf(SpannerDbType.PgNumeric) };
             yield return new object[] { SpannerDbType.ArrayOf(SpannerDbType.Numeric) };
             yield return new object[] { SpannerDbType.ArrayOf(SpannerDbType.Timestamp) };
             yield return new object[] { SpannerDbType.ArrayOf(SpannerDbType.Json) };
@@ -174,6 +216,59 @@ namespace Google.Cloud.Spanner.Data.Tests
             // Setting the size to the same (default) value should be allowed for all types.
             param.Size = 0;
             Assert.Equal(0, param.Size);
+        }
+
+        private static SpannerConversionOptions GetSpannerConversionOptions(bool useNumeric, bool usePgNumeric, bool useSpannerDate)
+        {
+            var connectionStringBuilder = new SpannerConnectionStringBuilder
+            {
+                UseSpannerNumericForDecimal = useNumeric,
+                UsePgNumericForDecimal = usePgNumeric,
+                UseSpannerDateForDate = useSpannerDate
+            };
+
+            return SpannerConversionOptions.ForConnectionStringBuilder(connectionStringBuilder);
+        }
+
+        public static IEnumerable<object[]> ConfiguredSpannerDbTypes()
+        {
+            // Format : SpannerParameter, SpannerConversionOptions, SpannerDbType.
+
+            // Cases where SpannerDbType is not explicitly provided for SpannerParameter.
+            // SpannerDbType will be inferred based on options.
+
+            // Float64, Numeric, PgNumeric.
+            yield return new object[] { new SpannerParameter { Value = 3.14M },
+                GetSpannerConversionOptions(false, false, false), SpannerDbType.Float64 };
+            yield return new object[] { new SpannerParameter { Value = 3.14M },
+                GetSpannerConversionOptions(true, false, false), SpannerDbType.Numeric };
+            yield return new object[] { new SpannerParameter { Value = 3.14M },
+                GetSpannerConversionOptions(false, true, false), SpannerDbType.PgNumeric };
+
+            // Cases where SpannerDbType is explicitly provided for SpannerParameter.
+            // Options will be ignored.
+
+            // Float64, Numeric and PgNumeric.
+            yield return new object[] { new SpannerParameter { Value = 3.14M, SpannerDbType = SpannerDbType.Float64 },
+                GetSpannerConversionOptions(false, false, false), SpannerDbType.Float64 };
+            yield return new object[] { new SpannerParameter { Value = 3.14M, SpannerDbType = SpannerDbType.Float64 },
+                GetSpannerConversionOptions(true, false, false), SpannerDbType.Float64 };
+            yield return new object[] { new SpannerParameter { Value = 3.14M, SpannerDbType = SpannerDbType.Numeric },
+                GetSpannerConversionOptions(false, false, false), SpannerDbType.Numeric };
+            yield return new object[] { new SpannerParameter { Value = 3.14M, SpannerDbType = SpannerDbType.Numeric },
+                GetSpannerConversionOptions(true, false, false), SpannerDbType.Numeric };
+            yield return new object[] { new SpannerParameter { Value = 3.14M, SpannerDbType = SpannerDbType.PgNumeric },
+                GetSpannerConversionOptions(false, false, false), SpannerDbType.PgNumeric };
+            yield return new object[] { new SpannerParameter { Value = 3.14M, SpannerDbType = SpannerDbType.PgNumeric },
+                GetSpannerConversionOptions(false, true, false), SpannerDbType.PgNumeric };
+        }
+
+        [Theory]
+        [MemberData(nameof(ConfiguredSpannerDbTypes))]
+        internal void GetConfiguredSpannerDbTypeTest(SpannerParameter parameter, SpannerConversionOptions options, SpannerDbType expectedType)
+        {
+            var actualType = parameter.GetConfiguredSpannerDbType(options);
+            Assert.Equal(expectedType, actualType);
         }
     }
 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/Keys.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/Keys.cs
@@ -312,8 +312,9 @@ namespace Google.Cloud.Spanner.Data
 
         private static ListValue ToListValue(SpannerParameterCollection parameters)
         {
-            // See comment at the top of GetMutations in SpannerCommand.ExecutableCommand.
-            // These options are currently not in use, but are required in the API.
+            // There is no access to Connection here, hence keeping options as it is.
+            // We can pass SpannerConversionOptions.Default if we want to.
+            // TODO: Check if SpannerConversionOptions.Default should be passed.
             SpannerConversionOptions options = null;
             return new ListValue
             {

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerBatchCommand.ExecutableCommand.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerBatchCommand.ExecutableCommand.cs
@@ -41,6 +41,7 @@ namespace Google.Cloud.Spanner.Data
             internal SpannerBatchCommandType CommandType { get; }
             internal Priority Priority { get; }
             internal string Tag { get; }
+            internal SpannerConversionOptions ConversionOptions { get; }
 
             public ExecutableCommand(SpannerBatchCommand command)
             {
@@ -51,6 +52,7 @@ namespace Google.Cloud.Spanner.Data
                 CommandType = command.CommandType;
                 Priority = command.Priority;
                 Tag = command.Tag;
+                ConversionOptions = SpannerConversionOptions.ForConnection(Connection);
             }
 
             /// <summary>
@@ -94,8 +96,8 @@ namespace Google.Cloud.Spanner.Data
                 };
                 foreach (var command in Commands)
                 {
-                    var statement = new Statement { Sql = command.CommandText };
-                    command.Parameters.FillSpannerCommandParams(out var parameters, statement.ParamTypes, null);
+                    var statement = new Statement { Sql = command.CommandText };          
+                    command.Parameters.FillSpannerCommandParams(out var parameters, statement.ParamTypes, ConversionOptions);
                     statement.Params = parameters;
                     request.Statements.Add(statement);
                 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerBatchCommand.ExecutableCommand.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerBatchCommand.ExecutableCommand.cs
@@ -96,7 +96,7 @@ namespace Google.Cloud.Spanner.Data
                 };
                 foreach (var command in Commands)
                 {
-                    var statement = new Statement { Sql = command.CommandText };          
+                    var statement = new Statement { Sql = command.CommandText };
                     command.Parameters.FillSpannerCommandParams(out var parameters, statement.ParamTypes, ConversionOptions);
                     statement.Params = parameters;
                     request.Statements.Add(statement);

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.ExecutableCommand.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.ExecutableCommand.cs
@@ -315,7 +315,7 @@ namespace Google.Cloud.Spanner.Data
                 // Whatever we do with the parameters, we'll need them in a ListValue.
                 var listValue = new ListValue
                 {
-                    Values = { Parameters.Select(x => x.SpannerDbType.ToProtobufValue(x.GetValidatedValue(), ConversionOptions)) }
+                    Values = { Parameters.Select(x => x.GetConfiguredSpannerDbType(ConversionOptions).ToProtobufValue(x.GetValidatedValue(), ConversionOptions)) }
                 };
 
                 if (CommandTextBuilder.SpannerCommandType != SpannerCommandType.Delete)

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnectionStringBuilder.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnectionStringBuilder.cs
@@ -52,6 +52,9 @@ namespace Google.Cloud.Spanner.Data
         private const string EnableGetSchemaTableKeyword = "EnableGetSchemaTable";
         private const string LogCommitStatsKeyword = "LogCommitStats";
         private const string EmulatorDetectionKeyword = "EmulatorDetection";
+        private const string UseSpannerDateForDateKeyword = "UseSpannerDateForDate";
+        private const string UseSpannerNumericForDecimalKeyword = "UseSpannerNumericForDecimal";
+        private const string UsePgNumericForDecimalKeyword = "UsePgNumericForDecimal";
 
         private InstanceName _instanceName;
         private DatabaseName _databaseName;
@@ -95,6 +98,99 @@ namespace Google.Cloud.Spanner.Data
         {
             get => GetValueOrDefault(UseClrDefaultForNullKeyword).Equals("True", StringComparison.OrdinalIgnoreCase);
             set => this[UseClrDefaultForNullKeyword] = value.ToString(); // Always "True" or "False", regardless of culture.
+        }
+
+        /// <summary>
+        /// Option to change the default CLR type used for reading Date type values. By default, <see cref="DateTime"/>
+        /// is used to handle Date and Timestamp column values. By setting this option to <c>true</c>, <see cref="SpannerDate"/> 
+        /// will be used as the default CLR type to read the Date type values, while working with Date type column. 
+        /// This option will have no impact while writing <see cref="DateTime"/> values to the database as 
+        /// <see cref="DateTime"/> can be used for both Timestamp and Date type columns and in the absence of explicitly specified
+        /// <see cref="SpannerDbType"/>, it is difficult to distinguish if user intends to work with Date or Timestamp. 
+        /// In general, <see cref="SpannerDate"/> type should be used to work with Date type columns and <see cref="DateTime"/> 
+        /// should be used with Timestamp type columns.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// If this is <c>false</c> (the default), <see cref="DateTime"/> will be used as the default CLR type 
+        /// to handle the value of Date type column.
+        /// </para>
+        /// <para>
+        /// If this is <c>true</c>, <see cref="SpannerDate"/> will be used as the default CLR type to read the value of Date type column.
+        /// Setting this option will have no impact while writing the <see cref="DateTime"/> value to the database.
+        /// </para> 
+        /// <para>
+        /// This property corresponds with the value of the "UseSpannerDateForDate" part of the connection string.
+        /// </para>
+        /// </remarks>
+        public bool UseSpannerDateForDate
+        {
+            get => GetValueOrDefault(UseSpannerDateForDateKeyword).Equals("True", StringComparison.OrdinalIgnoreCase);
+            set => this[UseSpannerDateForDateKeyword] = value.ToString(); // Always "True" or "False", regardless of culture.
+        }
+
+        /// <summary>
+        /// Option to change the default CLR type and default SpannerDbType used for the handling of decimal values. 
+        /// By default, CLR type <see cref="double"/> and <see cref="SpannerDbType.Float64"/> are used to handle decimal values. 
+        /// By setting this option to <c>true</c>, CLR type <see cref="SpannerNumeric"/> and <see cref="SpannerDbType.Numeric"/> 
+        /// will be used as default types to handle decimal values while working with numeric column. 
+        /// Setting this option to <c>true</c> with Float64 column will throw <see cref="SpannerException"/>,
+        /// if <see cref="SpannerDbType"/> for the corresponding parameter is not provided.
+        /// This option should be used to specify default type for handling decimal data while working with Numeric column 
+        /// in Spanner Google Standard SQL (GSQL) dialect database.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// If this is <c>false</c> (the default), <see cref="SpannerDbType.Float64"/> will be used as the default
+        /// <see cref="SpannerDbType"/> to handle the decimal values.
+        /// </para>
+        /// <para>
+        /// If this is <c>true</c>, <see cref="SpannerDbType.Numeric"/> will be used as the default 
+        /// <see cref="SpannerDbType"/> to handle the decimal values.
+        /// Setting this option to <c>true</c> with Float64 column will throw <see cref="SpannerException"/>,
+        /// if <see cref="SpannerDbType"/> for the corresponding parameter is not provided.
+        /// This should be used, only when working with Spanner Google Standard SQL (GSQL) dialect database.  
+        /// </para> 
+        /// <para>
+        /// This property corresponds with the value of the "UseSpannerNumericForDecimal" part of the connection string.
+        /// </para>
+        /// </remarks>
+        public bool UseSpannerNumericForDecimal
+        {
+            get => GetValueOrDefault(UseSpannerNumericForDecimalKeyword).Equals("True", StringComparison.OrdinalIgnoreCase);
+            set => this[UseSpannerNumericForDecimalKeyword] = value.ToString(); // Always "True" or "False", regardless of culture.
+        }
+
+        /// <summary>
+        /// Option to change the default CLR type and default SpannerDbType used for the handling of decimal values. 
+        /// By default, CLR type <see cref="double"/> and <see cref="SpannerDbType.Float64"/> are used to handle decimal values. 
+        /// By setting this option to <c>true</c>, CLR type <see cref="PgNumeric"/> and <see cref="SpannerDbType.PgNumeric"/> 
+        /// will be used as default types to handle decimal values while working with numeric column. 
+        /// Setting this option to <c>true</c> with Float64 column will throw <see cref="SpannerException"/>,
+        /// if <see cref="SpannerDbType"/> for the corresponding parameter is not provided. 
+        /// This option should be used to specify default type for handling decimal data while working with Numeric column 
+        /// in Spanner PostgreSQL dialect database.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// If this is <c>false</c> (the default), <see cref="SpannerDbType.Float64"/> will be used as the default
+        /// <see cref="SpannerDbType"/> to handle the decimal values.
+        /// </para>
+        /// <para>
+        /// If this is <c>true</c>, <see cref="SpannerDbType.PgNumeric"/> will be used as the default 
+        /// <see cref="SpannerDbType"/> to handle the decimal values.
+        /// Setting this option to <c>true</c> with Float64 column will throw <see cref="SpannerException"/>,
+        /// if <see cref="SpannerDbType"/> for the corresponding parameter is not provided.
+        /// This should be used, only when working with Spanner PostgreSQL dialect database.  
+        /// </para> 
+        /// <para>
+        /// This property corresponds with the value of the "UsePgNumericForDecimal" part of the connection string.
+        /// </para>
+        /// </remarks>
+        public bool UsePgNumericForDecimal
+        {
+            get => GetValueOrDefault(UsePgNumericForDecimalKeyword).Equals("True", StringComparison.OrdinalIgnoreCase);
+            set => this[UsePgNumericForDecimalKeyword] = value.ToString(); // Always "True" or "False", regardless of culture.
         }
 
         // Note: GetSchemaTable can't be a link as it wouldn't build on netstandard1.0.

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConversionOptions.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConversionOptions.cs
@@ -19,21 +19,39 @@ namespace Google.Cloud.Spanner.Data
     /// </summary>
     internal class SpannerConversionOptions
     {
-        // Predefined instances; these will change as the class grows, but hopefully
-        // for most cases we can avoid creating new instances.
-        private static readonly SpannerConversionOptions s_useDBNullForNull = new SpannerConversionOptions(true);
-        private static readonly SpannerConversionOptions s_useClrDefaultForNull = new SpannerConversionOptions(false);
-
-        internal static SpannerConversionOptions Default { get; } = s_useDBNullForNull;
+        internal static SpannerConversionOptions Default { get; } = new SpannerConversionOptions(true, false, false, false);
 
         /// <summary>
         /// True to return DBNull.Value for null values; false to return a null reference.
         /// </summary>
         internal bool UseDBNull { get; }
 
-        private SpannerConversionOptions(bool useDBNull)
+        /// <summary>
+        /// True to use <see cref="V1.SpannerDate"/> as default type for Date type values; false to use <see cref="System.DateTime"/>.
+        /// </summary>
+        internal bool UseSpannerDateForDate { get; }
+
+        /// <summary>
+        /// True to use <see cref="SpannerDbType.Numeric"/> as default type for decimal values; false to use <see cref="SpannerDbType.Float64"/>.
+        /// This should be used, only when working with Spanner Google Standard SQL (GSQL) dialect database.
+        /// </summary>
+        internal bool UseSpannerNumericForDecimal { get; }
+
+        /// <summary>
+        /// True to use <see cref="SpannerDbType.PgNumeric"/> as default for decimal values; false to use <c>Float</c>.
+        /// This should be used, only when working with Spanner PostgreSQL dialect database.
+        /// </summary>
+        internal bool UsePgNumericForDecimal { get; }
+
+        private SpannerConversionOptions(bool useDBNull,
+            bool useSpannerDateForDate,
+            bool useSpannerNumericForDecimal,
+            bool usePgNumericForDecimal)
         {
             UseDBNull = useDBNull;
+            UseSpannerDateForDate = useSpannerDateForDate;
+            UseSpannerNumericForDecimal = useSpannerNumericForDecimal;
+            UsePgNumericForDecimal = usePgNumericForDecimal;
         }
 
         /// <summary>
@@ -46,6 +64,6 @@ namespace Google.Cloud.Spanner.Data
         /// Determines the right conversion options to use based on the connection string of the given connection string builder.
         /// </summary>
         internal static SpannerConversionOptions ForConnectionStringBuilder(SpannerConnectionStringBuilder builder) =>
-            builder == null ? Default : builder.UseClrDefaultForNull ? s_useClrDefaultForNull : s_useDBNullForNull;
+            builder == null ? Default : new SpannerConversionOptions(!builder.UseClrDefaultForNull, builder.UseSpannerDateForDate, builder.UseSpannerNumericForDecimal, builder.UsePgNumericForDecimal);
     }
 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDataReader.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDataReader.cs
@@ -105,7 +105,7 @@ namespace Google.Cloud.Spanner.Data
         public override System.Type GetFieldType(int i)
         {
             var fieldMetadata = PopulateMetadata().RowType.Fields[i];
-            return SpannerDbType.FromProtobufType(fieldMetadata.Type).DefaultClrType;
+            return SpannerDbType.FromProtobufType(fieldMetadata.Type).GetConfiguredClrType(_conversionOptions);
         }
 
         /// <inheritdoc />
@@ -588,7 +588,7 @@ namespace Google.Cloud.Spanner.Data
 
                 row["ColumnName"] = field.Name;
                 row["ColumnOrdinal"] = ordinal;
-                row["DataType"] = dbType.DefaultClrType;
+                row["DataType"] = dbType.GetConfiguredClrType(_conversionOptions);
                 row["ProviderType"] = dbType;
                 table.Rows.Add(row);
 

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDbType.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDbType.cs
@@ -189,6 +189,11 @@ namespace Google.Cloud.Spanner.Data
                 return typeof(PgNumeric);
             }
 
+            if (TypeCode == TypeCode.Date && options.UseSpannerDateForDate)
+            {
+                return typeof(SpannerDate);
+            }
+
             return DefaultClrType;
         }
 
@@ -209,6 +214,8 @@ namespace Google.Cloud.Spanner.Data
                         return typeof(double);
                     case TypeCode.Timestamp:
                     case TypeCode.Date:
+                        // To keep the code backward compatible, SpannerDate is used for Date based on options while reading.
+                        // TODO: Check with Jon, Amanda if we need change here to have SpannerDate as default for Date.
                         return typeof(DateTime);
                     case TypeCode.String:
                         return typeof(string);
@@ -329,6 +336,10 @@ namespace Google.Cloud.Spanner.Data
             if (type == typeof(DateTime))
             {
                 return Timestamp;
+            }
+            if (type == typeof(SpannerDate))
+            {
+                return Date;
             }
             if (type == typeof(float) || type == typeof(double) || type == typeof(decimal))
             {

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDbType.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDbType.cs
@@ -46,7 +46,7 @@ namespace Google.Cloud.Spanner.Data
         public static SpannerDbType Int64 { get; } = new SpannerDbType(TypeCode.Int64);
 
         /// <summary>
-        /// 64 bit floating point number.
+        /// 64 bit floating point number. This is same as Float8 in PostgreSQL dialect.
         /// </summary>
         public static SpannerDbType Float64 { get; } = new SpannerDbType(TypeCode.Float64);
 
@@ -175,6 +175,21 @@ namespace Google.Cloud.Spanner.Data
                         return DbType.Object;
                 }
             }
+        }
+
+        internal System.Type GetConfiguredClrType(SpannerConversionOptions options)
+        {
+            if (TypeCode == TypeCode.Float64 && options.UseSpannerNumericForDecimal)
+            {
+                return typeof(SpannerNumeric);
+            }
+
+            if (TypeCode == TypeCode.Float64 && options.UsePgNumericForDecimal)
+            {
+                return typeof(PgNumeric);
+            }
+
+            return DefaultClrType;
         }
 
         /// <summary>

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerParameter.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerParameter.cs
@@ -149,9 +149,33 @@ namespace Google.Cloud.Spanner.Data
                     $"{nameof(SpannerDbType)} must be set to one of "
                     + $"({nameof(SpannerDbType.Bool)}, {nameof(SpannerDbType.Int64)}, {nameof(SpannerDbType.Float64)},"
                     + $" {nameof(SpannerDbType.Timestamp)}, {nameof(SpannerDbType.Date)}, {nameof(SpannerDbType.String)},"
-                    + $" {nameof(SpannerDbType.Bytes)}, {nameof(SpannerDbType.Json)}, {nameof(SpannerDbType.Numeric)})");
+                    + $" {nameof(SpannerDbType.Bytes)}, {nameof(SpannerDbType.Json)}, {nameof(SpannerDbType.Numeric)},"
+                    + $" {nameof(SpannerDbType.PgNumeric)})");
             }
             return Value;
+        }
+
+        internal SpannerDbType GetConfiguredSpannerDbType(SpannerConversionOptions options)
+        {
+            // Only if SpannerDbType of parameter is not explicitly provided by user.
+            if (_spannerDbType == null)
+            {
+                if (Value is decimal)
+                {
+                    // User needs to set the right dialect.
+                    if (options != null && options.UseSpannerNumericForDecimal)
+                    {
+                        return SpannerDbType.Numeric;
+                    }
+                    else if (options != null && options.UsePgNumericForDecimal)
+                    {
+                        return SpannerDbType.PgNumeric;
+                    }
+                }                
+            }
+
+            // If we are here, use defaults.
+            return SpannerDbType;
         }
 
         /// <inheritdoc />

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerParameter.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerParameter.cs
@@ -171,7 +171,14 @@ namespace Google.Cloud.Spanner.Data
                     {
                         return SpannerDbType.PgNumeric;
                     }
-                }                
+                }
+                // Currently, default SpannerDbType for DateTime ClrType is Timestamp.
+                // If SpannerDate ClrType is used, it corresponds to SpannerDbType.Date.
+                // No change to this, if SpannerDbType is not provided explicitly.
+                // Inferring SpannerDbType.Date would be incorrect for Timestamp and inferring
+                // SpannerDbType.DateTime would be incorrect for Date.
+                // So, changing defaults do no good.
+                // Ideally, SpannerDate should be used for Date and DateTime for Timestamp.
             }
 
             // If we are here, use defaults.

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerParameterCollection.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerParameterCollection.cs
@@ -239,7 +239,7 @@ namespace Google.Cloud.Spanner.Data
             SpannerConversionOptions options)
         {
             FillSpannerInternalValues(valueDictionary, options);
-            FillSpannerInternalTypes(requestParamTypes);
+            FillSpannerInternalTypes(requestParamTypes, options);
         }
 
         /// <summary>
@@ -254,16 +254,16 @@ namespace Google.Cloud.Spanner.Data
             foreach (var parameter in _innerList)
             {
                 valueDictionary[GetCorrectedParameterName(parameter.ParameterName)]
-                    = parameter.SpannerDbType.ToProtobufValue(parameter.GetValidatedValue(), options);
+                    = parameter.GetConfiguredSpannerDbType(options).ToProtobufValue(parameter.GetValidatedValue(), options);
             }
         }
 
-        private void FillSpannerInternalTypes(MapField<string, V1.Type> typeDictionary)
+        private void FillSpannerInternalTypes(MapField<string, V1.Type> typeDictionary, SpannerConversionOptions options)
         {
             foreach (var parameter in _innerList)
             {
                 typeDictionary[GetCorrectedParameterName(parameter.ParameterName)]
-                    = parameter.SpannerDbType.ToProtobufType();
+                    = parameter.GetConfiguredSpannerDbType(options).ToProtobufType();
             }
         }
 


### PR DESCRIPTION
Contains 3 commits:

1. Commit 1: 
    - New options in `SpannerConnectionBuilder` and its unit tests. 
    - Changes to ensure that `SpannerConversionOptions` are passed to APIs that require it. Currently, `null` is being passed in few call sites. There is still a place where `SpannerConnection` is not available and null is passed. Marked it as TODO to check if we should pass `SpannerConversionOptions.Default` or do anything else.
2. Commit 2:
    - Default handling for decimal using `SpannerConversionOptions` along with its unit tests and integration tests in GSQL and PostgreSQL dialects.   
3. Commit 3:
   - Default handling for date using `SpannerConversionOptions` along with its unit tests and integration tests in GSQL and PostgreSQL dialects.

Added TODO at couple of places to seek your input. 