### PR TITLE
Release Google.Cloud.Bigtable.Common.V2 version 3.0.0

### DIFF
--- a/apis/Google.Cloud.Bigtable.Common.V2/Google.Cloud.Bigtable.Common.V2/Google.Cloud.Bigtable.Common.V2.csproj
+++ b/apis/Google.Cloud.Bigtable.Common.V2/Google.Cloud.Bigtable.Common.V2/Google.Cloud.Bigtable.Common.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0-alpha05</Version>
+    <Version>3.0.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Common code used by Bigtable V2 APIs</Description>

--- a/apis/Google.Cloud.Bigtable.Common.V2/docs/history.md
+++ b/apis/Google.Cloud.Bigtable.Common.V2/docs/history.md
@@ -1,5 +1,27 @@
 # Version history
 
+## Version 3.0.0, released 2022-06-08
+
+This is the first version of this package to depend on GAX v4.
+
+There are some breaking changes, both in GAX v4 and in the generated
+code. The changes that aren't specific to any given API are [described in the Google Cloud
+documentation](https://cloud.google.com/dotnet/docs/reference/help/breaking-gax4).
+We don't anticipate any changes to most customer code, but please [file a
+GitHub issue](https://github.com/googleapis/google-cloud-dotnet/issues/new/choose)
+if you run into problems.
+
+The most important change in this release is the use of the Grpc.Net.Client package
+for gRPC communication, instead of Grpc.Core. When using .NET Core 3.1 or .NET 5.0+
+this should lead to a smaller installation footprint and greater compatibility (e.g.
+with Apple M1 chips). Any significant change in a core component comes with the risk
+of incompatibility, however - so again, please let us know if you encounter any
+issues.
+
+### Bigtable-specific breaking changes
+
+- Move InstanceName into Google.Cloud.Bigtable.Common.V2 ([commit cb8d93e](https://github.com/googleapis/google-cloud-dotnet/commit/cb8d93ebcc822c45361a1d756fdddf0d13fae051))
+  (Previously, this was in Google.Cloud.Bigtable.V2 and Google.Cloud.Bigtable.Admin.V2)
 ## Version 2.1.0, released 2021-05-25
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -484,7 +484,7 @@
       "id": "Google.Cloud.Bigtable.Common.V2",
       "type": "other",
       "targetFrameworks": "netstandard2.1;net462",
-      "version": "3.0.0-alpha05",
+      "version": "3.0.0",
       "description": "Common code used by Bigtable V2 APIs",
       "tags": [
         "Bigtable"


### PR DESCRIPTION

Changes in this release:

This is the first version of this package to depend on GAX v4.

There are some breaking changes, both in GAX v4 and in the generated code. The changes that aren't specific to any given API are [described in the Google Cloud documentation](https://cloud.google.com/dotnet/docs/reference/help/breaking-gax4). We don't anticipate any changes to most customer code, but please [file a GitHub issue](https://github.com/googleapis/google-cloud-dotnet/issues/new/choose) if you run into problems.

The most important change in this release is the use of the Grpc.Net.Client package for gRPC communication, instead of Grpc.Core. When using .NET Core 3.1 or .NET 5.0+ this should lead to a smaller installation footprint and greater compatibility (e.g. with Apple M1 chips). Any significant change in a core component comes with the risk of incompatibility, however - so again, please let us know if you encounter any issues.

### Bigtable-specific breaking changes

- Move InstanceName into Google.Cloud.Bigtable.Common.V2 ([commit cb8d93e](https://github.com/googleapis/google-cloud-dotnet/commit/cb8d93ebcc822c45361a1d756fdddf0d13fae051))
  (Previously, this was in Google.Cloud.Bigtable.V2 and Google.Cloud.Bigtable.Admin.V2)
