### PR TITLE
docs: Add more TOC entries

### DIFF
--- a/docs/devsite-help/toc.yml
+++ b/docs/devsite-help/toc.yml
@@ -2,6 +2,10 @@
   items:
   - name: Getting started
     href: getting-started.md
+  - name: Client lifecycle
+    href: client-lifecycle.md
+  - name: Transport selection
+    href: transports.md
   - name: Troubleshooting
     href: troubleshooting.md
   - name: Emulator support


### PR DESCRIPTION
We *don't* have TOC entries for major-version.md or
breaking-gax2.md, but I think that's okay.