### PR TITLE
chore: Fix Google.Cloud.AssuredWorkloads.V1Beta1 generation

### DIFF
--- a/apis/apis.json
+++ b/apis/apis.json
@@ -299,7 +299,7 @@
       "generator": "micro",
       "protoPath": "google/cloud/assuredworkloads/v1beta1",
       "shortName": "assuredworkloads",
-      "serviceConfigFile": "assuredworkloads_v1beta1.yaml"
+      "serviceConfigFile": "assuredworkloads.yaml"
     },
     {
       "id": "Google.Cloud.Audit",


### PR DESCRIPTION
The YAML file has been renamed; it's not entirely clear why, but it
needs to be reflected in apis.json.