### PR TITLE
Release Google.Cloud.Dialogflow.V2 version 4.0.0

### DIFF
--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.csproj
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.0.0-alpha05</Version>
+    <Version>4.0.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Dialogflow API.</Description>

--- a/apis/Google.Cloud.Dialogflow.V2/docs/history.md
+++ b/apis/Google.Cloud.Dialogflow.V2/docs/history.md
@@ -1,5 +1,32 @@
 # Version history
 
+## Version 4.0.0, released 2022-06-08
+
+This is the first version of this package to depend on GAX v4.
+
+There are some breaking changes, both in GAX v4 and in the generated
+code. The changes that aren't specific to any given API are [described in the Google Cloud
+documentation](https://cloud.google.com/dotnet/docs/reference/help/breaking-gax4).
+We don't anticipate any changes to most customer code, but please [file a
+GitHub issue](https://github.com/googleapis/google-cloud-dotnet/issues/new/choose)
+if you run into problems.
+
+The most important change in this release is the use of the Grpc.Net.Client package
+for gRPC communication, instead of Grpc.Core. When using .NET Core 3.1 or .NET 5.0+
+this should lead to a smaller installation footprint and greater compatibility (e.g.
+with Apple M1 chips). Any significant change in a core component comes with the risk
+of incompatibility, however - so again, please let us know if you encounter any
+issues.
+
+### API-specific Breaking changes
+
+- Correct broken ConversationModelEvaluation resource pattern ([commit 52734a8](https://github.com/googleapis/google-cloud-dotnet/commit/52734a83d8a941fc01978bffe260ea60bbbd27fb))
+
+### Documentation improvements
+
+- Add the fields for setting CX virtual agent session parameters ([commit f697491](https://github.com/googleapis/google-cloud-dotnet/commit/f69749149a6c84e32e18a50aacbc3b7ad838774f))
+- Added explanation for SuggestionResult ([commit 15b7174](https://github.com/googleapis/google-cloud-dotnet/commit/15b717491e9a3458e4b396e472a3503e49acf150))
+
 ## Version 3.11.0, released 2022-03-14
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1169,7 +1169,7 @@
       "protoPath": "google/cloud/dialogflow/v2",
       "productName": "Google Cloud Dialogflow",
       "productUrl": "https://cloud.google.com/dialogflow-enterprise/",
-      "version": "4.0.0-alpha05",
+      "version": "4.0.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Dialogflow API.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

This is the first version of this package to depend on GAX v4.

There are some breaking changes, both in GAX v4 and in the generated code. The changes that aren't specific to any given API are [described in the Google Cloud documentation](https://cloud.google.com/dotnet/docs/reference/help/breaking-gax4). We don't anticipate any changes to most customer code, but please [file a GitHub issue](https://github.com/googleapis/google-cloud-dotnet/issues/new/choose) if you run into problems.

The most important change in this release is the use of the Grpc.Net.Client package for gRPC communication, instead of Grpc.Core. When using .NET Core 3.1 or .NET 5.0+ this should lead to a smaller installation footprint and greater compatibility (e.g. with Apple M1 chips). Any significant change in a core component comes with the risk of incompatibility, however - so again, please let us know if you encounter any issues.

### API-specific Breaking changes

- Correct broken ConversationModelEvaluation resource pattern ([commit 52734a8](https://github.com/googleapis/google-cloud-dotnet/commit/52734a83d8a941fc01978bffe260ea60bbbd27fb))

### Documentation improvements

- Add the fields for setting CX virtual agent session parameters ([commit f697491](https://github.com/googleapis/google-cloud-dotnet/commit/f69749149a6c84e32e18a50aacbc3b7ad838774f))
- Added explanation for SuggestionResult ([commit 15b7174](https://github.com/googleapis/google-cloud-dotnet/commit/15b717491e9a3458e4b396e472a3503e49acf150))
