### PR TITLE
ci: Updates Document AI V1 pre-generation script.

### DIFF
--- a/apis/Google.Cloud.DocumentAI.V1/pregeneration.sh
+++ b/apis/Google.Cloud.DocumentAI.V1/pregeneration.sh
@@ -4,7 +4,4 @@ set -e
 
 # Delete the resource definition for the documentai.googleapis.com/Location type.
 # It has the same pattern as the common location type, so we want to use that instead.
-# Note that takes advantage of the fact that there's another resource definition
-# immediately after it - so it removes the first line of *that* resource definition,
-# but leaves the first line of the location definition, because sed doesn't backtrack.
-sed -i '/ type: "documentai.googleapis.com\/Location"/I,+3 d' $GOOGLEAPIS/google/cloud/documentai/v1/*.proto
+sed -i -z '/option (google.api.resource_definition) = {\n type: "documentai.googleapis.com\/Location"/I,+2 d' $GOOGLEAPIS/google/cloud/documentai/v1/*.proto


### PR DESCRIPTION
At least in some protos, the Location resource definition is the last resource definition so the previous scripts has stopped working.
This should fix the issues in #8979.