### PR TITLE
Release Google.Cloud.BigQuery.V2 version 3.0.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0-alpha05</Version>
+    <Version>3.0.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery API. It wraps the Google.Apis.Bigquery.v2 client library, making common operations simpler in client code. BigQuery is a data platform for customers to create, manage, share and query data.</Description>

--- a/apis/Google.Cloud.BigQuery.V2/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.V2/docs/history.md
@@ -1,5 +1,38 @@
 # Version history
 
+## Version 3.0.0, released 2022-06-08
+
+This is the first version of this package to depend on GAX v4.
+
+There are some breaking changes, both in GAX v4 and in the generated
+code. The changes that aren't specific to any given API are [described in the Google Cloud
+documentation](https://cloud.google.com/dotnet/docs/reference/help/breaking-gax4).
+We don't anticipate any changes to most customer code, but please [file a
+GitHub issue](https://github.com/googleapis/google-cloud-dotnet/issues/new/choose)
+if you run into problems.
+
+The most important change in this release is the use of the Grpc.Net.Client package
+for gRPC communication, instead of Grpc.Core. When using .NET Core 3.1 or .NET 5.0+
+this should lead to a smaller installation footprint and greater compatibility (e.g.
+with Apple M1 chips). Any significant change in a core component comes with the risk
+of incompatibility, however - so again, please let us know if you encounter any
+issues.
+
+### Bug fixes
+
+- Numeric truncation. ([commit 13ae78a](https://github.com/googleapis/google-cloud-dotnet/commit/13ae78ae3234173745c985fb6264c36911de2f04))
+
+### New features
+
+- Add BigQueryJob.ThrowOnFatalError ([commit 788a4d0](https://github.com/googleapis/google-cloud-dotnet/commit/788a4d01dde3b34f2ca799a634f5d971d91828a5))
+  - The existing BigQueryJob.ThrowOnAnyError will throw an exception if
+    *any* errors are detected, even if the job goes on to complete
+    successfully. This can happen in a query job against an external
+    data source which has been configured to permit a certain number of
+    "bad" rows, for example. The new method is a convenient way of
+    throwing an exception for a genuinely-failed job, as indicated by the
+    JobStatus.ErrorResult
+    property.
 ## Version 2.4.0, released 2022-05-05
 
 GA release of the features previously in beta: support for BigNumeric, and more detailed exceptions.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -419,7 +419,7 @@
       "id": "Google.Cloud.BigQuery.V2",
       "productName": "Google BigQuery",
       "productUrl": "https://cloud.google.com/bigquery/",
-      "version": "3.0.0-alpha05",
+      "version": "3.0.0",
       "type": "rest",
       "description": "Recommended Google client library to access the BigQuery API. It wraps the Google.Apis.Bigquery.v2 client library, making common operations simpler in client code. BigQuery is a data platform for customers to create, manage, share and query data.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

This is the first version of this package to depend on GAX v4.

There are some breaking changes, both in GAX v4 and in the generated code. The changes that aren't specific to any given API are [described in the Google Cloud documentation](https://cloud.google.com/dotnet/docs/reference/help/breaking-gax4). We don't anticipate any changes to most customer code, but please [file a GitHub issue](https://github.com/googleapis/google-cloud-dotnet/issues/new/choose) if you run into problems.

The most important change in this release is the use of the Grpc.Net.Client package for gRPC communication, instead of Grpc.Core. When using .NET Core 3.1 or .NET 5.0+ this should lead to a smaller installation footprint and greater compatibility (e.g. with Apple M1 chips). Any significant change in a core component comes with the risk of incompatibility, however - so again, please let us know if you encounter any issues.

### Bug fixes

- Numeric truncation. ([commit 13ae78a](https://github.com/googleapis/google-cloud-dotnet/commit/13ae78ae3234173745c985fb6264c36911de2f04))

### New features

- Add BigQueryJob.ThrowOnFatalError ([commit 788a4d0](https://github.com/googleapis/google-cloud-dotnet/commit/788a4d01dde3b34f2ca799a634f5d971d91828a5))
  - The existing BigQueryJob.ThrowOnAnyError will throw an exception if
    *any* errors are detected, even if the job goes on to complete
    successfully. This can happen in a query job against an external
    data source which has been configured to permit a certain number of
    "bad" rows, for example. The new method is a convenient way of
    throwing an exception for a genuinely-failed job, as indicated by the
    JobStatus.ErrorResult
    property.
