### PR TITLE
Release Google.Cloud.PubSub.V1 version 3.1.0

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0</Version>
+    <Version>3.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.</Description>

--- a/apis/Google.Cloud.PubSub.V1/docs/history.md
+++ b/apis/Google.Cloud.PubSub.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 3.1.0, released 2022-07-27
+
+### New features
+
+- Add SubscriberClientBuilder ([commit 5f830ac](https://github.com/googleapis/google-cloud-dotnet/commit/5f830acefb771d7a7f0c3f86fc7e71e5b482596e))
+- Add PublisherClientBuilder ([commit 09eeaa9](https://github.com/googleapis/google-cloud-dotnet/commit/09eeaa97a1ee617caf1d4b75f0ab97dcc14f1233))
+
 ## Version 3.0.0, released 2022-06-29
 
 No API surface changes since 3.0.0-beta01. (See 3.0.0-beta01 release notes for details.)

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2780,7 +2780,7 @@
       "protoPath": "google/pubsub/v1",
       "productName": "Cloud Pub/Sub",
       "productUrl": "https://cloud.google.com/pubsub/",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.",


### PR DESCRIPTION

Changes in this release:

### New features

- Add SubscriberClientBuilder ([commit 5f830ac](https://github.com/googleapis/google-cloud-dotnet/commit/5f830acefb771d7a7f0c3f86fc7e71e5b482596e))
- Add PublisherClientBuilder ([commit 09eeaa9](https://github.com/googleapis/google-cloud-dotnet/commit/09eeaa97a1ee617caf1d4b75f0ab97dcc14f1233))
