### PR TITLE
Release Google.Cloud.Datastore.Admin.V1 version 2.0.0

### DIFF
--- a/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.csproj
+++ b/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha05</Version>
+    <Version>2.0.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Datastore Admin API. This accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.</Description>

--- a/apis/Google.Cloud.Datastore.Admin.V1/docs/history.md
+++ b/apis/Google.Cloud.Datastore.Admin.V1/docs/history.md
@@ -1,5 +1,31 @@
 # Version history
 
+## Version 2.0.0, released 2022-06-08
+
+This is the first version of this package to depend on GAX v4.
+
+There are some breaking changes, both in GAX v4 and in the generated
+code. The changes that aren't specific to any given API are [described in the Google Cloud
+documentation](https://cloud.google.com/dotnet/docs/reference/help/breaking-gax4).
+We don't anticipate any changes to most customer code, but please [file a
+GitHub issue](https://github.com/googleapis/google-cloud-dotnet/issues/new/choose)
+if you run into problems.
+
+The most important change in this release is the use of the Grpc.Net.Client package
+for gRPC communication, instead of Grpc.Core. When using .NET Core 3.1 or .NET 5.0+
+this should lead to a smaller installation footprint and greater compatibility (e.g.
+with Apple M1 chips). Any significant change in a core component comes with the risk
+of incompatibility, however - so again, please let us know if you encounter any
+issues.
+
+### New features
+
+- New enum value `OPTIMISTIC_WITH_ENTITY_GROUPS` for `ConcurrencyMode` ([commit 20717a1](https://github.com/googleapis/google-cloud-dotnet/commit/20717a1d76222e984e7f32ac12016b78cc99b435))
+
+### Documentation improvements
+
+- Clarifications for `DatastoreFirestoreMigraitonMetadata` ([commit 20717a1](https://github.com/googleapis/google-cloud-dotnet/commit/20717a1d76222e984e7f32ac12016b78cc99b435))
+
 ## Version 1.4.0, released 2022-01-17
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -919,7 +919,7 @@
     },
     {
       "id": "Google.Cloud.Datastore.Admin.V1",
-      "version": "2.0.0-alpha05",
+      "version": "2.0.0",
       "type": "grpc",
       "productName": "Cloud Datastore",
       "description": "Recommended Google client library to access the Google Cloud Datastore Admin API. This accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.",


### PR DESCRIPTION

Changes in this release:

This is the first version of this package to depend on GAX v4.

There are some breaking changes, both in GAX v4 and in the generated code. The changes that aren't specific to any given API are [described in the Google Cloud documentation](https://cloud.google.com/dotnet/docs/reference/help/breaking-gax4). We don't anticipate any changes to most customer code, but please [file a GitHub issue](https://github.com/googleapis/google-cloud-dotnet/issues/new/choose) if you run into problems.

The most important change in this release is the use of the Grpc.Net.Client package for gRPC communication, instead of Grpc.Core. When using .NET Core 3.1 or .NET 5.0+ this should lead to a smaller installation footprint and greater compatibility (e.g. with Apple M1 chips). Any significant change in a core component comes with the risk of incompatibility, however - so again, please let us know if you encounter any issues.

### New features

- New enum value `OPTIMISTIC_WITH_ENTITY_GROUPS` for `ConcurrencyMode` ([commit 20717a1](https://github.com/googleapis/google-cloud-dotnet/commit/20717a1d76222e984e7f32ac12016b78cc99b435))

### Documentation improvements

- Clarifications for `DatastoreFirestoreMigraitonMetadata` ([commit 20717a1](https://github.com/googleapis/google-cloud-dotnet/commit/20717a1d76222e984e7f32ac12016b78cc99b435))
