### PR TITLE
chore: Update pip requirements again

### DIFF
--- a/.kokoro/requirements.txt
+++ b/.kokoro/requirements.txt
@@ -412,6 +412,10 @@ six==1.16.0 \
     #   gcp-docuploader
     #   google-auth
     #   python-dateutil
+typing-extensions==4.3.0 \
+    --hash=sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02 \
+    --hash=sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6
+    # via -r requirements.in
 urllib3==1.26.12 \
     --hash=sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e \
     --hash=sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997


### PR DESCRIPTION
It looks like some dependency needs typing-extensions on Python 3.7
(which is what our Kokoro machine has right now).