### PR TITLE
docs: First pass at GAX v4 docs

### DIFF
--- a/docs/devsite-help/cleanup.md
+++ b/docs/devsite-help/cleanup.md
@@ -35,6 +35,8 @@ when either the application domain is unloaded, or the process exits. For most a
 perfectly adequate; explicit shutdown is only required when your application needs to ensure that
 it has handled all requests appropriately before exiting.
 
+For more information, see the [client lifecycle documentation](client-lifecycle.md)
+
 ## REST-based APIs
 
 Summary: Use a single client if you can. Clients are threads-safe,

--- a/docs/devsite-help/client-lifecycle.md
+++ b/docs/devsite-help/client-lifecycle.md
@@ -1,0 +1,108 @@
+# Client lifecycle
+
+Note: much of this page is specific to the gRPC-based packages. The REST-based packages (Google.Cloud.Storage.V1,
+Google.Cloud.BigQuery.V2 and Google.Cloud.Translation.V2) do have builders, but some of the properties
+described below are not applicable. See the [clean-up page](cleanup.md) for more details about disposal of
+REST clients.
+
+Other than for some libraries with high-level manually-written API surfaces (such as Firestore and Spanner),
+the "entry-points" into the Google Cloud Client Libraries for .NET are clients. Some packages
+have multiple clients, others have only a single one; consult the reference documentation for the relevant package
+(linked from the [GitHub repository](https://github.com/googleapis/google-cloud-dotnet) or
+the [list of packages](https://cloud.google.com/dotnet/docs/reference)) to see the clients available for a particular
+package. The rest of this page assumes a client class called `ExampleClient`.
+
+## Creating a client
+
+There are multiple ways of creating clients, depending on the nature of the application you're writing.
+When integrating with ASP.NET Core, we recommend using dependency injection if possible.
+
+Regardless of the application type, clients are thread-safe and we recommend creating a single client per service
+unless you have specific requirements to use multiple instances (such as different credentials or endpoints per
+client). Using a single client instance the entire application lifetime removes the need to worry about
+cleaning up clients.
+
+### Default initialization
+
+The static `ExampleClient.Create()` method creates a new client using defaults for everything,
+including the application default credentials.
+
+### Explicitly using a builder
+
+Every client has a corresponding builder class (e.g. `ExampleClientBuilder`) with `Build` and `BuildAsync`
+methods.
+
+The builder allows you to customize various aspects of the client, most notably credentials. For example,
+if you load JSON containing the relevant credentials to use, you might construct a client with:
+
+```csharp
+var client = new ExampleClientBuilder
+{
+    JsonCredentials = json
+}.Build();
+```
+
+### Dependency injection (Microsoft.Extensions.DependencyInjection)
+
+Every library includes an extension method for each client in the `Microsoft.Extensions.DependencyInjection` namespace,
+targeting `IServiceCollection`. The name of the method is `Add` followed by the client class name. For example:
+
+```csharp
+public static IServiceCollection AddExampleClient(this IServiceCollection services, Action<ExampleClientBuilder> action = null)
+```
+
+This adds the client as a singleton, and returns the target service collection for the purposes of
+method chaining. So for example, in an ASP.NET Core application you might write:
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+builder.Services
+    .AddRazorPages()
+    .AddExampleClient();
+```
+
+This will use other services provided by dependency injection when constructing the client. The following
+types are requested from the service provider:
+
+- `ILogger<ExampleClient>`
+- `CallInvoker`
+- `GrpcAdapter`
+- `GrpcChannelOptions`
+- `ChannelCredentials`
+- `ICredential`
+- `GoogleCredential`
+
+If you need to configure the client builder more explicitly but still want to take advantage of
+dependency injection, you can use the `Build(IServiceProvider)` or `BuildAsync(IServiceProvider)` methods
+from the client builder.
+
+For example, the `FirestoreDbBuilder` class allows a project ID to be specified, so you might configure this with:
+
+```csharp
+builder.Services
+    .AddSingleton(provider => new FirestoreDbBuilder { ProjectId = "my-project-id" }.Build(provider));
+```
+
+Any properties explicitly set on the builder will not be requested from the service provider. For example,
+if credentials are configured (in any form) on the builder, the `Build(IServiceProvider)` method will
+not request `ChannelCredentials`, `ICredential` or `GoogleCredential`.
+
+## Clean-up
+
+When a single client is used for an entire application lifecycle, there is no need to clean anything up.
+
+When multiple clients are used but with the default application credentials and the default endpoint,
+a *channel pool* is used so all clients use the same network connection. This means no clean-up is necessary.
+
+When multiple clients are constructed in a customized way, each client requires its own network connection.
+While these will eventually be garbage collected, if your application executes in a constrained environment,
+you may wish to dispose of the channel directly.
+
+The client builder exposes a `LastCreatedChannel` property, which returns a `ChannelBase` if the most recent
+`Build` or `BuildAsync` call required the creation of a non-pooled channel, or null otherwise.
+Different `ChannelBase` implementations have different cleanup implementations, but the `Shutdown` extension
+method (in the `Google.Api.Gax.Grpc` namespace) will shut a channel down either synchronously or asynchronously
+depending on the implementation.
+
+In an ideal world, the clients themselves would implement `IDisposable` and "just do the right thing"; we expect
+to improve this aspect of the libraries in a future major version.

--- a/docs/devsite-help/platforms.md
+++ b/docs/devsite-help/platforms.md
@@ -5,22 +5,9 @@ set of environments as possible, where we have confidence that they
 will work correctly.
 
 The latest libraries (the ones with dependencies on Google.Api.Gax
-3.x) target the **netstandard2.0** and **net461** [Target
+4.x) target the **netstandard2.1** and **net462** [Target
 Framework Monikers](https://docs.microsoft.com/en-us/nuget/schema/target-frameworks).
-
-> Note: Grpc.Core, the current default impementation of gRPC, does
-> not support Apple M1 CPUs. If you are developing on a device using
-> an M1, please adapt your client creation code to specify the
-> Grpc.Net.Client implemenation [as shown here](https://github.com/googleapis/google-cloud-dotnet/issues/7560#issuecomment-975414370).
-> This will become the default implementation in the next major
-> version of the libraries.
-
-Older versions of libraries (targeting Google.Api.Gax 2.x) support
-older frameworks (netstandard1.3 or netstandard1.5, and net45) but
-those are incompatible with the latest versions of Grpc.Core and
-with C# 8 asynchronous sequences. We strongly recommend updating to
-a newer framework supported by the latest libraries if you possibly
-can.
+The `netstandard2.1` target is supported by .NET Core 3.1, and .NET 5+.
 
 ## Mobile platform support
 

--- a/docs/devsite-help/transports.md
+++ b/docs/devsite-help/transports.md
@@ -1,0 +1,109 @@
+# Transport selection
+
+Note: this page is only relevant to gRPC-based packages.
+The purely-rest-based packages of Google.Cloud.Storage.V1,
+Google.Cloud.BigQuery.V2 and Google.Cloud.Translation.V2 do not
+have the concept of transport selection.
+
+This page is relevant to any package with a dependency on Google.Api.Gax.Grpc,
+including transitive dependencies. (For example, Google.Cloud.Firestore depends
+on Google.Cloud.Firestore.V1 which depends on Google.Api.Gax.Grpc).
+
+The client libraries are based on API definitions expressed in
+[Protocol Buffers](https://developers.google.com/protocol-buffers).
+The API definitions themselves are [available on GitHub](https://github.com/googleapis/googleapis).
+
+Most APIs can be accessed via two different transports:
+
+- HTTP/1.1 with JSON requests and responses. This is also known as the REST transport.
+  (We make no claims that it's fully RESTful, but it's intended to be "somewhat REST-like".)
+- HTTP/2.0 with protobuf binary requests and responses. This is also known as the gRPC
+  transport.
+
+Within the Google Cloud .NET client libraries, the transport and implementation choice are
+represetned by the `GrpcAdapter` type. There are currently three implementations:
+
+- `GrpcNetClientAdapter` (based on the Grpc.Net.Client package)
+- `GrpcCoreAdapter` (based on the Grpc.Core package)
+- `RestGrpcAdapter` (implemented within Google.Api.Gax.Grpc)
+
+Although "REST gRPC adapter" sounds like a contradiction in terms, this is an implementation of the gRPC API
+in Grpc.Core.Api (and in particular its `ChannelBase` and `CallInvoker` aspects) that communicates using HTTP/1.1 and JSON.
+Using the gRPC API as a common abstraction allows most code to be transport-agnostic.
+
+As of June 2022, the Google.Cloud.Compute.V1 package *only* supports the REST transport, and all other
+packages *only* support the gRPC transport. Over time we expect more packages to support the REST
+transport, which may be useful in situations where HTTP/2.0 is not fully supported on customer networks.
+(For example, we sometimes see proxies which don't fully support it.)
+
+In many situations, application code does not need to customize the choice of gRPC adapter at all.
+However, it can provide additional control, and the remainder of this page documents the ways in which the
+gRPC adapter can be specified and customized.
+
+## Default selection
+
+By default - e.g. just using `ExampleClient.Create()` - the selection process is as follows:
+
+- Does the package support the gRPC transport? If so:
+  - Is the `GRPC_DEFAULT_ADAPTER_OVERRIDE` environment variable set? If so, use the adapter based on the value:
+    - A value of `Grpc.Net.Client` will use `GrpcNetClientAdapter`
+    - A value of `Grpc.Core` will use `GrpcCoreAdapter`
+    - An empty value is ignored
+    - Any other value will cause an exception
+  - Does constructing a `Grpc.Net.Client.GrpcChannel` succeed? If so, use `GrpcNetClientAdapter`
+  - Otherwise, use `GrpcCoreAdapter`
+- Otherwise, use `RestGrpcAdapter`
+
+## Specifying an implementation in code
+
+If you explicitly want to specify a `GrpcAdapter` in code, there are two options.
+
+Firstly, you can specify the adapter directly via the `GrpcAdapter` property in the client builder. For example:
+
+```csharp
+ExampleClient client = new ExampleClientBuilder
+{
+    GrpcAdapter = GrpcNetClientAdapter.Default
+}.Build();
+```
+
+Alternatively, if you're using dependency injection using `Microsoft.Extensions.DependencyInjection`,
+you can register the `GrpcAdapter` in the service collection. That will then be used by any clients
+created via that service collection, as described in the [client lifecycle documentation](client-lifecycle.md).
+
+You can register the adapter directly, or use the following extension methods in `GaxGrpcServiceCollectionExtensions`:
+
+- `AddGrpcNetClientAdapter` (with an optional `Action<IServiceProvider, Grpc.Net.Client.GrpcChannelOptions>` for additional configuration)
+- `AddGrpcCoreAdapter`
+- `AddRestGrpcAdapter`
+
+The `AddGrpcNetClientAdapter` configures dependency injection to pass the service provider to `GrpcChannelOptions`,
+which in turn means that other dependencies (such as logging and `HttpClient`) can be obtained in a consistent way.
+As such, when using dependency injection to construct clients (and where Grpc.Net.Client works - see below),
+we recommend using the extension method rather than just relying on the default selection process
+(which doesn't have access to dependency injection, and so can't configure logging etc).
+
+## Notes on using Grpc.Net.Client
+
+*In general*, Grpc.Net.Client works on .NET Core 3.1 and higher (including .NET 5+) but does not work on .NET Framework.
+Additional steps can be taken to enable it in .NET Framework, based on the availability of `WinHttpClientHandler`
+and Windows updates. See [the Microsoft
+documentation](https://docs.microsoft.com/en-us/aspnet/core/grpc/supported-platforms?view=aspnetcore-6.0#net-grpc-client-requirements) for more details.
+
+Google.Api.Gax.Grpc already depends on Grpc.Net.Client, so no additional dependencies are required.
+
+## Notes on using Grpc.Core
+
+Grpc.Core is an older implementation of the gRPC protocols for .NET, based on native code.
+The package is [in maintenance mode](https://grpc.io/blog/grpc-csharp-future/), and is supported
+primarily for the sake of .NET Framework workloads. Where possible, we recommend using Grpc.Net.Client instead.
+
+The Grpc.Core package is relatively large (around 17MB as of version 2.46.3), and as it is not required
+in modern environments (and not even in .NET Framework environments in some cases) there is no dependency
+on it in Google.Api.Gax.Grpc. Instead, the `GrpcCoreAdapter` attempts to use reflection in order to initialize
+it. If the `Grpc.Core` package is not installed, this will fail at execution time.
+
+Each of the Google Cloud Libraries for .NET has a *conditional* dependency on Grpc.Core: the `net462` target
+depends on Grpc.Core, but the `netstandard2.1` target does not. The intention of this is to allow *most*
+applications to work out of the box with a simple dependency on the required client library package, but without
+additional unnecessary dependencies.


### PR DESCRIPTION
This is definitely only a first pass; the getting started page needs
more work, for certain. However, merging this first attempt allows
us to publish this rudimentary documentation before we hone it later.