### PR TITLE
Release Google.Cloud.Bigtable.Admin.V2 version 3.1.0

### DIFF
--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.csproj
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0</Version>
+    <Version>3.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Bigtable Instance and Table Admin APIs.</Description>

--- a/apis/Google.Cloud.Bigtable.Admin.V2/docs/history.md
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 3.1.0, released 2022-07-11
+
+### New features
+
+- Cloud Bigtable Undelete Table service and message proto files ([commit 29d65e4](https://github.com/googleapis/google-cloud-dotnet/commit/29d65e457d8eab164868b11481792320aaf59dd2))
+- Add storage_utilization_gib_per_node to Autoscaling target ([commit f4e0a43](https://github.com/googleapis/google-cloud-dotnet/commit/f4e0a438a076afd46d97049006c1347fea15bddc))
+
 ## Version 3.0.0, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -557,7 +557,7 @@
       "protoPath": "google/bigtable/admin/v2",
       "productName": "Google Cloud Bigtable Administration",
       "productUrl": "https://cloud.google.com/bigtable/",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "commonResourcesConfig": "apis/Google.Cloud.Bigtable.Common.V2/CommonResourcesConfig.json",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Bigtable Instance and Table Admin APIs.",


### PR DESCRIPTION

Changes in this release:

### New features

- Cloud Bigtable Undelete Table service and message proto files ([commit 29d65e4](https://github.com/googleapis/google-cloud-dotnet/commit/29d65e457d8eab164868b11481792320aaf59dd2))
- Add storage_utilization_gib_per_node to Autoscaling target ([commit f4e0a43](https://github.com/googleapis/google-cloud-dotnet/commit/f4e0a438a076afd46d97049006c1347fea15bddc))
