### PR TITLE
feat: Prototype PR for adding connection string options support to Keys

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/KeysTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/KeysTests.cs
@@ -38,24 +38,32 @@ namespace Google.Cloud.Spanner.Data.Tests
                     { "", SpannerDbType.String, "test" },
                     { "", SpannerDbType.Timestamp, new DateTime(2021, 9, 10, 9, 37, 10, DateTimeKind.Utc) }
                 });
-            var index = 0;
-            Assert.True(key.KeyParts.Values[index++].BoolValue);
-            Assert.Equal(Convert.ToBase64String(new byte[] {1,2,3}), key.KeyParts.Values[index++].StringValue);
-            Assert.Equal("2021-09-10", key.KeyParts.Values[index++].StringValue);
-            Assert.Equal(3.14, key.KeyParts.Values[index++].NumberValue);
-            Assert.Equal("1", key.KeyParts.Values[index++].StringValue);
-            Assert.Equal("{\"key\": \"value\"}", key.KeyParts.Values[index++].StringValue);
-            Assert.Equal("10.1", key.KeyParts.Values[index++].StringValue);
-            Assert.Equal("20.1", key.KeyParts.Values[index++].StringValue);
-            Assert.Equal("test", key.KeyParts.Values[index++].StringValue);
-            Assert.Equal("2021-09-10T09:37:10Z", key.KeyParts.Values[index++].StringValue);
+
+            var actual = key.ToProtobuf(SpannerConversionOptions.Default);
+            var expected = new ListValue
+            {
+                Values =
+                {
+                    Value.ForBool(true),
+                    Value.ForString(Convert.ToBase64String(new byte[] {1,2,3})),
+                    Value.ForString("2021-09-10"),
+                    Value.ForNumber(3.14),
+                    Value.ForString("1"),
+                    Value.ForString("{\"key\": \"value\"}"),
+                    Value.ForString("10.1"),
+                    Value.ForString("20.1"),
+                    Value.ForString("test"),
+                    Value.ForString("2021-09-10T09:37:10Z")
+                }
+            };
+            Assert.Equal(expected, actual);
         }
 
         [Fact]
         public void CreateKeyFromEmptyParameters()
         {
             var key = new Key(new SpannerParameterCollection());
-            Assert.Empty(key.KeyParts.Values);
+            Assert.Empty(key.ToProtobuf(SpannerConversionOptions.Default).Values);
         }
 
         [Fact]
@@ -73,107 +81,246 @@ namespace Google.Cloud.Spanner.Data.Tests
                 "test",
                 new DateTime(2021, 9, 10, 9, 37, 10, DateTimeKind.Utc)
             );
-            var index = 0;
-            Assert.True(key.KeyParts.Values[index++].BoolValue);
-            Assert.Equal(Convert.ToBase64String(new byte[] {1,2,3}), key.KeyParts.Values[index++].StringValue);
-            Assert.Equal(3.14, key.KeyParts.Values[index++].NumberValue);
-            Assert.Equal("1", key.KeyParts.Values[index++].StringValue);
-            Assert.Equal("10.1", key.KeyParts.Values[index++].StringValue);
-            Assert.Equal("20.1", key.KeyParts.Values[index++].StringValue);
-            Assert.Equal("test", key.KeyParts.Values[index++].StringValue);
-            Assert.Equal("2021-09-10T09:37:10Z", key.KeyParts.Values[index++].StringValue);
+
+            var actual = key.ToProtobuf(SpannerConversionOptions.Default);
+            var expected = new ListValue
+            {
+                Values =
+                {
+                    Value.ForBool(true),
+                    Value.ForString(Convert.ToBase64String(new byte[] {1,2,3})),
+                    Value.ForNumber(3.14),
+                    Value.ForString("1"),
+                    Value.ForString("10.1"),
+                    Value.ForString("20.1"),
+                    Value.ForString("test"),
+                    Value.ForString("2021-09-10T09:37:10Z")
+                }
+            };
+            Assert.Equal(expected, actual);
         }
 
         [Fact]
         public void CreateEmptyKey()
         {
             var key = new Key();
-            Assert.Empty(key.KeyParts.Values);
+            Assert.Empty(key.ToProtobuf(SpannerConversionOptions.Default).Values);
         }
 
         [Fact]
         public void CreateKeyWithNullParts()
         {
             var key = new Key(null, 1L, null);
-            Assert.Collection(key.KeyParts.Values,
+            Assert.Collection(key.ToProtobuf(SpannerConversionOptions.Default).Values,
                 v => Assert.Equal(NullValue.NullValue, v.NullValue),
                 v => Assert.Equal("1", v.StringValue),
                 v => Assert.Equal(NullValue.NullValue, v.NullValue));
         }
+        
+        [Fact]
+        public void TypeMappings()
+        {
+            var builder = new SpannerConnectionStringBuilder();
+            var key = new Key(new SpannerParameterCollection { new SpannerParameter { ParameterName = "k1", Value = 3.14m },
+                new SpannerParameter { ParameterName = "k2", Value = new DateTime(2022, 06, 08) } });
 
+            Assert.Equal(new ListValue { Values = { Value.ForNumber(3.14), Value.ForString("2022-06-08T00:00:00Z") } }, 
+                key.ToProtobuf(builder.ConversionOptions));
+
+            // Specify the type mappings.
+            builder.ClrToSpannerTypeDefaultMappings = "DecimalToNumeric,DateTimeToDate";
+            Assert.Equal(new ListValue { Values = { Value.ForString("3.14"), Value.ForString("2022-06-08") } }, 
+                key.ToProtobuf(builder.ConversionOptions));
+
+            // Revert the type mappings.
+            builder.ClrToSpannerTypeDefaultMappings = "";
+            Assert.Equal(new ListValue { Values = { Value.ForNumber(3.14), Value.ForString("2022-06-08T00:00:00Z") } }, 
+                key.ToProtobuf(builder.ConversionOptions));
+        }
+
+        [Fact]
+        public void ToString_()
+        {
+            var builder = new SpannerConnectionStringBuilder();
+            var key = new Key(new SpannerParameterCollection { new SpannerParameter { ParameterName = "k1", Value = 3.14m },
+                new SpannerParameter { ParameterName = "k2", Value = new DateTime(2022, 06, 08) } });
+            Assert.Equal("[ 3.14, \"2022-06-08T00:00:00Z\" ]", key.ToString(builder));
+
+            // Specify the type mappings.
+            builder.ClrToSpannerTypeDefaultMappings = "DecimalToNumeric,DateTimeToDate";
+            Assert.Equal("[ \"3.14\", \"2022-06-08\" ]", key.ToString(builder));
+
+            // Revert the type mappings.
+            builder.ClrToSpannerTypeDefaultMappings = "";
+            Assert.Equal("[ 3.14, \"2022-06-08T00:00:00Z\" ]", key.ToString(builder));
+        }
+    }
+
+    public class KeyRangeTests
+    {
         [Fact]
         public void CreateKeyRangeClosedClosed()
         {
+            var options = SpannerConversionOptions.Default;
             var closedClosed = KeyRange.ClosedClosed(new Key("begin"), new Key("end"));
             Assert.True(closedClosed.BeginInclusive);
             Assert.True(closedClosed.EndInclusive);
-            Assert.Equal(new Key("begin"), closedClosed.BeginAt);
-            Assert.Equal(new Key("end"), closedClosed.End);
+            Assert.Equal(new ListValue { Values = { new[] { new Value { StringValue = "begin" } } } }, closedClosed.BeginAt.ToProtobuf(options));
+            Assert.Equal(new ListValue { Values = { new[] { new Value { StringValue = "end" } } } }, closedClosed.End.ToProtobuf(options));
+            Assert.Equal(new Key("begin").ToProtobuf(options), closedClosed.BeginAt.ToProtobuf(options));
+            Assert.Equal(new Key("end").ToProtobuf(options), closedClosed.End.ToProtobuf(options));
             Assert.Equal(
                 new V1.KeyRange
                 {
                     StartClosed = new ListValue { Values = { new[] { new Value { StringValue = "begin" } } } },
                     EndClosed = new ListValue { Values = { new[] { new Value { StringValue = "end" } } } }
-                }, closedClosed.Protobuf);
+                }, closedClosed.ToProtobuf(options));
         }
 
         [Fact]
         public void CreateKeyRangeClosedOpen()
         {
+            var options = SpannerConversionOptions.Default;
             var closedOpen = KeyRange.ClosedOpen(new Key(1L), new Key(100L));
             Assert.True(closedOpen.BeginInclusive);
             Assert.False(closedOpen.EndInclusive);
-            Assert.Equal(new Key(1L), closedOpen.BeginAt);
-            Assert.Equal(new Key(100L), closedOpen.End);
+            Assert.Equal(new ListValue { Values = { new[] { new Value { StringValue = "1" } } } }, closedOpen.BeginAt.ToProtobuf(options));
+            Assert.Equal(new ListValue { Values = { new[] { new Value { StringValue = "100" } } } }, closedOpen.End.ToProtobuf(options));
+            Assert.Equal(new Key(1L).ToProtobuf(options), closedOpen.BeginAt.ToProtobuf(options));
+            Assert.Equal(new Key(100L).ToProtobuf(options), closedOpen.End.ToProtobuf(options));
             Assert.Equal(
                 new V1.KeyRange
                 {
                     StartClosed = new ListValue { Values = { new[] { new Value { StringValue = "1" } } } },
                     EndOpen = new ListValue { Values = { new[] { new Value { StringValue = "100" } } } }
-                }, closedOpen.Protobuf);
+                }, closedOpen.ToProtobuf(options));
         }
 
         [Fact]
         public void CreateKeyRangeOpenClosed()
         {
+            var options = SpannerConversionOptions.Default;
             var openClosed = KeyRange.OpenClosed(new Key(1L, 3.14), new Key(100L, 100.0));
             Assert.False(openClosed.BeginInclusive);
             Assert.True(openClosed.EndInclusive);
-            Assert.Equal(new Key(1L, 3.14), openClosed.BeginAt);
-            Assert.Equal(new Key(100L, 100.0), openClosed.End);
+            Assert.Equal(new ListValue { Values = { new[] { new Value { StringValue = "1" }, new Value { NumberValue = 3.14 } } } }, openClosed.BeginAt.ToProtobuf(options));
+            Assert.Equal(new ListValue { Values = { new[] { new Value { StringValue = "100" }, new Value { NumberValue = 100.0 } } } }, openClosed.End.ToProtobuf(options));
+            Assert.Equal(new Key(1L, 3.14).ToProtobuf(options), openClosed.BeginAt.ToProtobuf(options));
+            Assert.Equal(new Key(100L, 100.0).ToProtobuf(options), openClosed.End.ToProtobuf(options));
             Assert.Equal(
                 new V1.KeyRange
                 {
                     StartOpen = new ListValue
-                        { Values = { new[] { new Value { StringValue = "1" }, new Value { NumberValue = 3.14 } } } },
+                    { Values = { new[] { new Value { StringValue = "1" }, new Value { NumberValue = 3.14 } } } },
                     EndClosed = new ListValue
-                        { Values = { new[] { new Value { StringValue = "100" }, new Value { NumberValue = 100.0 } } } }
-                }, openClosed.Protobuf);
+                    { Values = { new[] { new Value { StringValue = "100" }, new Value { NumberValue = 100.0 } } } }
+                }, openClosed.ToProtobuf(options));
         }
 
         [Fact]
         public void CreateKeyRangeOpenOpen()
         {
+            var options = SpannerConversionOptions.Default;
             var openOpen = KeyRange.OpenOpen(new Key(SpannerNumeric.Parse("0.1")), new Key(SpannerNumeric.Parse("100.1")));
             Assert.False(openOpen.BeginInclusive);
             Assert.False(openOpen.EndInclusive);
-            Assert.Equal(new Key(SpannerNumeric.Parse("0.1")), openOpen.BeginAt);
-            Assert.Equal(new Key(SpannerNumeric.Parse("100.1")), openOpen.End);
+            Assert.Equal(new ListValue { Values = { new[] { new Value { StringValue = "0.1" } } } }, openOpen.BeginAt.ToProtobuf(options));
+            Assert.Equal(new ListValue { Values = { new[] { new Value { StringValue = "100.1" } } } }, openOpen.End.ToProtobuf(options));
+            Assert.Equal(new Key(SpannerNumeric.Parse("0.1")).ToProtobuf(options), openOpen.BeginAt.ToProtobuf(options));
+            Assert.Equal(new Key(SpannerNumeric.Parse("100.1")).ToProtobuf(options), openOpen.End.ToProtobuf(options));
             Assert.Equal(new V1.KeyRange
             {
-                StartOpen = new ListValue{ Values = { new [] { new Value { StringValue = "0.1" } } } },
-                EndOpen = new ListValue{ Values = { new [] { new Value { StringValue = "100.1" } } } }
-            }, openOpen.Protobuf);
+                StartOpen = new ListValue { Values = { new[] { new Value { StringValue = "0.1" } } } },
+                EndOpen = new ListValue { Values = { new[] { new Value { StringValue = "100.1" } } } }
+            }, openOpen.ToProtobuf(options));
         }
 
         [Fact]
         public void CreateEmptyKeyRange()
         {
+            var options = SpannerConversionOptions.Default;
             var empty = KeyRange.ClosedOpen(new Key(), new Key());
-            Assert.Empty(empty.BeginAt.KeyParts.Values);
-            Assert.Empty(empty.End.KeyParts.Values);
+            Assert.Empty(empty.BeginAt.ToProtobuf(options).Values);
+            Assert.Empty(empty.End.ToProtobuf(options).Values);
         }
 
+        [Fact]
+        public void TypeMappings()
+        {
+            // Without specifying the type mapping.
+            var builder = new SpannerConnectionStringBuilder();
+            var range1 = KeyRange.ClosedOpen(new Key(new SpannerParameterCollection { new SpannerParameter { ParameterName = "k1", Value = 3.14m } }),
+               new Key(new SpannerParameterCollection { new SpannerParameter { ParameterName = "k2", Value = 1.71m } }));
+            var range2 = KeyRange.ClosedClosed(new Key(new SpannerParameterCollection { new SpannerParameter { ParameterName = "k3", Value = new DateTime(2022, 06, 08) } }),
+              new Key(new SpannerParameterCollection { new SpannerParameter { ParameterName = "k4", Value = new DateTime(2024, 06, 08) } }));
+
+            Assert.Equal(new V1.KeyRange
+            {
+                StartClosed = new ListValue { Values = { new[] { new Value { NumberValue = 3.14 } } } },
+                EndOpen = new ListValue { Values = { new[] { new Value { NumberValue = 1.71 } } } },
+            }, range1.ToProtobuf(builder.ConversionOptions));
+
+            Assert.Equal(new V1.KeyRange
+            {
+                StartClosed = new ListValue { Values = { new[] { new Value { StringValue = "2022-06-08T00:00:00Z" } } } },
+                EndClosed = new ListValue { Values = { new[] { new Value { StringValue = "2024-06-08T00:00:00Z" } } } },
+            }, range2.ToProtobuf(builder.ConversionOptions));
+
+            // Specifying the type mappings.
+            builder.ClrToSpannerTypeDefaultMappings = "DecimalToNumeric,DateTimeToDate";
+            Assert.Equal(new V1.KeyRange
+            {
+                StartClosed = new ListValue { Values = { new[] { new Value { StringValue = "3.14" } } } },
+                EndOpen = new ListValue { Values = { new[] { new Value { StringValue = "1.71" } } } },
+            }, range1.ToProtobuf(builder.ConversionOptions));
+
+            Assert.Equal(new V1.KeyRange
+            {
+                StartClosed = new ListValue { Values = { new[] { new Value { StringValue = "2022-06-08" } } } },
+                EndClosed = new ListValue { Values = { new[] { new Value { StringValue = "2024-06-08" } } } },
+            }, range2.ToProtobuf(builder.ConversionOptions));
+
+            // Revert the type mappings.
+            builder.ClrToSpannerTypeDefaultMappings = "";
+            Assert.Equal(new V1.KeyRange
+            {
+                StartClosed = new ListValue { Values = { new[] { new Value { NumberValue = 3.14 } } } },
+                EndOpen = new ListValue { Values = { new[] { new Value { NumberValue = 1.71 } } } },
+            }, range1.ToProtobuf(builder.ConversionOptions));
+
+            Assert.Equal(new V1.KeyRange
+            {
+                StartClosed = new ListValue { Values = { new[] { new Value { StringValue = "2022-06-08T00:00:00Z" } } } },
+                EndClosed = new ListValue { Values = { new[] { new Value { StringValue = "2024-06-08T00:00:00Z" } } } },
+            }, range2.ToProtobuf(builder.ConversionOptions));
+        }
+
+        [Fact]
+        public void ToString_()
+        {
+            var builder = new SpannerConnectionStringBuilder();
+            var range1 = KeyRange.ClosedOpen(new Key(new SpannerParameterCollection { new SpannerParameter { ParameterName = "k1", Value = 3.14m } }),
+                new Key(new SpannerParameterCollection { new SpannerParameter { ParameterName = "k2", Value = 1.71m } }));
+            var range2 = KeyRange.ClosedClosed(new Key(new SpannerParameterCollection { new SpannerParameter { ParameterName = "k3", Value = new DateTime(2022, 06, 08) } }),
+              new Key(new SpannerParameterCollection { new SpannerParameter { ParameterName = "k4", Value = new DateTime(2024, 06, 08) } }));
+
+            Assert.Equal("[[ 3.14 ], [ 1.71 ])", range1.ToString(builder));
+            Assert.Equal("[[ \"2022-06-08T00:00:00Z\" ], [ \"2024-06-08T00:00:00Z\" ]]", range2.ToString(builder));
+
+            // Specify the type mappings.(Numeric for decimal, Date for DateTime)
+            builder.ClrToSpannerTypeDefaultMappings = "DecimalToNumeric,DateTimeToDate";
+            Assert.Equal("[[ \"3.14\" ], [ \"1.71\" ])", range1.ToString(builder));
+            Assert.Equal("[[ \"2022-06-08\" ], [ \"2024-06-08\" ]]", range2.ToString(builder));
+
+            // Revert to default. (double for decimal, Timestamp for DateTime)
+            builder.ClrToSpannerTypeDefaultMappings = "";
+            Assert.Equal("[[ 3.14 ], [ 1.71 ])", range1.ToString(builder));
+            Assert.Equal("[[ \"2022-06-08T00:00:00Z\" ], [ \"2024-06-08T00:00:00Z\" ]]", range2.ToString(builder));
+        }
+    }
+
+    public class KeySetTests
+    {
         [Fact]
         public void CreateKeySetAll()
         {
@@ -184,37 +331,103 @@ namespace Google.Cloud.Spanner.Data.Tests
         [Fact]
         public void CreateKeySetFromKeys()
         {
+            var options = SpannerConversionOptions.Default;
             var keys = KeySet.FromKeys(new Key("k1"), new Key("k2"), new Key("k3"));
             Assert.Collection(
                 keys.Keys,
-                k => Assert.Equal("k1", k.KeyParts.Values[0].StringValue),
-                k => Assert.Equal("k2", k.KeyParts.Values[0].StringValue),
-                k => Assert.Equal("k3", k.KeyParts.Values[0].StringValue)
+                k => Assert.Equal("k1", k.ToProtobuf(options).Values[0].StringValue),
+                k => Assert.Equal("k2", k.ToProtobuf(options).Values[0].StringValue),
+                k => Assert.Equal("k3", k.ToProtobuf(options).Values[0].StringValue)
             );
+        }
+
+        [Fact]
+        public void TypeMappings()
+        {
+            // Without specifying the type mapping.
+            var builder = new SpannerConnectionStringBuilder();
+            var keySet = KeySet.FromParameters(new SpannerParameterCollection { new SpannerParameter { ParameterName = "k1", Value = 3.14m },
+                new SpannerParameter { ParameterName = "k2", Value = new DateTime(2022, 06, 08) } });
+            
+            var protobufValues = keySet.ToProtobuf(builder.ConversionOptions);
+            Assert.Equal(3.14d, protobufValues.Keys[0].Values[0].NumberValue); // default to double.
+            Assert.Equal("2022-06-08T00:00:00Z", protobufValues.Keys[0].Values[1].StringValue); // default to Timestamp.
+
+            // Specifying the type mappings.
+            builder.ClrToSpannerTypeDefaultMappings = "DecimalToNumeric,DateTimeToDate";
+            protobufValues = keySet.ToProtobuf(builder.ConversionOptions);
+            Assert.Equal("3.14", protobufValues.Keys[0].Values[0].StringValue); // Numeric string.
+            Assert.Equal("2022-06-08", protobufValues.Keys[0].Values[1].StringValue); // Date string.
+
+            // Revert the type mappings.
+            builder.ClrToSpannerTypeDefaultMappings = "";
+            protobufValues = keySet.ToProtobuf(builder.ConversionOptions);
+            Assert.Equal(3.14d, protobufValues.Keys[0].Values[0].NumberValue); // default to double.
+            Assert.Equal("2022-06-08T00:00:00Z", protobufValues.Keys[0].Values[1].StringValue); // default to Timestamp.
         }
 
         [Fact]
         public void CreateKeySetFromRanges()
         {
+            var options = SpannerConversionOptions.Default;
             var ranges = KeySet.FromRanges(
                 KeyRange.ClosedOpen(new Key("begin"), new Key("end")), KeyRange.ClosedClosed(new Key(1L), new Key(2L)));
             Assert.Collection(ranges.Ranges,
-                range => Assert.Equal(KeyRange.ClosedOpen(new Key("begin"), new Key("end")), range),
-                range => Assert.Equal(KeyRange.ClosedClosed(new Key(1L), new Key(2L)), range)
+                range => Assert.Equal(KeyRange.ClosedOpen(new Key("begin"), new Key("end")).ToProtobuf(options), range.ToProtobuf(options)),
+                range => Assert.Equal(KeyRange.ClosedClosed(new Key(1L), new Key(2L)).ToProtobuf(options), range.ToProtobuf(options))
             );
+        }
+
+        [Fact]
+        public void ToStringKeySetWithBuilder()
+        {
+            var builder = new SpannerConnectionStringBuilder();
+            var keySet = KeySet.FromParameters(new SpannerParameterCollection { new SpannerParameter { ParameterName = "k1", Value = 3.14m },
+                new SpannerParameter { ParameterName = "k2", Value = new DateTime(2022, 06, 08) } });
+
+            Assert.Collection(keySet.Keys,
+                key1 => Assert.Equal("[ 3.14, \"2022-06-08T00:00:00Z\" ]", key1.ToString(builder)));
+
+            // Specify the type mappings.
+            builder.ClrToSpannerTypeDefaultMappings = "DecimalToNumeric,DateTimeToDate";
+            Assert.Collection(keySet.Keys,
+               key1 => Assert.Equal("[ \"3.14\", \"2022-06-08\" ]", key1.ToString(builder)));
+
+            // Revert the type mappings.
+            builder.ClrToSpannerTypeDefaultMappings = "";
+            Assert.Collection(keySet.Keys,
+               key1 => Assert.Equal("[ 3.14, \"2022-06-08T00:00:00Z\" ]", key1.ToString(builder)));
         }
 
         [Fact]
         public void ToStringKeySetAll()
         {
-            Assert.Equal("KeySet {AllKeys = true}", KeySet.All.ToString());
+            Assert.Equal("KeySet {AllKeys = true}", KeySet.All.ToString(new SpannerConnectionStringBuilder()));
         }
 
         [Fact]
         public void ToStringKeySetFromKeys()
         {
             var keys = KeySet.FromKeys(new Key("k1.1", "k1.2"), new Key("k2.1", "k2.2"), new Key("k3.1", "k3.2"));
-            Assert.Equal("KeySet {Keys = [[ \"k1.1\", \"k1.2\" ], [ \"k2.1\", \"k2.2\" ], [ \"k3.1\", \"k3.2\" ]]}", keys.ToString());
+            Assert.Equal("KeySet {Keys = [[ \"k1.1\", \"k1.2\" ], [ \"k2.1\", \"k2.2\" ], [ \"k3.1\", \"k3.2\" ]]}", keys.ToString(new SpannerConnectionStringBuilder()));
+        }
+
+        [Fact]
+        public void ToStringKeySetFromKeysWithBuilder()
+        {
+            var builder = new SpannerConnectionStringBuilder();
+            var keys = KeySet.FromKeys(new Key(new SpannerParameterCollection { new SpannerParameter { ParameterName = "k1", Value = 3.14m } }),
+                new Key(new SpannerParameterCollection { new SpannerParameter { ParameterName = "k2", Value = new DateTime(2022, 06, 08) } }));
+
+            Assert.Equal("KeySet {Keys = [[ 3.14 ], [ \"2022-06-08T00:00:00Z\" ]]}", keys.ToString(builder));
+
+            // Specify the type mappings.(Numeric for decimal, Date for DateTime)
+            builder.ClrToSpannerTypeDefaultMappings = "DecimalToNumeric,DateTimeToDate";
+            Assert.Equal("KeySet {Keys = [[ \"3.14\" ], [ \"2022-06-08\" ]]}", keys.ToString(builder));
+
+            // Revert to default. (double for decimal, Timestamp for DateTime)
+            builder.ClrToSpannerTypeDefaultMappings = "";
+            Assert.Equal("KeySet {Keys = [[ 3.14 ], [ \"2022-06-08T00:00:00Z\" ]]}", keys.ToString(builder));
         }
 
         [Fact]
@@ -222,7 +435,28 @@ namespace Google.Cloud.Spanner.Data.Tests
         {
             var ranges = KeySet.FromRanges(
                 KeyRange.ClosedOpen(new Key("beginKeyPart1", "beginKeyPart2"), new Key("endKeyPart1", "endKeyPart2")), KeyRange.ClosedClosed(new Key(1L), new Key(2L)));
-            Assert.Equal("KeySet {Ranges = [[[ \"beginKeyPart1\", \"beginKeyPart2\" ], [ \"endKeyPart1\", \"endKeyPart2\" ]), [[ \"1\" ], [ \"2\" ]]]}", ranges.ToString());
+            Assert.Equal("KeySet {Ranges = [[[ \"beginKeyPart1\", \"beginKeyPart2\" ], [ \"endKeyPart1\", \"endKeyPart2\" ]), [[ \"1\" ], [ \"2\" ]]]}", ranges.ToString(new SpannerConnectionStringBuilder()));
+        }
+
+        [Fact]
+        public void ToStringKeySetFromRangesWithBuilder()
+        {
+            var builder = new SpannerConnectionStringBuilder();
+            var ranges = KeySet.FromRanges(
+                KeyRange.ClosedOpen(new Key(new SpannerParameterCollection { new SpannerParameter { ParameterName = "k1", Value = 3.14m } }),
+                new Key(new SpannerParameterCollection { new SpannerParameter { ParameterName = "k2", Value = 1.71m } })),
+                 KeyRange.ClosedClosed(new Key(new SpannerParameterCollection { new SpannerParameter { ParameterName = "k3", Value = new DateTime(2022, 06, 08) } }),
+                 new Key(new SpannerParameterCollection { new SpannerParameter { ParameterName = "k4", Value = new DateTime(2024, 06, 08) } })));
+
+            Assert.Equal("KeySet {Ranges = [[[ 3.14 ], [ 1.71 ]), [[ \"2022-06-08T00:00:00Z\" ], [ \"2024-06-08T00:00:00Z\" ]]]}", ranges.ToString(builder));
+
+            // Specify the type mappings.(Numeric for decimal, Date for DateTime)
+            builder.ClrToSpannerTypeDefaultMappings = "DecimalToNumeric,DateTimeToDate";
+            Assert.Equal("KeySet {Ranges = [[[ \"3.14\" ], [ \"1.71\" ]), [[ \"2022-06-08\" ], [ \"2024-06-08\" ]]]}", ranges.ToString(builder));
+
+            // Revert to default. (double for decimal, Timestamp for DateTime)
+            builder.ClrToSpannerTypeDefaultMappings = "";
+            Assert.Equal("KeySet {Ranges = [[[ 3.14 ], [ 1.71 ]), [[ \"2022-06-08T00:00:00Z\" ], [ \"2024-06-08T00:00:00Z\" ]]]}", ranges.ToString(builder));
         }
     }
 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/Keys.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/Keys.cs
@@ -56,9 +56,6 @@ namespace Google.Cloud.Spanner.Data
         /// </summary>
         public IEnumerable<KeyRange> Ranges { get; }
 
-        private Lazy<V1.KeySet> LazyProtobuf => new Lazy<V1.KeySet>(ToProtobuf);
-        internal V1.KeySet Protobuf => LazyProtobuf.Value;
-
         /// <summary>
         /// Returns a key set that selects all keys in the table or index.
         /// </summary>
@@ -99,15 +96,14 @@ namespace Google.Cloud.Spanner.Data
             Ranges = ranges;
         }
 
-        /// <inheritdoc/>
-        public override bool Equals(object other)
-            => other is KeySet keySet && Protobuf.Equals(keySet.Protobuf);
-
-        /// <inheritdoc/>
-        public override int GetHashCode() => Protobuf.GetHashCode();
-
-        /// <inheritdoc/>
-        public override string ToString()
+        /// <summary>
+        /// Returns the string representation of this KeySet using the type conversion options specified in 
+        /// <see cref="SpannerConnectionStringBuilder"/>. The string representation is only for diagnostic purposes
+        /// and the implementation may change over time.
+        /// </summary>
+        /// <param name="builder">The <see cref="SpannerConnectionStringBuilder"/> instance used to derive default conversion options.</param>
+        /// <returns>A string that represents the current KeySet.</returns>
+        public string ToString(SpannerConnectionStringBuilder builder)
         {
             if (AllKeys)
             {
@@ -117,19 +113,19 @@ namespace Google.Cloud.Spanner.Data
             // The KeySet is a collection of individual keys.
             if (Keys != null)
             {
-                return $"KeySet {{Keys = [{string.Join(", ", Keys)}]}}";
+                return $"KeySet {{Keys = [{string.Join(", ", Keys.Select(key => key.ToString(builder)))}]}}";
             }
 
             // The KeySet is a collection of key ranges.
             if (Ranges != null)
             {
-                return $"KeySet {{Ranges = [{string.Join(", ", Ranges)}]}}";
+                return $"KeySet {{Ranges = [{string.Join(", ", Ranges.Select(range => range.ToString(builder)))}]}}";
             }
 
             throw new InvalidOperationException("Implementation error, we should never have gotten here.");
         }
 
-        private V1.KeySet ToProtobuf()
+        internal V1.KeySet ToProtobuf(SpannerConversionOptions conversionOptions)
         {
             if (AllKeys)
             {
@@ -139,14 +135,14 @@ namespace Google.Cloud.Spanner.Data
             // The KeySet is a collection of individual keys.
             if (Keys != null)
             {
-                var protobufKeys = Keys.Select(k => k.KeyParts);
+                var protobufKeys = Keys.Select(k => k.ToProtobuf(conversionOptions));
                 return new V1.KeySet { Keys = { protobufKeys } };
             }
 
             // The KeySet is a collection of key ranges.
             if (Ranges != null)
             {
-                var protobufRanges = Ranges.Select(r => r.Protobuf);
+                var protobufRanges = Ranges.Select(r => r.ToProtobuf(conversionOptions));
                 return new V1.KeySet { Ranges = { protobufRanges } };
             }
 
@@ -178,9 +174,6 @@ namespace Google.Cloud.Spanner.Data
         /// True if the end of the key range is inclusive, and false if the end is exclusive.
         /// </summary>
         public bool EndInclusive { get; }
-
-        private Lazy<V1.KeyRange> LazyProtobuf => new Lazy<V1.KeyRange>(ToProtobuf);
-        internal V1.KeyRange Protobuf => LazyProtobuf.Value;
 
         /// <summary>
         /// Creates a new KeyRange with an inclusive begin and exclusive end.
@@ -226,45 +219,41 @@ namespace Google.Cloud.Spanner.Data
             EndInclusive = endInclusive;
         }
 
-        /// <inheritdoc/>
-        public override bool Equals(object other)
-            => other is KeyRange range && Protobuf.Equals(range.Protobuf);
+        /// <summary>
+        /// Returns the string representation of this KeyRange using the type conversion options specified in 
+        /// <see cref="SpannerConnectionStringBuilder"/>. The string representation is only for diagnostic purposes
+        /// and the implementation may change over time.
+        /// </summary>
+        /// <param name="builder">The <see cref="SpannerConnectionStringBuilder"/> instance.</param>
+        /// <returns>A string that represents the current KeyRange.</returns>
+        public string ToString(SpannerConnectionStringBuilder builder) =>
+            new StringBuilder()
+                .Append(BeginInclusive ? '[' : '(')
+                .Append(BeginAt.ToString(builder))
+                .Append(", ")
+                .Append(End.ToString(builder))
+                .Append(EndInclusive ? ']' : ')')
+                .ToString();
 
-        /// <inheritdoc/>
-        public override int GetHashCode() => Protobuf.GetHashCode();
-
-        /// <inheritdoc/>
-        public override string ToString()
-        {
-            var builder = new StringBuilder();
-            builder.Append(BeginInclusive ? '[' : '(');
-            builder.Append(BeginAt.KeyParts);
-            builder.Append(", ");
-            builder.Append(End.KeyParts);
-            builder.Append(EndInclusive ? ']' : ')');
-
-            return builder.ToString();
-        }
-
-        private V1.KeyRange ToProtobuf()
+        internal V1.KeyRange ToProtobuf(SpannerConversionOptions options)
         {
             var range = new V1.KeyRange();
             if (BeginInclusive)
             {
-                range.StartClosed = BeginAt.KeyParts;
+                range.StartClosed = BeginAt.ToProtobuf(options);
             }
             else
             {
-                range.StartOpen = BeginAt.KeyParts;
+                range.StartOpen = BeginAt.ToProtobuf(options);
             }
 
             if (EndInclusive)
             {
-                range.EndClosed = End.KeyParts;
+                range.EndClosed = End.ToProtobuf(options);
             }
             else
             {
-                range.EndOpen = End.KeyParts;
+                range.EndOpen = End.ToProtobuf(options);
             }
             return range;
         }
@@ -275,51 +264,49 @@ namespace Google.Cloud.Spanner.Data
     /// </summary>
     public sealed class Key
     {
-        /// <summary>
-        /// The values of this key.
-        /// </summary>
-        internal ListValue KeyParts { get; }
+        internal SpannerParameterCollection Parameters { get; }
 
         /// <summary>
         /// Creates a key from the values in the parameter collection.
+        /// A reference to <paramref name="keyParts"/> is stored in this class so,
+        /// changes to the parameter collection will be visible when the key is used.
         /// </summary>
         /// <param name="keyParts">The values that define the key</param>
         internal Key(SpannerParameterCollection keyParts)
         {
-            KeyParts = ToListValue(keyParts);
+            Parameters = keyParts;
         }
 
         /// <summary>
         /// Creates a key consisting of the given key parts.
         /// </summary>
         /// <param name="keyParts">The values that define the key</param>
-        public Key(params object[] keyParts)
+        public Key(params object[] keyParts) : this(new SpannerParameterCollection(keyParts.Select(keyPart => new SpannerParameter { Value = keyPart })))
         {
-            var protobufValues = keyParts.Select(
-                v => SpannerDbType.FromClrType(v?.GetType())?.ToProtobufValue(v) ?? Value.ForNull());
-            KeyParts = new ListValue { Values = { protobufValues } };
         }
 
-        /// <inheritdoc/>
-        public override bool Equals(object other)
-            => other is Key key && KeyParts.Equals(key.KeyParts);
+        /// <summary>
+        /// Returns the string representation of this key using the type conversion options specified in 
+        /// <see cref="SpannerConnectionStringBuilder"/>. The string representation is only for diagnostic purposes
+        /// and the implementation may change over time.
+        /// </summary>
+        /// <param name="builder">The <see cref="SpannerConnectionStringBuilder"/> instance.</param>
+        /// <returns>A string that represents the current key.</returns>
+        public string ToString(SpannerConnectionStringBuilder builder) => ToProtobuf(builder.ConversionOptions).ToString();
 
-        /// <inheritdoc/>
-        public override int GetHashCode() => KeyParts.GetHashCode();
-
-        /// <inheritdoc/>
-        public override string ToString() => KeyParts.ToString();
-
-        private static ListValue ToListValue(SpannerParameterCollection parameters)
-        {
-            return new ListValue
+        /// <summary>
+        /// Converts this key to a protobuf value, with default type conversion options as supplied in <paramref name="options" />.
+        /// </summary>
+        /// <param name="options">The options for conversion between protobuf and CLR types.</param>
+        /// <returns>The values of this Key.</returns>
+        internal ListValue ToProtobuf(SpannerConversionOptions options) =>
+            new ListValue
             {
                 Values =
                 {
-                    parameters.Select(
-                        x => x.SpannerDbType.ToProtobufValue(x.GetValidatedValue()))
+                    Parameters.Select(
+                        x => x.GetConfiguredSpannerDbType(options).ToProtobufValue(x.GetValidatedValue()))
                 }
             };
-        }
     }
 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.ExecutableCommand.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.ExecutableCommand.cs
@@ -414,7 +414,7 @@ namespace Google.Cloud.Spanner.Data
                     Table = CommandTextBuilder.TargetTable,
                     Index = CommandTextBuilder.ReadOptions.IndexName ?? "",
                     Limit = CommandTextBuilder.ReadOptions.Limit ?? 0L,
-                    KeySet = KeySet.Protobuf,
+                    KeySet = KeySet.ToProtobuf(ConversionOptions),
                     Columns = { CommandTextBuilder.ReadOptions.Columns },
                     RequestOptions = BuildRequestOptions()
                 };


### PR DESCRIPTION
Draft Prototype PR for adding support of connection string options to Keys.

Fixed existing tests with backward compatible changes in ToString implementation.

Will write new tests once the main code is ok. 

There are a couple of TODOs to implement IEqualityComparer<T> for KeyRanges and if implementation of IEqualityComparer<T> should be in a new file.

Fixes #8541 