### PR TITLE
Release Google.Maps.Routing.V2 version 1.0.0-beta04

### DIFF
--- a/apis/Google.Maps.Routing.V2/Google.Maps.Routing.V2/Google.Maps.Routing.V2.csproj
+++ b/apis/Google.Maps.Routing.V2/Google.Maps.Routing.V2/Google.Maps.Routing.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta03</Version>
+    <Version>1.0.0-beta04</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Maps Routes Preferred API.</Description>

--- a/apis/Google.Maps.Routing.V2/docs/history.md
+++ b/apis/Google.Maps.Routing.V2/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 1.0.0-beta04, released 2022-09-05
+
+### Documentation improvements
+
+- Update documentation for RoutingPreference to better describe behaviors ([commit 991aeac](https://github.com/googleapis/google-cloud-dotnet/commit/991aeac0e3443845dde54cfd651cb057d92c9d46))
+- Update comment for Waypoint.side_of_road to accurately describe functionality ([commit 0ec23a7](https://github.com/googleapis/google-cloud-dotnet/commit/0ec23a74a4f77572e6f8115e3417a1787410bf66))
+
 ## Version 1.0.0-beta03, released 2022-08-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4165,7 +4165,7 @@
     },
     {
       "id": "Google.Maps.Routing.V2",
-      "version": "1.0.0-beta03",
+      "version": "1.0.0-beta04",
       "type": "grpc",
       "productName": "Maps Routing",
       "productUrl": "https://developers.google.com/maps/documentation/routes_preferred",


### PR DESCRIPTION

Changes in this release:

### Documentation improvements

- Update documentation for RoutingPreference to better describe behaviors ([commit 991aeac](https://github.com/googleapis/google-cloud-dotnet/commit/991aeac0e3443845dde54cfd651cb057d92c9d46))
- Update comment for Waypoint.side_of_road to accurately describe functionality ([commit 0ec23a7](https://github.com/googleapis/google-cloud-dotnet/commit/0ec23a74a4f77572e6f8115e3417a1787410bf66))
