### PR TITLE
Release Google.Cloud.Notebooks.V1 version 1.0.0-beta04

### DIFF
--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.csproj
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta03</Version>
+    <Version>1.0.0-beta04</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AI Platform Notebooks API (v1), which is used to manage notebook resources in Google Cloud.</Description>

--- a/apis/Google.Cloud.Notebooks.V1/docs/history.md
+++ b/apis/Google.Cloud.Notebooks.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta04, released 2022-05-24
+
+### Documentation improvements
+
+- Modifies the project ID pattern in comment for Workbench environment ([commit 9f67d86](https://github.com/googleapis/google-cloud-dotnet/commit/9f67d8655c028fcde14849d480b53e3d26873caf))
+
 ## Version 1.0.0-beta03, released 2022-04-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2254,7 +2254,7 @@
     },
     {
       "id": "Google.Cloud.Notebooks.V1",
-      "version": "1.0.0-beta03",
+      "version": "1.0.0-beta04",
       "type": "grpc",
       "productName": "AI Platform Notebooks",
       "productUrl": "https://cloud.google.com/ai-platform-notebooks",


### PR DESCRIPTION

Changes in this release:

### Documentation improvements

- Modifies the project ID pattern in comment for Workbench environment ([commit 9f67d86](https://github.com/googleapis/google-cloud-dotnet/commit/9f67d8655c028fcde14849d480b53e3d26873caf))
