### PR TITLE
Release Google.Cloud.Compute.V1 version 2.1.0

### DIFF
--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Compute Engine API.</Description>

--- a/apis/Google.Cloud.Compute.V1/docs/history.md
+++ b/apis/Google.Cloud.Compute.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.1.0, released 2022-08-04
+
+### New features
+
+- Update Compute Engine API to revision 20220720 ([issue 723](https://github.com/googleapis/google-cloud-dotnet/issues/723)) ([commit 5bdaae8](https://github.com/googleapis/google-cloud-dotnet/commit/5bdaae8eeb7d8081d22329285ce5fc27e3cc8a8d))
+
 ## Version 2.0.0, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -936,7 +936,7 @@
     },
     {
       "id": "Google.Cloud.Compute.V1",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "type": "regapic",
       "productName": "Compute Engine",
       "productUrl": "https://cloud.google.com/compute",


### PR DESCRIPTION

Changes in this release:

### New features

- Update Compute Engine API to revision 20220720 ([issue 723](https://github.com/googleapis/google-cloud-dotnet/issues/723)) ([commit 5bdaae8](https://github.com/googleapis/google-cloud-dotnet/commit/5bdaae8eeb7d8081d22329285ce5fc27e3cc8a8d))
