### PR TITLE
Release Google.Cloud.GkeHub.V1Beta1 version 2.0.0-beta01

### DIFF
--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.csproj
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha05</Version>
+    <Version>2.0.0-beta01</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the GKE Hub API, version v1beta1.</Description>

--- a/apis/Google.Cloud.GkeHub.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/docs/history.md
@@ -1,5 +1,33 @@
 # Version history
 
+## Version 2.0.0-beta01, released 2022-06-08
+
+This is the first version of this package to depend on GAX v4.
+
+There are some breaking changes, both in GAX v4 and in the generated
+code. The changes that aren't specific to any given API are [described in the Google Cloud
+documentation](https://cloud.google.com/dotnet/docs/reference/help/breaking-gax4).
+We don't anticipate any changes to most customer code, but please [file a
+GitHub issue](https://github.com/googleapis/google-cloud-dotnet/issues/new/choose)
+if you run into problems.
+
+The most important change in this release is the use of the Grpc.Net.Client package
+for gRPC communication, instead of Grpc.Core. When using .NET Core 3.1 or .NET 5.0+
+this should lead to a smaller installation footprint and greater compatibility (e.g.
+with Apple M1 chips). Any significant change in a core component comes with the risk
+of incompatibility, however - so again, please let us know if you encounter any
+issues.
+
+### New features
+
+- Add EdgeCluster as a new membershipEndpoint type ([commit d4f5e63](https://github.com/googleapis/google-cloud-dotnet/commit/d4f5e636b90f2bf01f1ee45d54e2ecf513976b2e))
+- Add ApplianceCluster as a new membershipEndpoint type ([commit d4f5e63](https://github.com/googleapis/google-cloud-dotnet/commit/d4f5e636b90f2bf01f1ee45d54e2ecf513976b2e))
+- Add API annotations ([commit d4f5e63](https://github.com/googleapis/google-cloud-dotnet/commit/d4f5e636b90f2bf01f1ee45d54e2ecf513976b2e))
+
+### Documentation improvements
+
+- Minor changes on code and doc format ([commit d4f5e63](https://github.com/googleapis/google-cloud-dotnet/commit/d4f5e636b90f2bf01f1ee45d54e2ecf513976b2e))
+
 ## Version 1.0.0-beta04, released 2022-02-28
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1595,7 +1595,7 @@
     },
     {
       "id": "Google.Cloud.GkeHub.V1Beta1",
-      "version": "2.0.0-alpha05",
+      "version": "2.0.0-beta01",
       "type": "grpc",
       "productName": "GKE Hub",
       "productUrl": "https://cloud.google.com/anthos/multicluster-management/connect/registering-a-cluster",


### PR DESCRIPTION

Changes in this release:

This is the first version of this package to depend on GAX v4.

There are some breaking changes, both in GAX v4 and in the generated code. The changes that aren't specific to any given API are [described in the Google Cloud documentation](https://cloud.google.com/dotnet/docs/reference/help/breaking-gax4). We don't anticipate any changes to most customer code, but please [file a GitHub issue](https://github.com/googleapis/google-cloud-dotnet/issues/new/choose) if you run into problems.

The most important change in this release is the use of the Grpc.Net.Client package for gRPC communication, instead of Grpc.Core. When using .NET Core 3.1 or .NET 5.0+ this should lead to a smaller installation footprint and greater compatibility (e.g. with Apple M1 chips). Any significant change in a core component comes with the risk of incompatibility, however - so again, please let us know if you encounter any issues.

### New features

- Add EdgeCluster as a new membershipEndpoint type ([commit d4f5e63](https://github.com/googleapis/google-cloud-dotnet/commit/d4f5e636b90f2bf01f1ee45d54e2ecf513976b2e))
- Add ApplianceCluster as a new membershipEndpoint type ([commit d4f5e63](https://github.com/googleapis/google-cloud-dotnet/commit/d4f5e636b90f2bf01f1ee45d54e2ecf513976b2e))
- Add API annotations ([commit d4f5e63](https://github.com/googleapis/google-cloud-dotnet/commit/d4f5e636b90f2bf01f1ee45d54e2ecf513976b2e))

### Documentation improvements

- Minor changes on code and doc format ([commit d4f5e63](https://github.com/googleapis/google-cloud-dotnet/commit/d4f5e636b90f2bf01f1ee45d54e2ecf513976b2e))
