### PR TITLE
Release Google.Cloud.BareMetalSolution.V2 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.BareMetalSolution.V2/.repo-metadata.json
+++ b/apis/Google.Cloud.BareMetalSolution.V2/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.BareMetalSolution.V2",
-  "release_level": "preview",
+  "release_level": "stable",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.BareMetalSolution.V2/latest",
   "library_type": "GAPIC_AUTO",
   "api_shortname": "baremetalsolution"

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.csproj
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Bare Metal Solution API (v2), which provides ways to manage Bare Metal Solution hardware installed in a regional extension located near a Google Cloud data center.</Description>

--- a/apis/Google.Cloud.BareMetalSolution.V2/docs/history.md
+++ b/apis/Google.Cloud.BareMetalSolution.V2/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0, released 2022-09-15
+
+No API surface changes; just dependency updates and promotion to GA.
+
 ## Version 1.0.0-beta01, released 2022-06-20
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -395,7 +395,7 @@
     },
     {
       "id": "Google.Cloud.BareMetalSolution.V2",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Bare Metal Solution",
       "productUrl": "https://cloud.google.com/bare-metal/",
@@ -405,9 +405,11 @@
         "hardware"
       ],
       "dependencies": {
+        "Google.Api.Gax.Grpc": "4.1.1",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
-        "Google.LongRunning": "3.0.0"
+        "Google.LongRunning": "3.0.0",
+        "Grpc.Core": "2.46.3"
       },
       "generator": "micro",
       "protoPath": "google/cloud/baremetalsolution/v2",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates and promotion to GA.
