### PR TITLE
feat: Passing SpannerConversionOptions to the APIs requiring it.

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerDbTypeTests.ValueConversions.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerDbTypeTests.ValueConversions.cs
@@ -518,7 +518,7 @@ namespace Google.Cloud.Spanner.Data.Tests
                 try
                 {
                     string expected = expectedJsonValue;
-                    var jsonValue = spannerDbType.ToProtobufValue(clrValue, options: null);
+                    var jsonValue = spannerDbType.ToProtobufValue(clrValue);
                     string actual = jsonValue.ToString();
                     if (expected != actual)
                     {
@@ -683,7 +683,7 @@ namespace Google.Cloud.Spanner.Data.Tests
             var exceptionCaught = false;
             try
             {
-                type.ToProtobufValue(value, options: null);
+                type.ToProtobufValue(value);
             }
             catch (Exception e) when (e is OverflowException || e is InvalidCastException || e is FormatException || e is ArgumentException)
             {

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerDbTypeTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerDbTypeTests.cs
@@ -221,8 +221,7 @@ namespace Google.Cloud.Spanner.Data.Tests
         [Fact]
         public void CommitTimestampConversion_Success()
         {
-            var options = SpannerConversionOptions.Default;
-            var actual = SpannerDbType.Timestamp.ToProtobufValue(SpannerParameter.CommitTimestamp, options);
+            var actual = SpannerDbType.Timestamp.ToProtobufValue(SpannerParameter.CommitTimestamp);
             var expected = new Value { StringValue = CommitTimestamp.ProtoStringValue };
             Assert.Equal(expected, actual);
         }
@@ -230,8 +229,7 @@ namespace Google.Cloud.Spanner.Data.Tests
         [Fact]
         public void CommitTimestampConversion_WrongType()
         {
-            var options = SpannerConversionOptions.Default;
-            Assert.Throws<InvalidOperationException>(() => SpannerDbType.Date.ToProtobufValue(SpannerParameter.CommitTimestamp, options));
+            Assert.Throws<InvalidOperationException>(() => SpannerDbType.Date.ToProtobufValue(SpannerParameter.CommitTimestamp));
         }
     }
 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/Keys.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/Keys.cs
@@ -296,7 +296,7 @@ namespace Google.Cloud.Spanner.Data
         public Key(params object[] keyParts)
         {
             var protobufValues = keyParts.Select(
-                v => SpannerDbType.FromClrType(v?.GetType())?.ToProtobufValue(v, SpannerConversionOptions.Default) ?? Value.ForNull());
+                v => SpannerDbType.FromClrType(v?.GetType())?.ToProtobufValue(v) ?? Value.ForNull());
             KeyParts = new ListValue { Values = { protobufValues } };
         }
 
@@ -312,15 +312,12 @@ namespace Google.Cloud.Spanner.Data
 
         private static ListValue ToListValue(SpannerParameterCollection parameters)
         {
-            // See comment at the top of GetMutations in SpannerCommand.ExecutableCommand.
-            // These options are currently not in use, but are required in the API.
-            SpannerConversionOptions options = null;
             return new ListValue
             {
                 Values =
                 {
                     parameters.Select(
-                        x => x.SpannerDbType.ToProtobufValue(x.GetValidatedValue(), options))
+                        x => x.SpannerDbType.ToProtobufValue(x.GetValidatedValue()))
                 }
             };
         }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.ExecutableCommand.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.ExecutableCommand.cs
@@ -62,6 +62,7 @@ namespace Google.Cloud.Spanner.Data
             internal QueryOptions QueryOptions { get; }
             internal Priority Priority { get; }
             internal string Tag { get; }
+            internal SpannerConversionOptions ConversionOptions => SpannerConversionOptions.ForConnection(Connection);
 
             public ExecutableCommand(SpannerCommand command)
             {
@@ -126,12 +127,11 @@ namespace Google.Cloud.Spanner.Data
                 var resultSet = await ExecuteReadOrQueryRequestAsync(singleUseReadSettings, effectiveTransaction, cancellationToken)
                         .ConfigureAwait(false);
 
-                var conversionOptions = SpannerConversionOptions.ForConnection(Connection);
                 var enableGetSchemaTable = Connection.Builder.EnableGetSchemaTable;
                 // When the data reader is closed, we may need to dispose of the connection.
                 IDisposable resourceToClose = (behavior & CommandBehavior.CloseConnection) == CommandBehavior.CloseConnection ? Connection : null;
 
-                return new SpannerDataReader(Connection.Logger, resultSet, Transaction?.ReadTimestamp, resourceToClose, conversionOptions, enableGetSchemaTable, CommandTimeout);
+                return new SpannerDataReader(Connection.Logger, resultSet, Transaction?.ReadTimestamp, resourceToClose, ConversionOptions, enableGetSchemaTable, CommandTimeout);
             }
 
             private Task<ReliableStreamReader> ExecuteReadOrQueryRequestAsync(TimestampBound singleUseReadSettings, ISpannerTransaction effectiveTransaction, CancellationToken cancellationToken)
@@ -311,17 +311,12 @@ namespace Google.Cloud.Spanner.Data
 
             private List<Mutation> GetMutations()
             {
-                // Currently, ToProtobufValue doesn't use the options it's provided. They're only
-                // required to prevent us from accidentally adding call sites that wouldn't be able to obtain
-                // valid options. For efficiency, we just pass in null for now. If we ever need real options
-                // from the connection string, uncomment the following line to initialize the options from the connection.
-                // SpannerConversionOptions options = SpannerConversionOptions.ForConnection(SpannerConnection);
-                SpannerConversionOptions conversionOptions = null;
-
+                // Avoid calling method multiple times in the loop.
+                var conversionOptions = ConversionOptions;
                 // Whatever we do with the parameters, we'll need them in a ListValue.
                 var listValue = new ListValue
                 {
-                    Values = { Parameters.Select(x => x.SpannerDbType.ToProtobufValue(x.GetValidatedValue(), conversionOptions)) }
+                    Values = { Parameters.Select(x => x.GetConfiguredSpannerDbType(conversionOptions).ToProtobufValue(x.GetValidatedValue())) }
                 };
 
                 if (CommandTextBuilder.SpannerCommandType != SpannerCommandType.Delete)
@@ -399,9 +394,7 @@ namespace Google.Cloud.Spanner.Data
                     RequestOptions = BuildRequestOptions()
                 };
 
-                // See comment at the start of GetMutations.
-                SpannerConversionOptions options = null;
-                Parameters.FillSpannerCommandParams(out var parameters, request.ParamTypes, options);
+                Parameters.FillSpannerCommandParams(out var parameters, request.ParamTypes, ConversionOptions);
                 request.Params = parameters;
 
                 return request;

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDataReader.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDataReader.cs
@@ -105,7 +105,7 @@ namespace Google.Cloud.Spanner.Data
         public override System.Type GetFieldType(int i)
         {
             var fieldMetadata = PopulateMetadata().RowType.Fields[i];
-            return SpannerDbType.FromProtobufType(fieldMetadata.Type).DefaultClrType;
+            return SpannerDbType.FromProtobufType(fieldMetadata.Type).GetConfiguredClrType(_conversionOptions);
         }
 
         /// <inheritdoc />
@@ -588,7 +588,7 @@ namespace Google.Cloud.Spanner.Data
 
                 row["ColumnName"] = field.Name;
                 row["ColumnOrdinal"] = ordinal;
-                row["DataType"] = dbType.DefaultClrType;
+                row["DataType"] = dbType.GetConfiguredClrType(_conversionOptions);
                 row["ProviderType"] = dbType;
                 table.Rows.Add(row);
 

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDbType.ValueConversion.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDbType.ValueConversion.cs
@@ -65,7 +65,7 @@ namespace Google.Cloud.Spanner.Data
             if (targetClrType == typeof(object))
             {
                 //then we decide the type for you
-                targetClrType = DefaultClrType;
+                targetClrType = GetConfiguredClrType(options);
             }
             var possibleUnderlyingType = Nullable.GetUnderlyingType(targetClrType);
             if (possibleUnderlyingType != null)
@@ -117,9 +117,7 @@ namespace Google.Cloud.Spanner.Data
             return ConvertToClrTypeImpl(protobufValue, targetClrType, options);
         }
 
-        // Note: the options can *currently* be null because we're not using them, but
-        // every call site should check that it could provide options if they become required.
-        internal Value ToProtobufValue(object value, SpannerConversionOptions options)
+        internal Value ToProtobufValue(object value)
         {
             if (value == null || value is DBNull)
             {
@@ -200,7 +198,7 @@ namespace Google.Cloud.Spanner.Data
                     {
                         return Value.ForList(
                             enumerable.Cast<object>()
-                                .Select(x => ArrayElementType.ToProtobufValue(x, options)).ToArray());
+                                .Select(x => ArrayElementType.ToProtobufValue(x)).ToArray());
                     }
                     throw new ArgumentException("The given array instance needs to implement IEnumerable.");
                 case TypeCode.Struct:
@@ -210,7 +208,7 @@ namespace Google.Cloud.Spanner.Data
                         {
                             ListValue = new ListValue
                             {
-                                Values = { spannerStruct.Select(f => f.Type.ToProtobufValue(f.Value, options)) }
+                                Values = { spannerStruct.Select(f => f.Type.ToProtobufValue(f.Value)) }
                             }
                         };
                     }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDbType.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDbType.cs
@@ -178,45 +178,50 @@ namespace Google.Cloud.Spanner.Data
         }
 
         /// <summary>
-        /// The default <see cref="System.Type"/> for this Cloud Spanner type.
+        /// Gets the configured <see cref="System.Type"/> for this SpannerDbType based on <see cref="SpannerConversionOptions"/>.
+        /// If the configuration for this type doesn't exist in options, the default CLR type is returned.
         /// </summary>
-        public System.Type DefaultClrType
+        /// <param name="options">Options to configure the CLR Type for this SpannerDbType.</param>
+        /// <returns>The configured <see cref="System.Type"/>.</returns>
+        internal System.Type GetConfiguredClrType(SpannerConversionOptions options)
         {
-            get
+            switch (TypeCode)
             {
-                switch (TypeCode)
-                {
-                    case TypeCode.Bool:
-                        return typeof(bool);
-                    case TypeCode.Int64:
-                        return typeof(long);
-                    case TypeCode.Float64:
-                        return typeof(double);
-                    case TypeCode.Timestamp:
-                    case TypeCode.Date:
-                        return typeof(DateTime);
-                    case TypeCode.String:
-                        return typeof(string);
-                    case TypeCode.Bytes:
-                        return typeof(byte[]);
-                    case TypeCode.Array:
-                        return typeof(List<>).MakeGenericType(ArrayElementType.DefaultClrType);
-                    case TypeCode.Struct:
-                        return typeof(SpannerStruct);
-                    case TypeCode.Numeric:
-                        if (TypeAnnotationCode == TypeAnnotationCode.PgNumeric)
-                        {
-                            return typeof(PgNumeric);
-                        }
-                        return typeof(SpannerNumeric);
-                    case TypeCode.Json:
-                        return typeof(string);
-                    default:
-                        //if we don't recognize it (or its a struct), we use the google native wellknown type.
-                        return typeof(Value);
-                }
+                case TypeCode.Bool:
+                    return typeof(bool);
+                case TypeCode.Int64:
+                    return typeof(long);
+                case TypeCode.Float64:
+                    return typeof(double);
+                case TypeCode.Timestamp:
+                case TypeCode.Date:
+                    return typeof(DateTime);
+                case TypeCode.String:
+                    return typeof(string);
+                case TypeCode.Bytes:
+                    return typeof(byte[]);
+                case TypeCode.Array:
+                    return typeof(List<>).MakeGenericType(ArrayElementType.GetConfiguredClrType(options));
+                case TypeCode.Struct:
+                    return typeof(SpannerStruct);
+                case TypeCode.Numeric:
+                    if (TypeAnnotationCode == TypeAnnotationCode.PgNumeric)
+                    {
+                        return typeof(PgNumeric);
+                    }
+                    return typeof(SpannerNumeric);
+                case TypeCode.Json:
+                    return typeof(string);
+                default:
+                    // If we don't recognize it (or it's a struct), we use the protobuf Value well-known type.
+                    return typeof(Value);
             }
         }
+
+        /// <summary>
+        /// The default <see cref="System.Type"/> for this Cloud Spanner type.
+        /// </summary>
+        public System.Type DefaultClrType => GetConfiguredClrType(default);
 
         /// <summary>
         /// Converts a <see cref="DbType"/> to the corresponding <see cref="SpannerDbType"/>

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerParameter.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerParameter.cs
@@ -154,6 +154,14 @@ namespace Google.Cloud.Spanner.Data
             return Value;
         }
 
+        /// <summary>
+        /// Gets the configured SpannerDbType for this SpannerParameter based on <see cref="SpannerConversionOptions"/>.
+        /// This returns <see cref="SpannerDbType"/> of the SpannerParameter if the configuration for type doesn't exist in options.
+        /// </summary>
+        /// <param name="options">Options to configure the <c>SpannerDbType</c> for this <c>SpannerParameter</c>.</param>
+        /// <returns>The configured <see cref="SpannerDbType"/>.</returns>
+        internal SpannerDbType GetConfiguredSpannerDbType(SpannerConversionOptions options) => SpannerDbType;
+
         /// <inheritdoc />
         public override void ResetDbType()
         {

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerParameterCollection.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerParameterCollection.cs
@@ -239,7 +239,7 @@ namespace Google.Cloud.Spanner.Data
             SpannerConversionOptions options)
         {
             FillSpannerInternalValues(valueDictionary, options);
-            FillSpannerInternalTypes(requestParamTypes);
+            FillSpannerInternalTypes(requestParamTypes, options);
         }
 
         /// <summary>
@@ -254,16 +254,16 @@ namespace Google.Cloud.Spanner.Data
             foreach (var parameter in _innerList)
             {
                 valueDictionary[GetCorrectedParameterName(parameter.ParameterName)]
-                    = parameter.SpannerDbType.ToProtobufValue(parameter.GetValidatedValue(), options);
+                    = parameter.GetConfiguredSpannerDbType(options).ToProtobufValue(parameter.GetValidatedValue());
             }
         }
 
-        private void FillSpannerInternalTypes(MapField<string, V1.Type> typeDictionary)
+        private void FillSpannerInternalTypes(MapField<string, V1.Type> typeDictionary, SpannerConversionOptions options)
         {
             foreach (var parameter in _innerList)
             {
                 typeDictionary[GetCorrectedParameterName(parameter.ParameterName)]
-                    = parameter.SpannerDbType.ToProtobufType();
+                    = parameter.GetConfiguredSpannerDbType(options).ToProtobufType();
             }
         }
 


### PR DESCRIPTION
Passing `SpannerConversionOptions` to the APIs that require it. Option will be used in subsequent PRs where default type handling will be done based on options. 