### PR TITLE
Release Google.Cloud.ApigeeRegistry.V1 version 1.0.0-beta03

### DIFF
--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.csproj
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Apigee Registry API which allows teams to upload and share machine-readable descriptions of APIs that are in use and in development.</Description>

--- a/apis/Google.Cloud.ApigeeRegistry.V1/docs/history.md
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta03, released 2022-09-05
+
+### Bug fixes
+
+- Additional error codes added to service configuration for retry ([commit 0235c94](https://github.com/googleapis/google-cloud-dotnet/commit/0235c94a4bbfde3133c397d6623a2fb5bcec884a))
+
 ## Version 1.0.0-beta02, released 2022-08-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -184,7 +184,7 @@
     },
     {
       "id": "Google.Cloud.ApigeeRegistry.V1",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0-beta03",
       "type": "grpc",
       "productName": "Apigee Registry",
       "description": "Recommended Google client library to access the Apigee Registry API which allows teams to upload and share machine-readable descriptions of APIs that are in use and in development.",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Additional error codes added to service configuration for retry ([commit 0235c94](https://github.com/googleapis/google-cloud-dotnet/commit/0235c94a4bbfde3133c397d6623a2fb5bcec884a))
