### PR TITLE
tools: Change where the friendlyApiName item ends up in the devsite YAML

### DIFF
--- a/tools/Google.Cloud.Tools.PostProcessDevSite/Google.Cloud.Tools.PostProcessDevSite.csproj
+++ b/tools/Google.Cloud.Tools.PostProcessDevSite/Google.Cloud.Tools.PostProcessDevSite.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Instead of being directly in the root node, it should be in the first element
of the items root node.