### PR TITLE
build: Clean build/docs output at end of Kokoro build

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -23,6 +23,11 @@ df -h
 echo "Available disk space after running build.sh"
 df -h
 
+./clean.sh
+
+echo "Available disk space after running clean.sh"
+df -h
+
 ./processbuildtiminglog.sh
 
 echo "Available disk space after running processbuildtiminglog.sh"

--- a/.kokoro/builddocs.sh
+++ b/.kokoro/builddocs.sh
@@ -19,4 +19,7 @@ git submodule update
 cd docs
 ./builddocs.sh
 cd ..
+
+# Clean up to make artifact copying quicker
+./clean.sh
 ./processbuildtiminglog.sh

--- a/.kokoro/runintegrationtests.sh
+++ b/.kokoro/runintegrationtests.sh
@@ -82,6 +82,9 @@ df -h
 echo "Available disk space after running createcoveragereport.sh"
 df -h
 
+# Clean up to make artifact copying quicker
+./clean.sh
+
 ./processbuildtiminglog.sh
 
 echo "Available disk space after running processbuildtiminglog.sh"

--- a/build.sh
+++ b/build.sh
@@ -121,6 +121,8 @@ fi
 
 log_build_action "(Start) build.sh"
 
+log_build_action "(Start) Building"
+
 # Then build the requested APIs, working out the test projects as we go.
 > AllTests.txt
 for api in ${apis[*]}
@@ -156,6 +158,8 @@ do
     rm -rf $apidir/*/bin/Release/net[0-9]*
   fi
 done
+
+log_build_action "(End) Building"
 
 if [[ "$runtests" = true ]]
 then

--- a/clean.sh
+++ b/clean.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+source toolversions.sh
+
+log_build_action "(Start) Cleaning build output"
+find apis -name bin | xargs rm -rf
+find apis -name obj | xargs rm -rf
+log_build_action "(End) Cleaning build output"
+
+log_build_action "(Start) Cleaning docs output"
+rm -rf docs/output
+log_build_action "(End) Cleaning docs output"


### PR DESCRIPTION
This reduces the time between the build finishing and the Kokoro job finishing.