### PR TITLE
Release Google.Cloud.VMMigration.V1 version 2.1.0

### DIFF
--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.csproj
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the VM Migration API, which allows you to programmatically migrate workloads.</Description>

--- a/apis/Google.Cloud.VMMigration.V1/docs/history.md
+++ b/apis/Google.Cloud.VMMigration.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 2.1.0, released 2022-07-25
+
+### New features
+
+- Rename product ([commit f3b6e78](https://github.com/googleapis/google-cloud-dotnet/commit/f3b6e78f207771c908bdd9016c6be22e001566b9))
+- API updates ([commit f3b6e78](https://github.com/googleapis/google-cloud-dotnet/commit/f3b6e78f207771c908bdd9016c6be22e001566b9))
+
 ## Version 2.0.0, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3708,7 +3708,7 @@
     },
     {
       "id": "Google.Cloud.VMMigration.V1",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "type": "grpc",
       "productName": "VM Migration",
       "productUrl": "https://cloud.google.com/migrate/compute-engine/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Rename product ([commit f3b6e78](https://github.com/googleapis/google-cloud-dotnet/commit/f3b6e78f207771c908bdd9016c6be22e001566b9))
- API updates ([commit f3b6e78](https://github.com/googleapis/google-cloud-dotnet/commit/f3b6e78f207771c908bdd9016c6be22e001566b9))
