### PR TITLE
fix(spanner/admin/database): switch service config

### DIFF
--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3311,7 +3311,7 @@
       },
       "noVersionHistory": true,
       "shortName": "spanner",
-      "serviceConfigFile": "spanner_admin_database.yaml"
+      "serviceConfigFile": "spanner.yaml"
     },
     {
       "id": "Google.Cloud.Spanner.Admin.Instance.V1",


### PR DESCRIPTION
This switches the generation config to use the new, more up-to-date service config file. The next generation of this client may include some differences as a result.