### PR TITLE
Release Google.Cloud.Logging.Console version 1.0.0

### DIFF
--- a/apis/Google.Cloud.Logging.Console/.repo-metadata.json
+++ b/apis/Google.Cloud.Logging.Console/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.Logging.Console",
-  "release_level": "preview",
+  "release_level": "stable",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Logging.Console/latest",
   "library_type": "INTEGRATION"
 }

--- a/apis/Google.Cloud.Logging.Console/Google.Cloud.Logging.Console/Google.Cloud.Logging.Console.csproj
+++ b/apis/Google.Cloud.Logging.Console/Google.Cloud.Logging.Console/Google.Cloud.Logging.Console.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>ConsoleFormatter for Google Cloud Logging.</Description>

--- a/apis/Google.Cloud.Logging.Console/docs/history.md
+++ b/apis/Google.Cloud.Logging.Console/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0, released 2022-07-19
+
+First GA release.
+
 ## Version 1.0.0-beta01, released 2022-06-09
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2024,7 +2024,7 @@
     },
     {
       "id": "Google.Cloud.Logging.Console",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0",
       "type": "other",
       "metadataType": "INTEGRATION",
       "targetFrameworks": "netstandard2.1",


### PR DESCRIPTION

Changes in this release:

First GA release.
