### PR TITLE
docs: Add TOC entry for GAX v4 breaking changes

### DIFF
--- a/docs/devsite-help/toc.yml
+++ b/docs/devsite-help/toc.yml
@@ -22,3 +22,5 @@
     href: cleanup.md
   - name: Versioning
     href: versioning.md
+  - name: GAX v4 breaking changes
+    href: breaking-gax4.md


### PR DESCRIPTION
Without this, it looks like the file isn't actually published on
cloud.google.com.