### PR TITLE
Release Google.Cloud.RecaptchaEnterprise.V1Beta1 version 1.0.0-beta06

### DIFF
--- a/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.csproj
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta05</Version>
+    <Version>1.0.0-beta06</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud reCAPTCHA for Enterprise API v1beta1.</Description>

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 1.0.0-beta06, released 2022-05-24
+
+### Bug fixes
+
+- **BREAKING CHANGE** Remove key management API ([commit 388080d](https://github.com/googleapis/google-cloud-dotnet/commit/388080deee4af00ea62e2b43f115fc53becb38cb))
+
+### New features
+
+- Introduced Reason, PasswordLeakVerification, AccountDefenderAssessment ([commit 388080d](https://github.com/googleapis/google-cloud-dotnet/commit/388080deee4af00ea62e2b43f115fc53becb38cb))
+
 ## Version 1.0.0-beta05, released 2021-09-01
 
 - [Commit ac367e2](https://github.com/googleapis/google-cloud-dotnet/commit/ac367e2): feat: Regenerate all APIs to support self-signed JWTs

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2602,7 +2602,7 @@
       "protoPath": "google/cloud/recaptchaenterprise/v1beta1",
       "productName": "Google Cloud reCAPTCHA Enterprise",
       "productUrl": "https://cloud.google.com/recaptcha-enterprise/",
-      "version": "1.0.0-beta05",
+      "version": "1.0.0-beta06",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud reCAPTCHA for Enterprise API v1beta1.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- **BREAKING CHANGE** Remove key management API ([commit 388080d](https://github.com/googleapis/google-cloud-dotnet/commit/388080deee4af00ea62e2b43f115fc53becb38cb))

### New features

- Introduced Reason, PasswordLeakVerification, AccountDefenderAssessment ([commit 388080d](https://github.com/googleapis/google-cloud-dotnet/commit/388080deee4af00ea62e2b43f115fc53becb38cb))
