### PR TITLE
Release Google.Cloud.BigQuery.V2 version 3.1.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0</Version>
+    <Version>3.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery API. It wraps the Google.Apis.Bigquery.v2 client library, making common operations simpler in client code. BigQuery is a data platform for customers to create, manage, share and query data.</Description>

--- a/apis/Google.Cloud.BigQuery.V2/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.1.0, released 2022-07-25
+
+### New features
+
+- Adds table ACLs support ([commit 22b00e2](https://github.com/googleapis/google-cloud-dotnet/commit/22b00e2ef09095a5cd2bc1c0261a8967bbdff6b4))
+- Add support for BigQuery job metadata deletion. ([commit 2b501e8](https://github.com/googleapis/google-cloud-dotnet/commit/2b501e824bd8ab6a5a88ef8cbfee137d13b65576))
 ## Version 3.0.0, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -617,7 +617,7 @@
       "id": "Google.Cloud.BigQuery.V2",
       "productName": "Google BigQuery",
       "productUrl": "https://cloud.google.com/bigquery/",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "type": "rest",
       "description": "Recommended Google client library to access the BigQuery API. It wraps the Google.Apis.Bigquery.v2 client library, making common operations simpler in client code. BigQuery is a data platform for customers to create, manage, share and query data.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Adds table ACLs support ([commit 22b00e2](https://github.com/googleapis/google-cloud-dotnet/commit/22b00e2ef09095a5cd2bc1c0261a8967bbdff6b4))
- Add support for BigQuery job metadata deletion. ([commit 2b501e8](https://github.com/googleapis/google-cloud-dotnet/commit/2b501e824bd8ab6a5a88ef8cbfee137d13b65576))
