### PR TITLE
Release Google.Cloud.NetworkSecurity.V1Beta1 version 2.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.csproj
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta01</Version>
+    <Version>2.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Network Security API version v1beta1, which provides security management for Traffic Director.</Description>

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 2.0.0-beta02, released 2022-07-25
+
+### Bug fixes
+
+- **BREAKING CHANGE** Fix annotation of parent in Create*Request ([commit 6584bbb](https://github.com/googleapis/google-cloud-dotnet/commit/6584bbb28914477079153b5287ef6012c9f43f9a))
+
+### Documentation improvements
+
+- Update the comments of various networksecurity resources ([commit 6584bbb](https://github.com/googleapis/google-cloud-dotnet/commit/6584bbb28914477079153b5287ef6012c9f43f9a))
+
 ## Version 2.0.0-beta01, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2451,7 +2451,7 @@
     },
     {
       "id": "Google.Cloud.NetworkSecurity.V1Beta1",
-      "version": "2.0.0-beta01",
+      "version": "2.0.0-beta02",
       "type": "grpc",
       "productName": "Network Security",
       "productUrl": "https://cloud.google.com/traffic-director/docs/security-overview",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- **BREAKING CHANGE** Fix annotation of parent in Create*Request ([commit 6584bbb](https://github.com/googleapis/google-cloud-dotnet/commit/6584bbb28914477079153b5287ef6012c9f43f9a))

### Documentation improvements

- Update the comments of various networksecurity resources ([commit 6584bbb](https://github.com/googleapis/google-cloud-dotnet/commit/6584bbb28914477079153b5287ef6012c9f43f9a))
