### PR TITLE
Release Google.Cloud.BigQuery.Migration.V2 version 1.0.0-beta03

### DIFF
--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.csproj
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery Migration service, exposing apis for migration jobs operations, and agent management.</Description>

--- a/apis/Google.Cloud.BigQuery.Migration.V2/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta03, released 2022-08-26
+
+### New features
+
+- Add MySQL dialect to bigquerymigration v2 client library ([commit 039f088](https://github.com/googleapis/google-cloud-dotnet/commit/039f088e2f44d416ea484ca7c71ce157e7782698))
+
 ## Version 1.0.0-beta02, released 2022-07-25
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -613,7 +613,7 @@
     },
     {
       "id": "Google.Cloud.BigQuery.Migration.V2",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0-beta03",
       "type": "grpc",
       "productName": "BigQuery Migration",
       "productUrl": "https://cloud.google.com/bigquery/docs/migration-intro",


### PR DESCRIPTION

Changes in this release:

### New features

- Add MySQL dialect to bigquerymigration v2 client library ([commit 039f088](https://github.com/googleapis/google-cloud-dotnet/commit/039f088e2f44d416ea484ca7c71ce157e7782698))
