### PR TITLE
chore: Remove pregeneration scripts for Google.Cloud.NetworkSecurity.V1Beta1

### DIFF
--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/.OwlBot-ForceRegeneration.txt
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/.OwlBot-ForceRegeneration.txt
@@ -1,1 +1,0 @@
-API requires pre/mid-generation tweaks.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1/NetworkSecurityClient.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1/NetworkSecurityClient.g.cs
@@ -508,7 +508,6 @@ namespace Google.Cloud.NetworkSecurity.V1Beta1
     /// Network Security API provides resources to configure authentication and
     /// authorization policies. Refer to per API resource documentation for more
     /// information.
-    /// Network Security service.
     /// </remarks>
     public abstract partial class NetworkSecurityClient
     {
@@ -2661,7 +2660,6 @@ namespace Google.Cloud.NetworkSecurity.V1Beta1
     /// Network Security API provides resources to configure authentication and
     /// authorization policies. Refer to per API resource documentation for more
     /// information.
-    /// Network Security service.
     /// </remarks>
     public sealed partial class NetworkSecurityClientImpl : NetworkSecurityClient
     {

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1/NetworkSecurityGrpc.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1/NetworkSecurityGrpc.g.cs
@@ -27,7 +27,6 @@ namespace Google.Cloud.NetworkSecurity.V1Beta1 {
   /// Network Security API provides resources to configure authentication and
   /// authorization policies. Refer to per API resource documentation for more
   /// information.
-  /// Network Security service.
   /// </summary>
   public static partial class NetworkSecurity
   {

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/postgeneration.sh
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/postgeneration.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -e
-
-# Undo the changes made in pregeneration.sh
-git -C $GOOGLEAPIS checkout google/cloud/networksecurity/v1beta1

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/pregeneration.sh
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/pregeneration.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -e
-
-# Add a minimalist comment to the NetworkSecurity service so it will generate.
-sed -i 's/service NetworkSecurity/\/\/ Network Security service.\nservice NetworkSecurity/g' \
-  $GOOGLEAPIS/google/cloud/networksecurity/v1beta1/network_security.proto


### PR DESCRIPTION
First 3 commits (at time of creation) are from #9063 