### PR TITLE
docs: Remove XML escaping within backticks

### DIFF
--- a/docs/Google.Cloud.DocTools.sln
+++ b/docs/Google.Cloud.DocTools.sln
@@ -33,6 +33,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Tools.DocfxMet
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Tools.FetchDependencyXrefmaps", "..\tools\Google.Cloud.Tools.FetchDependencyXrefmaps\Google.Cloud.Tools.FetchDependencyXrefmaps.csproj", "{3734E267-99C5-4C80-9D73-D411B6773BC5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Tools.UnescapeDocfxMetadataXml", "..\tools\Google.Cloud.Tools.UnescapeDocfxMetadataXml\Google.Cloud.Tools.UnescapeDocfxMetadataXml.csproj", "{60920FE5-243D-4A75-9B42-D03DF86AA6AF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -223,6 +225,18 @@ Global
 		{3734E267-99C5-4C80-9D73-D411B6773BC5}.Release|x64.Build.0 = Release|Any CPU
 		{3734E267-99C5-4C80-9D73-D411B6773BC5}.Release|x86.ActiveCfg = Release|Any CPU
 		{3734E267-99C5-4C80-9D73-D411B6773BC5}.Release|x86.Build.0 = Release|Any CPU
+		{60920FE5-243D-4A75-9B42-D03DF86AA6AF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{60920FE5-243D-4A75-9B42-D03DF86AA6AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{60920FE5-243D-4A75-9B42-D03DF86AA6AF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{60920FE5-243D-4A75-9B42-D03DF86AA6AF}.Debug|x64.Build.0 = Debug|Any CPU
+		{60920FE5-243D-4A75-9B42-D03DF86AA6AF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{60920FE5-243D-4A75-9B42-D03DF86AA6AF}.Debug|x86.Build.0 = Debug|Any CPU
+		{60920FE5-243D-4A75-9B42-D03DF86AA6AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{60920FE5-243D-4A75-9B42-D03DF86AA6AF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{60920FE5-243D-4A75-9B42-D03DF86AA6AF}.Release|x64.ActiveCfg = Release|Any CPU
+		{60920FE5-243D-4A75-9B42-D03DF86AA6AF}.Release|x64.Build.0 = Release|Any CPU
+		{60920FE5-243D-4A75-9B42-D03DF86AA6AF}.Release|x86.ActiveCfg = Release|Any CPU
+		{60920FE5-243D-4A75-9B42-D03DF86AA6AF}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/docs/builddocs.sh
+++ b/docs/builddocs.sh
@@ -40,6 +40,10 @@ build_api_docs() {
   $DOCFX metadata --logLevel Warning -f output/$api/docfx-devsite.json | tee errors.txt | grep -v "Invalid file link"
   (! grep --quiet 'Build failed.' errors.txt)
 
+  # Unescape the metadata files for both devsite and googleapis.dev
+  dotnet run --no-build --no-restore --project ../tools/Google.Cloud.Tools.UnescapeDocfxMetadataXml -- output/$api/obj/api
+  dotnet run --no-build --no-restore --project ../tools/Google.Cloud.Tools.UnescapeDocfxMetadataXml -- output/$api/obj/bareapi
+
   # Generate the snippet markdown
   dotnet run --no-build --no-restore --project ../tools/Google.Cloud.Tools.GenerateSnippetMarkdown -- $api
   

--- a/tools/Google.Cloud.Tools.UnescapeDocfxMetadataXml/Google.Cloud.Tools.UnescapeDocfxMetadataXml.csproj
+++ b/tools/Google.Cloud.Tools.UnescapeDocfxMetadataXml/Google.Cloud.Tools.UnescapeDocfxMetadataXml.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/tools/Google.Cloud.Tools.UnescapeDocfxMetadataXml/Program.cs
+++ b/tools/Google.Cloud.Tools.UnescapeDocfxMetadataXml/Program.cs
@@ -1,0 +1,82 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+
+// This console application finds all the yml files in the specified directory,
+// and removes any XML escaping from summary comments, only within backticks.
+
+using System.Text;
+using System.Text.RegularExpressions;
+
+if (args.Length != 1)
+{
+    Console.WriteLine("Error: specify the directory containing metadata files");
+    return 1;
+}
+
+Regex summaryRegex = new Regex("^  summary: \"(.*)\"$");
+
+foreach (var file in Directory.GetFiles(args[0], "*.yml"))
+{
+    if (Path.GetFileName(file) == "toc.yml")
+    {
+        continue;
+    }
+    var lines = File.ReadAllLines(file);
+    for (int i = 0; i < lines.Length; i++)
+    {
+        var match = summaryRegex.Match(lines[i]);
+        if (match.Success)
+        {
+            var unescaped = Unescape(match.Groups[1].Value);
+            lines[i] = $"  summary: \"{unescaped}\"";
+        }
+    }
+    File.WriteAllLines(file, lines);
+}
+return 0;
+
+string Unescape(string summary)
+{
+    if (summary.Length < 5 || !summary.Contains("&amp;") && !summary.Contains("&lt;"))
+    {
+        return summary;
+    }
+    bool inBackticks = false;
+    StringBuilder builder = new StringBuilder();
+    for (int i = 0; i < summary.Length - 5; i++)
+    {
+        if (summary[i] == '`')
+        {
+            inBackticks = !inBackticks;
+        }
+        if (inBackticks && summary[i] == '&' && summary.Substring(i, 5) == "&amp;")
+        {
+            builder.Append("&");
+            i += 4;
+        }
+        else if (inBackticks && summary[i] == '&' && summary.Substring(i, 4) == "&lt;")
+        {
+            builder.Append("<");
+            i += 3;
+        }
+        else
+        {
+            builder.Append(summary[i]);
+        }
+    }
+
+    builder.Append(summary[^5..]);
+    return builder.ToString();
+}


### PR DESCRIPTION
Workaround for https://github.com/dotnet/docfx/issues/2723

(When the angle brackets aren't in backticks, it's fine.)