### PR TITLE
Release Google.Cloud.AccessApproval.V1 version 1.4.0

### DIFF
--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.csproj
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>An API for controlling access to data by Google personnel.</Description>

--- a/apis/Google.Cloud.AccessApproval.V1/docs/history.md
+++ b/apis/Google.Cloud.AccessApproval.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.4.0, released 2022-05-24
+
+### New features
+
+- Update protos to include InvalidateApprovalRequest and GetAccessApprovalServiceAccount APIs ([commit 35064fa](https://github.com/googleapis/google-cloud-dotnet/commit/35064fa422497ab9577ec95e466896778472ec8f))
+
 ## Version 1.3.0, released 2022-02-14
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -64,7 +64,7 @@
     },
     {
       "id": "Google.Cloud.AccessApproval.V1",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "type": "grpc",
       "productName": "Access Approval",
       "productUrl": "https://cloud.google.com/access-approval/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Update protos to include InvalidateApprovalRequest and GetAccessApprovalServiceAccount APIs ([commit 35064fa](https://github.com/googleapis/google-cloud-dotnet/commit/35064fa422497ab9577ec95e466896778472ec8f))
