### PR TITLE
Release Google.Cloud.SecurityCenter.V1P1Beta1 version 3.0.0-beta01

### DIFF
--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.csproj
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0-alpha05</Version>
+    <Version>3.0.0-beta01</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Security Command Center API version v1p1beta1, which helps security teams gather data, identify threats, and act on them before they result in business damage or loss.</Description>

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/docs/history.md
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/docs/history.md
@@ -1,5 +1,24 @@
 # Version history
 
+## Version 3.0.0-beta01, released 2022-06-08
+
+This is the first version of this package to depend on GAX v4.
+
+There are some breaking changes, both in GAX v4 and in the generated
+code. The changes that aren't specific to any given API are [described in the Google Cloud
+documentation](https://cloud.google.com/dotnet/docs/reference/help/breaking-gax4).
+We don't anticipate any changes to most customer code, but please [file a
+GitHub issue](https://github.com/googleapis/google-cloud-dotnet/issues/new/choose)
+if you run into problems.
+
+The most important change in this release is the use of the Grpc.Net.Client package
+for gRPC communication, instead of Grpc.Core. When using .NET Core 3.1 or .NET 5.0+
+this should lead to a smaller installation footprint and greater compatibility (e.g.
+with Apple M1 chips). Any significant change in a core component comes with the risk
+of incompatibility, however - so again, please let us know if you encounter any
+issues.
+
+
 ## Version 2.0.0-beta07, released 2021-12-07
 
 - [Commit 8598bf5](https://github.com/googleapis/google-cloud-dotnet/commit/8598bf5): docs: fix docstring formatting

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2910,7 +2910,7 @@
       "protoPath": "google/cloud/securitycenter/v1p1beta1",
       "productName": "Google Cloud Security Command Center",
       "productUrl": "https://cloud.google.com/security-command-center/",
-      "version": "3.0.0-alpha05",
+      "version": "3.0.0-beta01",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Security Command Center API version v1p1beta1, which helps security teams gather data, identify threats, and act on them before they result in business damage or loss.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

This is the first version of this package to depend on GAX v4.

There are some breaking changes, both in GAX v4 and in the generated code. The changes that aren't specific to any given API are [described in the Google Cloud documentation](https://cloud.google.com/dotnet/docs/reference/help/breaking-gax4). We don't anticipate any changes to most customer code, but please [file a GitHub issue](https://github.com/googleapis/google-cloud-dotnet/issues/new/choose) if you run into problems.

The most important change in this release is the use of the Grpc.Net.Client package for gRPC communication, instead of Grpc.Core. When using .NET Core 3.1 or .NET 5.0+ this should lead to a smaller installation footprint and greater compatibility (e.g. with Apple M1 chips). Any significant change in a core component comes with the risk of incompatibility, however - so again, please let us know if you encounter any issues.
