### PR TITLE
Release Google.Cloud.Iap.V1 version 1.2.0

### DIFF
--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.csproj
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud IAP API, which controls access to cloud applications running on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Iap.V1/docs/history.md
+++ b/apis/Google.Cloud.Iap.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 1.2.0, released 2022-05-24
+
+### New features
+
+- Add the TunnelDestGroup-related methods and types ([commit 307ef07](https://github.com/googleapis/google-cloud-dotnet/commit/307ef071ed89aac467dbe3aaf1142e953237dec0))
+- Add ReauthSettings to the UpdateIapSettingsRequest ([commit 307ef07](https://github.com/googleapis/google-cloud-dotnet/commit/307ef071ed89aac467dbe3aaf1142e953237dec0))
+
 ## Version 1.1.0, released 2021-08-31
 
 - [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1751,7 +1751,7 @@
     },
     {
       "id": "Google.Cloud.Iap.V1",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "type": "grpc",
       "productName": "Cloud Identity-Aware Proxy",
       "productUrl": "https://cloud.google.com/iap/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add the TunnelDestGroup-related methods and types ([commit 307ef07](https://github.com/googleapis/google-cloud-dotnet/commit/307ef071ed89aac467dbe3aaf1142e953237dec0))
- Add ReauthSettings to the UpdateIapSettingsRequest ([commit 307ef07](https://github.com/googleapis/google-cloud-dotnet/commit/307ef071ed89aac467dbe3aaf1142e953237dec0))
