### PR TITLE
Release Google.Cloud.Datastream.V1 version 2.1.0

### DIFF
--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.csproj
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Datastream API (v1), which allows you to synchronize data across heterogeneous databases and applications reliably, and with minimal latency and downtime.</Description>

--- a/apis/Google.Cloud.Datastream.V1/docs/history.md
+++ b/apis/Google.Cloud.Datastream.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.1.0, released 2022-08-26
+
+### New features
+
+- Added support for BigQuery destination and PostgreSQL source types ([commit 675d15d](https://github.com/googleapis/google-cloud-dotnet/commit/675d15ddd7a0ff36cfdd35e2f1257669a25a464f))
+
 ## Version 2.0.0, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1200,7 +1200,7 @@
     },
     {
       "id": "Google.Cloud.Datastream.V1",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "type": "grpc",
       "productName": "DataStream",
       "productUrl": "https://cloud.google.com/datastream/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Added support for BigQuery destination and PostgreSQL source types ([commit 675d15d](https://github.com/googleapis/google-cloud-dotnet/commit/675d15ddd7a0ff36cfdd35e2f1257669a25a464f))
