### PR TITLE
Release Google.Cloud.AccessApproval.V1 version 2.1.0

### DIFF
--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.csproj
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>An API for controlling access to data by Google personnel.</Description>

--- a/apis/Google.Cloud.AccessApproval.V1/docs/history.md
+++ b/apis/Google.Cloud.AccessApproval.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.1.0, released 2022-08-26
+
+### Documentation improvements
+
+- Added Cloud Dataproc and Secret Manager to the list of supported services ([commit 2e67e98](https://github.com/googleapis/google-cloud-dotnet/commit/2e67e9886da7e0c76743b4176bf3a9509e7db922))
+
 ## Version 2.0.0, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -80,7 +80,7 @@
     },
     {
       "id": "Google.Cloud.AccessApproval.V1",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "type": "grpc",
       "productName": "Access Approval",
       "productUrl": "https://cloud.google.com/access-approval/docs/",


### PR DESCRIPTION

Changes in this release:

### Documentation improvements

- Added Cloud Dataproc and Secret Manager to the list of supported services ([commit 2e67e98](https://github.com/googleapis/google-cloud-dotnet/commit/2e67e9886da7e0c76743b4176bf3a9509e7db922))
