### PR TITLE
fix!: Address changes in Spanner ADO API due to netstandard2.1 async methods

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnection.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnection.cs
@@ -273,8 +273,18 @@ namespace Google.Cloud.Spanner.Data
         /// </summary>
         public new SpannerTransaction BeginTransaction() => (SpannerTransaction)base.BeginTransaction();
 
-        // FIXME: This is "new" because there's now BeginTransactionAsync in the BCL.
-        // We should probably override BeginDbTransactionAsync...
+#if NETSTANDARD2_1_OR_GREATER
+        /// <inheritdoc />
+        protected override async ValueTask<DbTransaction> BeginDbTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken)
+        {
+            if (isolationLevel != IsolationLevel.Unspecified && isolationLevel != IsolationLevel.Serializable)
+            {
+                throw new NotSupportedException(
+                    $"Cloud Spanner only supports isolation levels {IsolationLevel.Serializable} and {IsolationLevel.Unspecified}.");
+            }
+            return await BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+        }
+#endif
 
         /// <summary>
         /// Begins a new read/write transaction.


### PR DESCRIPTION
BREAKING CHANGE: CommitAsync has been renamed to avoid clashing with a standard method that differs only by return type.

Users who were not using the returned timestamp won't notice any difference, as the CommitAsync method returning a Task will return the same task as before - it just doesn't have the timestamp in (at least in terms of compile-time checking; the actual returned task is the same).

Amanda: no need to review this before you're back, but we do need to do so before we release the new major version.