### PR TITLE
Release Google.Cloud.DataCatalog.V1 version 2.1.0

### DIFF
--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.csproj
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Data Catalog API. Data Catalog is a fully managed and highly scalable data discovery and metadata management service.</Description>

--- a/apis/Google.Cloud.DataCatalog.V1/docs/history.md
+++ b/apis/Google.Cloud.DataCatalog.V1/docs/history.md
@@ -1,5 +1,18 @@
 # Version history
 
+## Version 2.1.0, released 2022-08-02
+
+### Bug fixes
+
+- **BREAKING CHANGE** Fix datacatalog resource name config ([commit 0c58375](https://github.com/googleapis/google-cloud-dotnet/commit/0c58375c78330939465587655212289d608ef3ea))
+
+This breaking change affects the `CreateTag` and `ListEntryGroups`
+operations. In both cases, the resource name type being used was
+inappropriate, and would have led to invalid requests. As these
+methods could not have been used successfully in their current form,
+we're releasing this bug fix as a minor version bump instead of a
+major one.
+
 ## Version 2.0.0, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -985,7 +985,7 @@
       "protoPath": "google/cloud/datacatalog/v1",
       "productName": "Data Catalog",
       "productUrl": "https://cloud.google.com/data-catalog/docs",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Data Catalog API. Data Catalog is a fully managed and highly scalable data discovery and metadata management service.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- **BREAKING CHANGE** Fix datacatalog resource name config ([commit 0c58375](https://github.com/googleapis/google-cloud-dotnet/commit/0c58375c78330939465587655212289d608ef3ea))

This breaking change affects the `CreateTag` and `ListEntryGroups` operations. In both cases, the resource name type being used was inappropriate, and would have led to invalid requests. As these methods could not have been used successfully in their current form, we're releasing this bug fix as a minor version bump instead of a major one.
