### PR TITLE
Release Google.Cloud.NetworkManagement.V1 version 2.1.0

### DIFF
--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.csproj
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Network Management API, which provides a collection of network performance monitoring and diagnostic capabilities.</Description>

--- a/apis/Google.Cloud.NetworkManagement.V1/docs/history.md
+++ b/apis/Google.Cloud.NetworkManagement.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.1.0, released 2022-07-11
+
+### New features
+
+- Introduce a projects_missing_permissions field in the AbortInfo structure ([commit 6f1a4bd](https://github.com/googleapis/google-cloud-dotnet/commit/6f1a4bdf27f364ce96cb71954926e5ce0dc01e00))
+
 ## Version 2.0.0, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2303,7 +2303,7 @@
     },
     {
       "id": "Google.Cloud.NetworkManagement.V1",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "type": "grpc",
       "productName": "Network Management",
       "productUrl": "https://cloud.google.com/network-intelligence-center/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Introduce a projects_missing_permissions field in the AbortInfo structure ([commit 6f1a4bd](https://github.com/googleapis/google-cloud-dotnet/commit/6f1a4bdf27f364ce96cb71954926e5ce0dc01e00))
