### PR TITLE
chore: Update Dockerfile for OwlBot to install .NET Core 3.1

### DIFF
--- a/owl-bot-post-processor/Dockerfile
+++ b/owl-bot-post-processor/Dockerfile
@@ -21,9 +21,17 @@
 FROM mcr.microsoft.com/dotnet/sdk:6.0-focal
 
 # Additional tooling required to regenerate.
+
+# Temporarily, install .NET Core 3.1 as well as .NET 6
+# This (and the apt-get install of dotnet-sdk-3.1) can
+# be removed when the generator is updated to use .NET 6
+RUN wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+RUN dpkg -i packages-microsoft-prod.deb
+
 RUN apt-get update
 RUN apt-get install -y unzip
 RUN apt-get install -y python3
+RUN apt-get install -y dotnet-sdk-3.1
 
 # Note: main.sh is not packed into the docker image.  This command
 # invokes the current main.sh in the repo.


### PR DESCRIPTION
This is required while the generator still uses .NET Core 3.1.
While we expect to update this soon, this temporary measure is the
smallest change that will get OwlBot working.