### PR TITLE
Release Google.Cloud.BigQuery.DataExchange.V1Beta1 version 2.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.csproj
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta01</Version>
+    <Version>2.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery DataExchange API, which allows users to exchange data and analytics assets securely and efficiently.</Description>

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/docs/history.md
@@ -1,5 +1,27 @@
 # Version history
 
+## Version 2.0.0-beta02, released 2022-09-02
+
+### Bug fixes
+
+- **BREAKING CHANGE** Refactor references to Category message ([commit 56b0759](https://github.com/googleapis/google-cloud-dotnet/commit/56b0759444c88b64334b25873891ff81edcd74bd))
+
+### New features
+
+- **BREAKING CHANGE** Update BigQuery Analytics Hub API v1beta1 client ([commit 56b0759](https://github.com/googleapis/google-cloud-dotnet/commit/56b0759444c88b64334b25873891ff81edcd74bd))
+
+### Documentation improvements
+
+- Improve proto documentation. ([commit 56b0759](https://github.com/googleapis/google-cloud-dotnet/commit/56b0759444c88b64334b25873891ff81edcd74bd))
+
+### Breaking changes
+
+- Refresh current dataexchange/v1beta1/* directory to include recent change in protos. Removed common directory and use local enum Category ([commit 56b0759](https://github.com/googleapis/google-cloud-dotnet/commit/56b0759444c88b64334b25873891ff81edcd74bd))
+
+Note that the Google.Cloud.BigQuery.DataExchange.Common package is
+no longer a dependency of this package, and will be delisted from
+nuget.org.
+
 ## Version 2.0.0-beta01, released 2022-06-09
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -557,7 +557,7 @@
     },
     {
       "id": "Google.Cloud.BigQuery.DataExchange.V1Beta1",
-      "version": "2.0.0-beta01",
+      "version": "2.0.0-beta02",
       "type": "grpc",
       "productName": "Analytics Hub",
       "productUrl": "https://cloud.google.com/analytics-hub",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- **BREAKING CHANGE** Refactor references to Category message ([commit 56b0759](https://github.com/googleapis/google-cloud-dotnet/commit/56b0759444c88b64334b25873891ff81edcd74bd))

### New features

- **BREAKING CHANGE** Update BigQuery Analytics Hub API v1beta1 client ([commit 56b0759](https://github.com/googleapis/google-cloud-dotnet/commit/56b0759444c88b64334b25873891ff81edcd74bd))

### Documentation improvements

- Improve proto documentation. ([commit 56b0759](https://github.com/googleapis/google-cloud-dotnet/commit/56b0759444c88b64334b25873891ff81edcd74bd))

### Breaking changes

- Refresh current dataexchange/v1beta1/* directory to include recent change in protos. Removed common directory and use local enum Category ([commit 56b0759](https://github.com/googleapis/google-cloud-dotnet/commit/56b0759444c88b64334b25873891ff81edcd74bd))

Note that the Google.Cloud.BigQuery.DataExchange.Common package is no longer a dependency of this package, and will be delisted from nuget.org.
