### PR TITLE
Release Google.Cloud.ApiKeys.V2 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.ApiKeys.V2/.repo-metadata.json
+++ b/apis/Google.Cloud.ApiKeys.V2/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.ApiKeys.V2",
-  "release_level": "preview",
+  "release_level": "stable",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.ApiKeys.V2/latest",
   "library_type": "GAPIC_AUTO",
   "api_shortname": "apikeys"

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.csproj
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the API Keys API (v2), which manages the API keys associated with developer projects.</Description>

--- a/apis/Google.Cloud.ApiKeys.V2/docs/history.md
+++ b/apis/Google.Cloud.ApiKeys.V2/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0, released 2022-09-15
+
+No API surface changes; just dependency updates and promotion to GA.
+
 ## Version 1.0.0-beta01, released 2022-08-16
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -144,7 +144,7 @@
     },
     {
       "id": "Google.Cloud.ApiKeys.V2",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "API Keys",
       "productUrl": "https://cloud.google.com/api-keys/docs",
@@ -154,7 +154,9 @@
         "authorization"
       ],
       "dependencies": {
-        "Google.LongRunning": "3.0.0"
+        "Google.Api.Gax.Grpc": "4.1.1",
+        "Google.LongRunning": "3.0.0",
+        "Grpc.Core": "2.46.3"
       },
       "generator": "micro",
       "protoPath": "google/api/apikeys/v2",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates and promotion to GA.
