### PR TITLE
Release Google.Cloud.Ids.V1 version 2.0.0

### DIFF
--- a/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.csproj
+++ b/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha05</Version>
+    <Version>2.0.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud IDS API. Cloud IDS (Cloud Intrusion Detection System) detects malware, spyware, command-and-control attacks, and other network-based threats.</Description>

--- a/apis/Google.Cloud.Ids.V1/docs/history.md
+++ b/apis/Google.Cloud.Ids.V1/docs/history.md
@@ -1,5 +1,24 @@
 # Version history
 
+## Version 2.0.0, released 2022-06-08
+
+This is the first version of this package to depend on GAX v4.
+
+There are some breaking changes, both in GAX v4 and in the generated
+code. The changes that aren't specific to any given API are [described in the Google Cloud
+documentation](https://cloud.google.com/dotnet/docs/reference/help/breaking-gax4).
+We don't anticipate any changes to most customer code, but please [file a
+GitHub issue](https://github.com/googleapis/google-cloud-dotnet/issues/new/choose)
+if you run into problems.
+
+The most important change in this release is the use of the Grpc.Net.Client package
+for gRPC communication, instead of Grpc.Core. When using .NET Core 3.1 or .NET 5.0+
+this should lead to a smaller installation footprint and greater compatibility (e.g.
+with Apple M1 chips). Any significant change in a core component comes with the risk
+of incompatibility, however - so again, please let us know if you encounter any
+issues.
+
+
 ## Version 1.0.0, released 2022-01-25
 
 No API surface changes; just dependency updates and promotion to 1.0.0.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1751,7 +1751,7 @@
     },
     {
       "id": "Google.Cloud.Ids.V1",
-      "version": "2.0.0-alpha05",
+      "version": "2.0.0",
       "type": "grpc",
       "productName": "Cloud IDS",
       "productUrl": "https://cloud.google.com/intrusion-detection-system",


### PR DESCRIPTION

Changes in this release:

This is the first version of this package to depend on GAX v4.

There are some breaking changes, both in GAX v4 and in the generated code. The changes that aren't specific to any given API are [described in the Google Cloud documentation](https://cloud.google.com/dotnet/docs/reference/help/breaking-gax4). We don't anticipate any changes to most customer code, but please [file a GitHub issue](https://github.com/googleapis/google-cloud-dotnet/issues/new/choose) if you run into problems.

The most important change in this release is the use of the Grpc.Net.Client package for gRPC communication, instead of Grpc.Core. When using .NET Core 3.1 or .NET 5.0+ this should lead to a smaller installation footprint and greater compatibility (e.g. with Apple M1 chips). Any significant change in a core component comes with the risk of incompatibility, however - so again, please let us know if you encounter any issues.
