### PR TITLE
chore: Init and update submodules in OwlBot post-processor

### DIFF
--- a/owl-bot-post-processor/main.sh
+++ b/owl-bot-post-processor/main.sh
@@ -123,6 +123,9 @@ copy_one_api() {
   fi
 }
 
+# Avoid .NET complaining about submodules being missing
+git submodule update --init --recursive
+
 # Iterate over all the apis in the /owl-bot-staging directory, and copy
 # the files into the /apis directory.
 if [[ -d owl-bot-staging ]]


### PR DESCRIPTION
This isn't usually *necessary*, but avoids a lot of distracting log entries.