### PR TITLE
Release Google.Cloud.Run.V2 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/Google.Cloud.Run.V2.csproj
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/Google.Cloud.Run.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Run Admin API (v2)</Description>

--- a/apis/Google.Cloud.Run.V2/docs/history.md
+++ b/apis/Google.Cloud.Run.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2022-05-11
+
+### Bug fixes
+
+- **BREAKING CHANGE** Updates pre-release Cloud Run v2 Preview client libraries to work with the latest API revision ([commit f438701](https://github.com/googleapis/google-cloud-dotnet/commit/f438701b1c7d1ebd9611522c597084daa1f85a7e))
+
 ## Version 1.0.0-beta01, released 2022-04-22
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2710,7 +2710,7 @@
     },
     {
       "id": "Google.Cloud.Run.V2",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Cloud Run Admin",
       "productUrl": "https://cloud.google.com/run/docs",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- **BREAKING CHANGE** Updates pre-release Cloud Run v2 Preview client libraries to work with the latest API revision ([commit f438701](https://github.com/googleapis/google-cloud-dotnet/commit/f438701b1c7d1ebd9611522c597084daa1f85a7e))
