### PR TITLE
Release Google.Cloud.AIPlatform.V1 version 2.0.0

### DIFF
--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha05</Version>
+    <Version>2.0.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AI Platform API, which allows you to train high-quality custom machine learning models with minimal machine learning expertise and effort.</Description>

--- a/apis/Google.Cloud.AIPlatform.V1/docs/history.md
+++ b/apis/Google.Cloud.AIPlatform.V1/docs/history.md
@@ -1,5 +1,31 @@
 # Version history
 
+## Version 2.0.0, released 2022-06-08
+
+This is the first version of this package to depend on GAX v4.
+
+There are some breaking changes, both in GAX v4 and in the generated
+code. The changes that aren't specific to any given API are [described in the Google Cloud
+documentation](https://cloud.google.com/dotnet/docs/reference/help/breaking-gax4).
+We don't anticipate any changes to most customer code, but please [file a
+GitHub issue](https://github.com/googleapis/google-cloud-dotnet/issues/new/choose)
+if you run into problems.
+
+The most important change in this release is the use of the Grpc.Net.Client package
+for gRPC communication, instead of Grpc.Core. When using .NET Core 3.1 or .NET 5.0+
+this should lead to a smaller installation footprint and greater compatibility (e.g.
+with Apple M1 chips). Any significant change in a core component comes with the risk
+of incompatibility, however - so again, please let us know if you encounter any
+issues.
+
+### New features also in this release
+
+- Add monitor_window to ModelDeploymentMonitoringScheduleConfig proto in aiplatform v1/v1beta1 model_deployment_monitoring_job.proto ([commit 4a6d865](https://github.com/googleapis/google-cloud-dotnet/commit/4a6d865f55d52f480e4d5f792d0ff3bf0b68b620))
+- Add failure_policy to PipelineJob in aiplatform v1 & v1beta1 pipeline_job.proto ([commit 660482a](https://github.com/googleapis/google-cloud-dotnet/commit/660482a467778c562889b98c382edfaded70446c))
+- Add latent_space_source to ExplanationMetadata in aiplatform v1 explanation_metadata.proto ([commit ce1e55d](https://github.com/googleapis/google-cloud-dotnet/commit/ce1e55d51e8e8837f572b470001a6772db87ddab))
+- Add scaling to OnlineServingConfig in aiplatform v1 featurestore.proto ([commit ce1e55d](https://github.com/googleapis/google-cloud-dotnet/commit/ce1e55d51e8e8837f572b470001a6772db87ddab))
+- Add template_metadata to PipelineJob in aiplatform v1 pipeline_job.proto ([commit ce1e55d](https://github.com/googleapis/google-cloud-dotnet/commit/ce1e55d51e8e8837f572b470001a6772db87ddab))
+
 ## Version 1.8.0, released 2022-05-24
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -105,7 +105,7 @@
     },
     {
       "id": "Google.Cloud.AIPlatform.V1",
-      "version": "2.0.0-alpha05",
+      "version": "2.0.0",
       "type": "grpc",
       "productName": "Cloud AI Platform",
       "productUrl": "https://cloud.google.com/ai-platform/docs/",


### PR DESCRIPTION

Changes in this release:

This is the first version of this package to depend on GAX v4.

There are some breaking changes, both in GAX v4 and in the generated code. The changes that aren't specific to any given API are [described in the Google Cloud documentation](https://cloud.google.com/dotnet/docs/reference/help/breaking-gax4). We don't anticipate any changes to most customer code, but please [file a GitHub issue](https://github.com/googleapis/google-cloud-dotnet/issues/new/choose) if you run into problems.

The most important change in this release is the use of the Grpc.Net.Client package for gRPC communication, instead of Grpc.Core. When using .NET Core 3.1 or .NET 5.0+ this should lead to a smaller installation footprint and greater compatibility (e.g. with Apple M1 chips). Any significant change in a core component comes with the risk of incompatibility, however - so again, please let us know if you encounter any issues.

### New features also in this release

- Add monitor_window to ModelDeploymentMonitoringScheduleConfig proto in aiplatform v1/v1beta1 model_deployment_monitoring_job.proto ([commit 4a6d865](https://github.com/googleapis/google-cloud-dotnet/commit/4a6d865f55d52f480e4d5f792d0ff3bf0b68b620))
- Add failure_policy to PipelineJob in aiplatform v1 & v1beta1 pipeline_job.proto ([commit 660482a](https://github.com/googleapis/google-cloud-dotnet/commit/660482a467778c562889b98c382edfaded70446c))
- Add latent_space_source to ExplanationMetadata in aiplatform v1 explanation_metadata.proto ([commit ce1e55d](https://github.com/googleapis/google-cloud-dotnet/commit/ce1e55d51e8e8837f572b470001a6772db87ddab))
- Add scaling to OnlineServingConfig in aiplatform v1 featurestore.proto ([commit ce1e55d](https://github.com/googleapis/google-cloud-dotnet/commit/ce1e55d51e8e8837f572b470001a6772db87ddab))
- Add template_metadata to PipelineJob in aiplatform v1 pipeline_job.proto ([commit ce1e55d](https://github.com/googleapis/google-cloud-dotnet/commit/ce1e55d51e8e8837f572b470001a6772db87ddab))
