### PR TITLE
Release Google.Cloud.Batch.V1Alpha version 1.0.0-alpha03

### DIFF
--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.csproj
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha02</Version>
+    <Version>1.0.0-alpha03</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Batch API (v1alpha), which allows you to manage the running of batch jobs on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Batch.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.Batch.V1Alpha/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 1.0.0-alpha03, released 2022-09-05
+
+### Bug fixes
+
+- Mark service_account_email as deprecated ([commit 28348ae](https://github.com/googleapis/google-cloud-dotnet/commit/28348ae1f06940c5c6ac8ee7403e537b2af1ec12))
+
+### Documentation improvements
+
+- Removing comment from a deprecated field ([commit 28348ae](https://github.com/googleapis/google-cloud-dotnet/commit/28348ae1f06940c5c6ac8ee7403e537b2af1ec12))
+
 ## Version 1.0.0-alpha02, released 2022-08-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -417,7 +417,7 @@
     },
     {
       "id": "Google.Cloud.Batch.V1Alpha",
-      "version": "1.0.0-alpha02",
+      "version": "1.0.0-alpha03",
       "type": "grpc",
       "productName": "Batch",
       "productUrl": "https://cloud.google.com/batch/docs/",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Mark service_account_email as deprecated ([commit 28348ae](https://github.com/googleapis/google-cloud-dotnet/commit/28348ae1f06940c5c6ac8ee7403e537b2af1ec12))

### Documentation improvements

- Removing comment from a deprecated field ([commit 28348ae](https://github.com/googleapis/google-cloud-dotnet/commit/28348ae1f06940c5c6ac8ee7403e537b2af1ec12))
