### PR TITLE
Release Google.Analytics.Admin.V1Alpha version 2.0.0-alpha02

### DIFF
--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha01</Version>
+    <Version>2.0.0-alpha02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Analytics Admin API (v1alpha)</Description>

--- a/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
+++ b/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 2.0.0-alpha02, released 2022-08-26
+
+### New features
+
+- Add `RunAccessReport` method to the Admin API v1alpha ([commit aefb670](https://github.com/googleapis/google-cloud-dotnet/commit/aefb670273c7d80966120278a4be22648601bd4e))
+- Add `GetAudience`, 'ListAudience', 'CreateAudience', 'UpdateAudience', 'ArchiveAudience' methods to the Admin API v1alpha ([commit 12697c8](https://github.com/googleapis/google-cloud-dotnet/commit/12697c884fbb2bb660ff58413c6d4ef5a1b7436f))
+- Add `GetAttributionSettings`, `UpdateAttributionSettings` methods to the Admin API v1alpha ([commit 12697c8](https://github.com/googleapis/google-cloud-dotnet/commit/12697c884fbb2bb660ff58413c6d4ef5a1b7436f))
+
 ## Version 2.0.0-alpha01, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2,7 +2,7 @@
   "apis": [
     {
       "id": "Google.Analytics.Admin.V1Alpha",
-      "version": "2.0.0-alpha01",
+      "version": "2.0.0-alpha02",
       "type": "grpc",
       "productName": "Analytics Admin",
       "productUrl": "https://developers.google.com/analytics",


### PR DESCRIPTION

Changes in this release:

### New features

- Add `RunAccessReport` method to the Admin API v1alpha ([commit aefb670](https://github.com/googleapis/google-cloud-dotnet/commit/aefb670273c7d80966120278a4be22648601bd4e))
- Add `GetAudience`, 'ListAudience', 'CreateAudience', 'UpdateAudience', 'ArchiveAudience' methods to the Admin API v1alpha ([commit 12697c8](https://github.com/googleapis/google-cloud-dotnet/commit/12697c884fbb2bb660ff58413c6d4ef5a1b7436f))
- Add `GetAttributionSettings`, `UpdateAttributionSettings` methods to the Admin API v1alpha ([commit 12697c8](https://github.com/googleapis/google-cloud-dotnet/commit/12697c884fbb2bb660ff58413c6d4ef5a1b7436f))
