### PR TITLE
docs: Tweaks for client library help

### DIFF
--- a/docs/devsite-help-docfx.json
+++ b/docs/devsite-help-docfx.json
@@ -1,0 +1,29 @@
+// This JSON file is not used for the real build;
+// it's present to help check content before releasing the help.
+{
+  "build": {
+    "content": [
+      {
+        "files": ["**/*.yml", "**/*.md"],
+        "src": "api",
+        "dest": "api"
+      }
+    ],
+    "globalMetadata": {
+      "_appTitle": "Test",
+      "_packageVersion": "0.0.0",
+      "_disableContribution": true,
+      "_appFooter": " ",
+      "_disableNavbar": true,
+      "_disableBreadcrumb": true,
+      "_enableSearch": false,
+      "_disableToc": true,
+      "_disableSideFilter": true,
+      "_disableAffix": true,
+      "_disableFooter": true,
+      "_rootPath": "/",
+      "_projectPath": "/"
+    },
+    "dest": "site"
+  }
+}

--- a/docs/devsite-help/toc.yml
+++ b/docs/devsite-help/toc.yml
@@ -2,6 +2,8 @@
   items:
   - name: Getting started
     href: getting-started.md
+  - name: Client configuration
+    href: client-configuration.md
   - name: Client lifecycle
     href: client-lifecycle.md
   - name: Transport selection

--- a/docs/generate-devsite-help.sh
+++ b/docs/generate-devsite-help.sh
@@ -8,6 +8,10 @@ then
   exit 1
 fi
 
+source ../toolversions.sh
+
+install_docfx
+
 if [[ "$2" != "" ]]
 then
   declare -r SERVICE_ACCOUNT_JSON=$2
@@ -62,5 +66,9 @@ else
 fi
 
 cd ../..
+
+echo 'Building site for local debugging purposes'
+cp devsite-help-docfx.json output/devsite-help/docfx.json
+$DOCFX build --disableGitFeatures output/devsite-help/docfx.json
 
 echo 'Done'


### PR DESCRIPTION
- Add client configuration to the TOC
- Generate the site with docfx at the end of
  generate-devsite-help.sh, to allow for local proofreading