### PR TITLE
Release Google.Cloud.Speech.V1 version 2.9.0

### DIFF
--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.csproj
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.8.0</Version>
+    <Version>2.9.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Speech API, which performs speech recognition.</Description>

--- a/apis/Google.Cloud.Speech.V1/docs/history.md
+++ b/apis/Google.Cloud.Speech.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 2.9.0, released 2022-05-24
+
+### New features
+
+- Add adaptation proto for v1 api ([commit 1c5ae72](https://github.com/googleapis/google-cloud-dotnet/commit/1c5ae72d726a594e08e92a3a652f61a2263bbdc2))
+
+### Documentation improvements
+
+- Add documentation for latest models to RecognitionConfig ([commit f50b641](https://github.com/googleapis/google-cloud-dotnet/commit/f50b641216be4dc3847aa954fb291fcccfed4101))
+
 ## Version 2.8.0, released 2022-04-26
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3188,7 +3188,7 @@
       "protoPath": "google/cloud/speech/v1",
       "productName": "Google Cloud Speech",
       "productUrl": "https://cloud.google.com/speech",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Speech API, which performs speech recognition.",


### PR DESCRIPTION

Changes in this release:

### New features

- Add adaptation proto for v1 api ([commit 1c5ae72](https://github.com/googleapis/google-cloud-dotnet/commit/1c5ae72d726a594e08e92a3a652f61a2263bbdc2))

### Documentation improvements

- Add documentation for latest models to RecognitionConfig ([commit f50b641](https://github.com/googleapis/google-cloud-dotnet/commit/f50b641216be4dc3847aa954fb291fcccfed4101))
