### PR TITLE
Release Google.Cloud.BigQuery.Migration.V2 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.csproj
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery Migration service, exposing apis for migration jobs operations, and agent management.</Description>

--- a/apis/Google.Cloud.BigQuery.Migration.V2/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2022-07-25
+
+### New features
+
+- Add Presto dialect to bigquerymigration v2 client library ([commit 63ae256](https://github.com/googleapis/google-cloud-dotnet/commit/63ae25692472c9fa7f2d43feeebebda2fc90535e))
+
 ## Version 1.0.0-beta01, released 2022-06-28
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -578,7 +578,7 @@
     },
     {
       "id": "Google.Cloud.BigQuery.Migration.V2",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "BigQuery Migration",
       "productUrl": "https://cloud.google.com/bigquery/docs/migration-intro",


### PR DESCRIPTION

Changes in this release:

### New features

- Add Presto dialect to bigquerymigration v2 client library ([commit 63ae256](https://github.com/googleapis/google-cloud-dotnet/commit/63ae25692472c9fa7f2d43feeebebda2fc90535e))
