### PR TITLE
Release Google.Cloud.BigQuery.Storage.V1 version 3.2.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.1.0</Version>
+    <Version>3.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery Storage API.</Description>

--- a/apis/Google.Cloud.BigQuery.Storage.V1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 3.2.0, released 2022-08-26
+
+### New features
+
+- Allow users to set Apache Avro output format options through avro_serialization_options param in TableReadOptions message ([commit 9c2cc6c](https://github.com/googleapis/google-cloud-dotnet/commit/9c2cc6cb2215773f75923eddec131204b6da03ea))
+
+### Documentation improvements
+
+- Clarify size limitations for AppendRowsRequest ([commit 8b061b5](https://github.com/googleapis/google-cloud-dotnet/commit/8b061b52b56c6bc7649d2b62a7771ea9ef48da69))
+
 ## Version 3.1.0, released 2022-07-11
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -674,7 +674,7 @@
       "protoPath": "google/cloud/bigquery/storage/v1",
       "productName": "Google BigQuery Storage",
       "productUrl": "https://cloud.google.com/bigquery/docs/reference/storage/",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the BigQuery Storage API.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Allow users to set Apache Avro output format options through avro_serialization_options param in TableReadOptions message ([commit 9c2cc6c](https://github.com/googleapis/google-cloud-dotnet/commit/9c2cc6cb2215773f75923eddec131204b6da03ea))

### Documentation improvements

- Clarify size limitations for AppendRowsRequest ([commit 8b061b5](https://github.com/googleapis/google-cloud-dotnet/commit/8b061b52b56c6bc7649d2b62a7771ea9ef48da69))
