### PR TITLE
Release Google.Cloud.DocumentAI.V1Beta3 version 2.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.csproj
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta01</Version>
+    <Version>2.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Document AI API (v1beta3), which is a service to parse structured information from unstructured or semi-structured documents using state-of-the-art Google AI such as natural language, computer vision, translation, and AutoML.</Description>

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/docs/history.md
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/docs/history.md
@@ -1,5 +1,21 @@
 # Version history
 
+## Version 2.0.0-beta02, released 2022-08-26
+
+### New features
+
+- Added field_mask to ProcessRequest object in document_processor_service.proto ([commit a750fad](https://github.com/googleapis/google-cloud-dotnet/commit/a750fad672712acf62c7b5d4a98b7095bfeed4ea))
+- Added parent_ids to Revision object in document.proto ([commit a750fad](https://github.com/googleapis/google-cloud-dotnet/commit/a750fad672712acf62c7b5d4a98b7095bfeed4ea))
+- Added integer_values, float_values and non_present to Entity object in document.proto ([commit a750fad](https://github.com/googleapis/google-cloud-dotnet/commit/a750fad672712acf62c7b5d4a98b7095bfeed4ea))
+- Added corrected_key_text, correct_value_text to FormField object in document.proto ([commit a750fad](https://github.com/googleapis/google-cloud-dotnet/commit/a750fad672712acf62c7b5d4a98b7095bfeed4ea))
+- Added OperationMetadata resource ([commit a750fad](https://github.com/googleapis/google-cloud-dotnet/commit/a750fad672712acf62c7b5d4a98b7095bfeed4ea))
+- Added Barcode support ([commit a750fad](https://github.com/googleapis/google-cloud-dotnet/commit/a750fad672712acf62c7b5d4a98b7095bfeed4ea))
+- **BREAKING CHANGE** Added Processor Management and Processor Version support to v1 library ([commit a750fad](https://github.com/googleapis/google-cloud-dotnet/commit/a750fad672712acf62c7b5d4a98b7095bfeed4ea))
+
+### Breaking changes
+
+- Changed the name field for ProcessRequest and BatchProcessorRequest to accept * so the name field can accept Processor and ProcessorVersion. ([commit a750fad](https://github.com/googleapis/google-cloud-dotnet/commit/a750fad672712acf62c7b5d4a98b7095bfeed4ea))
+
 ## Version 2.0.0-beta01, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1477,7 +1477,7 @@
     },
     {
       "id": "Google.Cloud.DocumentAI.V1Beta3",
-      "version": "2.0.0-beta01",
+      "version": "2.0.0-beta02",
       "type": "grpc",
       "productName": "Cloud Document AI",
       "productUrl": "https://cloud.google.com/solutions/document-ai",


### PR DESCRIPTION

Changes in this release:

### New features

- Added field_mask to ProcessRequest object in document_processor_service.proto ([commit a750fad](https://github.com/googleapis/google-cloud-dotnet/commit/a750fad672712acf62c7b5d4a98b7095bfeed4ea))
- Added parent_ids to Revision object in document.proto ([commit a750fad](https://github.com/googleapis/google-cloud-dotnet/commit/a750fad672712acf62c7b5d4a98b7095bfeed4ea))
- Added integer_values, float_values and non_present to Entity object in document.proto ([commit a750fad](https://github.com/googleapis/google-cloud-dotnet/commit/a750fad672712acf62c7b5d4a98b7095bfeed4ea))
- Added corrected_key_text, correct_value_text to FormField object in document.proto ([commit a750fad](https://github.com/googleapis/google-cloud-dotnet/commit/a750fad672712acf62c7b5d4a98b7095bfeed4ea))
- Added OperationMetadata resource ([commit a750fad](https://github.com/googleapis/google-cloud-dotnet/commit/a750fad672712acf62c7b5d4a98b7095bfeed4ea))
- Added Barcode support ([commit a750fad](https://github.com/googleapis/google-cloud-dotnet/commit/a750fad672712acf62c7b5d4a98b7095bfeed4ea))
- **BREAKING CHANGE** Added Processor Management and Processor Version support to v1 library ([commit a750fad](https://github.com/googleapis/google-cloud-dotnet/commit/a750fad672712acf62c7b5d4a98b7095bfeed4ea))

### Breaking changes

- Changed the name field for ProcessRequest and BatchProcessorRequest to accept * so the name field can accept Processor and ProcessorVersion. ([commit a750fad](https://github.com/googleapis/google-cloud-dotnet/commit/a750fad672712acf62c7b5d4a98b7095bfeed4ea))
