### PR TITLE
Release Google.Cloud.BigQuery.Storage.V1 version 3.1.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0</Version>
+    <Version>3.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery Storage API.</Description>

--- a/apis/Google.Cloud.BigQuery.Storage.V1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 3.1.0, released 2022-07-11
+
+### Bug fixes
+
+- Modify client lib retry policy for CreateWriteStream with longer backoff, more error code and longer overall time ([commit 51e9621](https://github.com/googleapis/google-cloud-dotnet/commit/51e9621868b3fe3daf573c0c1509217d50097f7c))
+
+### New features
+
+- Add fields to eventually contain row level errors ([commit 2b870d5](https://github.com/googleapis/google-cloud-dotnet/commit/2b870d51a51b79b3b36aacdf02a29d36207b2bad))
+
 ## Version 3.0.0, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -538,7 +538,7 @@
       "protoPath": "google/cloud/bigquery/storage/v1",
       "productName": "Google BigQuery Storage",
       "productUrl": "https://cloud.google.com/bigquery/docs/reference/storage/",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the BigQuery Storage API.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Modify client lib retry policy for CreateWriteStream with longer backoff, more error code and longer overall time ([commit 51e9621](https://github.com/googleapis/google-cloud-dotnet/commit/51e9621868b3fe3daf573c0c1509217d50097f7c))

### New features

- Add fields to eventually contain row level errors ([commit 2b870d5](https://github.com/googleapis/google-cloud-dotnet/commit/2b870d51a51b79b3b36aacdf02a29d36207b2bad))
