### PR TITLE
Release Google.Cloud.ApigeeRegistry.V1 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.csproj
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Apigee Registry API which allows teams to upload and share machine-readable descriptions of APIs that are in use and in development.</Description>

--- a/apis/Google.Cloud.ApigeeRegistry.V1/docs/history.md
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2022-08-26
+
+### New features
+
+- Added support for `force` field for API and API version deletion ([commit f4c4c28](https://github.com/googleapis/google-cloud-dotnet/commit/f4c4c28da03aa7e81cb7c57a3152684d60b31e20))
+
+### Documentation improvements
+
+- Updated proto comments to align with the public documentation ([commit f4c4c28](https://github.com/googleapis/google-cloud-dotnet/commit/f4c4c28da03aa7e81cb7c57a3152684d60b31e20))
+
 ## Version 1.0.0-beta01, released 2022-06-13
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -184,7 +184,7 @@
     },
     {
       "id": "Google.Cloud.ApigeeRegistry.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Apigee Registry",
       "description": "Recommended Google client library to access the Apigee Registry API which allows teams to upload and share machine-readable descriptions of APIs that are in use and in development.",


### PR DESCRIPTION

Changes in this release:

### New features

- Added support for `force` field for API and API version deletion ([commit f4c4c28](https://github.com/googleapis/google-cloud-dotnet/commit/f4c4c28da03aa7e81cb7c57a3152684d60b31e20))

### Documentation improvements

- Updated proto comments to align with the public documentation ([commit f4c4c28](https://github.com/googleapis/google-cloud-dotnet/commit/f4c4c28da03aa7e81cb7c57a3152684d60b31e20))
