### PR TITLE
Release Google.Cloud.Storage.V1 version 4.1.0

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.0.0</Version>
+    <Version>4.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Storage API. It wraps the Google.Apis.Storage.v1 client library, making common operations simpler in client code. Google Cloud Storage stores and retrieves potentially large, immutable data objects.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Rest" Version="[4.0.0, 5.0.0)" />
-    <PackageReference Include="Google.Apis.Storage.v1" Version="[1.57.0.2685, 2.0.0.0)" />
+    <PackageReference Include="Google.Apis.Storage.v1" Version="[1.57.0.2742, 2.0.0.0)" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="StorageClient.*.cs">

--- a/apis/Google.Cloud.Storage.V1/docs/history.md
+++ b/apis/Google.Cloud.Storage.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 4.1.0, released 2022-07-22
+
+No API surface changes; just dependency updates.
+
 ## Version 4.0.0, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.
@@ -19,6 +23,7 @@ if you run into problems.
 ### Breaking changes
 
 - Changes to IBlogSigner to support HMAC signing. ([commit b82fed2](https://github.com/googleapis/google-cloud-dotnet/commit/b82fed27f2ebeb3c345290b477c7f53ff3c0148e))
+
 ## Version 3.7.0, released 2022-01-27
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3450,12 +3450,12 @@
       "id": "Google.Cloud.Storage.V1",
       "productName": "Google Cloud Storage",
       "productUrl": "https://cloud.google.com/storage/",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "type": "rest",
       "description": "Recommended Google client library to access the Google Cloud Storage API. It wraps the Google.Apis.Storage.v1 client library, making common operations simpler in client code. Google Cloud Storage stores and retrieves potentially large, immutable data objects.",
       "dependencies": {
         "Google.Api.Gax.Rest": "4.0.0",
-        "Google.Apis.Storage.v1": "1.57.0.2685"
+        "Google.Apis.Storage.v1": "1.57.0.2742"
       },
       "testDependencies": {
         "Google.Api.Gax.Testing": "4.0.0",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
