### PR TITLE
Release Google.Cloud.RecaptchaEnterprise.V1 version 2.0.0

### DIFF
--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.csproj
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha05</Version>
+    <Version>2.0.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud reCAPTCHA for Enterprise API v1.</Description>

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/docs/history.md
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/docs/history.md
@@ -1,5 +1,33 @@
 # Version history
 
+## Version 2.0.0, released 2022-06-08
+
+This is the first version of this package to depend on GAX v4.
+
+There are some breaking changes, both in GAX v4 and in the generated
+code. The changes that aren't specific to any given API are [described in the Google Cloud
+documentation](https://cloud.google.com/dotnet/docs/reference/help/breaking-gax4).
+We don't anticipate any changes to most customer code, but please [file a
+GitHub issue](https://github.com/googleapis/google-cloud-dotnet/issues/new/choose)
+if you run into problems.
+
+The most important change in this release is the use of the Grpc.Net.Client package
+for gRPC communication, instead of Grpc.Core. When using .NET Core 3.1 or .NET 5.0+
+this should lead to a smaller installation footprint and greater compatibility (e.g.
+with Apple M1 chips). Any significant change in a core component comes with the risk
+of incompatibility, however - so again, please let us know if you encounter any
+issues.
+
+
+### API-specific breaking change
+
+- Rename parent to project in SearchRelatedAccountGroupMembershipsRequest ([commit 4ff737b](https://github.com/googleapis/google-cloud-dotnet/commit/4ff737b1dbfb31525c0632419cd3799f4fa1bd1c))
+
+### New features
+
+- Add support for Password Check through the private_password_leak_verification field in the reCAPTCHA Assessment ([commit eee8397](https://github.com/googleapis/google-cloud-dotnet/commit/eee8397500f513afcdd3565b1ed8d4bfe8301554))
+- Introduced WafSettings ([commit 4ff737b](https://github.com/googleapis/google-cloud-dotnet/commit/4ff737b1dbfb31525c0632419cd3799f4fa1bd1c))
+
 ## Version 1.6.0, released 2021-12-07
 
 - [Commit 308c733](https://github.com/googleapis/google-cloud-dotnet/commit/308c733): feat: add new reCAPTCHA Enterprise fraud annotations

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2563,7 +2563,7 @@
       "protoPath": "google/cloud/recaptchaenterprise/v1",
       "productName": "Google Cloud reCAPTCHA Enterprise",
       "productUrl": "https://cloud.google.com/recaptcha-enterprise/",
-      "version": "2.0.0-alpha05",
+      "version": "2.0.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud reCAPTCHA for Enterprise API v1.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

This is the first version of this package to depend on GAX v4.

There are some breaking changes, both in GAX v4 and in the generated code. The changes that aren't specific to any given API are [described in the Google Cloud documentation](https://cloud.google.com/dotnet/docs/reference/help/breaking-gax4). We don't anticipate any changes to most customer code, but please [file a GitHub issue](https://github.com/googleapis/google-cloud-dotnet/issues/new/choose) if you run into problems.

The most important change in this release is the use of the Grpc.Net.Client package for gRPC communication, instead of Grpc.Core. When using .NET Core 3.1 or .NET 5.0+ this should lead to a smaller installation footprint and greater compatibility (e.g. with Apple M1 chips). Any significant change in a core component comes with the risk of incompatibility, however - so again, please let us know if you encounter any issues.

### API-specific breaking change

- Rename parent to project in SearchRelatedAccountGroupMembershipsRequest ([commit 4ff737b](https://github.com/googleapis/google-cloud-dotnet/commit/4ff737b1dbfb31525c0632419cd3799f4fa1bd1c))

### New features

- Add support for Password Check through the private_password_leak_verification field in the reCAPTCHA Assessment ([commit eee8397](https://github.com/googleapis/google-cloud-dotnet/commit/eee8397500f513afcdd3565b1ed8d4bfe8301554))
- Introduced WafSettings ([commit 4ff737b](https://github.com/googleapis/google-cloud-dotnet/commit/4ff737b1dbfb31525c0632419cd3799f4fa1bd1c))
