### PR TITLE
Release Google.Cloud.SecurityCenter.V1 version 3.2.0

### DIFF
--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.csproj
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.1.0</Version>
+    <Version>3.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Security Command Center API, which helps security teams gather data, identify threats, and act on them before they result in business damage or loss.</Description>

--- a/apis/Google.Cloud.SecurityCenter.V1/docs/history.md
+++ b/apis/Google.Cloud.SecurityCenter.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 3.2.0, released 2022-07-25
+
+### New features
+
+- Added container field to findings attributes ([commit e8abc9d](https://github.com/googleapis/google-cloud-dotnet/commit/e8abc9dbb4d34da3f91ddbdc45067c2f86e16d4d))
+- Added kubernetes field to findings attribute. This field is populated only when the container is a kubernetes cluster explicitly ([commit e8abc9d](https://github.com/googleapis/google-cloud-dotnet/commit/e8abc9dbb4d34da3f91ddbdc45067c2f86e16d4d))
+
 ## Version 3.1.0, released 2022-07-11
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3131,7 +3131,7 @@
       "protoPath": "google/cloud/securitycenter/v1",
       "productName": "Google Cloud Security Command Center",
       "productUrl": "https://cloud.google.com/security-command-center/",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Security Command Center API, which helps security teams gather data, identify threats, and act on them before they result in business damage or loss.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Added container field to findings attributes ([commit e8abc9d](https://github.com/googleapis/google-cloud-dotnet/commit/e8abc9dbb4d34da3f91ddbdc45067c2f86e16d4d))
- Added kubernetes field to findings attribute. This field is populated only when the container is a kubernetes cluster explicitly ([commit e8abc9d](https://github.com/googleapis/google-cloud-dotnet/commit/e8abc9dbb4d34da3f91ddbdc45067c2f86e16d4d))
