### PR TITLE
build: Update location dependencies in Document AI.

### DIFF
--- a/apis/Google.Cloud.DocumentAI.V1/pregeneration.sh
+++ b/apis/Google.Cloud.DocumentAI.V1/pregeneration.sh
@@ -4,4 +4,16 @@ set -e
 
 # Delete the resource definition for the documentai.googleapis.com/Location type.
 # It has the same pattern as the common location type, so we want to use that instead.
-sed -i -z '/option (google.api.resource_definition) = {\n type: "documentai.googleapis.com\/Location"/I,+2 d' $GOOGLEAPIS/google/cloud/documentai/v1/*.proto
+
+proto_files=$(dir $GOOGLEAPIS/google/cloud/documentai/v1/*.proto)
+
+for proto_file in $proto_files
+do
+  index=$(grep -n -h -- 'type: "documentai.googleapis.com\/Location"' $proto_file | sed 's/:.*//')
+  if [[ $index != "" ]]
+  then
+    start="$(($index-1))"
+    end="$(($index+2))"
+    sed -i ""$start","$end"d" $proto_file
+  fi
+done

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/pregeneration.sh
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/pregeneration.sh
@@ -4,7 +4,16 @@ set -e
 
 # Delete the resource definition for the documentai.googleapis.com/Location type.
 # It has the same pattern as the common location type, so we want to use that instead.
-# Note that takes advantage of the fact that there's another resource definition
-# immediately after it - so it removes the first line of *that* resource definition,
-# but leaves the first line of the location definition, because sed doesn't backtrack.
-sed -i '/ type: "documentai.googleapis.com\/Location"/I,+3 d' $GOOGLEAPIS/google/cloud/documentai/v1beta3/*.proto
+
+proto_files=$(dir $GOOGLEAPIS/google/cloud/documentai/v1beta3/*.proto)
+
+for proto_file in $proto_files
+do
+  index=$(grep -n -h -- 'type: "documentai.googleapis.com\/Location"' $proto_file | sed 's/:.*//')
+  if [[ $index != "" ]]
+  then
+    start="$(($index-1))"
+    end="$(($index+2))"
+    sed -i ""$start","$end"d" $proto_file
+  fi
+done

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1445,6 +1445,7 @@
       ],
       "dependencies": {
         "Google.Api.Gax.Grpc": "4.0.0",
+        "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
         "Grpc.Core": "2.46.3"
       },
@@ -1469,6 +1470,7 @@
         "automl"
       ],
       "dependencies": {
+        "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0"
       },
       "generator": "micro",


### PR DESCRIPTION
- Updates preprocessing script to remove the resource definition for the documentai.googleapis.com/Location type without relying on it not being the last resource definition.
- Add Google.Cloud.Location dependencies as Location mixins are being generated now.
- This change apply to both Document AI V1 and V1Beta3 (the CL for V1Beta3 is coming).