### PR TITLE
Release Google.Cloud.VpcAccess.V1 version 2.1.0

### DIFF
--- a/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.csproj
+++ b/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>API for managing VPC access connectors.</Description>

--- a/apis/Google.Cloud.VpcAccess.V1/docs/history.md
+++ b/apis/Google.Cloud.VpcAccess.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.1.0, released 2022-08-26
+
+### New features
+
+- Adds support for configuring scaling settings ([commit a9bbe6f](https://github.com/googleapis/google-cloud-dotnet/commit/a9bbe6f8aa80cfa8a6e23b614d506508fa787c61))
+
 ## Version 2.0.0, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3871,7 +3871,7 @@
     },
     {
       "id": "Google.Cloud.VpcAccess.V1",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "type": "grpc",
       "productName": "Serverless VPC Access",
       "productUrl": "https://cloud.google.com/vpc/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Adds support for configuring scaling settings ([commit a9bbe6f](https://github.com/googleapis/google-cloud-dotnet/commit/a9bbe6f8aa80cfa8a6e23b614d506508fa787c61))
