### PR TITLE
tools: Allow a default message to be specified in batch release

### DIFF
--- a/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/BatchReleaseCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/BatchReleaseCommand.cs
@@ -57,7 +57,8 @@ namespace Google.Cloud.Tools.ReleaseManager.BatchRelease
                 config.PostMajorVersion
                 ? (id, sv) => sv.AfterMajorVersion(id)
                 : (id, sv) => sv.AfterIncrement();
-            var proposals = criterion.GetProposals(catalog, versionIncrementer);
+            string defaultMessage = config.DefaultHistoryMessageFile is null ? null : File.ReadAllText(config.DefaultHistoryMessageFile);
+            var proposals = criterion.GetProposals(catalog, versionIncrementer, defaultMessage);
 
             foreach (var proposal in proposals)
             {

--- a/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/BatchReleaseConfig.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/BatchReleaseConfig.cs
@@ -71,6 +71,12 @@ namespace Google.Cloud.Tools.ReleaseManager.BatchRelease
         /// </remarks>
         public bool PostMajorVersion { get; set; }
 
+        /// <summary>
+        /// Path to a file containing a default history message, for APIs that don't have any other
+        /// notable changes. (If not specified, the normal "just dependencies" will be used.)
+        /// </summary>
+        public string DefaultHistoryMessageFile { get; set; }
+
         internal IEnumerable<IBatchCriterion> GetCriteria()
         {
             if (KnownCommits is object)

--- a/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/IBatchCriterion.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/IBatchCriterion.cs
@@ -23,6 +23,6 @@ namespace Google.Cloud.Tools.ReleaseManager.BatchRelease
         /// <summary>
         /// Returns the proposed releases for all APIs in the catalog
         /// </summary>
-        IEnumerable<ReleaseProposal> GetProposals(ApiCatalog catalog, Func<string, StructuredVersion, StructuredVersion> versionIncrementer);
+        IEnumerable<ReleaseProposal> GetProposals(ApiCatalog catalog, Func<string, StructuredVersion, StructuredVersion> versionIncrementer, string defaultMessage);
     }
 }

--- a/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/KnownCommitsCriterion.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/KnownCommitsCriterion.cs
@@ -35,7 +35,7 @@ namespace Google.Cloud.Tools.ReleaseManager.BatchRelease
         /// </summary>
         public HashSet<string> Commits { get; set; }
 
-        IEnumerable<ReleaseProposal> IBatchCriterion.GetProposals(ApiCatalog catalog, Func<string, StructuredVersion, StructuredVersion> versionIncrementer)
+        IEnumerable<ReleaseProposal> IBatchCriterion.GetProposals(ApiCatalog catalog, Func<string, StructuredVersion, StructuredVersion> versionIncrementer, string defaultMessage)
         {
             var root = DirectoryLayout.DetermineRootDirectory();
             using var repo = new Repository(root);
@@ -50,7 +50,7 @@ namespace Google.Cloud.Tools.ReleaseManager.BatchRelease
                     continue;
                 }
                 var newVersion = versionIncrementer(api.Id, api.StructuredVersion);
-                var proposal = ReleaseProposal.CreateFromHistory(repo, api.Id, newVersion);
+                var proposal = ReleaseProposal.CreateFromHistory(repo, api.Id, newVersion, defaultMessage);
 
                 // Potentially replace the natural history with an override
                 if (!string.IsNullOrEmpty(HistoryOverride) && proposal.NewHistorySection is HistoryFile.Section newSection)

--- a/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/ReleaseAllCriterion.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/ReleaseAllCriterion.cs
@@ -25,7 +25,7 @@ namespace Google.Cloud.Tools.ReleaseManager.BatchRelease
     /// </summary>
     public sealed class ReleaseAllCriterion : IBatchCriterion
     {
-        IEnumerable<ReleaseProposal> IBatchCriterion.GetProposals(ApiCatalog catalog, Func<string, StructuredVersion, StructuredVersion> versionIncrementer)
+        IEnumerable<ReleaseProposal> IBatchCriterion.GetProposals(ApiCatalog catalog, Func<string, StructuredVersion, StructuredVersion> versionIncrementer, string defaultMessage)
         {
             var root = DirectoryLayout.DetermineRootDirectory();
             using var repo = new Repository(root);
@@ -48,7 +48,7 @@ namespace Google.Cloud.Tools.ReleaseManager.BatchRelease
                 }
                 var newVersion = versionIncrementer(api.Id, api.StructuredVersion);
 
-                yield return ReleaseProposal.CreateFromHistory(repo, api.Id, newVersion);
+                yield return ReleaseProposal.CreateFromHistory(repo, api.Id, newVersion, defaultMessage);
             }
         }
     }

--- a/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/ReleaseProposal.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/ReleaseProposal.cs
@@ -58,7 +58,7 @@ namespace Google.Cloud.Tools.ReleaseManager.BatchRelease
         private ReleaseProposal(ApiMetadata api, StructuredVersion oldVersion, StructuredVersion newVersion, HistoryFile historyFile) =>
             (this.api, OldVersion, NewVersion, ModifiedHistoryFile) = (api, oldVersion, newVersion, historyFile);
 
-        public static ReleaseProposal CreateFromHistory(Repository repo, string id, StructuredVersion newVersion)
+        public static ReleaseProposal CreateFromHistory(Repository repo, string id, StructuredVersion newVersion, string defaultMessage)
         {
             var catalog = ApiCatalog.Load();
             var api = catalog[id];
@@ -69,7 +69,7 @@ namespace Google.Cloud.Tools.ReleaseManager.BatchRelease
             var historyFile = HistoryFile.Load(historyFilePath);
             if (!api.NoVersionHistory)
             {
-                var sectionsInserted = historyFile.MergeReleases(releases);
+                var sectionsInserted = historyFile.MergeReleases(releases, defaultMessage);
                 if (sectionsInserted.Count != 1)
                 {
                     throw new UserErrorException($"API {api.Id} would have {sectionsInserted.Count} new history sections");

--- a/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/SpecifiedApisCriterion.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/SpecifiedApisCriterion.cs
@@ -28,7 +28,7 @@ namespace Google.Cloud.Tools.ReleaseManager.BatchRelease
             _apis = new HashSet<string>(apis);
         }
 
-        public IEnumerable<ReleaseProposal> GetProposals(ApiCatalog catalog, Func<string, StructuredVersion, StructuredVersion> versionIncrementer)
+        public IEnumerable<ReleaseProposal> GetProposals(ApiCatalog catalog, Func<string, StructuredVersion, StructuredVersion> versionIncrementer, string defaultMessage)
         {
             var root = DirectoryLayout.DetermineRootDirectory();
             using var repo = new Repository(root);
@@ -41,7 +41,7 @@ namespace Google.Cloud.Tools.ReleaseManager.BatchRelease
                 }
                 var newVersion = versionIncrementer(api.Id, api.StructuredVersion);
 
-                yield return ReleaseProposal.CreateFromHistory(repo, api.Id, newVersion);
+                yield return ReleaseProposal.CreateFromHistory(repo, api.Id, newVersion, defaultMessage);
             }
         }
     }

--- a/tools/Google.Cloud.Tools.ReleaseManager/UpdateHistoryCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/UpdateHistoryCommand.cs
@@ -16,7 +16,6 @@ using Google.Cloud.Tools.Common;
 using Google.Cloud.Tools.ReleaseManager.History;
 using LibGit2Sharp;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
@@ -59,7 +58,7 @@ namespace Google.Cloud.Tools.ReleaseManager
             using var repo = new Repository(root);
             var releases = Release.LoadReleases(repo, catalog, api).ToList();
             var historyFile = HistoryFile.Load(historyFilePath);
-            var sectionsInserted = historyFile.MergeReleases(releases);
+            var sectionsInserted = historyFile.MergeReleases(releases, defaultMessage: null);
             if (sectionsInserted.Count != 0)
             {
                 historyFile.Save(historyFilePath);


### PR DESCRIPTION
The "default default" message is just "No API surface changes; just
dependency updates" but for new major versions (or similar) that's
not as useful as a canned message.