### PR TITLE
chore: Fix and re-release Compute 2.1.0

### DIFF
--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/AcceleratorTypesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/AcceleratorTypesClient.g.cs
@@ -204,7 +204,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(AcceleratorTypes.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(AcceleratorTypes.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/AddressesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/AddressesClient.g.cs
@@ -264,7 +264,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Addresses.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Addresses.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/AutoscalersClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/AutoscalersClient.g.cs
@@ -328,7 +328,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Autoscalers.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Autoscalers.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/BackendBucketsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/BackendBucketsClient.g.cs
@@ -404,7 +404,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(BackendBuckets.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(BackendBuckets.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/BackendServicesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/BackendServicesClient.g.cs
@@ -471,7 +471,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(BackendServices.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(BackendServices.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/DiskTypesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/DiskTypesClient.g.cs
@@ -201,7 +201,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(DiskTypes.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(DiskTypes.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/DisksClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/DisksClient.g.cs
@@ -468,7 +468,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Disks.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Disks.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ExternalVpnGatewaysClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ExternalVpnGatewaysClient.g.cs
@@ -289,7 +289,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(ExternalVpnGateways.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(ExternalVpnGateways.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/FirewallPoliciesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/FirewallPoliciesClient.g.cs
@@ -613,7 +613,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(FirewallPolicies.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(FirewallPolicies.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/FirewallsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/FirewallsClient.g.cs
@@ -306,7 +306,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Firewalls.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Firewalls.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ForwardingRulesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ForwardingRulesClient.g.cs
@@ -361,7 +361,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(ForwardingRules.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(ForwardingRules.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/GlobalAddressesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/GlobalAddressesClient.g.cs
@@ -242,7 +242,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(GlobalAddresses.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(GlobalAddresses.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/GlobalForwardingRulesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/GlobalForwardingRulesClient.g.cs
@@ -340,7 +340,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(GlobalForwardingRules.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(GlobalForwardingRules.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/GlobalNetworkEndpointGroupsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/GlobalNetworkEndpointGroupsClient.g.cs
@@ -325,7 +325,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(GlobalNetworkEndpointGroups.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(GlobalNetworkEndpointGroups.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/GlobalOperationsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/GlobalOperationsClient.g.cs
@@ -227,7 +227,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(GlobalOperations.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(GlobalOperations.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/GlobalOrganizationOperationsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/GlobalOrganizationOperationsClient.g.cs
@@ -193,7 +193,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(GlobalOrganizationOperations.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(GlobalOrganizationOperations.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/GlobalPublicDelegatedPrefixesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/GlobalPublicDelegatedPrefixesClient.g.cs
@@ -279,7 +279,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(GlobalPublicDelegatedPrefixes.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(GlobalPublicDelegatedPrefixes.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/HealthChecksClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/HealthChecksClient.g.cs
@@ -328,7 +328,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(HealthChecks.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(HealthChecks.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ImageFamilyViewsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ImageFamilyViewsClient.g.cs
@@ -157,7 +157,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(ImageFamilyViews.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(ImageFamilyViews.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ImagesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ImagesClient.g.cs
@@ -404,7 +404,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Images.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Images.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InstanceGroupManagersClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InstanceGroupManagersClient.g.cs
@@ -712,7 +712,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(InstanceGroupManagers.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(InstanceGroupManagers.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InstanceGroupsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InstanceGroupsClient.g.cs
@@ -374,7 +374,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(InstanceGroups.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(InstanceGroups.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InstanceTemplatesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InstanceTemplatesClient.g.cs
@@ -292,7 +292,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(InstanceTemplates.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(InstanceTemplates.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InstancesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InstancesClient.g.cs
@@ -1420,7 +1420,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Instances.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Instances.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InterconnectAttachmentsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InterconnectAttachmentsClient.g.cs
@@ -300,7 +300,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(InterconnectAttachments.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(InterconnectAttachments.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InterconnectLocationsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InterconnectLocationsClient.g.cs
@@ -182,7 +182,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(InterconnectLocations.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(InterconnectLocations.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InterconnectsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InterconnectsClient.g.cs
@@ -297,7 +297,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Interconnects.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Interconnects.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/LicenseCodesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/LicenseCodesClient.g.cs
@@ -169,7 +169,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(LicenseCodes.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(LicenseCodes.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/LicensesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/LicensesClient.g.cs
@@ -290,7 +290,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Licenses.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Licenses.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/MachineImagesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/MachineImagesClient.g.cs
@@ -291,7 +291,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(MachineImages.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(MachineImages.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/MachineTypesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/MachineTypesClient.g.cs
@@ -201,7 +201,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(MachineTypes.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(MachineTypes.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NetworkEdgeSecurityServicesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NetworkEdgeSecurityServicesClient.g.cs
@@ -278,7 +278,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(NetworkEdgeSecurityServices.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(NetworkEdgeSecurityServices.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NetworkEndpointGroupsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NetworkEndpointGroupsClient.g.cs
@@ -362,7 +362,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(NetworkEndpointGroups.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(NetworkEndpointGroups.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NetworkFirewallPoliciesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NetworkFirewallPoliciesClient.g.cs
@@ -566,7 +566,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(NetworkFirewallPolicies.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(NetworkFirewallPolicies.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NetworksClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NetworksClient.g.cs
@@ -446,7 +446,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Networks.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Networks.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NodeGroupsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NodeGroupsClient.g.cs
@@ -453,7 +453,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(NodeGroups.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(NodeGroups.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NodeTemplatesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NodeTemplatesClient.g.cs
@@ -313,7 +313,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(NodeTemplates.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(NodeTemplates.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NodeTypesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NodeTypesClient.g.cs
@@ -201,7 +201,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(NodeTypes.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(NodeTypes.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/PacketMirroringsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/PacketMirroringsClient.g.cs
@@ -310,7 +310,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(PacketMirrorings.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(PacketMirrorings.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ProjectsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ProjectsClient.g.cs
@@ -501,7 +501,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Projects.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Projects.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/PublicAdvertisedPrefixesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/PublicAdvertisedPrefixesClient.g.cs
@@ -277,7 +277,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(PublicAdvertisedPrefixes.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(PublicAdvertisedPrefixes.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/PublicDelegatedPrefixesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/PublicDelegatedPrefixesClient.g.cs
@@ -300,7 +300,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(PublicDelegatedPrefixes.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(PublicDelegatedPrefixes.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionAutoscalersClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionAutoscalersClient.g.cs
@@ -307,7 +307,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(RegionAutoscalers.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(RegionAutoscalers.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionBackendServicesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionBackendServicesClient.g.cs
@@ -321,7 +321,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(RegionBackendServices.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(RegionBackendServices.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionCommitmentsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionCommitmentsClient.g.cs
@@ -265,7 +265,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(RegionCommitments.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(RegionCommitments.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionDiskTypesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionDiskTypesClient.g.cs
@@ -180,7 +180,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(RegionDiskTypes.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(RegionDiskTypes.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionDisksClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionDisksClient.g.cs
@@ -449,7 +449,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(RegionDisks.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(RegionDisks.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionHealthCheckServicesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionHealthCheckServicesClient.g.cs
@@ -277,7 +277,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(RegionHealthCheckServices.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(RegionHealthCheckServices.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionHealthChecksClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionHealthChecksClient.g.cs
@@ -306,7 +306,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(RegionHealthChecks.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(RegionHealthChecks.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionInstanceGroupManagersClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionInstanceGroupManagersClient.g.cs
@@ -690,7 +690,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(RegionInstanceGroupManagers.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(RegionInstanceGroupManagers.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionInstanceGroupsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionInstanceGroupsClient.g.cs
@@ -224,7 +224,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(RegionInstanceGroups.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(RegionInstanceGroups.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionInstancesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionInstancesClient.g.cs
@@ -166,7 +166,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(RegionInstances.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(RegionInstances.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionNetworkEndpointGroupsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionNetworkEndpointGroupsClient.g.cs
@@ -244,7 +244,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(RegionNetworkEndpointGroups.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(RegionNetworkEndpointGroups.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionNetworkFirewallPoliciesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionNetworkFirewallPoliciesClient.g.cs
@@ -596,7 +596,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(RegionNetworkFirewallPolicies.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(RegionNetworkFirewallPolicies.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionNotificationEndpointsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionNotificationEndpointsClient.g.cs
@@ -245,7 +245,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(RegionNotificationEndpoints.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(RegionNotificationEndpoints.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionOperationsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionOperationsClient.g.cs
@@ -204,7 +204,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(RegionOperations.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(RegionOperations.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionSecurityPoliciesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionSecurityPoliciesClient.g.cs
@@ -277,7 +277,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(RegionSecurityPolicies.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(RegionSecurityPolicies.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionSslCertificatesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionSslCertificatesClient.g.cs
@@ -245,7 +245,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(RegionSslCertificates.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(RegionSslCertificates.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionTargetHttpProxiesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionTargetHttpProxiesClient.g.cs
@@ -277,7 +277,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(RegionTargetHttpProxies.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(RegionTargetHttpProxies.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionTargetHttpsProxiesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionTargetHttpsProxiesClient.g.cs
@@ -342,7 +342,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(RegionTargetHttpsProxies.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(RegionTargetHttpsProxies.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionUrlMapsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionUrlMapsClient.g.cs
@@ -320,7 +320,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(RegionUrlMaps.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(RegionUrlMaps.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionsClient.g.cs
@@ -178,7 +178,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Regions.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Regions.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ReservationsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ReservationsClient.g.cs
@@ -376,7 +376,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Reservations.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Reservations.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ResourcePoliciesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ResourcePoliciesClient.g.cs
@@ -313,7 +313,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(ResourcePolicies.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(ResourcePolicies.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RoutersClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RoutersClient.g.cs
@@ -383,7 +383,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Routers.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Routers.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RoutesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RoutesClient.g.cs
@@ -239,7 +239,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Routes.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Routes.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/SecurityPoliciesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/SecurityPoliciesClient.g.cs
@@ -438,7 +438,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(SecurityPolicies.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(SecurityPolicies.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ServiceAttachmentsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ServiceAttachmentsClient.g.cs
@@ -346,7 +346,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(ServiceAttachments.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(ServiceAttachments.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/SnapshotsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/SnapshotsClient.g.cs
@@ -322,7 +322,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Snapshots.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Snapshots.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/SslCertificatesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/SslCertificatesClient.g.cs
@@ -265,7 +265,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(SslCertificates.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(SslCertificates.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/SslPoliciesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/SslPoliciesClient.g.cs
@@ -296,7 +296,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(SslPolicies.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(SslPolicies.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/SubnetworksClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/SubnetworksClient.g.cs
@@ -431,7 +431,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Subnetworks.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Subnetworks.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetGrpcProxiesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetGrpcProxiesClient.g.cs
@@ -275,7 +275,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(TargetGrpcProxies.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(TargetGrpcProxies.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetHttpProxiesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetHttpProxiesClient.g.cs
@@ -329,7 +329,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(TargetHttpProxies.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(TargetHttpProxies.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetHttpsProxiesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetHttpsProxiesClient.g.cs
@@ -459,7 +459,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(TargetHttpsProxies.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(TargetHttpsProxies.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetInstancesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetInstancesClient.g.cs
@@ -265,7 +265,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(TargetInstances.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(TargetInstances.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetPoolsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetPoolsClient.g.cs
@@ -437,7 +437,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(TargetPools.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(TargetPools.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetSslProxiesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetSslProxiesClient.g.cs
@@ -403,7 +403,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(TargetSslProxies.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(TargetSslProxies.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetTcpProxiesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetTcpProxiesClient.g.cs
@@ -307,7 +307,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(TargetTcpProxies.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(TargetTcpProxies.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetVpnGatewaysClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetVpnGatewaysClient.g.cs
@@ -265,7 +265,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(TargetVpnGateways.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(TargetVpnGateways.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/UrlMapsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/UrlMapsClient.g.cs
@@ -371,7 +371,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(UrlMaps.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(UrlMaps.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/VpnGatewaysClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/VpnGatewaysClient.g.cs
@@ -331,7 +331,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(VpnGateways.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(VpnGateways.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/VpnTunnelsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/VpnTunnelsClient.g.cs
@@ -264,7 +264,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(VpnTunnels.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(VpnTunnels.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ZoneOperationsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ZoneOperationsClient.g.cs
@@ -204,7 +204,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(ZoneOperations.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(ZoneOperations.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ZonesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ZonesClient.g.cs
@@ -178,7 +178,7 @@ namespace Google.Cloud.Compute.V1
         });
 
         /// <summary>The service metadata associated with this client type.</summary>
-        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Zones.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Grpc, PackageApiMetadata.ApiMetadata);
+        public static gaxgrpc::ServiceMetadata ServiceMetadata { get; } = new gaxgrpc::ServiceMetadata(Zones.Descriptor, DefaultEndpoint, DefaultScopes, true, gax::ApiTransports.Rest, PackageApiMetadata.ApiMetadata);
 
         internal static gaxgrpc::ChannelPool ChannelPool { get; } = new gaxgrpc::ChannelPool(ServiceMetadata);
 


### PR DESCRIPTION
This was generated with the wrong transport (gRPC instead of REST)
leading to all integration tests failing.

After this is merged, this commit will be tagged with the release,
but https://github.com/googleapis/google-cloud-dotnet/pull/8968 is
still the PR with all the relevant details.