### PR TITLE
fix: Fixes the extra indentation of braces upon creating a new class or method

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -159,7 +159,7 @@ csharp_new_line_between_query_expression_clauses = true
 
 # Indentation preferences
 csharp_indent_block_contents = true
-csharp_indent_braces = true
+csharp_indent_braces = false
 csharp_indent_case_contents = true
 csharp_indent_case_contents_when_block = true
 csharp_indent_switch_labels = true


### PR DESCRIPTION
The property csharp_indent_braces was set as true which adds extra indentation. Changed it to false to fix it. Details - https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/csharp-formatting-options#csharp_indent_braces