### PR TITLE
Release Google.Cloud.Logging.Console version 1.0.0-beta01

### DIFF
--- a/apis/Google.Cloud.Logging.Console/Google.Cloud.Logging.Console/Google.Cloud.Logging.Console.csproj
+++ b/apis/Google.Cloud.Logging.Console/Google.Cloud.Logging.Console/Google.Cloud.Logging.Console.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha05</Version>
+    <Version>1.0.0-beta01</Version>
     <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>ConsoleFormatter for Google Cloud Logging.</Description>

--- a/apis/Google.Cloud.Logging.Console/docs/history.md
+++ b/apis/Google.Cloud.Logging.Console/docs/history.md
@@ -1,0 +1,5 @@
+# Version history
+
+## Version 1.0.0-beta01, released 2022-06-09
+
+Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1899,7 +1899,7 @@
     },
     {
       "id": "Google.Cloud.Logging.Console",
-      "version": "2.0.0-alpha05",
+      "version": "1.0.0-beta01",
       "releaseLevelOverride": "unreleased",
       "type": "other",
       "metadataType": "INTEGRATION",


### PR DESCRIPTION

Changes in this release:

Initial release.
