### PR TITLE
Release Google.Cloud.Datastore.V1 version 4.2.0

### DIFF
--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.1.0</Version>
+    <Version>4.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Datastore API, which accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.</Description>

--- a/apis/Google.Cloud.Datastore.V1/docs/history.md
+++ b/apis/Google.Cloud.Datastore.V1/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+## Version 4.2.0, released 2022-07-27
+
+### New features
+
+- Added database ID to request messages ([commit adf2d20](https://github.com/googleapis/google-cloud-dotnet/commit/adf2d202eb0fc206df6195cb46df98e7a6486160))
 ## Version 4.1.0, released 2022-06-22
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1144,7 +1144,7 @@
       "protoPath": "google/datastore/v1",
       "productName": "Google Cloud Datastore",
       "productUrl": "https://cloud.google.com/datastore/docs/concepts/overview",
-      "version": "4.1.0",
+      "version": "4.2.0",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Datastore API, which accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.",


### PR DESCRIPTION

Changes in this release:

### New features

- Added database ID to request messages ([commit adf2d20](https://github.com/googleapis/google-cloud-dotnet/commit/adf2d202eb0fc206df6195cb46df98e7a6486160))
