### PR TITLE
Release Google.Cloud.CertificateManager.V1 version 2.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.csproj
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta01</Version>
+    <Version>2.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Certificate Manager API, which lets you acquire and manage TLS (SSL) certificates for use with Cloud Load Balancing</Description>

--- a/apis/Google.Cloud.CertificateManager.V1/docs/history.md
+++ b/apis/Google.Cloud.CertificateManager.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.0.0-beta02, released 2022-07-11
+
+### Bug fixes
+
+- **BREAKING CHANGE** Removed resource definition of Compute API resources and incorrect resource references that used them ([commit 0fff1eb](https://github.com/googleapis/google-cloud-dotnet/commit/0fff1ebe5d0be93eeb28fc8dd750f0fd2f77d3b7))
+
 ## Version 2.0.0-beta01, released 2022-06-09
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -722,7 +722,7 @@
     },
     {
       "id": "Google.Cloud.CertificateManager.V1",
-      "version": "2.0.0-beta01",
+      "version": "2.0.0-beta02",
       "type": "grpc",
       "productName": "Certificate Manager",
       "productUrl": "https://cloud.google.com/certificate-manager/docs",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- **BREAKING CHANGE** Removed resource definition of Compute API resources and incorrect resource references that used them ([commit 0fff1eb](https://github.com/googleapis/google-cloud-dotnet/commit/0fff1ebe5d0be93eeb28fc8dd750f0fd2f77d3b7))
