### PR TITLE
feat: default handling of decimal and Float64

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerConnectionStringBuilderTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerConnectionStringBuilderTests.cs
@@ -215,5 +215,67 @@ namespace Google.Cloud.Spanner.Data.Tests
             builder = builder.WithDatabase(null);
             Assert.Null(builder.SpannerDatabase);
         }
+
+        [Fact]
+        public void ClrToSpannerTypeDefaultMappings()
+        {
+            // Defaults - When property is not set.
+            var builder = new SpannerConnectionStringBuilder();
+            Assert.True(string.IsNullOrEmpty(builder.ClrToSpannerTypeDefaultMappings)); 
+            
+            // Explicitly set valid type mapping.
+            builder = new SpannerConnectionStringBuilder("ClrToSpannerTypeDefaultMappings=DecimalToNumeric,DateTimeToDate");
+            // DbConnectionStringBuilder lower-cases keywords, annoyingly.
+            Assert.Equal("clrtospannertypedefaultmappings=DecimalToNumeric,DateTimeToDate", builder.ToString());
+
+            // Explicitly set valid type mappings. Latest should be reflected.
+            // Also check that strings  are case insensitive.
+            builder.ClrToSpannerTypeDefaultMappings = "decimalTofloat64,dateTimetotimestamp";
+            // DbConnectionStringBuilder lower-cases keywords, annoyingly.
+            Assert.Equal("clrtospannertypedefaultmappings=decimalTofloat64,dateTimetotimestamp", builder.ToString());
+        }
+
+        [Fact]
+        public void SpannerToClrTypeDefaultMappings()
+        {
+            // Defaults - When property is not set.
+            var builder = new SpannerConnectionStringBuilder();
+            Assert.True(string.IsNullOrEmpty(builder.SpannerToClrTypeDefaultMappings));
+
+            // Explicitly set valid type mappings.
+            builder = new SpannerConnectionStringBuilder("SpannerToClrTypeDefaultMappings=Float64ToSpannerNumeric,DateToDateTime");
+            // DbConnectionStringBuilder lower-cases keywords, annoyingly.
+            Assert.Equal("spannertoclrtypedefaultmappings=Float64ToSpannerNumeric,DateToDateTime", builder.ToString());
+
+            // Explicitly set valid type mappings. Latest should be reflected.
+            // Also check that strings  are case insensitive.
+            builder.SpannerToClrTypeDefaultMappings = "float64Todecimal,dateTospannerDate";
+            // DbConnectionStringBuilder lower-cases keywords, annoyingly.
+            Assert.Equal("spannertoclrtypedefaultmappings=float64Todecimal,dateTospannerDate", builder.ToString());
+        }
+
+        [Theory]        
+        [InlineData("DecimalToFloat64,DecimalToNumeric,DateTimeToDate")] // Multiple mappings for a type.
+        [InlineData("DecimalToFloat64,DecimalToPgNumeric,DateTimeToDate,DateTimeToTimestamp")] // Multiple mappings for a type.
+        [InlineData("DecimalToFloat64   ,DecimalToNumeric,DateTimeToDate")] // Multiple mappings and whitespace.       
+        [InlineData("DecimalToFloat64   ,  DateTimeToDate")] // Valid mapping with whitespace.
+        [InlineData("UseFloat64ForDecimal,DecimalToNumeric,DateTimeToDate")] // Invalid values.
+        public void BadClrToSpannerTypeDefaultMappingsThrows(string clrToSpannerTypeMappings)
+        {
+            Assert.Throws<ArgumentException>(() => new SpannerConnectionStringBuilder($"ClrToSpannerTypeDefaultMappings={clrToSpannerTypeMappings}"));            
+            Assert.Throws<ArgumentException>(() => new SpannerConnectionStringBuilder { ClrToSpannerTypeDefaultMappings = clrToSpannerTypeMappings });
+        }
+
+        [Theory]        
+        [InlineData("Float64ToDouble,Float64ToDecimal,DateToDateTime")] // Multiple mappings for a type.
+        [InlineData("Float64ToDecimal,Float64ToPgNumeric,DateToSpannerDate")] // Multiple mappings for a type.        
+        [InlineData("Float64ToDecimal   ,DateToDateTime")] // Whitespace.
+        [InlineData("Float64ToDecimal   ,  DateToDateTime")] // Whitespace.        
+        [InlineData("UseDecimalForFloat,DateToSpannerDate")] // Invalid value.
+        public void BadSpannerToClrTypeDefaultMappingsThrows(string spannerToClrTypeMappings)
+        {
+            Assert.Throws<ArgumentException>(() => new SpannerConnectionStringBuilder($"SpannerToClrTypeDefaultMappings={spannerToClrTypeMappings}"));
+            Assert.Throws<ArgumentException>(() => new SpannerConnectionStringBuilder { SpannerToClrTypeDefaultMappings = spannerToClrTypeMappings });
+        }
     }
 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerConversionOptionsTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerConversionOptionsTests.cs
@@ -1,0 +1,125 @@
+﻿// Copyright 2022 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using Google.Cloud.Spanner.V1;
+using System;
+using Xunit;
+
+namespace Google.Cloud.Spanner.Data.Tests
+{
+    public class SpannerConversionOptionsTests
+    {
+        [Fact]
+        public void WithClrDefaultForNullSetting()
+        {
+            var options = SpannerConversionOptions.Default;
+            options = options.WithClrDefaultForNullSetting(true);
+            Assert.Equal(false, options.UseDBNull);
+            options = options.WithClrDefaultForNullSetting(false);
+            Assert.Equal(true, options.UseDBNull);
+            
+            // Test with builder as well.
+            var builder = new SpannerConnectionStringBuilder();
+            builder.UseClrDefaultForNull = true;
+            Assert.Equal(false, builder.ConversionOptions.UseDBNull);
+
+            // Explicitly set valid type mapping.
+            builder = new SpannerConnectionStringBuilder("UseClrDefaultForNull=false");
+            Assert.Equal(true, builder.ConversionOptions.UseDBNull);
+        }
+
+        [Fact]
+        public void WithSpannerToClrMappings()
+        {
+            var options = SpannerConversionOptions.Default;
+            options = options.WithSpannerToClrMappings("Float64ToPgNumeric,DateToDateTime");
+            Assert.Equal(typeof(PgNumeric), options.Float64ToConfiguredClrType);
+            Assert.Equal(typeof(DateTime), options.DateToConfiguredClrType);
+
+            options = options.WithSpannerToClrMappings("Float64ToSingle,DateToSpannerDate");
+            Assert.Equal(typeof(float), options.Float64ToConfiguredClrType);
+            Assert.Equal(typeof(SpannerDate), options.DateToConfiguredClrType);
+            
+            // Test with builder as well.
+            var builder = new SpannerConnectionStringBuilder();
+            builder.SpannerToClrTypeDefaultMappings = "Float64ToDouble,DateToDateTime";
+            Assert.Equal(typeof(double), builder.ConversionOptions.Float64ToConfiguredClrType);
+            Assert.Equal(typeof(DateTime), builder.ConversionOptions.DateToConfiguredClrType);
+
+            // Explicitly set valid type mapping.
+            builder = new SpannerConnectionStringBuilder("SpannerToClrTypeDefaultMappings=Float64ToDecimal,DateToSpannerDate");
+            Assert.Equal(typeof(decimal), builder.ConversionOptions.Float64ToConfiguredClrType);
+            Assert.Equal(typeof(SpannerDate), builder.ConversionOptions.DateToConfiguredClrType);
+
+            // Check that properties are case insensitive.
+            builder = new SpannerConnectionStringBuilder();
+            builder.SpannerToClrTypeDefaultMappings = "float64Todouble,datetodatetime";
+            Assert.Equal(typeof(double), builder.ConversionOptions.Float64ToConfiguredClrType);
+            Assert.Equal(typeof(DateTime), builder.ConversionOptions.DateToConfiguredClrType);
+        }
+
+        [Fact]
+        public void WithClrToSpannerMappings()
+        {
+            var options = SpannerConversionOptions.Default;
+            options = options.WithClrToSpannerMappings("DecimalToNumeric,DateTimeToDate");
+            Assert.Equal(SpannerDbType.Numeric, options.DecimalToConfiguredSpannerType);
+            Assert.Equal(SpannerDbType.Date, options.DateTimeToConfiguredSpannerType);
+
+            options = options.WithClrToSpannerMappings("DecimalToPgNumeric,DateTimeToTimestamp");
+            Assert.Equal(SpannerDbType.PgNumeric, options.DecimalToConfiguredSpannerType);
+            Assert.Equal(SpannerDbType.Timestamp, options.DateTimeToConfiguredSpannerType);
+
+            // Test with builder as well.
+            var builder = new SpannerConnectionStringBuilder();
+            builder.ClrToSpannerTypeDefaultMappings = "DecimalToFloat64,DateTimeToDate";
+            Assert.Equal(SpannerDbType.Float64, builder.ConversionOptions.DecimalToConfiguredSpannerType);
+            Assert.Equal(SpannerDbType.Date, builder.ConversionOptions.DateTimeToConfiguredSpannerType);
+
+            // Explicitly set valid type mapping.
+            builder = new SpannerConnectionStringBuilder("ClrToSpannerTypeDefaultMappings=DecimalToNumeric,DateTimeToTimestamp");
+            Assert.Equal(SpannerDbType.Numeric, builder.ConversionOptions.DecimalToConfiguredSpannerType);
+            Assert.Equal(SpannerDbType.Timestamp, builder.ConversionOptions.DateTimeToConfiguredSpannerType);
+
+            // Check that properties are case-insensitive.
+            builder = new SpannerConnectionStringBuilder();
+            builder.ClrToSpannerTypeDefaultMappings = "decimaltofloat64,datetimeTodate";
+            Assert.Equal(SpannerDbType.Float64, builder.ConversionOptions.DecimalToConfiguredSpannerType);
+            Assert.Equal(SpannerDbType.Date, builder.ConversionOptions.DateTimeToConfiguredSpannerType);
+        }
+
+        [Theory]
+        [InlineData("DecimalToFloat64,DecimalToNumeric,DateTimeToDate")] // Multiple mappings for a type.
+        [InlineData("DecimalToFloat64,DecimalToPgNumeric,DateTimeToDate,DateTimeToTimestamp")] // Multiple mappings for a type.
+        [InlineData("DecimalToFloat64   ,DecimalToNumeric,DateTimeToDate")] // Multiple mappings and whitespace.       
+        [InlineData("DecimalToFloat64   ,  DateTimeToDate")] // Valid mapping with whitespace.
+        [InlineData("UseFloat64ForDecimal,DecimalToNumeric,DateTimeToDate")] // Invalid values.
+        public void BadClrToSpannerTypeDefaultMappingsThrows(string clrToSpannerTypeMappings)
+        {
+            var options = SpannerConversionOptions.Default;
+            Assert.Throws<ArgumentException>(() => options.WithClrToSpannerMappings(clrToSpannerTypeMappings));
+        }
+
+        [Theory]
+        [InlineData("Float64ToDouble,Float64ToDecimal,DateToDateTime")] // Multiple mappings for a type.
+        [InlineData("Float64ToDecimal,Float64ToPgNumeric,DateToSpannerDate")] // Multiple mappings for a type.        
+        [InlineData("Float64ToDecimal   ,DateToDateTime")] // Whitespace.
+        [InlineData("Float64ToDecimal   ,  DateToDateTime")] // Whitespace.        
+        [InlineData("UseDecimalForFloat,DateToSpannerDate")] // Invalid value.
+        public void BadSpannerToClrTypeDefaultMappingsThrows(string spannerToClrTypeMappings)
+        {
+            var options = SpannerConversionOptions.Default;
+            Assert.Throws<ArgumentException>(() => options.WithSpannerToClrMappings(spannerToClrTypeMappings));
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SpannerClientHelpers.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SpannerClientHelpers.cs
@@ -205,7 +205,10 @@ namespace Google.Cloud.Spanner.V1.Tests
             return spannerClientMock;
         }
 
-        internal static Mock<SpannerClient> SetupExecuteStreamingSql(this Mock<SpannerClient> spannerClientMock)
+        internal static Mock<SpannerClient> SetupExecuteStreamingSql(this Mock<SpannerClient> spannerClientMock) =>
+            SetupExecuteStreamingSql(spannerClientMock, new ExecuteSqlRequest());
+
+        internal static Mock<SpannerClient> SetupExecuteStreamingSql(this Mock<SpannerClient> spannerClientMock, ExecuteSqlRequest requestReceiver)
         {
             spannerClientMock
                 .Setup(client => client.ExecuteStreamingSql(
@@ -213,6 +216,8 @@ namespace Google.Cloud.Spanner.V1.Tests
                     It.IsAny<CallSettings>()))
                 .Returns<ExecuteSqlRequest, CallSettings>((request, _) =>
                 {
+                    // Copy the executed request into the receiver so that callers can perform further checking later.
+                    requestReceiver.MergeFrom(request);
                     IEnumerable<PartialResultSet> results = new string[] {"token1", "token2", "token3"}
                     .Select((resumeToken, index) => new PartialResultSet
                     {
@@ -232,7 +237,10 @@ namespace Google.Cloud.Spanner.V1.Tests
             return spannerClientMock;
         }
 
-        internal static Mock<SpannerClient> SetupStreamingRead(this Mock<SpannerClient> spannerClientMock)
+        internal static Mock<SpannerClient> SetupStreamingRead(this Mock<SpannerClient> spannerClientMock) => 
+            SetupStreamingRead(spannerClientMock, new ReadRequest());
+
+        internal static Mock<SpannerClient> SetupStreamingRead(this Mock<SpannerClient> spannerClientMock, ReadRequest readRequestReceiver)
         {
             spannerClientMock
                 .Setup(client => client.StreamingRead(
@@ -240,6 +248,8 @@ namespace Google.Cloud.Spanner.V1.Tests
                     It.IsAny<CallSettings>()))
                 .Returns<ReadRequest, CallSettings>((request, _) =>
                 {
+                    // Copy the executed request into the receiver so that callers can perform further checking later.
+                    readRequestReceiver.MergeFrom(request);
                     IEnumerable<PartialResultSet> results = new string[] {"token1", "token2", "token3"}
                         .Select((resumeToken, index) => new PartialResultSet
                         {

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConversionOptions.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConversionOptions.cs
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Cloud.Spanner.V1;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
 namespace Google.Cloud.Spanner.Data
 {
     /// <summary>
@@ -19,21 +24,85 @@ namespace Google.Cloud.Spanner.Data
     /// </summary>
     internal class SpannerConversionOptions
     {
+        /// <summary>
+        /// The set of valid CLR to Spanner type mappings used to validate <see cref="SpannerConnectionStringBuilder.ClrToSpannerTypeDefaultMappings"/>.
+        /// </summary>
+        internal static readonly HashSet<string> AllowedClrToSpannerTypeMappings = new HashSet<string>()
+        {
+            DecimalToFloat64,
+            DecimalToNumeric,
+            DecimalToPgNumeric,
+            DateTimeToDate,
+            DateTimeToTimestamp
+        };
+
+        /// <summary>
+        /// The set of valid Spanner to CLR type mappings used to validate <see cref="SpannerConnectionStringBuilder.SpannerToClrTypeDefaultMappings"/>.
+        /// </summary>
+        internal static readonly HashSet<string> AllowedSpannerToClrTypeMappings = new HashSet<string>()
+        {
+            Float64ToSingle,
+            Float64ToDouble,
+            Float64ToDecimal,
+            Float64ToSpannerNumeric,
+            Float64ToPgNumeric,
+            DateToDateTime,
+            DateToSpannerDate
+        };
+
+        // Constants for CLR to Spanner type mappings.
+        internal const string DecimalToFloat64 = nameof(DecimalToFloat64);
+        internal const string DecimalToNumeric = nameof(DecimalToNumeric);
+        internal const string DecimalToPgNumeric = nameof(DecimalToPgNumeric);
+        internal const string DateTimeToDate = nameof(DateTimeToDate);
+        internal const string DateTimeToTimestamp = nameof(DateTimeToTimestamp);
+
+        // Constants for Spanner To CLR type mappings.
+        internal const string Float64ToSingle = nameof(Float64ToSingle);
+        internal const string Float64ToDouble = nameof(Float64ToDouble);
+        internal const string Float64ToDecimal = nameof(Float64ToDecimal);
+        internal const string Float64ToSpannerNumeric = nameof(Float64ToSpannerNumeric);
+        internal const string Float64ToPgNumeric = nameof(Float64ToPgNumeric);
+        internal const string DateToSpannerDate = nameof(DateToSpannerDate);
+        internal const string DateToDateTime = nameof(DateToDateTime);
+
         // Predefined instances; these will change as the class grows, but hopefully
         // for most cases we can avoid creating new instances.
         private static readonly SpannerConversionOptions s_useDBNullForNull = new SpannerConversionOptions(true);
-        private static readonly SpannerConversionOptions s_useClrDefaultForNull = new SpannerConversionOptions(false);
 
         internal static SpannerConversionOptions Default { get; } = s_useDBNullForNull;
 
         /// <summary>
         /// True to return DBNull.Value for null values; false to return a null reference.
         /// </summary>
-        internal bool UseDBNull { get; }
+        internal bool UseDBNull { get; private set; }
+
+        /// <summary>
+        /// Gets the configured SpannerDbType for the decimal CLR type.
+        /// </summary>
+        internal SpannerDbType DecimalToConfiguredSpannerType { get; private set; }
+
+        /// <summary>
+        /// Gets the configured SpannerDbType for the DateTime CLR type.
+        /// </summary>
+        internal SpannerDbType DateTimeToConfiguredSpannerType { get; private set; }
+
+        /// <summary>
+        /// Gets the configured CLR type for the Date SpannerDbType.
+        /// </summary>
+        internal System.Type DateToConfiguredClrType { get; private set; }
+
+        /// <summary>
+        /// Gets the configured CLR type for the Float64 SpannerDbType.
+        /// </summary>
+        internal System.Type Float64ToConfiguredClrType { get; private set; }
 
         private SpannerConversionOptions(bool useDBNull)
         {
             UseDBNull = useDBNull;
+            // Set to defaults.
+            SetClrToSpannerTypeDefaults();
+            SetSpannerToClrTypeDefaults();
         }
 
         /// <summary>
@@ -46,6 +115,184 @@ namespace Google.Cloud.Spanner.Data
         /// Determines the right conversion options to use based on the connection string of the given connection string builder.
         /// </summary>
         internal static SpannerConversionOptions ForConnectionStringBuilder(SpannerConnectionStringBuilder builder) =>
-            builder == null ? Default : builder.UseClrDefaultForNull ? s_useClrDefaultForNull : s_useDBNullForNull;
+            builder == null ? Default : builder.ConversionOptions;
+
+        internal SpannerConversionOptions Clone() => new SpannerConversionOptions(UseDBNull)
+        {
+            DateTimeToConfiguredSpannerType = DateTimeToConfiguredSpannerType,
+            DecimalToConfiguredSpannerType = DecimalToConfiguredSpannerType,
+            DateToConfiguredClrType = DateToConfiguredClrType,
+            Float64ToConfiguredClrType = Float64ToConfiguredClrType
+        };
+
+        internal SpannerConversionOptions WithClrDefaultForNullSetting(bool useClrDefaultToNull)
+        {
+            var clone = Clone();
+            clone.UseDBNull = !useClrDefaultToNull;
+            return clone;
+        }
+
+        internal SpannerConversionOptions WithClrToSpannerMappings(string clrToSpannerMappings)
+        {
+            var clone = Clone();
+            ValidateAndParseClrToSpannerTypeMappings(clrToSpannerMappings, clone);
+            return clone;
+        }
+
+        internal SpannerConversionOptions WithSpannerToClrMappings(string spannerToClrMappings)
+        {
+            var clone = Clone();
+            ValidateAndParseSpannerToClrTypeMappings(spannerToClrMappings, clone);
+            return clone;
+        }
+
+        // TODO: Reuse code in both validation methods and remove code duplication.
+        private void ValidateAndParseSpannerToClrTypeMappings(string input, SpannerConversionOptions options)
+        {
+            // Empty string or null is valid to unset the values.
+            if (string.IsNullOrEmpty(input))
+            {
+                // Set defaults.
+                options.SetSpannerToClrTypeDefaults();
+                return;
+            }
+
+            // Get all type mappings.
+            var mappings = input.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+
+            // Validate that mappings are valid.
+            if (!mappings.Any())
+            {
+                throw new ArgumentException($"'{input}' is not a valid value for ${nameof(SpannerConnectionStringBuilder.SpannerToClrTypeDefaultMappings)}");
+            }
+
+            // Validate that mapping matches one of the pre-defined values.
+            var invalidMappings = mappings.Except(AllowedSpannerToClrTypeMappings, StringComparer.OrdinalIgnoreCase);
+            if (invalidMappings.Any())
+            {
+                throw new ArgumentException($"The following mappings are invalid:'{string.Join(",", invalidMappings)}' for ${nameof(SpannerConnectionStringBuilder.SpannerToClrTypeDefaultMappings)}");
+            }
+
+            // Check multiples for each type.
+            // Currently, we have Float64 and Date to check.
+            if (mappings.Count(j => j.StartsWith("Float64", StringComparison.OrdinalIgnoreCase)) > 1)
+            {
+                throw new ArgumentException($"'{input}' is not a valid value as multiple mappings from Float64 to CLR type are provided for ${nameof(SpannerConnectionStringBuilder.SpannerToClrTypeDefaultMappings)}");
+            }
+
+            if (mappings.Count(j => j.StartsWith("Date", StringComparison.OrdinalIgnoreCase)) > 1)
+            {
+                throw new ArgumentException($"'{input}' is not a valid value as multiple mappings from Date to CLR type are provided for ${nameof(SpannerConnectionStringBuilder.SpannerToClrTypeDefaultMappings)}");
+            }
+
+            // If we reach here, all is well.
+            foreach (var mapping in mappings)
+            {
+                if (string.Equals(mapping, Float64ToDecimal, StringComparison.OrdinalIgnoreCase))
+                {
+                    options.Float64ToConfiguredClrType = typeof(decimal);
+                }
+                else if (string.Equals(mapping, Float64ToDouble, StringComparison.OrdinalIgnoreCase))
+                {
+                    options.Float64ToConfiguredClrType = typeof(double);
+                }
+                else if (string.Equals(mapping, Float64ToSingle, StringComparison.OrdinalIgnoreCase))
+                {
+                    options.Float64ToConfiguredClrType = typeof(float);
+                }
+                else if (string.Equals(mapping, Float64ToSpannerNumeric, StringComparison.OrdinalIgnoreCase))
+                {
+                    options.Float64ToConfiguredClrType = typeof(SpannerNumeric);
+                }
+                else if (string.Equals(mapping, Float64ToPgNumeric, StringComparison.OrdinalIgnoreCase))
+                {
+                    options.Float64ToConfiguredClrType = typeof(PgNumeric);
+                }
+                else if (string.Equals(mapping, DateToDateTime, StringComparison.OrdinalIgnoreCase))
+                {
+                    options.DateToConfiguredClrType = typeof(DateTime);
+                }
+                else if (string.Equals(mapping, DateToSpannerDate, StringComparison.OrdinalIgnoreCase))
+                {
+                    options.DateToConfiguredClrType = typeof(SpannerDate);
+                }
+            }
+        }
+
+        internal void SetClrToSpannerTypeDefaults()
+        {
+            DecimalToConfiguredSpannerType = SpannerDbType.Float64;
+            DateTimeToConfiguredSpannerType = SpannerDbType.Timestamp;
+        }
+
+        internal void SetSpannerToClrTypeDefaults()
+        {
+            DateToConfiguredClrType = typeof(DateTime);
+            Float64ToConfiguredClrType = typeof(double);
+        }
+
+        private void ValidateAndParseClrToSpannerTypeMappings(string input, SpannerConversionOptions options)
+        {
+            // Empty string or null is valid to unset the values.
+            if (string.IsNullOrEmpty(input))
+            {
+                // Set default mappings.
+                options.SetClrToSpannerTypeDefaults();
+                return;
+            }
+
+            // Get all type mappings.
+            var mappings = input.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+
+            // Validate that mappings are valid.
+            if (!mappings.Any())
+            {
+                throw new ArgumentException($"'{input}' is not a valid value for ${nameof(SpannerConnectionStringBuilder.ClrToSpannerTypeDefaultMappings)}");
+            }
+
+            // Validate that mapping, matches one of the pre-defined values.
+            var invalidMappings = mappings.Except(AllowedClrToSpannerTypeMappings, StringComparer.OrdinalIgnoreCase);
+            if (invalidMappings.Any())
+            {
+                throw new ArgumentException($"The following mappings are invalid:'{string.Join(",", invalidMappings)}' for ${nameof(SpannerConnectionStringBuilder.ClrToSpannerTypeDefaultMappings)}");
+            }
+
+            // Check multiples for each type.
+            // Currently, we have Decimal and DateTime to check.
+            if (mappings.Count(j => j.StartsWith("Decimal", StringComparison.OrdinalIgnoreCase)) > 1)
+            {
+                throw new ArgumentException($"'{input}' is not a valid value as multiple mappings from Decimal to SpannerDbType are provided for ${nameof(SpannerConnectionStringBuilder.ClrToSpannerTypeDefaultMappings)}");
+            }
+
+            if (mappings.Count(j => j.StartsWith("DateTime", StringComparison.OrdinalIgnoreCase)) > 1)
+            {
+                throw new ArgumentException($"'{input}' is not a valid value as multiple mappings from DateTime to SpannerDbType are provided for ${nameof(SpannerConnectionStringBuilder.ClrToSpannerTypeDefaultMappings)}");
+            }
+
+            // If we reach here all is well.
+            foreach (var mapping in mappings)
+            {
+                if (string.Equals(mapping, DecimalToFloat64, StringComparison.OrdinalIgnoreCase))
+                {
+                    options.DecimalToConfiguredSpannerType = SpannerDbType.Float64;
+                }
+                else if (string.Equals(mapping, DecimalToNumeric, StringComparison.OrdinalIgnoreCase))
+                {
+                    options.DecimalToConfiguredSpannerType = SpannerDbType.Numeric;
+                }
+                else if (string.Equals(mapping, DecimalToPgNumeric, StringComparison.OrdinalIgnoreCase))
+                {
+                    options.DecimalToConfiguredSpannerType = SpannerDbType.PgNumeric;
+                }
+                else if (string.Equals(mapping, DateTimeToDate, StringComparison.OrdinalIgnoreCase))
+                {
+                    options.DateTimeToConfiguredSpannerType = SpannerDbType.Date;
+                }
+                else if (string.Equals(mapping, DateTimeToTimestamp, StringComparison.OrdinalIgnoreCase))
+                {
+                    options.DateTimeToConfiguredSpannerType = SpannerDbType.Timestamp;
+                }
+            }
+        }
     }
 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDbType.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDbType.cs
@@ -46,7 +46,7 @@ namespace Google.Cloud.Spanner.Data
         public static SpannerDbType Int64 { get; } = new SpannerDbType(TypeCode.Int64);
 
         /// <summary>
-        /// 64 bit floating point number.
+        /// 64 bit floating point number. This is equivalent to Float8 in the PostgreSQL dialect.
         /// </summary>
         public static SpannerDbType Float64 { get; } = new SpannerDbType(TypeCode.Float64);
 
@@ -192,10 +192,11 @@ namespace Google.Cloud.Spanner.Data
                 case TypeCode.Int64:
                     return typeof(long);
                 case TypeCode.Float64:
-                    return typeof(double);
+                    return options.Float64ToConfiguredClrType;
                 case TypeCode.Timestamp:
-                case TypeCode.Date:
                     return typeof(DateTime);
+                case TypeCode.Date:
+                    return options.DateToConfiguredClrType;
                 case TypeCode.String:
                     return typeof(string);
                 case TypeCode.Bytes:
@@ -221,7 +222,7 @@ namespace Google.Cloud.Spanner.Data
         /// <summary>
         /// The default <see cref="System.Type"/> for this Cloud Spanner type.
         /// </summary>
-        public System.Type DefaultClrType => GetConfiguredClrType(default);
+        public System.Type DefaultClrType => GetConfiguredClrType(SpannerConversionOptions.Default);
 
         /// <summary>
         /// Converts a <see cref="DbType"/> to the corresponding <see cref="SpannerDbType"/>
@@ -315,6 +316,10 @@ namespace Google.Cloud.Spanner.Data
             if (typeof(IEnumerable<byte>).IsAssignableFrom(type))
             {
                 return Bytes;
+            }
+            if (type == typeof(SpannerDate))
+            {
+                return Date;
             }
             if (type == typeof(DateTime))
             {

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerParameter.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerParameter.cs
@@ -149,7 +149,8 @@ namespace Google.Cloud.Spanner.Data
                     $"{nameof(SpannerDbType)} must be set to one of "
                     + $"({nameof(SpannerDbType.Bool)}, {nameof(SpannerDbType.Int64)}, {nameof(SpannerDbType.Float64)},"
                     + $" {nameof(SpannerDbType.Timestamp)}, {nameof(SpannerDbType.Date)}, {nameof(SpannerDbType.String)},"
-                    + $" {nameof(SpannerDbType.Bytes)}, {nameof(SpannerDbType.Json)}, {nameof(SpannerDbType.Numeric)})");
+                    + $" {nameof(SpannerDbType.Bytes)}, {nameof(SpannerDbType.Json)}, {nameof(SpannerDbType.Numeric)},"
+                    + $" {nameof(SpannerDbType.PgNumeric)})");
             }
             return Value;
         }
@@ -160,7 +161,25 @@ namespace Google.Cloud.Spanner.Data
         /// </summary>
         /// <param name="options">Options to configure the <c>SpannerDbType</c> for this <c>SpannerParameter</c>.</param>
         /// <returns>The configured <see cref="SpannerDbType"/>.</returns>
-        internal SpannerDbType GetConfiguredSpannerDbType(SpannerConversionOptions options) => SpannerDbType;
+        internal SpannerDbType GetConfiguredSpannerDbType(SpannerConversionOptions options)
+        {
+            // Only if SpannerDbType of parameter is not explicitly provided by user.
+            if (_spannerDbType == null)
+            {
+                if (Value is decimal)
+                {
+                    return options.DecimalToConfiguredSpannerType;
+                }
+
+                if (Value is DateTime)
+                {
+                    return options.DateTimeToConfiguredSpannerType;
+                }
+            }
+
+            // If we are here, use defaults.
+            return SpannerDbType;
+        }
 
         /// <inheritdoc />
         public override void ResetDbType()


### PR DESCRIPTION
Default handling of decimal and Float64 with unit tests.
 
The implementation uses string splitting and parsing and makes use of dictionary to keep strongly typed mappings. 

Commit 1: Decimal and Float64 default handling.
Commit 2: Builds on top of Commit 1 and adds support for default DateTime and Date handling.

Will raise a new PR for integration tests once this PR is good. 