### PR TITLE
Release Google.Cloud.DocumentAI.V1 version 3.0.0

### DIFF
--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.csproj
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0-beta00</Version>
+    <Version>3.0.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Document AI API (v1), which is a service to parse structured information from unstructured or semi-structured documents using state-of-the-art Google AI such as natural language, computer vision, translation, and AutoML.</Description>

--- a/apis/Google.Cloud.DocumentAI.V1/docs/history.md
+++ b/apis/Google.Cloud.DocumentAI.V1/docs/history.md
@@ -1,5 +1,25 @@
 # Version history
 
+## Version 3.0.0, released 2022-08-16
+
+### New features
+
+- Regenerate DocumentAI manually ([commit d5df4a6](https://github.com/googleapis/google-cloud-dotnet/commit/d5df4a6a513faac93c7b382498efacbf64237def))
+- Added field_mask to ProcessRequest object in document_processor_service.proto ([commit d5df4a6](https://github.com/googleapis/google-cloud-dotnet/commit/d5df4a6a513faac93c7b382498efacbf64237def))
+- Added parent_ids to Revision object in document.proto ([commit d5df4a6](https://github.com/googleapis/google-cloud-dotnet/commit/d5df4a6a513faac93c7b382498efacbf64237def))
+- Added integer_values, float_values and non_present to Entity object in document.proto ([commit d5df4a6](https://github.com/googleapis/google-cloud-dotnet/commit/d5df4a6a513faac93c7b382498efacbf64237def))
+- Added corrected_key_text, correct_value_text to FormField object in document.proto ([commit d5df4a6](https://github.com/googleapis/google-cloud-dotnet/commit/d5df4a6a513faac93c7b382498efacbf64237def))
+- Added OperationMetadata resource ([commit d5df4a6](https://github.com/googleapis/google-cloud-dotnet/commit/d5df4a6a513faac93c7b382498efacbf64237def))
+- Added Processor Management and Processor Version support to v1 library ([commit d5df4a6](https://github.com/googleapis/google-cloud-dotnet/commit/d5df4a6a513faac93c7b382498efacbf64237def))
+
+### Documentation improvements
+
+- Fix minor docstring formatting ([commit d5df4a6](https://github.com/googleapis/google-cloud-dotnet/commit/d5df4a6a513faac93c7b382498efacbf64237def))
+
+### Breaking changes
+
+- Changed the name field for ProcessRequest and BatchProcessorRequest to accept `*` so the name field can accept Processor and ProcessorVersion. ([commit d5df4a6](https://github.com/googleapis/google-cloud-dotnet/commit/d5df4a6a513faac93c7b382498efacbf64237def))
+
 ## Version 2.0.0, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1430,7 +1430,7 @@
     },
     {
       "id": "Google.Cloud.DocumentAI.V1",
-      "version": "3.0.0-beta00",
+      "version": "3.0.0",
       "type": "grpc",
       "productName": "Cloud Document AI",
       "productUrl": "https://cloud.google.com/solutions/document-ai",


### PR DESCRIPTION

Changes in this release:

### New features

- Regenerate DocumentAI manually ([commit d5df4a6](https://github.com/googleapis/google-cloud-dotnet/commit/d5df4a6a513faac93c7b382498efacbf64237def))
- Added field_mask to ProcessRequest object in document_processor_service.proto ([commit d5df4a6](https://github.com/googleapis/google-cloud-dotnet/commit/d5df4a6a513faac93c7b382498efacbf64237def))
- Added parent_ids to Revision object in document.proto ([commit d5df4a6](https://github.com/googleapis/google-cloud-dotnet/commit/d5df4a6a513faac93c7b382498efacbf64237def))
- Added integer_values, float_values and non_present to Entity object in document.proto ([commit d5df4a6](https://github.com/googleapis/google-cloud-dotnet/commit/d5df4a6a513faac93c7b382498efacbf64237def))
- Added corrected_key_text, correct_value_text to FormField object in document.proto ([commit d5df4a6](https://github.com/googleapis/google-cloud-dotnet/commit/d5df4a6a513faac93c7b382498efacbf64237def))
- Added OperationMetadata resource ([commit d5df4a6](https://github.com/googleapis/google-cloud-dotnet/commit/d5df4a6a513faac93c7b382498efacbf64237def))
- Added Processor Management and Processor Version support to v1 library ([commit d5df4a6](https://github.com/googleapis/google-cloud-dotnet/commit/d5df4a6a513faac93c7b382498efacbf64237def))

### Documentation improvements

- Fix minor docstring formatting ([commit d5df4a6](https://github.com/googleapis/google-cloud-dotnet/commit/d5df4a6a513faac93c7b382498efacbf64237def))

### Breaking changes

- Changed the name field for ProcessRequest and BatchProcessorRequest to accept `*` so the name field can accept Processor and ProcessorVersion. ([commit d5df4a6](https://github.com/googleapis/google-cloud-dotnet/commit/d5df4a6a513faac93c7b382498efacbf64237def))
