### PR TITLE
Release Google.Cloud.AssuredWorkloads.V1Beta1 version 2.0.0-beta04

### DIFF
--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.csproj
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta03</Version>
+    <Version>2.0.0-beta04</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Assured Workloads API (v1beta1)</Description>

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 2.0.0-beta04, released 2022-09-05
+
+### New features
+
+- Add compliant_but_disallowed_services field to the v1beta1 Workload proto ([commit b632564](https://github.com/googleapis/google-cloud-dotnet/commit/b63256454b6baf3b7e879508b441d305250c5a9b))
+- Updated v1beta1 analyzeWorkloadMove documentation ([commit 80d91f3](https://github.com/googleapis/google-cloud-dotnet/commit/80d91f38efd947425ce6f785d523857e16fbf1eb))
+
 ## Version 2.0.0-beta03, released 2022-07-25
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -319,7 +319,7 @@
     },
     {
       "id": "Google.Cloud.AssuredWorkloads.V1Beta1",
-      "version": "2.0.0-beta03",
+      "version": "2.0.0-beta04",
       "type": "grpc",
       "productName": "Assured Workloads",
       "productUrl": "https://cloud.google.com/assured-workloads/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Add compliant_but_disallowed_services field to the v1beta1 Workload proto ([commit b632564](https://github.com/googleapis/google-cloud-dotnet/commit/b63256454b6baf3b7e879508b441d305250c5a9b))
- Updated v1beta1 analyzeWorkloadMove documentation ([commit 80d91f3](https://github.com/googleapis/google-cloud-dotnet/commit/80d91f38efd947425ce6f785d523857e16fbf1eb))
