### PR TITLE
feat: Add BigQueryJob.ThrowOnFatalError

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/QueryTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/QueryTest.cs
@@ -577,7 +577,7 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
         /// Creates a table associated with a CSV file on Google Cloud Storage, which has some invalid data.
         /// A query on that table can provide the valid data but still have errors.
         /// </summary>
-        [Fact(Skip = "https://github.com/googleapis/google-cloud-dotnet/issues/8470")]
+        [Fact]
         public void PartiallyBrokenQuery()
         {
             string[] csvRows =


### PR DESCRIPTION
The existing BigQueryJob.ThrowOnAnyError will throw an exception if
*any* errors are detected, even if the job goes on to complete
successfully. This can happen in a query job against an external
data source which has been configured to permit a certain number of
"bad" rows, for example.

The new method is a convenient way of throwing an exception for a
genuinely-failed job, as indicated by the JobStatus.ErrorResult
property.

Fixes #8470.