### PR TITLE
Release Google.Cloud.Retail.V2 version 2.1.0

### DIFF
--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.csproj
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Cloud Retail service enables customers to build end-to-end personalized recommendation systems without requiring a high level of expertise in machine learning, recommendation system, or Google Cloud.</Description>

--- a/apis/Google.Cloud.Retail.V2/docs/history.md
+++ b/apis/Google.Cloud.Retail.V2/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 2.1.0, released 2022-08-04
+
+### New features
+
+- Support case insensitive match on search facets ([commit 10c0429](https://github.com/googleapis/google-cloud-dotnet/commit/10c0429387e35ac500c1947dee81b3b25327e99c))
+- Allow to return min/max values on search numeric facets ([commit 10c0429](https://github.com/googleapis/google-cloud-dotnet/commit/10c0429387e35ac500c1947dee81b3b25327e99c))
+- Allow to use serving configs as an alias of placements ([commit 10c0429](https://github.com/googleapis/google-cloud-dotnet/commit/10c0429387e35ac500c1947dee81b3b25327e99c))
+
+### Documentation improvements
+
+- Keep the API doc up-to-date with recent changes ([commit 10c0429](https://github.com/googleapis/google-cloud-dotnet/commit/10c0429387e35ac500c1947dee81b3b25327e99c))
+
 ## Version 2.0.0, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2973,7 +2973,7 @@
     },
     {
       "id": "Google.Cloud.Retail.V2",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "type": "grpc",
       "productName": "Retail",
       "productUrl": "https://cloud.google.com/retail/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Support case insensitive match on search facets ([commit 10c0429](https://github.com/googleapis/google-cloud-dotnet/commit/10c0429387e35ac500c1947dee81b3b25327e99c))
- Allow to return min/max values on search numeric facets ([commit 10c0429](https://github.com/googleapis/google-cloud-dotnet/commit/10c0429387e35ac500c1947dee81b3b25327e99c))
- Allow to use serving configs as an alias of placements ([commit 10c0429](https://github.com/googleapis/google-cloud-dotnet/commit/10c0429387e35ac500c1947dee81b3b25327e99c))

### Documentation improvements

- Keep the API doc up-to-date with recent changes ([commit 10c0429](https://github.com/googleapis/google-cloud-dotnet/commit/10c0429387e35ac500c1947dee81b3b25327e99c))
