### PR TITLE
Release Google.Maps.Routing.V2 version 1.0.0-beta03

### DIFF
--- a/apis/Google.Maps.Routing.V2/Google.Maps.Routing.V2/Google.Maps.Routing.V2.csproj
+++ b/apis/Google.Maps.Routing.V2/Google.Maps.Routing.V2/Google.Maps.Routing.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Maps Routes Preferred API.</Description>

--- a/apis/Google.Maps.Routing.V2/docs/history.md
+++ b/apis/Google.Maps.Routing.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta03, released 2022-08-26
+
+### New features
+
+- Add new toll passes ([commit a1b8de9](https://github.com/googleapis/google-cloud-dotnet/commit/a1b8de9cb4d86242de9e9590cad118f72056201d))
+
 ## Version 1.0.0-beta02, released 2022-08-18
 
 ### Documentation improvements

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4143,7 +4143,7 @@
     },
     {
       "id": "Google.Maps.Routing.V2",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0-beta03",
       "type": "grpc",
       "productName": "Maps Routing",
       "productUrl": "https://developers.google.com/maps/documentation/routes_preferred",


### PR DESCRIPTION

Changes in this release:

### New features

- Add new toll passes ([commit a1b8de9](https://github.com/googleapis/google-cloud-dotnet/commit/a1b8de9cb4d86242de9e9590cad118f72056201d))
