### PR TITLE
Release Google.Cloud.AssuredWorkloads.V1Beta1 version 2.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.csproj
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta01</Version>
+    <Version>2.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Assured Workloads API (v1beta1)</Description>

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 2.0.0-beta02, released 2022-07-11
+
+### New features
+
+- ITAR June Preview Launch ([commit ba28a2b](https://github.com/googleapis/google-cloud-dotnet/commit/ba28a2b7bddc1a2195492181ae9041839c6f58db))
+- **BREAKING CHANGE** Removed _v1beta1 suffix from proto file names ([commit dc3a4e7](https://github.com/googleapis/google-cloud-dotnet/commit/dc3a4e7e6ffaea438a1999cbb625579ac817272f))
+
+### Breaking changes
+
+- Proto file name is changed from assuredworkloads_v1beta1.proto to assuredworkloads.proto ([commit dc3a4e7](https://github.com/googleapis/google-cloud-dotnet/commit/dc3a4e7e6ffaea438a1999cbb625579ac817272f))
+
 ## Version 2.0.0-beta01, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -284,7 +284,7 @@
     },
     {
       "id": "Google.Cloud.AssuredWorkloads.V1Beta1",
-      "version": "2.0.0-beta01",
+      "version": "2.0.0-beta02",
       "type": "grpc",
       "productName": "Assured Workloads",
       "productUrl": "https://cloud.google.com/assured-workloads/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- ITAR June Preview Launch ([commit ba28a2b](https://github.com/googleapis/google-cloud-dotnet/commit/ba28a2b7bddc1a2195492181ae9041839c6f58db))
- **BREAKING CHANGE** Removed _v1beta1 suffix from proto file names ([commit dc3a4e7](https://github.com/googleapis/google-cloud-dotnet/commit/dc3a4e7e6ffaea438a1999cbb625579ac817272f))

### Breaking changes

- Proto file name is changed from assuredworkloads_v1beta1.proto to assuredworkloads.proto ([commit dc3a4e7](https://github.com/googleapis/google-cloud-dotnet/commit/dc3a4e7e6ffaea438a1999cbb625579ac817272f))
