### PR TITLE
feat: Integration tests for PostgreSQL dialect.

### DIFF
--- a/.github/workflows/spanner-emulator-pr-push.yml
+++ b/.github/workflows/spanner-emulator-pr-push.yml
@@ -44,5 +44,5 @@ jobs:
           SPANNER_EMULATOR_HOST: localhost:9010
           TEST_PROJECT: emulator-test-project
       run: |
-        dotnet test -c Release ./apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests
+        dotnet test -c Release ./apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests --filter SkipOnEmulator\!=Yes
         dotnet test -c Release ./apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.CommonTesting/Constants.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.CommonTesting/Constants.cs
@@ -1,0 +1,26 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+namespace Google.Cloud.Spanner.Data.CommonTesting;
+
+public static class Constants
+{
+    public const string Category = nameof(Category);
+    public const string GSQL = nameof(GSQL);
+    public const string PostgreSQL = nameof(PostgreSQL);
+    public const string Admin = nameof(Admin);
+    public const string SkipOnEmulator = nameof(SkipOnEmulator);
+    public const string Yes = nameof(Yes);
+    public const string No = nameof(No);
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.CommonTesting/SpannerFixtureBasePostgreSql.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.CommonTesting/SpannerFixtureBasePostgreSql.cs
@@ -1,0 +1,35 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+using Google.Cloud.ClientTesting;
+using Google.Cloud.Spanner.Common.V1;
+using Google.Cloud.Spanner.V1.Internal.Logging;
+
+namespace Google.Cloud.Spanner.Data.CommonTesting;
+
+/// <summary>
+/// Base class for the test fixtures for Spanner PostgreSQL database.
+/// </summary>
+public abstract class SpannerFixtureBasePostgreSql : CloudProjectFixtureBase
+{
+    public SpannerTestDatabasePostgreSql Database { get; }
+    public DatabaseName DatabaseName => Database.DatabaseName;
+    public SpannerConnection GetConnection() => Database.GetConnection();
+    public SpannerConnection GetConnection(Logger logger, bool logCommitStats = false) => Database.GetConnection(logger, logCommitStats);
+    public string ConnectionString => Database.ConnectionString;
+    public bool RunningOnEmulator => SpannerClientCreationOptions.UsesEmulator;
+    internal SpannerClientCreationOptions SpannerClientCreationOptions => Database.SpannerClientCreationOptions;
+
+    protected SpannerFixtureBasePostgreSql() => Database = SpannerTestDatabasePostgreSql.GetInstance(ProjectId);
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.CommonTesting/SpannerTableFixturePostgreSql.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.CommonTesting/SpannerTableFixturePostgreSql.cs
@@ -1,0 +1,66 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+using Google.Cloud.Spanner.V1.Internal.Logging;
+
+namespace Google.Cloud.Spanner.Data.CommonTesting;
+
+/// <summary>
+/// Base class for test fixtures for PostgreSQL tables.
+/// </summary>
+public abstract class SpannerTableFixturePostgreSql : SpannerFixtureBasePostgreSql
+{
+    public string TableName { get; }
+
+    protected SpannerTableFixturePostgreSql(string tableName)
+    {
+        TableName = tableName;
+        if (Database.Fresh)
+        {
+            Logger.DefaultLogger.Debug($"Creating PostgreSQL table {TableName}");
+            CreateTable();
+        }
+        RetryHelpers.ResetStats();
+        Logger.DefaultLogger.Debug($"Populating PostgreSQL table {TableName}");
+        PopulateTable(Database.Fresh);
+        Logger.DefaultLogger.Debug($"Ready to run PostgreSQL tests");
+        RetryHelpers.MaybeLogStats($"Population of PostgreSQL table {TableName}");
+        RetryHelpers.ResetStats();
+    }
+
+    /// <summary>
+    /// Creates the table. This method is only called when a new database has been created.
+    /// </summary>
+    protected abstract void CreateTable();
+
+    /// <summary>
+    /// Optional operation; populates the table, potentially doing different things based on whether
+    /// the database is new or not.
+    /// </summary>
+    protected virtual void PopulateTable(bool fresh)
+    {
+    }
+
+    protected void ExecuteDdl(string ddl)
+    {
+        using var connection = GetConnection();
+        connection.CreateDdlCommand(ddl).ExecuteNonQuery();
+    }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+        RetryHelpers.MaybeLogStats($"Disposal of fixture for PostgreSQL table {TableName}");
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.CommonTesting/SpannerTestDatabase.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.CommonTesting/SpannerTestDatabase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2018 Google LLC
+// Copyright 2018 Google LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,13 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Google.Api.Gax;
-using Google.Api.Gax.ResourceNames;
 using Google.Cloud.ClientTesting;
-using Google.Cloud.Spanner.Admin.Instance.V1;
-using Google.Cloud.Spanner.Common.V1;
-using Google.Cloud.Spanner.V1.Internal.Logging;
-using Grpc.Core;
+using Google.Cloud.Spanner.Admin.Database.V1;
 using System;
 
 namespace Google.Cloud.Spanner.Data.CommonTesting
@@ -28,9 +23,8 @@ namespace Google.Cloud.Spanner.Data.CommonTesting
     /// (This may be used by multiple fixtures, each created and then disposed, within the same test run.)
     /// A tool is provided to clean up test databases.
     /// </summary>
-    public class SpannerTestDatabase
+    public class SpannerTestDatabase : SpannerTestDatabaseBase
     {
-        private static readonly object s_lock = new object();
         private static SpannerTestDatabase s_instance = null;
 
         /// <summary>
@@ -55,118 +49,15 @@ namespace Google.Cloud.Spanner.Data.CommonTesting
 
         private static readonly string s_generatedDatabaseName = IdGenerator.FromDateTime(prefix: "testdb_", pattern: "yyyyMMdd't'HHmmss");
 
-        public string SpannerHost { get; } = GetEnvironmentVariableOrDefault("TEST_SPANNER_HOST", null);
-        public string SpannerPort { get; } = GetEnvironmentVariableOrDefault("TEST_SPANNER_PORT", null);
-        public string SpannerInstance { get; } = GetEnvironmentVariableOrDefault("TEST_SPANNER_INSTANCE", "spannerintegration");
-        public string SpannerDatabase { get; } = GetEnvironmentVariableOrDefault("TEST_SPANNER_DATABASE", s_generatedDatabaseName);
+        public override string SpannerDatabase { get; } = GetEnvironmentVariableOrDefault("TEST_SPANNER_DATABASE", s_generatedDatabaseName);
 
         // This is the simplest way of checking whether the environment variable was specified or not.
         // It's a little ugly, but simpler than the alternatives.
+        /// <inheritdoc/>
+        public override bool Fresh => SpannerDatabase == s_generatedDatabaseName;
 
-        /// <summary>
-        /// Returns true if the database was created just for this test, or false if the database was an existing one
-        /// specified through an environment variable.
-        /// </summary>
-        public bool Fresh => SpannerDatabase == s_generatedDatabaseName;
-
-        // Connection string including database, generated from the above properties
-        public string ConnectionString { get; }
-        // Connection string without the database, generated from the above properties
-        public string NoDbConnectionString { get; }
-        public string ProjectId { get; }
-        public DatabaseName DatabaseName { get; }
-        internal SpannerClientCreationOptions SpannerClientCreationOptions { get; }
-
-        private SpannerTestDatabase(string projectId)
+        private SpannerTestDatabase(string projectId) : base(projectId, DatabaseDialect.GoogleStandardSql)
         {
-            TestLogger.Install();
-
-            ProjectId = projectId;
-            var builder = new SpannerConnectionStringBuilder
-            {
-                Host = SpannerHost,
-                DataSource = $"projects/{ProjectId}/instances/{SpannerInstance}",
-                EmulatorDetection = EmulatorDetection.EmulatorOrProduction
-            };
-            if (SpannerPort != null)
-            {
-                builder.Port = int.Parse(SpannerPort);
-            }
-            NoDbConnectionString = builder.ConnectionString;
-            SpannerClientCreationOptions = new SpannerClientCreationOptions(builder);
-            var databaseBuilder = builder.WithDatabase(SpannerDatabase);
-            ConnectionString = databaseBuilder.ConnectionString;
-            DatabaseName = databaseBuilder.DatabaseName;
-
-            MaybeCreateInstanceOnEmulator(projectId);
-            if (Fresh)
-            {
-                using (var connection = new SpannerConnection(NoDbConnectionString))
-                {
-                    var createCmd = connection.CreateDdlCommand($"CREATE DATABASE {SpannerDatabase}");
-                    createCmd.ExecuteNonQuery();
-                    Logger.DefaultLogger.Debug($"Created database {SpannerDatabase}");
-                }
-            }
-            else
-            {
-                Logger.DefaultLogger.Debug($"Using existing database {SpannerDatabase}");
-            }
         }
-
-        private static string GetEnvironmentVariableOrDefault(string name, string defaultValue)
-        {
-            string value = Environment.GetEnvironmentVariable(name);
-            return string.IsNullOrEmpty(value) ? defaultValue : value;
-        }
-
-        private void MaybeCreateInstanceOnEmulator(string projectId)
-        {
-            if (SpannerClientCreationOptions.UsesEmulator)
-            {
-#if NETSTANDARD2_1
-                // On .NET Core 3.1 (but not .NET 6) Grpc.Net.Client needs an additional switch
-                // to allow an insecure channel in HTTP/2.
-                AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
-#endif
-                // Try to create an instance on the emulator and ignore any AlreadyExists error.
-                var adminClientBuilder = new InstanceAdminClientBuilder
-                {
-                    EmulatorDetection = EmulatorDetection.EmulatorOnly
-                };
-                var instanceAdminClient = adminClientBuilder.Build();
-
-                var instanceName = InstanceName.FromProjectInstance(projectId, SpannerInstance);
-                try
-                {
-                    instanceAdminClient.CreateInstance(new CreateInstanceRequest
-                    {
-                        InstanceId = instanceName.InstanceId,
-                        ParentAsProjectName = ProjectName.FromProject(projectId),
-                        Instance = new Instance
-                        {
-                            InstanceName = instanceName,
-                            ConfigAsInstanceConfigName = new InstanceConfigName(projectId, "emulator-config"),
-                            DisplayName = "Test Instance",
-                            NodeCount = 1,
-                        },
-                    }).PollUntilCompleted();
-                }
-                catch (RpcException e) when (e.StatusCode == StatusCode.AlreadyExists)
-                {
-                    // Ignore
-                }
-            }
-        }
-
-        public SpannerConnection GetConnection() => new SpannerConnection(ConnectionString);
-
-        // Creates a SpannerConnection with a specific logger.
-        public SpannerConnection GetConnection(Logger logger, bool logCommitStats = false) =>
-            new SpannerConnection(new SpannerConnectionStringBuilder(ConnectionString)
-            { 
-                SessionPoolManager = SessionPoolManager.Create(new V1.SessionPoolOptions(), logger),
-                LogCommitStats = logCommitStats
-            });
     }
 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.CommonTesting/SpannerTestDatabaseBase.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.CommonTesting/SpannerTestDatabaseBase.cs
@@ -1,0 +1,179 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+using Google.Api.Gax;
+using Google.Api.Gax.ResourceNames;
+using Google.Cloud.Spanner.Admin.Database.V1;
+using Google.Cloud.Spanner.Admin.Instance.V1;
+using Google.Cloud.Spanner.Common.V1;
+using Google.Cloud.Spanner.V1.Internal.Logging;
+using Grpc.Core;
+using System;
+
+namespace Google.Cloud.Spanner.Data.CommonTesting;
+
+public abstract class SpannerTestDatabaseBase
+{
+    protected static readonly object s_lock = new object();
+
+    public virtual string SpannerHost { get; } = GetEnvironmentVariableOrDefault("TEST_SPANNER_HOST", null);
+    public virtual string SpannerPort { get; } = GetEnvironmentVariableOrDefault("TEST_SPANNER_PORT", null);
+    public virtual string SpannerInstance { get; } = GetEnvironmentVariableOrDefault("TEST_SPANNER_INSTANCE", "spannerintegration");
+    public abstract string SpannerDatabase { get; }
+
+    /// <summary>
+    /// Returns true if the database was created just for this test, or false if the database was an existing one
+    /// specified through an environment variable.
+    /// </summary>
+    public abstract bool Fresh { get; }
+
+    // Connection string including database, generated from the above properties
+    public string ConnectionString { get; }
+    // Connection string without the database, generated from the above properties
+    public string NoDbConnectionString { get; }
+    public string ProjectId { get; }
+    public DatabaseName DatabaseName { get; }
+    internal SpannerClientCreationOptions SpannerClientCreationOptions { get; }
+
+    protected SpannerTestDatabaseBase(string projectId, DatabaseDialect dialect)
+    {
+        TestLogger.Install();
+        ProjectId = projectId;
+        var builder = new SpannerConnectionStringBuilder
+        {
+            Host = SpannerHost,
+            DataSource = $"projects/{ProjectId}/instances/{SpannerInstance}",
+            EmulatorDetection = dialect == DatabaseDialect.Postgresql ? EmulatorDetection.None : EmulatorDetection.EmulatorOrProduction
+        };
+        if (SpannerPort != null)
+        {
+            builder.Port = int.Parse(SpannerPort);
+        }
+        NoDbConnectionString = builder.ConnectionString;
+        SpannerClientCreationOptions = new SpannerClientCreationOptions(builder);
+        var databaseBuilder = builder.WithDatabase(SpannerDatabase);
+        ConnectionString = databaseBuilder.ConnectionString;
+        DatabaseName = databaseBuilder.DatabaseName;
+
+        if (dialect != DatabaseDialect.Postgresql)
+        {
+            // We create instance only on emulator. In production, we expect the instance to exist.
+            MaybeCreateInstanceOnEmulator(projectId);
+        }
+
+        if (Fresh)
+        {
+            CreateDatabase(dialect);
+            Logger.DefaultLogger.Debug($"Created database {SpannerDatabase} with {dialect} dialect.");
+        }
+        else
+        {
+            Logger.DefaultLogger.Debug($"Using existing database {SpannerDatabase}");
+        }
+    }
+
+    protected static string GetEnvironmentVariableOrDefault(string name, string defaultValue)
+    {
+        string value = Environment.GetEnvironmentVariable(name);
+        return string.IsNullOrEmpty(value) ? defaultValue : value;
+    }
+
+    protected virtual void CreateDatabase(DatabaseDialect dialect)
+    {
+        // PostgreSQL database can only be created by Admin APIs, which is not supported by Emulator for GSQL database creation.
+        if (dialect == DatabaseDialect.Postgresql)
+        {
+            DatabaseAdminClient databaseAdminClient = DatabaseAdminClient.Create();
+            CreateDatabaseRequest createDatabaseRequest = new CreateDatabaseRequest
+            {
+                CreateStatement = $"CREATE DATABASE {SpannerDatabase}",
+                DatabaseDialect = dialect,
+                ParentAsInstanceName = InstanceName.FromProjectInstance(ProjectId, SpannerInstance)
+            };
+
+            try
+            {
+                var operation = databaseAdminClient.CreateDatabase(createDatabaseRequest);
+                var completedResponse = operation.PollUntilCompleted();
+                if (completedResponse.IsFaulted)
+                {
+                    Logger.DefaultLogger.Debug($"Error while creating database with dialect {dialect}: {completedResponse.Exception}");
+                    throw completedResponse.Exception;
+                }
+
+                Logger.DefaultLogger.Debug($"The database {SpannerDatabase} with dialect {dialect} created successfully.");
+            }
+            catch (RpcException e) when (e.StatusCode == StatusCode.AlreadyExists)
+            {
+                // Ignore.
+            }
+        }
+        else
+        {
+            using var connection = new SpannerConnection(NoDbConnectionString);
+            var createCmd = connection.CreateDdlCommand($"CREATE DATABASE {SpannerDatabase}");
+            createCmd.ExecuteNonQuery();
+            Logger.DefaultLogger.Debug($"Created database {SpannerDatabase}");
+        }
+    }
+
+    protected virtual void MaybeCreateInstanceOnEmulator(string projectId)
+    {
+        if (SpannerClientCreationOptions.UsesEmulator)
+        {
+#if NETSTANDARD2_1
+            // On .NET Core 3.1 (but not .NET 6) Grpc.Net.Client needs an additional switch
+            // to allow an insecure channel in HTTP/2.
+            AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
+#endif
+            // Try to create an instance on the emulator and ignore any AlreadyExists error.
+            var adminClientBuilder = new InstanceAdminClientBuilder
+            {
+                EmulatorDetection = EmulatorDetection.EmulatorOnly
+            };
+            var instanceAdminClient = adminClientBuilder.Build();
+
+            var instanceName = InstanceName.FromProjectInstance(projectId, SpannerInstance);
+            try
+            {
+                instanceAdminClient.CreateInstance(new CreateInstanceRequest
+                {
+                    InstanceId = instanceName.InstanceId,
+                    ParentAsProjectName = ProjectName.FromProject(projectId),
+                    Instance = new Instance
+                    {
+                        InstanceName = instanceName,
+                        ConfigAsInstanceConfigName = new InstanceConfigName(projectId, "emulator-config"),
+                        DisplayName = "Test Instance",
+                        NodeCount = 1,
+                    },
+                }).PollUntilCompleted();
+            }
+            catch (RpcException e) when (e.StatusCode == StatusCode.AlreadyExists)
+            {
+                // Ignore
+            }
+        }
+    }
+
+    public virtual SpannerConnection GetConnection() => new SpannerConnection(ConnectionString);
+
+    // Creates a SpannerConnection with a specific logger.
+    public virtual SpannerConnection GetConnection(Logger logger, bool logCommitStats = false) =>
+        new SpannerConnection(new SpannerConnectionStringBuilder(ConnectionString)
+        {
+            SessionPoolManager = SessionPoolManager.Create(new V1.SessionPoolOptions(), logger),
+            LogCommitStats = logCommitStats
+        });
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.CommonTesting/SpannerTestDatabasePostgreSql.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.CommonTesting/SpannerTestDatabasePostgreSql.cs
@@ -1,0 +1,61 @@
+// Copyright 2022 Google LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.ClientTesting;
+using Google.Cloud.Spanner.Admin.Database.V1;
+using System;
+
+namespace Google.Cloud.Spanner.Data.CommonTesting;
+
+/// <summary>
+/// A database with PostgreSQL dialect created on-demand for testing. This is never dropped, partly as it's hard to know when to do so.
+/// (This may be used by multiple fixtures, each created and then disposed, within the same test run.)
+/// </summary>
+public sealed class SpannerTestDatabasePostgreSql : SpannerTestDatabaseBase
+{
+    private static SpannerTestDatabasePostgreSql s_instance = null;
+
+    /// <summary>
+    /// Fetches the PostgreSQL database, creating it if necessary.
+    /// </summary>
+    /// <param name="projectId">The project ID to use, typically from a fixture.</param>
+    public static SpannerTestDatabasePostgreSql GetInstance(string projectId)
+    {
+        lock (s_lock)
+        {
+            if (s_instance == null)
+            {
+                s_instance = new SpannerTestDatabasePostgreSql(projectId);
+            }
+            else if (s_instance.ProjectId != projectId)
+            {
+                throw new ArgumentException($"A PostgreSQL database for project ID {s_instance.ProjectId} has already been created; this test requested {projectId}");
+            }
+            return s_instance;
+        }
+    }
+
+    private static readonly string s_generatedDatabaseName = IdGenerator.FromDateTime(prefix: "testdb_pg_", pattern: "yyyyMMdd't'HHmmss");
+
+    public override string SpannerDatabase { get; } = GetEnvironmentVariableOrDefault("TEST_SPANNER_POSTGRESQL_DATABASE", s_generatedDatabaseName);
+
+    // This is the simplest way of checking whether the environment variable was specified or not.
+    // It's a little ugly, but simpler than the alternatives.
+    /// <inheritdoc/>
+    public override bool Fresh => SpannerDatabase == s_generatedDatabaseName;
+
+    private SpannerTestDatabasePostgreSql(string projectId) : base(projectId, DatabaseDialect.Postgresql)
+    {
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/AdminTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/AdminTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// Copyright 2017 Google Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
     // easiest way of doing that though (and we can use the database name as a prefix, handily)
     [Collection(nameof(SpannerDatabaseFixture))]
     [CommonTestDiagnostics]
+    [Trait(Constants.Category, Constants.Admin)]
     public class AdminTests
     {
         private readonly SpannerDatabaseFixture _fixture;

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/AllTypesTableFixturePostgreSql.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/AllTypesTableFixturePostgreSql.cs
@@ -1,0 +1,95 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+using Google.Cloud.Spanner.Data.CommonTesting;
+using Xunit;
+
+namespace Google.Cloud.Spanner.Data.IntegrationTests;
+
+[CollectionDefinition(nameof(AllTypesTableFixturePostgreSql))]
+public class AllTypesTableFixturePostgreSql : SpannerTableFixturePostgreSql, ICollectionFixture<AllTypesTableFixturePostgreSql>
+{
+    public AllTypesTableFixturePostgreSql() : base("TypesTable")
+    {
+    }
+
+    /// <summary>
+    /// Creates INSERT command for the table created after executing the <see cref="CreateTable"/> method execution.
+    /// </summary>
+    /// <returns>The DML command to insert data into a table.</returns>
+    public string CreateInsertCommand() =>
+        $@"INSERT INTO {TableName} (
+            K,
+            BigIntValue,
+            BoolValue,
+            FloatValue,
+            StringValue,
+            PgNumericValue,
+            BytesValue,
+            TimestampValue,
+            DateValue,           
+            BoolArrayValue,
+            BigIntArrayValue,
+            FloatArrayValue,
+            PgNumericArrayValue,
+            StringArrayValue,                 
+            BytesArrayValue,
+            Base64ArrayValue,
+            TimestampArrayValue,
+            DateArrayValue           
+            ) VALUES(
+            $1, 
+            $2, 
+            $3, 
+            $4, 
+            $5, 
+            $6, 
+            $7, 
+            $8, 
+            $9, 
+            $10,
+            $11,
+            $12,
+            $13,
+            $14,
+            $15, 
+            $16,      
+            $17,
+            $18 
+            )";
+
+    protected override void CreateTable() =>
+        ExecuteDdl($@"CREATE TABLE {TableName}(
+            K                   VARCHAR(4096) NOT NULL PRIMARY KEY,
+            BigIntValue         BIGINT,
+            BoolValue           BOOLEAN,
+            FloatValue          FLOAT,
+            StringValue         TEXT,
+            PgNumericValue      NUMERIC,
+            BytesValue          BYTEA,
+            TimestampValue      TIMESTAMPTZ,
+            DateValue           DATE,
+            BoolArrayValue      BOOLEAN[],
+            BigIntArrayValue    BIGINT[],
+            FloatArrayValue     FLOAT[],
+            PgNumericArrayValue NUMERIC[],
+            StringArrayValue    TEXT[],
+            BytesArrayValue     BYTEA[],
+            Base64ArrayValue    BYTEA[],
+            TimestampArrayValue TIMESTAMPTZ[],
+            DateArrayValue      DATE[]
+            );");
+    //JsonbValue          JSONB,
+    //JsonbArrayValue     JSONB[]
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/BatchDmlTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/BatchDmlTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2018 Google LLC
+// Copyright 2018 Google LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/BindingTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/BindingTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// Copyright 2017 Google Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Cloud.Spanner.Data.CommonTesting;
 using Google.Cloud.Spanner.V1;
 using System;
 using System.Collections.Generic;
@@ -22,6 +23,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
 {
     [Collection(nameof(SpannerDatabaseFixture))]
     [CommonTestDiagnostics]
+    [Trait(Constants.Category, Constants.GSQL)]
     public class BindingTests
     {
         private readonly SpannerDatabaseFixture _fixture;
@@ -239,26 +241,29 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             SpannerDbType.ArrayOf(SpannerDbType.Timestamp),
             new DateTime?[] { });
 
-        [SkippableFact]
+        [Fact]
+        [Trait(Constants.SkipOnEmulator, Constants.Yes)]
         public async Task BindJson()
         {
-            Skip.If(_fixture.RunningOnEmulator, "The emulator doesn't yet support the JSON type");
+            // The emulator doesn't yet support the JSON type.
             await TestBindNonNull(SpannerDbType.Json, "{\"key\":\"value\"}", r => r.GetString(0));
         }
 
-        [SkippableFact]
+        [Fact]
+        [Trait(Constants.SkipOnEmulator, Constants.Yes)]
         public async Task BindJsonArray()
         {
-            Skip.If(_fixture.RunningOnEmulator, "The emulator doesn't yet support the JSON type");
+            // The emulator doesn't yet support the JSON type.
             await TestBindNonNull(
                 SpannerDbType.ArrayOf(SpannerDbType.Json),
                 new string[] { "{\"key\":\"value\"}", null, "{\"other-key\":\"other-value\"}" });
         }
-
-        [SkippableFact]
+        
+        [Fact]
+        [Trait(Constants.SkipOnEmulator, Constants.Yes)]
         public async Task BindJsonEmptyArray()
         {
-            Skip.If(_fixture.RunningOnEmulator, "The emulator doesn't yet support the JSON type");
+            // The emulator doesn't yet support the JSON type.
             await TestBindNonNull(SpannerDbType.ArrayOf(SpannerDbType.Json), new string[] { });
         }
     }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/BindingTestsPostgreSql.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/BindingTestsPostgreSql.cs
@@ -1,0 +1,218 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+using Google.Cloud.Spanner.Data.CommonTesting;
+using Google.Cloud.Spanner.V1;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Cloud.Spanner.Data.IntegrationTests;
+
+[Collection(nameof(SpannerDatabaseFixturePostgreSql))]
+[CommonTestDiagnostics]
+[Trait(Constants.Category, Constants.PostgreSQL)]
+[Trait(Constants.SkipOnEmulator, Constants.Yes)]
+public class BindingTestsPostgreSql
+{
+    private readonly SpannerDatabaseFixturePostgreSql _fixture;
+
+    public BindingTestsPostgreSql(SpannerDatabaseFixturePostgreSql fixture) =>
+        _fixture = fixture;
+
+    public static TheoryData<SpannerDbType> BindNullData { get; } = new TheoryData<SpannerDbType>
+    {
+        SpannerDbType.Bool,
+        SpannerDbType.String,
+        SpannerDbType.Int64,
+        SpannerDbType.Timestamp,
+        SpannerDbType.Float64,
+        SpannerDbType.PgNumeric,
+        SpannerDbType.Date,
+        SpannerDbType.Bytes,
+        //SpannerDbType.PgJsonb,
+        SpannerDbType.ArrayOf(SpannerDbType.Bool),
+        SpannerDbType.ArrayOf(SpannerDbType.String),
+        SpannerDbType.ArrayOf(SpannerDbType.Int64),
+        SpannerDbType.ArrayOf(SpannerDbType.Timestamp),
+        SpannerDbType.ArrayOf(SpannerDbType.Float64),
+        SpannerDbType.ArrayOf(SpannerDbType.PgNumeric),
+        SpannerDbType.ArrayOf(SpannerDbType.Date),
+        SpannerDbType.ArrayOf(SpannerDbType.Bytes),
+        //SpannerDbType.ArrayOf(SpannerDbType.PgJsonb)
+    };
+
+    [Fact]
+    public Task BindBoolean() =>
+        TestBindNonNull(SpannerDbType.Bool, true, r => r.GetBoolean(0));
+
+    [Fact]
+    public Task BindBooleanArray() =>
+        TestBindNonNull(SpannerDbType.ArrayOf(SpannerDbType.Bool), new bool?[] { true, null, false });
+
+    [Fact]
+    public Task BindBooleanEmptyArray() =>
+        TestBindNonNull(SpannerDbType.ArrayOf(SpannerDbType.Bool), new bool[] { });
+
+    [Fact]
+    public Task BindString() =>
+        TestBindNonNull(SpannerDbType.String, "abc", r => r.GetString(0));
+
+    [Fact]
+    public Task BindStringArray() =>
+        TestBindNonNull(SpannerDbType.ArrayOf(SpannerDbType.String), new[] { "abc", null, "123" });
+
+    [Fact]
+    public Task BindStringEmptyArray() =>
+        TestBindNonNull(SpannerDbType.ArrayOf(SpannerDbType.String), new string[] { });
+
+    [Fact]
+    public Task BindByteArray() =>
+        TestBindNonNull(SpannerDbType.Bytes, new byte[] { 1, 2, 3 });
+
+    [Fact]
+    public Task BindByteArrayList() =>
+        TestBindNonNull(SpannerDbType.ArrayOf(SpannerDbType.Bytes), new List<byte[]> { new byte[] { 1, 2, 3 }, new byte[] { 4, 5, 6 }, null });
+
+    [Fact]
+    public Task BindEmptyByteArrayList() =>
+        TestBindNonNull(SpannerDbType.ArrayOf(SpannerDbType.Bytes), new List<byte[]>());
+
+    [Fact]
+    public Task BindDate() =>
+        TestBindNonNull(SpannerDbType.Date, new DateTime(2017, 5, 26));
+
+    [Fact]
+    public Task BindDateArray() =>
+        TestBindNonNull(SpannerDbType.ArrayOf(SpannerDbType.Date), new DateTime?[] { new DateTime(2017, 5, 26), null, new DateTime(2017, 5, 9) });
+
+    [Fact]
+    public Task BindDateEmptyArray() =>
+        TestBindNonNull(SpannerDbType.ArrayOf(SpannerDbType.Date), new DateTime?[] { });
+
+    [Fact]
+    public Task BindFloat() =>
+        TestBindNonNull(SpannerDbType.Float64, 1.0, r => r.GetDouble(0));
+
+    [Fact]
+    public Task BindFloatArray() =>
+        TestBindNonNull(SpannerDbType.ArrayOf(SpannerDbType.Float64), new double?[] { 0.0, null, 1.0 });
+
+    [Fact]
+    public Task BindFloatEmptyArray() =>
+        TestBindNonNull(SpannerDbType.ArrayOf(SpannerDbType.Float64), new double[] { });
+
+    [Fact]
+    public Task BindBigInt() =>
+        TestBindNonNull(SpannerDbType.Int64, 1, r => r.GetInt64(0));
+
+    [Fact]
+    public Task BindBigIntArray() =>
+        TestBindNonNull(SpannerDbType.ArrayOf(SpannerDbType.Int64), new long?[] { 1, null, 0 });
+
+    [Fact]
+    public Task BindBigIntEmptyArray() =>
+        TestBindNonNull(SpannerDbType.ArrayOf(SpannerDbType.Int64), new long[] { });
+
+    //[Fact]
+    //public async Task BindPgJsonb() =>
+    //    await TestBindNonNull(SpannerDbType.PgJsonb, "{\"key\":\"value\"}", r => r.GetString(0));
+
+    //[Fact]
+    //public async Task BindPgJsonbArray() =>
+    //    await TestBindNonNull(SpannerDbType.ArrayOf(SpannerDbType.PgJsonb), new string[] { "{\"key\":\"value\"}", null, "{\"other-key\":\"other-value\"}" });
+
+    //[Fact]
+    //public async Task BindPgJsonbEmptyArray() =>
+    //    await TestBindNonNull(SpannerDbType.ArrayOf(SpannerDbType.PgJsonb), new string[] { });
+
+    [Fact]
+    public async Task BindPgNumeric() =>
+        await TestBindNonNull(SpannerDbType.PgNumeric, PgNumeric.Parse("1.0"), r => r.GetPgNumeric(0));
+
+    [Fact]
+    public async Task BindPgNumericArray() =>
+        await TestBindNonNull(SpannerDbType.ArrayOf(SpannerDbType.PgNumeric), new PgNumeric?[] { PgNumeric.Parse("0.0"), null, PgNumeric.Parse("1.0") });
+
+    [Fact]
+    public async Task BindPgNumericEmptyArray() =>
+        await TestBindNonNull(SpannerDbType.ArrayOf(SpannerDbType.PgNumeric), new PgNumeric[] { });
+
+    [Fact]
+    public Task BindTimestamp() =>
+        TestBindNonNull(SpannerDbType.Timestamp, new DateTime(2017, 5, 26, 15, 0, 0));
+
+    [Fact]
+    public Task BindTimestampArray() =>
+        TestBindNonNull(SpannerDbType.ArrayOf(SpannerDbType.Timestamp), new DateTime?[] { new DateTime(2017, 5, 26, 3, 15, 0), null, new DateTime(2017, 5, 9, 12, 30, 0) });
+
+    [Fact]
+    public Task BindTimestampEmptyArray() =>
+        TestBindNonNull(SpannerDbType.ArrayOf(SpannerDbType.Timestamp), new DateTime?[] { });
+
+    [Theory]
+    [MemberData(nameof(BindNullData))]
+    public async Task BindNull(SpannerDbType parameterType)
+    {
+        using var connection = _fixture.GetConnection();
+        var cmd = connection.CreateSelectCommand("SELECT $1");
+        _ = cmd.Parameters.Add("p1", parameterType, null);
+        using var reader = await cmd.ExecuteReaderAsync();
+        Assert.True(await reader.ReadAsync());
+        Assert.True(reader.IsDBNull(0));
+        Assert.Equal(DBNull.Value, reader.GetValue(0));
+        Assert.False(await reader.ReadAsync());
+    }
+
+    private async Task TestBindNonNull<T>(SpannerDbType parameterType, T value, Func<SpannerDataReader, T> typeSpecificReader = null)
+    {
+        int rowsRead;
+        var valueRead = default(T);
+
+        using var connection = _fixture.GetConnection();
+        var cmd = connection.CreateSelectCommand("SELECT $1");
+        _ = cmd.Parameters.Add("p1", parameterType, value);
+        using var reader = await cmd.ExecuteReaderAsync();
+        rowsRead = 0;
+        while (await reader.ReadAsync())
+        {
+            valueRead = reader.GetFieldValue<T>(0);
+            // Optional extra test for certain built in types
+            if (typeSpecificReader != null)
+            {
+                Assert.Equal(typeSpecificReader(reader), valueRead);
+                Assert.False(reader.IsDBNull(0));
+            }
+
+            rowsRead++;
+        }
+
+        Assert.Equal(1, rowsRead);
+        if (value is Array valueAsArray)
+        {
+            var valueReadAsArray = valueRead as Array;
+            Assert.NotNull(valueReadAsArray);
+            Assert.Equal(valueAsArray.Length, valueReadAsArray.Length);
+            for (int i = 0; i < valueAsArray.Length; i++)
+            {
+                Assert.Equal(valueAsArray.GetValue(i), valueReadAsArray.GetValue(i));
+            }
+        }
+        else
+        {
+            Assert.Equal(value, valueRead);
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/ChunkingTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/ChunkingTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// Copyright 2017 Google Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/DataAdapterTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/DataAdapterTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// Copyright 2017 Google Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/DateTimestampReadTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/DateTimestampReadTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2021 Google LLC
+// Copyright 2021 Google LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Cloud.Spanner.Data.CommonTesting;
 using Google.Cloud.Spanner.V1;
 using System;
 using System.Collections.Generic;

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/DmlTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/DmlTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2018 Google LLC
+// Copyright 2018 Google LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/GetSchemaTableTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/GetSchemaTableTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2018 Google LLC
+// Copyright 2018 Google LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Cloud.Spanner.Data.CommonTesting;
 using Google.Cloud.Spanner.V1;
 using System;
 using System.Collections.Generic;

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/GetSchemaTableTestsPostgreSql.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/GetSchemaTableTestsPostgreSql.cs
@@ -1,0 +1,109 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+using Google.Cloud.Spanner.Data.CommonTesting;
+using Google.Cloud.Spanner.V1;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Cloud.Spanner.Data.IntegrationTests;
+
+[Collection(nameof(AllTypesTableFixturePostgreSql))]
+[CommonTestDiagnostics]
+[Trait(Constants.Category, Constants.GSQL)]
+[Trait(Constants.SkipOnEmulator, Constants.Yes)]
+public class GetSchemaTableTestsPostgreSql
+{
+    private readonly AllTypesTableFixturePostgreSql _fixture;
+
+    public GetSchemaTableTestsPostgreSql(AllTypesTableFixturePostgreSql fixture) =>
+        _fixture = fixture;
+
+    [Fact]
+    public async Task GetSchemaTable_Default_ReturnsNull()
+    {
+        using var connection = _fixture.GetConnection();
+        var command = connection.CreateSelectCommand($"SELECT * FROM {_fixture.TableName}");
+        using var reader = await command.ExecuteReaderAsync();
+        Assert.Null(reader.GetSchemaTable());
+    }
+
+    [MemberData(nameof(SchemaTestData))]
+    [Theory]
+    public async Task GetSchemaTable_WithFlagEnabled_ReturnsSchema(string columnName, System.Type type, SpannerDbType spannerDbType)
+    {
+        using var connection = new SpannerConnection($"{_fixture.ConnectionString};EnableGetSchemaTable=true");
+        var command = connection.CreateSelectCommand($"SELECT {columnName} FROM {_fixture.TableName}");
+        using var reader = await command.ExecuteReaderAsync();
+        var table = reader.GetSchemaTable();
+        Assert.Equal(1, table.Rows.Count);
+
+        var row = table.Rows[0];
+        Assert.Equal(columnName, (string) row["ColumnName"]);
+        Assert.Equal(0, (int) row["ColumnOrdinal"]);
+        Assert.Equal(type, row["DataType"]);
+        Assert.Equal(spannerDbType, (SpannerDbType) row["ProviderType"]);
+        // These fields are (currently) not filled as Spanner does not provided enough
+        // information to fill them.
+        Assert.True(row.IsNull("ColumnSize"));
+        Assert.True(row.IsNull("NumericPrecision"));
+        Assert.True(row.IsNull("NumericScale"));
+    }
+
+    public static TheoryData<string, System.Type, SpannerDbType> SchemaTestData { get; } =
+        new TheoryData<string, System.Type, SpannerDbType>
+        {
+            // Base types.
+            { "bigintvalue", typeof(long), SpannerDbType.Int64 },
+            { "boolvalue", typeof(bool), SpannerDbType.Bool },
+            { "floatvalue", typeof(double), SpannerDbType.Float64 },
+            { "stringvalue", typeof(string), SpannerDbType.String },
+            { "pgnumericvalue", typeof(PgNumeric), SpannerDbType.PgNumeric },
+            { "bytesvalue", typeof(byte[]), SpannerDbType.Bytes },
+            { "timestampvalue", typeof(DateTime), SpannerDbType.Timestamp },
+            { "datevalue", typeof(DateTime), SpannerDbType.Date },            
+            // Array types.
+            { "boolarrayvalue", typeof(List<bool>), SpannerDbType.ArrayOf(SpannerDbType.Bool) },
+            { "bigintarrayvalue", typeof(List<long>), SpannerDbType.ArrayOf(SpannerDbType.Int64) },
+            { "floatarrayvalue", typeof(List<double>), SpannerDbType.ArrayOf(SpannerDbType.Float64) },
+            { "pgnumericarrayvalue", typeof(List<PgNumeric>), SpannerDbType.ArrayOf(SpannerDbType.PgNumeric) },
+            { "stringarrayvalue", typeof(List<string>), SpannerDbType.ArrayOf(SpannerDbType.String) },
+            { "bytesarrayvalue", typeof(List<byte[]>), SpannerDbType.ArrayOf(SpannerDbType.Bytes) },
+            { "base64arrayvalue", typeof(List<byte[]>), SpannerDbType.ArrayOf(SpannerDbType.Bytes) },
+            { "timestamparrayvalue", typeof(List<DateTime>), SpannerDbType.ArrayOf(SpannerDbType.Timestamp) },
+            { "datearrayvalue", typeof(List<DateTime>), SpannerDbType.ArrayOf(SpannerDbType.Date) },
+            //{ "JsonbValue", typeof(string), SpannerDbType.PgJsonb },
+            //{ "JsonbArrayValue", typeof(List<string>), SpannerDbType.ArrayOf(SpannerDbType.PgJsonb) },
+        };
+
+    [Fact]
+    public async Task GetSchemaTable_WithFlagEnabled_ReturnsColumnOrdinals()
+    {
+        using var connection = new SpannerConnection($"{_fixture.ConnectionString};EnableGetSchemaTable=true");
+        var command = connection.CreateSelectCommand($"SELECT * FROM {_fixture.TableName}");
+        using var reader = await command.ExecuteReaderAsync();
+        var table = reader.GetSchemaTable();
+        // The table also contains the `K` column that is the primary key.
+        var expectedRowCount = SchemaTestData.Count() + 1;
+        Assert.Equal(expectedRowCount, table.Rows.Count);
+        for (var ordinal = 1; ordinal < expectedRowCount; ordinal++)
+        {
+            var row = table.Rows[ordinal];
+            Assert.Equal(ordinal, (int) row["ColumnOrdinal"]);
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/PartitionedReadTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/PartitionedReadTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// Copyright 2017 Google Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Cloud.Spanner.Data.CommonTesting;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/QueryOptionsTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/QueryOptionsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Google Inc. All Rights Reserved.
+// Copyright 2020 Google Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,10 +33,11 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
         public QueryOptionsTests(ReadTableFixture fixture) =>
             _fixture = fixture;
 
-        [SkippableFact]
+        [Fact]
+        [Trait(Constants.SkipOnEmulator, Constants.Yes)]
         public async Task PointReadWithConnectionLevelQueryOptions()
         {
-            Skip.If(_fixture.RunningOnEmulator, "Emulator doesn't yet support an optimizer statistics package");
+            // Emulator doesn't yet support an optimizer statistics package.
             using (var connection = _fixture.GetConnection())
             {
                 connection.QueryOptions = QueryOptions.Empty
@@ -54,10 +55,11 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             }
         }
 
-        [SkippableFact]
+        [Fact]
+        [Trait(Constants.SkipOnEmulator, Constants.Yes)]
         public async Task PointReadWithQueryLevelOptions()
         {
-            Skip.If(_fixture.RunningOnEmulator, "Emulator doesn't yet support an optimizer statistics package");
+            // Emulator doesn't yet support an optimizer statistics package.
             using (var connection = _fixture.GetConnection())
             {
                 var cmd = connection.CreateSelectCommand($"SELECT * FROM {_fixture.TableName} WHERE Key = 'k1'");
@@ -75,10 +77,11 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             }
         }
 
-        [SkippableFact]
+        [Fact]
+        [Trait(Constants.SkipOnEmulator, Constants.Yes)]
         public async Task PointReadWithInvalidConnectionLevelQueryOptions()
         {
-            Skip.If(_fixture.RunningOnEmulator, "Emulator doesn't fail with invalid optimizer versions");
+            // Emulator doesn't fail with invalid optimizer versions.
             using (var connection = _fixture.GetConnection())
             {
                 connection.QueryOptions = QueryOptions.Empty.WithOptimizerVersion("invalid");

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/ReadTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/ReadTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// Copyright 2017 Google Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -93,10 +93,11 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             }
         }
 
-        [SkippableFact]
+        [Fact]
+        [Trait(Constants.SkipOnEmulator, Constants.Yes)]
         public async Task CancelRead()
         {
-            Skip.If(_fixture.RunningOnEmulator, "The emulator can return before query is cancelled");
+            // The emulator can return before query is canceled.
             using (var connection = _fixture.GetConnection())
             {
                 var cmd = connection.CreateSelectCommand($"SELECT * FROM {_fixture.TableName}");
@@ -382,10 +383,11 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             }
         }
 
-        [SkippableFact]
+        [Fact]
+        [Trait(Constants.SkipOnEmulator, Constants.Yes)]
         public async Task CommandTimeout()
         {
-            Skip.If(_fixture.RunningOnEmulator, "The emulator returns too quickly to trigger timeout");
+            // The emulator returns too quickly to trigger timeout.
             using (var connection =
                 new SpannerConnection($"{_fixture.ConnectionString};{nameof(SpannerConnectionStringBuilder.AllowImmediateTimeouts)}=true"))
             {
@@ -396,10 +398,11 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             }
         }
 
-        [SkippableFact]
+        [Fact]
+        [Trait(Constants.SkipOnEmulator, Constants.Yes)]
         public async Task TimeoutFromOptions()
         {
-            Skip.If(_fixture.RunningOnEmulator, "The emulator returns too quickly to trigger timeout");
+            // The emulator returns too quickly to trigger timeout.
             var connectionStringBuilder = new SpannerConnectionStringBuilder(_fixture.ConnectionString)
             {
                 Timeout = 0,

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/RetriableTransactionTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/RetriableTransactionTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2019 Google LLC
+// Copyright 2019 Google LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Cloud.Spanner.Data.CommonTesting;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -87,10 +88,11 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             Assert.Equal(expected, actual);
         }
 
-        [SkippableFact]
+        [Fact]
+        [Trait(Constants.SkipOnEmulator, Constants.Yes)]
         public async Task RetriesOnce()
         {
-            Skip.If(_fixture.RunningOnEmulator, "Requires multiple read/write transactions");
+            // Requires multiple read/write transactions which is not supported on emulator.
             string key = _fixture.CreateTestRows();
 
             ManualResetEventSlim firstTaskUpdateAttempted = new ManualResetEventSlim(false);

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/SpannerDatabaseFixturePostgreSql.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/SpannerDatabaseFixturePostgreSql.cs
@@ -1,0 +1,26 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+using Google.Cloud.Spanner.Data.CommonTesting;
+using Xunit;
+
+namespace Google.Cloud.Spanner.Data.IntegrationTests;
+
+/// <summary>
+/// A fixture for tests that need a PostgreSQL database to be present, but don't need any tables.
+/// </summary>
+[CollectionDefinition(nameof(SpannerDatabaseFixturePostgreSql))]
+public class SpannerDatabaseFixturePostgreSql : SpannerFixtureBasePostgreSql, ICollectionFixture<SpannerDatabaseFixturePostgreSql>
+{
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/SpannerStressTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/SpannerStressTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// Copyright 2017 Google Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -55,11 +55,11 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             });
         }
 
-        [SkippableFact]
+        [Fact]
+        [Trait(Constants.SkipOnEmulator, Constants.Yes)]
         public Task RunParallelTransactionStress()
         {
-            Skip.If(_fixture.RunningOnEmulator, "Stress tests are flaky when running against the emulator");
-
+            // Stress tests are flaky when running against the emulator.
             return RunStress(connectionStringBuilder => RetryHelpers.ExecuteWithRetryAsync(async () =>
             {
                 using (var connection = new SpannerConnection(connectionStringBuilder))
@@ -93,10 +93,11 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             }));
         }
 
-        [SkippableFact]
+        [Fact]
+        [Trait(Constants.SkipOnEmulator, Constants.Yes)]
         public async Task RunReadStress()
         {
-            Skip.If(_fixture.RunningOnEmulator, "Stress tests are flaky when running against the emulator");
+            // Stress tests are flaky when running against the emulator.
 
             // Insert a single row first, but remember the ID so we can read it.
             int localCounter = Interlocked.Increment(ref s_rowCounter);

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/StructParameterTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/StructParameterTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2018 Google LLC
+// Copyright 2018 Google LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Cloud.Spanner.Data.CommonTesting;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -304,10 +305,11 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             }
         }
 
-        [SkippableFact]
+        [Fact]
+        [Trait(Constants.SkipOnEmulator, Constants.Yes)]
         public async Task SelectStructFails()
         {
-            Skip.If(_fixture.RunningOnEmulator, "Emulator allows structs to be selected");
+            // Emulator allows structs to be selected.
             var structParam = new SpannerStruct
             {
                 { "x", SpannerDbType.Int64, 1 },
@@ -326,10 +328,11 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             }
         }
 
-        [SkippableFact]
+        [Fact]
+        [Trait(Constants.SkipOnEmulator, Constants.Yes)]
         public async Task SelectStructArrayFails()
         {
-            Skip.If(_fixture.RunningOnEmulator, "Emulator allows struct arrays to be selected");
+            // Emulator allows struct arrays to be selected.
             var structParam = new SpannerStruct
             {
                 { "x", SpannerDbType.Int64, 1 },

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/TransactionScopeTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/TransactionScopeTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2018 Google LLC
+// Copyright 2018 Google LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/TransactionTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/TransactionTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// Copyright 2017 Google Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -120,10 +120,12 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             }
         }
 
-        [SkippableFact]
+        [Fact]
+        [Trait(Constants.SkipOnEmulator, Constants.Yes)]
         public async Task AbortedThrownCorrectly()
         {
-            Skip.If(_fixture.RunningOnEmulator, "Requires multiple read/write transactions");
+            // Requires multiple read/write transactions which is not supported on emulator.
+            
             // connection 1 starts a transaction and reads
             // connection 2 starts a transaction and reads the same row
             // connection 1 writes and commits
@@ -558,10 +560,12 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             }
         }
 
-        [SkippableFact]
+        [Fact]
+        [Trait(Constants.SkipOnEmulator, Constants.Yes)]
         public async Task ReturnCommitStats_ExplicitTransaction()
         {
-            Skip.If(_fixture.RunningOnEmulator, "Emulator does not yet support CommitStats");
+            // Emulator does not yet support CommitStats.
+            
             CommitStatsCapturerLogger logger = new CommitStatsCapturerLogger();
             string key = IdGenerator.FromGuid();
             await RetryHelpers.ExecuteWithRetryAsync(async () =>
@@ -595,10 +599,11 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             });
         }
 
-        [SkippableFact]
+        [Fact]
+        [Trait(Constants.SkipOnEmulator, Constants.Yes)]
         public async Task ReturnCommitStats_EphemeralTransaction()
         {
-            Skip.If(_fixture.RunningOnEmulator, "Emulator does not yet support CommitStats");
+            // Emulator does not yet support CommitStats.
             CommitStatsCapturerLogger logger = new CommitStatsCapturerLogger();
             string key = IdGenerator.FromGuid();
             await RetryHelpers.ExecuteWithRetryAsync(async () =>

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/V1/ReliableStreamReaderTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/V1/ReliableStreamReaderTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2019 Google LLC
+// Copyright 2019 Google LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Google.Cloud.Spanner.Data;
+using Google.Cloud.Spanner.Data.CommonTesting;
 using Google.Cloud.Spanner.Data.IntegrationTests;
 using Google.Protobuf.WellKnownTypes;
 using System.Threading.Tasks;

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/V1/SessionPoolTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/V1/SessionPoolTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2018 Google LLC
+// Copyright 2018 Google LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 
 using Google.Api.Gax.Grpc;
 using Google.Cloud.Spanner.Data;
+using Google.Cloud.Spanner.Data.CommonTesting;
 using Google.Cloud.Spanner.Data.IntegrationTests;
 using Google.Cloud.Spanner.V1.Internal.Logging;
 using System;
@@ -90,10 +91,11 @@ namespace Google.Cloud.Spanner.V1.IntegrationTests
             }
         }
 
-        [SkippableFact]
+        [Fact]
+        [Trait(Constants.SkipOnEmulator, Constants.Yes)]
         public async Task SessionLabels()
         {
-            Skip.If(_fixture.RunningOnEmulator, "Emulator does not support filtering by labels");
+            // Emulator does not support filtering by labels.
             string guid = Guid.NewGuid().ToString().ToLowerInvariant();
             var options = new SessionPoolOptions
             {

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/WriteTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/WriteTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// Copyright 2017 Google Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -381,10 +381,11 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             }
         }
 
-        [SkippableFact]
+        [Fact]
+        [Trait(Constants.SkipOnEmulator, Constants.Yes)]
         public async Task CommandTimeout()
         {
-            Skip.If(_fixture.RunningOnEmulator, "The emulator returns too quickly to trigger timeout");
+            // The emulator returns too quickly to trigger timeout.
             var values = new SpannerParameterCollection
             {
                 {"StringValue", SpannerDbType.String, "abc"},

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/WriteTestsPostgreSql.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/WriteTestsPostgreSql.cs
@@ -1,0 +1,359 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+using Google.Cloud.ClientTesting;
+using Google.Cloud.Spanner.Data.CommonTesting;
+using Google.Cloud.Spanner.V1;
+using Google.Cloud.Spanner.V1.Internal.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Cloud.Spanner.Data.IntegrationTests;
+
+[Collection(nameof(AllTypesTableFixturePostgreSql))]
+[CommonTestDiagnostics]
+[Trait(Constants.Category, Constants.PostgreSQL)]
+[Trait(Constants.SkipOnEmulator, Constants.Yes)]
+public class WriteTestsPostgreSql
+{
+    private readonly AllTypesTableFixturePostgreSql _fixture;
+    private string _lastKey;
+
+    public WriteTestsPostgreSql(AllTypesTableFixturePostgreSql fixture) =>
+        _fixture = fixture;
+
+    private Task<int> InsertAsync(string name, SpannerDbType type, object value) =>
+        InsertAsync(new SpannerParameterCollection { { name, type, value } });
+
+    private async Task<int> InsertAsync(SpannerParameterCollection values)
+    {
+        using var connection = _fixture.GetConnection();
+        _ = values.Add("K", SpannerDbType.String, _lastKey = IdGenerator.FromGuid());
+        var cmd = connection.CreateInsertCommand(_fixture.TableName, values);
+        return await cmd.ExecuteNonQueryAsyncWithRetry();
+    }
+
+    private async Task InsertAndRecordBytesAsync(byte[] bytes, IDictionary<string, byte[]> record)
+    {
+        Assert.Equal(1, await InsertAsync("BytesValue", SpannerDbType.Bytes, bytes));
+        record[_lastKey] = bytes;
+    }
+
+    private async Task WithLastRowAsync(Action<SpannerDataReader> readerAction)
+    {
+        using var connection = _fixture.GetConnection();
+        var cmd = connection.CreateSelectCommand($"SELECT * FROM {_fixture.TableName} WHERE K=$1");
+        _ = cmd.Parameters.Add("p1", SpannerDbType.String, _lastKey);
+        using var reader = await cmd.ExecuteReaderAsync();
+        Assert.True(await reader.ReadAsync());
+        readerAction(reader);
+    }
+
+    private async Task ExecuteWriteNullsTest(Func<SpannerParameterCollection, Task<int>> insertCommand, bool isDml)
+    {
+        var parameters = new SpannerParameterCollection
+            {
+                { isDml ? "p2" : "BigIntValue", SpannerDbType.Int64, null },
+                { isDml ? "p3" : "BoolValue", SpannerDbType.Bool, null },
+                { isDml ? "p4" : "FloatValue", SpannerDbType.Float64, null },
+                { isDml ? "p5" : "StringValue", SpannerDbType.String, null },
+                { isDml ? "p6" : "PgNumericValue", SpannerDbType.PgNumeric, null },
+                { isDml ? "p7" : "BytesValue", SpannerDbType.Bytes, null },
+                { isDml ? "p8" : "TimestampValue", SpannerDbType.Timestamp, null },
+                { isDml ? "p9" : "DateValue", SpannerDbType.Date, null },
+                { isDml ? "p10" : "BoolArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Bool), null },
+                { isDml ? "p11" : "BigIntArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Int64), null },
+                { isDml ? "p12" : "FloatArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Float64), null },
+                { isDml ? "p13" : "PgNumericArrayValue", SpannerDbType.ArrayOf(SpannerDbType.PgNumeric), null },
+                { isDml ? "p14" : "StringArrayValue", SpannerDbType.ArrayOf(SpannerDbType.String), null },
+                { isDml ? "p15" : "BytesArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Bytes), null },
+                { isDml ? "p16" : "Base64ArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Bytes), null },
+                { isDml ? "p17" : "TimestampArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Timestamp), null },
+                { isDml ? "p18" : "DateArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Date), null }
+                //{ isDml ? "p19" : "JsonbValue", SpannerDbType.PgJsonb, null },
+                //{ isDml ? "p20" : "JsonbArrayValue", SpannerDbType.ArrayOf(SpannerDbType.PgJsonb), null }
+            };
+
+        Assert.Equal(1, await insertCommand(parameters));
+        await WithLastRowAsync(reader =>
+        {
+            Assert.True(reader.IsDBNull(reader.GetOrdinal("bigintvalue")));
+            Assert.True(reader.IsDBNull(reader.GetOrdinal("boolvalue")));
+            Assert.True(reader.IsDBNull(reader.GetOrdinal("floatvalue")));
+            Assert.True(reader.IsDBNull(reader.GetOrdinal("stringvalue")));
+            Assert.True(reader.IsDBNull(reader.GetOrdinal("pgnumericvalue")));
+            Assert.True(reader.IsDBNull(reader.GetOrdinal("bytesvalue")));
+            Assert.True(reader.IsDBNull(reader.GetOrdinal("timestampvalue")));
+            Assert.True(reader.IsDBNull(reader.GetOrdinal("datevalue")));
+            Assert.True(reader.IsDBNull(reader.GetOrdinal("boolarrayvalue")));
+            Assert.True(reader.IsDBNull(reader.GetOrdinal("bigintarrayvalue")));
+            Assert.True(reader.IsDBNull(reader.GetOrdinal("floatarrayvalue")));
+            Assert.True(reader.IsDBNull(reader.GetOrdinal("pgnumericarrayvalue")));
+            Assert.True(reader.IsDBNull(reader.GetOrdinal("stringarrayvalue")));
+            Assert.True(reader.IsDBNull(reader.GetOrdinal("base64arrayvalue")));
+            Assert.True(reader.IsDBNull(reader.GetOrdinal("bytesarrayvalue")));
+            Assert.True(reader.IsDBNull(reader.GetOrdinal("timestamparrayvalue")));
+            Assert.True(reader.IsDBNull(reader.GetOrdinal("datearrayvalue")));
+            //Assert.True(reader.IsDBNull(reader.GetOrdinal("jsonbvalue")));
+            //Assert.True(reader.IsDBNull(reader.GetOrdinal("jsonbarrayvalue")));
+        });
+    }
+
+    private async Task ExecuteWriteValuesTest(Func<SpannerParameterCollection, Task<int>> insertCommand, bool isDml)
+    {
+        var testTimestamp = new DateTime(2022, 3, 17, 15, 30, 0);
+        var testDate = new DateTime(2022, 5, 9);
+        bool?[] boolArray = { true, null, false };
+        long?[] longArray = { 0, null, 1 };
+        double?[] doubleArray = { 0.0, null, 2.0 };
+        PgNumeric?[] numericArray = { PgNumeric.Parse("0.0"), null, PgNumeric.Parse("2.0") };
+        string[] jsonArray = { "{\"f1\":\"v1\"}", "{}", "[]", null };
+        string[] stringArray = { "abs", null, "123" };
+        string[] base64Array =
+        {
+            Convert.ToBase64String(new byte[] {0, 1, 2}),
+            null,
+            Convert.ToBase64String(new byte[] {1, 2, 3})
+        };
+        byte[][] byteArray =
+        {
+             new byte[] {0, 1, 2},
+             null,
+             new byte[] {1, 2, 3}
+        };
+
+        DateTime?[] dateArray = { new DateTime(2022, 3, 17), null, new DateTime(2022, 5, 9) };
+        DateTime?[] dateTimeArray = { new DateTime(2022, 3, 17, 5, 30, 0), null, new DateTime(2022, 5, 9, 12, 45, 0) };
+
+        var parameters = new SpannerParameterCollection
+            {
+                { isDml ? "p2" : "BigIntValue", SpannerDbType.Int64, 1 },
+                { isDml ? "p3" : "BoolValue", SpannerDbType.Bool, true },
+                { isDml ? "p4" : "FloatValue", SpannerDbType.Float64, 2.0 },
+                { isDml ? "p5" : "StringValue", SpannerDbType.String, "abc" },
+                { isDml ? "p6" : "PgNumericValue", SpannerDbType.PgNumeric, PgNumeric.Parse("2.0") },
+                { isDml ? "p7" : "BytesValue", SpannerDbType.Bytes, new byte[] { 4, 5, 6 } },
+                { isDml ? "p8" : "TimestampValue", SpannerDbType.Timestamp, testTimestamp },
+                { isDml ? "p9" : "DateValue", SpannerDbType.Date, testDate },
+                { isDml ? "p10" : "BoolArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Bool), boolArray },
+                { isDml ? "p11" : "BigIntArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Int64), longArray },
+                { isDml ? "p12" : "FloatArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Float64), doubleArray },
+                { isDml ? "p13" : "PgNumericArrayValue", SpannerDbType.ArrayOf(SpannerDbType.PgNumeric), numericArray },
+                { isDml ? "p14" : "StringArrayValue", SpannerDbType.ArrayOf(SpannerDbType.String), stringArray },
+                { isDml ? "p15" : "BytesArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Bytes), byteArray },
+                { isDml ? "p16" : "Base64ArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Bytes), base64Array },
+                { isDml ? "p17" : "TimestampArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Timestamp), dateTimeArray },
+                { isDml ? "p18" : "DateArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Date), dateArray }
+                //{ isDml ? "p19" : "JsonbValue", SpannerDbType.PgJsonb, "{\"f1\":\"v1\"}" },
+                //{ isDml ? "p20" : "JsonbArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Json), jsonArray }
+            };
+
+        Assert.Equal(1, await insertCommand(parameters));
+        await WithLastRowAsync(reader =>
+        {
+            Assert.Equal(1, reader.GetFieldValue<long>(reader.GetOrdinal("bigintvalue")));
+            Assert.True(reader.GetFieldValue<bool>(reader.GetOrdinal("boolvalue")));
+            Assert.Equal(2.0, reader.GetFieldValue<double>(reader.GetOrdinal("floatvalue")), 1);
+            Assert.Equal("abc", reader.GetFieldValue<string>(reader.GetOrdinal("stringvalue")));
+            Assert.Equal(PgNumeric.Parse("2.0"), reader.GetFieldValue<PgNumeric>(reader.GetOrdinal("pgnumericvalue")));
+            Assert.Equal(new byte[] { 4, 5, 6 }, reader.GetFieldValue<byte[]>(reader.GetOrdinal("bytesvalue")));
+            long length = reader.GetBytes(reader.GetOrdinal("bytesvalue"), 0L, null, 0, int.MaxValue);
+            Assert.Equal(3L, length);
+            var buffer = new byte[length];
+            Assert.Equal(3, reader.GetBytes(reader.GetOrdinal("bytesvalue"), 0L, buffer, 0, (int) length));
+            Assert.Equal(testTimestamp, reader.GetFieldValue<DateTime>(reader.GetOrdinal("timestampvalue")));
+            Assert.Equal(testDate, reader.GetFieldValue<DateTime>(reader.GetOrdinal("datevalue")));
+            Assert.Equal(boolArray, reader.GetFieldValue<bool?[]>(reader.GetOrdinal("boolarrayvalue")));
+            Assert.Equal(longArray, reader.GetFieldValue<long?[]>(reader.GetOrdinal("bigintarrayvalue")));
+            Assert.Equal(doubleArray, reader.GetFieldValue<double?[]>(reader.GetOrdinal("floatarrayvalue")));
+            Assert.Equal(numericArray, reader.GetFieldValue<PgNumeric?[]>(reader.GetOrdinal("pgnumericarrayvalue")));
+            Assert.Equal(stringArray, reader.GetFieldValue<string[]>(reader.GetOrdinal("stringarrayvalue")));
+            Assert.Equal(byteArray, reader.GetFieldValue<byte[][]>(reader.GetOrdinal("bytesarrayvalue")));
+            Assert.Equal(base64Array, reader.GetFieldValue<string[]>(reader.GetOrdinal("base64arrayvalue")));
+            Assert.Equal(dateTimeArray, reader.GetFieldValue<DateTime?[]>(reader.GetOrdinal("timestamparrayvalue")));
+            Assert.Equal(dateArray, reader.GetFieldValue<DateTime?[]>(reader.GetOrdinal("datearrayvalue")));
+            //Assert.Equal("{\"f1\":\"v1\"}", reader.GetFieldValue<string>(reader.GetOrdinal("jsonbvalue")));
+            //Assert.Equal(jsonArray, reader.GetFieldValue<string[]>(reader.GetOrdinal("jsonbarrayvalue")));
+        });
+    }
+    
+    [Fact]
+    public async Task WriteValues() =>
+        await ExecuteWriteValuesTest(InsertAsync, false);
+
+    [Fact]
+    public async Task WriteValuesDml() =>
+        await ExecuteWriteValuesTest(InsertDmlAsync, true);
+
+    private async Task<int> InsertDmlAsync(SpannerParameterCollection values)
+    {
+        using var connection = _fixture.GetConnection();
+        values.Insert(0, new SpannerParameter("p1", SpannerDbType.String, _lastKey = IdGenerator.FromGuid()));
+        SpannerCommand cmd = connection.CreateDmlCommand(_fixture.CreateInsertCommand(), values);
+        return await cmd.ExecuteNonQueryAsync();
+    }
+
+    [Fact]
+    public async Task BadColumnName()
+    {
+        using var connection = _fixture.GetConnection();
+        var cmd = connection.CreateInsertCommand(_fixture.TableName);
+        cmd.Parameters.Add("badjuju", SpannerDbType.String, IdGenerator.FromGuid());
+        var e = await Assert.ThrowsAsync<SpannerException>(() => cmd.ExecuteNonQueryAsyncWithRetry());
+        Logger.DefaultLogger.Debug($"BadColumnName: Caught error code: {e.ErrorCode}");
+        Assert.Equal(ErrorCode.NotFound, e.ErrorCode);
+        Assert.False(e.IsTransientSpannerFault());
+    }
+
+    [Fact]
+    public async Task BadColumnType()
+    {
+        using var connection = _fixture.GetConnection();
+        var cmd = connection.CreateInsertCommand(_fixture.TableName);
+        cmd.Parameters.Add("K", SpannerDbType.Float64, 0.1);
+        var e = await Assert.ThrowsAsync<SpannerException>(() => cmd.ExecuteNonQueryAsyncWithRetry());
+        Logger.DefaultLogger.Debug($"BadColumnType: Caught error code: {e.ErrorCode}");
+        Assert.Equal(ErrorCode.FailedPrecondition, e.ErrorCode);
+        Assert.False(e.IsTransientSpannerFault());
+    }
+
+    [Fact]
+    public async Task BadTableName()
+    {
+        using var connection = _fixture.GetConnection();
+        var cmd = connection.CreateInsertCommand("badjuju");
+        cmd.Parameters.Add("K", SpannerDbType.String, IdGenerator.FromGuid());
+        var e = await Assert.ThrowsAsync<SpannerException>(() => cmd.ExecuteNonQueryAsyncWithRetry());
+        Logger.DefaultLogger.Debug($"BadTableName: Caught error code: {e.ErrorCode}");
+        Assert.Equal(ErrorCode.NotFound, e.ErrorCode);
+        Assert.False(e.IsTransientSpannerFault());
+    }
+
+    [Fact]
+    public async Task WriteEmpties()
+    {
+        var parameters = new SpannerParameterCollection
+            {
+                { "BoolArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Bool), new bool[0] },
+                { "BigIntArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Int64), new long[0] },
+                { "FloatArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Float64), new double[0] },
+                { "StringArrayValue", SpannerDbType.ArrayOf(SpannerDbType.String), new string[0] },
+                { "BytesArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Bytes), new byte[0][] },
+                { "TimestampArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Timestamp), new DateTime[0] },
+                { "DateArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Date), new DateTime[0] },
+                { "PgNumericArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Numeric), new SpannerNumeric[0] }
+                //{ "JsonbArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Json), new string[0] }
+            };
+
+        Assert.Equal(1, await InsertAsync(parameters));
+        await WithLastRowAsync(reader =>
+        {
+            Assert.Equal(new bool[] { }, reader.GetFieldValue<bool[]>(reader.GetOrdinal("boolarrayvalue")));
+            Assert.Equal(new long[] { }, reader.GetFieldValue<long[]>(reader.GetOrdinal("bigintarrayvalue")));
+            Assert.Equal(new double[] { }, reader.GetFieldValue<double[]>(reader.GetOrdinal("floatarrayvalue")));
+            Assert.Equal(new string[] { }, reader.GetFieldValue<string[]>(reader.GetOrdinal("stringarrayvalue")));
+            Assert.Equal(new byte[][] { }, reader.GetFieldValue<byte[][]>(reader.GetOrdinal("bytesarrayvalue")));
+            Assert.Equal(new DateTime[] { }, reader.GetFieldValue<DateTime[]>(reader.GetOrdinal("timestamparrayvalue")));
+            Assert.Equal(new DateTime[] { }, reader.GetFieldValue<DateTime[]>(reader.GetOrdinal("datearrayvalue")));
+            Assert.Equal(new PgNumeric[] { }, reader.GetFieldValue<PgNumeric[]>(reader.GetOrdinal("pgnumericarrayvalue")));
+            //Assert.Equal(new string[] { }, reader.GetFieldValue<string[]>(reader.GetOrdinal("jsonbarrayvalue")));
+        });
+    }
+
+    [Fact]
+    public async Task WriteInfinity()
+    {
+        Assert.Equal(1, await InsertAsync("FloatValue", SpannerDbType.Float64, double.PositiveInfinity));
+        await WithLastRowAsync(reader => Assert.True(double.IsPositiveInfinity(reader.GetFieldValue<double>("floatvalue"))));
+    }
+
+    [Fact]
+    public async Task WriteNanValue()
+    {
+        Assert.Equal(1, await InsertAsync("FloatValue", SpannerDbType.Float64, double.NaN));
+        await WithLastRowAsync(reader => Assert.True(double.IsNaN(reader.GetFieldValue<double>("floatvalue"))));
+    }
+
+    [Fact]
+    public async Task WriteNegativeInfinity()
+    {
+        Assert.Equal(1, await InsertAsync("FloatValue", SpannerDbType.Float64, double.NegativeInfinity));
+        await WithLastRowAsync(reader => Assert.True(double.IsNegativeInfinity(reader.GetFieldValue<double>("floatvalue"))));
+    }
+
+    [Fact]
+    public async Task WriteNulls() =>
+        await ExecuteWriteNullsTest(InsertAsync, false);
+
+    [Fact]
+    public async Task WriteNullsDml() =>
+        await ExecuteWriteNullsTest(InsertDmlAsync, true);
+
+    [Fact]
+    public async Task WriteRandomBytes()
+    {
+        var seedByte = (byte) (Environment.TickCount % 256);
+        var rnd = new Random(seedByte);
+
+        // We write 1-50 rows where each row contains a bytearray of size 1-50
+        // whose bytes are randomly generated with the given seed.
+        // The seed itself is written as the first row in an array of size=1.
+        var recordedValues = new Dictionary<string, byte[]>();
+
+        await InsertAndRecordBytesAsync(new[] { seedByte }, recordedValues);
+
+        var numRows = rnd.Next(50);
+        for (var i = 0; i < numRows; i++)
+        {
+            var byteArray = new byte[rnd.Next(50)];
+            rnd.NextBytes(byteArray);
+            await InsertAndRecordBytesAsync(byteArray, recordedValues);
+        }
+
+        using var connection = _fixture.GetConnection();
+        string sqlQuery = $@"SELECT K,BytesValue
+                                FROM {_fixture.TableName}
+                                WHERE K IN ({string.Join(", ", recordedValues.Keys.Select(x => $"'{x}'"))})";
+
+        var cmd = connection.CreateSelectCommand(sqlQuery);
+        using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            var key = reader.GetFieldValue<string>("k");
+            var value = reader.GetFieldValue<byte[]>("bytesvalue");
+            Assert.Equal(recordedValues[key], value);
+            recordedValues.Remove(key);
+        }
+        Assert.Equal(0, recordedValues.Count);
+    }
+
+    [Fact]
+    public async Task CommandTimeout()
+    {
+        var values = new SpannerParameterCollection
+            {
+                {"StringValue", SpannerDbType.String, "abc"},
+                {"K", SpannerDbType.String, _lastKey = IdGenerator.FromGuid()}
+            };
+
+        using var connection = new SpannerConnection($"{_fixture.ConnectionString};{nameof(SpannerConnectionStringBuilder.AllowImmediateTimeouts)}=true");
+        var cmd = connection.CreateInsertCommand(_fixture.TableName, values);
+        cmd.CommandTimeout = 0;
+        var e = await Assert.ThrowsAsync<SpannerException>(() => cmd.ExecuteNonQueryAsync());
+        SpannerAssert.IsTimeout(e);
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/run-emulator-tests.sh
+++ b/apis/Google.Cloud.Spanner.Data/run-emulator-tests.sh
@@ -30,5 +30,5 @@ EMULATOR_PID=$!
 trap "kill -15 $EMULATOR_PID; echo \"Cleaned up the emulator\";" EXIT
 
 # Run the tests.
-dotnet test -c Release Google.Cloud.Spanner.Data.IntegrationTests
+dotnet test -c Release Google.Cloud.Spanner.Data.IntegrationTests --filter SkipOnEmulator\!=Yes
 dotnet test -c Release Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets


### PR DESCRIPTION
This draft PR contains the following:

- First pass at the integration tests for PostgreSQL dialect.
- Created a base class SpannerTestDatabaseBase from which SpannerTestDatabase and SpannerTestDatabasePostgreSql derives.
- Added Traits to all the test classes, so that test suites can be run based on category. This is again a first pass and not exhaustive.
- Updated .sh and .yml to not execute the tests that cannot be run on emulator.

The purpose of this PR is to gather feedback on how we want to go ahead with the Traits, base class and PostgreSQL dialect. I can split the changes into multiple commits/PRs after I gather feedback from this PR. 