### PR TITLE
Release Google.Cloud.SecurityCenter.V1 version 3.3.0

### DIFF
--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.csproj
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.2.0</Version>
+    <Version>3.3.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Security Command Center API, which helps security teams gather data, identify threats, and act on them before they result in business damage or loss.</Description>

--- a/apis/Google.Cloud.SecurityCenter.V1/docs/history.md
+++ b/apis/Google.Cloud.SecurityCenter.V1/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 3.3.0, released 2022-08-26
+
+### New features
+
+- ServiceAccountKeyName, serviceAccountDelegationInfo, and principalSubject attributes added to the existing access attribute. These new attributes provide additional context about the principals that are associated with the finding ([commit 5870e2d](https://github.com/googleapis/google-cloud-dotnet/commit/5870e2dfdb9221503f15406e530bdb42c86830a9))
+- Adding database access information, such as queries field to a finding. A database may be a sub-resource of an instance (as in the case of CloudSQL instances or Cloud Spanner instances), or the database instance itself ([commit e48b4d0](https://github.com/googleapis/google-cloud-dotnet/commit/e48b4d01db1d5d636b298d9c85918c43b528ffb9))
+- Adding uris to indicator of compromise (IOC) field ([commit 70d4dca](https://github.com/googleapis/google-cloud-dotnet/commit/70d4dca37b7f50c8f243fcd8b17a23ce3a544663))
+
 ## Version 3.2.0, released 2022-07-25
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3171,7 +3171,7 @@
       "protoPath": "google/cloud/securitycenter/v1",
       "productName": "Google Cloud Security Command Center",
       "productUrl": "https://cloud.google.com/security-command-center/",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Security Command Center API, which helps security teams gather data, identify threats, and act on them before they result in business damage or loss.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- ServiceAccountKeyName, serviceAccountDelegationInfo, and principalSubject attributes added to the existing access attribute. These new attributes provide additional context about the principals that are associated with the finding ([commit 5870e2d](https://github.com/googleapis/google-cloud-dotnet/commit/5870e2dfdb9221503f15406e530bdb42c86830a9))
- Adding database access information, such as queries field to a finding. A database may be a sub-resource of an instance (as in the case of CloudSQL instances or Cloud Spanner instances), or the database instance itself ([commit e48b4d0](https://github.com/googleapis/google-cloud-dotnet/commit/e48b4d01db1d5d636b298d9c85918c43b528ffb9))
- Adding uris to indicator of compromise (IOC) field ([commit 70d4dca](https://github.com/googleapis/google-cloud-dotnet/commit/70d4dca37b7f50c8f243fcd8b17a23ce3a544663))
