### PR TITLE
Release Google.Cloud.PubSub.V1 version 3.2.0

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.1.0</Version>
+    <Version>3.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.</Description>

--- a/apis/Google.Cloud.PubSub.V1/docs/history.md
+++ b/apis/Google.Cloud.PubSub.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 3.2.0, released 2022-08-26
+
+### New features
+
+- Exactly once delivery ([commit e93c4d3](https://github.com/googleapis/google-cloud-dotnet/commit/e93c4d38bd93f2ff0547022a77578f10b0abd884))
+- Add support for exactly once subscription ([commit 46d8b0d](https://github.com/googleapis/google-cloud-dotnet/commit/46d8b0d0581c9098b1e756663c59856430106634))
+
 ## Version 3.1.0, released 2022-07-27
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2819,7 +2819,7 @@
       "protoPath": "google/pubsub/v1",
       "productName": "Cloud Pub/Sub",
       "productUrl": "https://cloud.google.com/pubsub/",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.",


### PR DESCRIPTION

Changes in this release:

### New features

- Exactly once delivery ([commit e93c4d3](https://github.com/googleapis/google-cloud-dotnet/commit/e93c4d38bd93f2ff0547022a77578f10b0abd884))
- Add support for exactly once subscription ([commit 46d8b0d](https://github.com/googleapis/google-cloud-dotnet/commit/46d8b0d0581c9098b1e756663c59856430106634))
