### PR TITLE
chore: Fix smoke tests

### DIFF
--- a/tools/Google.Cloud.Tools.ApiIndex.V1/Google.Cloud.Tools.ApiIndex.V1.csproj
+++ b/tools/Google.Cloud.Tools.ApiIndex.V1/Google.Cloud.Tools.ApiIndex.V1.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.19.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.21.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The production code depends on Google.Protobuf 3.21.0, and the API
Index tooling project dependency on 3.19.0 was causing failures.