### PR TITLE
Release Google.Cloud.BigQuery.Migration.V2 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.Migration.V2/.repo-metadata.json
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.BigQuery.Migration.V2",
-  "release_level": "preview",
+  "release_level": "stable",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.BigQuery.Migration.V2/latest",
   "library_type": "GAPIC_AUTO",
   "api_shortname": "bigquerymigration"

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.csproj
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta03</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery Migration service, exposing apis for migration jobs operations, and agent management.</Description>

--- a/apis/Google.Cloud.BigQuery.Migration.V2/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0, released 2022-09-15
+
+No API surface changes; just dependency updates and promotion to GA.
+
 ## Version 1.0.0-beta03, released 2022-08-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -653,7 +653,7 @@
     },
     {
       "id": "Google.Cloud.BigQuery.Migration.V2",
-      "version": "1.0.0-beta03",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "BigQuery Migration",
       "productUrl": "https://cloud.google.com/bigquery/docs/migration-intro",
@@ -662,7 +662,10 @@
         "BigQuery",
         "migration"
       ],
-      "dependencies": {},
+      "dependencies": {
+        "Google.Api.Gax.Grpc": "4.1.1",
+        "Grpc.Core": "2.46.3"
+      },
       "generator": "micro",
       "protoPath": "google/cloud/bigquery/migration/v2",
       "shortName": "bigquerymigration",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates and promotion to GA.
