### PR TITLE
Prototype of what CloudEvent integration might look like

### DIFF
--- a/apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1.Snippets/Google.Cloud.Eventarc.Publishing.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1.Snippets/Google.Cloud.Eventarc.Publishing.V1.Snippets.csproj
@@ -17,4 +17,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="6.0.0" />
+  </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1.Snippets/PublisherClientSnippets.cs
+++ b/apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1.Snippets/PublisherClientSnippets.cs
@@ -1,0 +1,56 @@
+﻿// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using CloudNative.CloudEvents;
+using System;
+using System.Text.Json;
+using Xunit;
+
+namespace Google.Cloud.Eventarc.Publishing.V1.Snippets;
+
+public class PublisherClientSnippets
+{
+    [Fact]
+    public void PublishSingleCloudEvent()
+    {
+        // Prepare the CloudEvent
+        var data = new
+        {
+            Date = DateTime.Parse("2019-08-01"),
+            TemperatureCelsius = 25,
+            Summary = "Hot"
+        };
+
+        var cloudEvent = new CloudEvent
+        {
+            Id = Guid.NewGuid().ToString(),
+            Type = "event-type",
+            Source = new Uri("/cloudevents/spec/pull/123", UriKind.RelativeOrAbsolute),
+            // Note: any way of creating the JSON is fine, but Eventarc does require a JSON payload.
+            Data = JsonSerializer.Serialize(data),
+            DataContentType = "application/json"
+        };
+
+        // Construct the channel name
+        // TODO: A Channel resource defined in the API would make this simpler.
+        string projectId = "...";
+        string location = "...";
+        string channelId = "...";
+        string channelName = $"projects/{projectId}/locations/{location}/channels/{channelId}";
+
+        // Publish the event
+        var client = PublisherClient.Create();
+        client.PublishEvent(channelName, cloudEvent);
+    }
+}

--- a/apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1.csproj
+++ b/apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1.csproj
@@ -8,6 +8,7 @@
     <PackageTags>events;cloudevents;Google;Cloud</PackageTags>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="CloudNative.CloudEvents.Protobuf" Version="2.3.0" />
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.0.0, 5.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />

--- a/apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1/PublisherClient.cs
+++ b/apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1/PublisherClient.cs
@@ -1,0 +1,83 @@
+﻿// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using CloudNative.CloudEvents;
+using CloudNative.CloudEvents.Protobuf;
+using Google.Api.Gax.Grpc;
+using Google.Protobuf.WellKnownTypes;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Cloud.Eventarc.Publishing.V1;
+
+// Partial class for adding CloudEvents SDK integration.
+
+public partial class PublisherClient
+{
+    /// <summary>
+    /// TODO
+    /// </summary>
+    public PublishEventsResponse PublishEvent(string channel, CloudEvent cloudEvent, CallSettings callSettings = null) =>
+        PublishEvents(channel, new[] { cloudEvent }, callSettings);
+
+    /// <summary>
+    /// TODO
+    /// </summary>
+    public PublishEventsResponse PublishEvents(string channel, IEnumerable<CloudEvent> cloudEvents, CallSettings callSettings = null)
+    {
+        var request = new PublishEventsRequest
+        {
+            Channel = channel,
+            Events = { cloudEvents.Select(ToAny) }
+        };
+        return PublishEvents(request, callSettings);
+    }
+
+    /// <summary>
+    /// TODO
+    /// </summary>
+    public Task<PublishEventsResponse> PublishEventAsync(string channel, CloudEvent cloudEvent, CancellationToken cancellationToken) =>
+        PublishEventAsync(channel, cloudEvent, CallSettings.FromCancellationToken(cancellationToken));
+
+    /// <summary>
+    /// TODO
+    /// </summary>
+    public Task<PublishEventsResponse> PublishEventAsync(string channel, CloudEvent cloudEvent, CallSettings callSettings = null) =>
+        PublishEventsAsync(channel, new[] { cloudEvent }, callSettings);
+
+    /// <summary>
+    /// TODO
+    /// </summary>
+    public Task<PublishEventsResponse> PublishEventsAsync(string channel, IEnumerable<CloudEvent> cloudEvents, CancellationToken cancellationToken) =>
+        PublishEventsAsync(channel, cloudEvents, CallSettings.FromCancellationToken(cancellationToken));
+
+    /// <summary>
+    /// TODO
+    /// </summary>
+    public async Task<PublishEventsResponse> PublishEventsAsync(string channel, IEnumerable<CloudEvent> cloudEvents, CallSettings callSettings = null)
+    {
+        var request = new PublishEventsRequest
+        {
+            Channel = channel,
+            Events = { cloudEvents.Select(ToAny) }
+        };
+        return await PublishEventsAsync(request, callSettings).ConfigureAwait(false);
+    }
+
+    private static readonly ProtobufEventFormatter s_eventFormatter = new ProtobufEventFormatter();
+
+    private Any ToAny(CloudEvent cloudEvent) => Any.Pack(s_eventFormatter.ConvertToProto(cloudEvent));
+}

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1346,7 +1346,9 @@
         "events",
         "cloudevents"
       ],
-      "dependencies": {},
+      "dependencies": {
+        "CloudNative.CloudEvents.SystemTextJson": "2.3.0"
+      },
       "generator": "micro",
       "protoPath": "google/cloud/eventarc/publishing/v1",
       "shortName": "eventarcpublishing",


### PR DESCRIPTION
Using extension methods, we could end up with much the same experience but with a separate library. That would avoid the "pure API" library from needing a CloudEvents dependency.

If we were to use a JSON representation instead of a protobuf representation, we could depend on one of the CloudEvents JSON format packages, allowing the data to be serialized automatically - but that would be opinionated in terms of which JSON library was being used.