### PR TITLE
Release Google.Maps.Routing.V2 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Maps.Routing.V2/Google.Maps.Routing.V2/Google.Maps.Routing.V2.csproj
+++ b/apis/Google.Maps.Routing.V2/Google.Maps.Routing.V2/Google.Maps.Routing.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Maps Routes Preferred API.</Description>

--- a/apis/Google.Maps.Routing.V2/docs/history.md
+++ b/apis/Google.Maps.Routing.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2022-08-18
+
+### Documentation improvements
+
+- Refer to request field by correct name: routing_preference ([commit 9e3c24d](https://github.com/googleapis/google-cloud-dotnet/commit/9e3c24dac93688f3ac51e87fdb894e61af1d5a42))
+
 ## Version 1.0.0-beta01, released 2022-08-03
 
 Initial release.

--- a/apis/Google.Maps.Routing.V2/docs/index.md
+++ b/apis/Google.Maps.Routing.V2/docs/index.md
@@ -1,6 +1,7 @@
 {{title}}
 
-{{description}}
+`Google.Maps.Routing.V2` is a.NET client library for the Maps
+Routing API, which is currently in private preview.
 
 {{version}}
 

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4140,7 +4140,7 @@
     },
     {
       "id": "Google.Maps.Routing.V2",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Maps Routing",
       "productUrl": "https://developers.google.com/maps/documentation/routes_preferred",


### PR DESCRIPTION

Changes in this release:

### Documentation improvements

- Refer to request field by correct name: routing_preference ([commit 9e3c24d](https://github.com/googleapis/google-cloud-dotnet/commit/9e3c24dac93688f3ac51e87fdb894e61af1d5a42))
