### PR TITLE
Release Google.Cloud.Speech.V1P1Beta1 version 2.0.0-beta09

### DIFF
--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.csproj
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta08</Version>
+    <Version>2.0.0-beta09</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google client library to access the Google Cloud Speech API version v1p1beta1 with upcoming features.</Description>

--- a/apis/Google.Cloud.Speech.V1P1Beta1/docs/history.md
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 2.0.0-beta09, released 2022-05-24
+
+### Documentation improvements
+
+- Update client libraries for v1p1beta1 api ([commit f6e9deb](https://github.com/googleapis/google-cloud-dotnet/commit/f6e9deb2fc0e462b27bc347eb537b357bfd1c0f7))
+- Add documentation for latest models to RecognitionConfig ([commit ed7287c](https://github.com/googleapis/google-cloud-dotnet/commit/ed7287c8dc25ec0a1f37469b18f4569a478c03e0))
+
 ## Version 2.0.0-beta08, released 2022-04-26
 
 ### Documentation improvements

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3209,7 +3209,7 @@
       "protoPath": "google/cloud/speech/v1p1beta1",
       "productName": "Google Cloud Speech",
       "productUrl": "https://cloud.google.com/speech",
-      "version": "2.0.0-beta08",
+      "version": "2.0.0-beta09",
       "releaseLevelOverride": "preview",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",


### PR DESCRIPTION

Changes in this release:

### Documentation improvements

- Update client libraries for v1p1beta1 api ([commit f6e9deb](https://github.com/googleapis/google-cloud-dotnet/commit/f6e9deb2fc0e462b27bc347eb537b357bfd1c0f7))
- Add documentation for latest models to RecognitionConfig ([commit ed7287c](https://github.com/googleapis/google-cloud-dotnet/commit/ed7287c8dc25ec0a1f37469b18f4569a478c03e0))
