### PR TITLE
feat: using xUnit Trait to filter not supported tests on emulator

### DIFF
--- a/.github/workflows/spanner-emulator-pr-push.yml
+++ b/.github/workflows/spanner-emulator-pr-push.yml
@@ -44,5 +44,5 @@ jobs:
           SPANNER_EMULATOR_HOST: localhost:9010
           TEST_PROJECT: emulator-test-project
       run: |
-        dotnet test -c Release ./apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests
+        dotnet test -c Release ./apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests --filter SupportedOnEmulator\!=No
         dotnet test -c Release ./apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.CommonTesting/Constants.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.CommonTesting/Constants.cs
@@ -1,0 +1,36 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+namespace Google.Cloud.Spanner.Data.CommonTesting;
+
+/// <summary>
+/// This class defines the string constants used in the test classes for specifying the trait names and values.
+/// </summary>
+public static class Constants
+{
+    /// <summary>
+    /// The constant string representing the trait name to determine if the test is supported on the emulator.
+    /// </summary>
+    public const string SupportedOnEmulator = nameof(SupportedOnEmulator);
+
+    /// <summary>
+    /// The constant string representing the value of "No".
+    /// </summary>
+    public const string No = nameof(No);
+
+    /// <summary>
+    /// The constant string representing the value of "Yes".
+    /// </summary>
+    public const string Yes = nameof(Yes);
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/BindingTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/BindingTests.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Cloud.Spanner.Data.CommonTesting;
 using Google.Cloud.Spanner.V1;
 using System;
 using System.Collections.Generic;
@@ -239,26 +240,29 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             SpannerDbType.ArrayOf(SpannerDbType.Timestamp),
             new DateTime?[] { });
 
-        [SkippableFact]
+        [Fact]
+        [Trait(Constants.SupportedOnEmulator, Constants.No)]
         public async Task BindJson()
         {
-            Skip.If(_fixture.RunningOnEmulator, "The emulator doesn't yet support the JSON type");
+            // The emulator doesn't yet support the JSON type.
             await TestBindNonNull(SpannerDbType.Json, "{\"key\":\"value\"}", r => r.GetString(0));
         }
 
-        [SkippableFact]
+        [Fact]
+        [Trait(Constants.SupportedOnEmulator, Constants.No)]
         public async Task BindJsonArray()
         {
-            Skip.If(_fixture.RunningOnEmulator, "The emulator doesn't yet support the JSON type");
+            // The emulator doesn't yet support the JSON type.
             await TestBindNonNull(
                 SpannerDbType.ArrayOf(SpannerDbType.Json),
                 new string[] { "{\"key\":\"value\"}", null, "{\"other-key\":\"other-value\"}" });
         }
 
-        [SkippableFact]
+        [Fact]
+        [Trait(Constants.SupportedOnEmulator, Constants.No)]
         public async Task BindJsonEmptyArray()
         {
-            Skip.If(_fixture.RunningOnEmulator, "The emulator doesn't yet support the JSON type");
+            // The emulator doesn't yet support the JSON type.
             await TestBindNonNull(SpannerDbType.ArrayOf(SpannerDbType.Json), new string[] { });
         }
     }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/QueryOptionsTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/QueryOptionsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Google Inc. All Rights Reserved.
+// Copyright 2020 Google Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,10 +33,11 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
         public QueryOptionsTests(ReadTableFixture fixture) =>
             _fixture = fixture;
 
-        [SkippableFact]
+        [Fact]
+        [Trait(Constants.SupportedOnEmulator, Constants.No)]
         public async Task PointReadWithConnectionLevelQueryOptions()
         {
-            Skip.If(_fixture.RunningOnEmulator, "Emulator doesn't yet support an optimizer statistics package");
+            // Emulator doesn't yet support an optimizer statistics package.
             using (var connection = _fixture.GetConnection())
             {
                 connection.QueryOptions = QueryOptions.Empty
@@ -54,10 +55,11 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             }
         }
 
-        [SkippableFact]
+        [Fact]
+        [Trait(Constants.SupportedOnEmulator, Constants.No)]
         public async Task PointReadWithQueryLevelOptions()
         {
-            Skip.If(_fixture.RunningOnEmulator, "Emulator doesn't yet support an optimizer statistics package");
+            // Emulator doesn't yet support an optimizer statistics package.
             using (var connection = _fixture.GetConnection())
             {
                 var cmd = connection.CreateSelectCommand($"SELECT * FROM {_fixture.TableName} WHERE Key = 'k1'");
@@ -75,10 +77,11 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             }
         }
 
-        [SkippableFact]
+        [Fact]
+        [Trait(Constants.SupportedOnEmulator, Constants.No)]
         public async Task PointReadWithInvalidConnectionLevelQueryOptions()
         {
-            Skip.If(_fixture.RunningOnEmulator, "Emulator doesn't fail with invalid optimizer versions");
+            // Emulator doesn't fail with invalid optimizer versions.
             using (var connection = _fixture.GetConnection())
             {
                 connection.QueryOptions = QueryOptions.Empty.WithOptimizerVersion("invalid");

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/ReadTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/ReadTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// Copyright 2017 Google Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -93,10 +93,11 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             }
         }
 
-        [SkippableFact]
+        [Fact]
+        [Trait(Constants.SupportedOnEmulator, Constants.No)]
         public async Task CancelRead()
         {
-            Skip.If(_fixture.RunningOnEmulator, "The emulator can return before query is cancelled");
+            // The emulator can return before query is cancelled.
             using (var connection = _fixture.GetConnection())
             {
                 var cmd = connection.CreateSelectCommand($"SELECT * FROM {_fixture.TableName}");
@@ -382,10 +383,11 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             }
         }
 
-        [SkippableFact]
+        [Fact]
+        [Trait(Constants.SupportedOnEmulator, Constants.No)]
         public async Task CommandTimeout()
         {
-            Skip.If(_fixture.RunningOnEmulator, "The emulator returns too quickly to trigger timeout");
+            // The emulator returns too quickly to trigger timeout.
             using (var connection =
                 new SpannerConnection($"{_fixture.ConnectionString};{nameof(SpannerConnectionStringBuilder.AllowImmediateTimeouts)}=true"))
             {
@@ -396,10 +398,11 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             }
         }
 
-        [SkippableFact]
+        [Fact]
+        [Trait(Constants.SupportedOnEmulator, Constants.No)]
         public async Task TimeoutFromOptions()
         {
-            Skip.If(_fixture.RunningOnEmulator, "The emulator returns too quickly to trigger timeout");
+            // The emulator returns too quickly to trigger timeout.
             var connectionStringBuilder = new SpannerConnectionStringBuilder(_fixture.ConnectionString)
             {
                 Timeout = 0,

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/RetriableTransactionTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/RetriableTransactionTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2019 Google LLC
+// Copyright 2019 Google LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Cloud.Spanner.Data.CommonTesting;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -87,10 +88,11 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             Assert.Equal(expected, actual);
         }
 
-        [SkippableFact]
+        [Fact]
+        [Trait(Constants.SupportedOnEmulator, Constants.No)]
         public async Task RetriesOnce()
         {
-            Skip.If(_fixture.RunningOnEmulator, "Requires multiple read/write transactions");
+            // Requires multiple read/write transactions which is not supported on the emulator.
             string key = _fixture.CreateTestRows();
 
             ManualResetEventSlim firstTaskUpdateAttempted = new ManualResetEventSlim(false);

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/SpannerStressTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/SpannerStressTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// Copyright 2017 Google Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -55,10 +55,11 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             });
         }
 
-        [SkippableFact]
+        [Fact]
+        [Trait(Constants.SupportedOnEmulator, Constants.No)]
         public Task RunParallelTransactionStress()
         {
-            Skip.If(_fixture.RunningOnEmulator, "Stress tests are flaky when running against the emulator");
+            // Stress tests are flaky when running against the emulator.
 
             return RunStress(connectionStringBuilder => RetryHelpers.ExecuteWithRetryAsync(async () =>
             {
@@ -93,10 +94,11 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             }));
         }
 
-        [SkippableFact]
+        [Fact]
+        [Trait(Constants.SupportedOnEmulator, Constants.No)]
         public async Task RunReadStress()
         {
-            Skip.If(_fixture.RunningOnEmulator, "Stress tests are flaky when running against the emulator");
+            // Stress tests are flaky when running against the emulator.
 
             // Insert a single row first, but remember the ID so we can read it.
             int localCounter = Interlocked.Increment(ref s_rowCounter);

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/StructParameterTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/StructParameterTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2018 Google LLC
+// Copyright 2018 Google LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Cloud.Spanner.Data.CommonTesting;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -304,10 +305,11 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             }
         }
 
-        [SkippableFact]
+        [Fact]
+        [Trait(Constants.SupportedOnEmulator, Constants.No)]
         public async Task SelectStructFails()
         {
-            Skip.If(_fixture.RunningOnEmulator, "Emulator allows structs to be selected");
+            // Emulator allows structs to be selected.
             var structParam = new SpannerStruct
             {
                 { "x", SpannerDbType.Int64, 1 },
@@ -326,10 +328,11 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             }
         }
 
-        [SkippableFact]
+        [Fact]
+        [Trait(Constants.SupportedOnEmulator, Constants.No)]
         public async Task SelectStructArrayFails()
         {
-            Skip.If(_fixture.RunningOnEmulator, "Emulator allows struct arrays to be selected");
+            // Emulator allows struct arrays to be selected.
             var structParam = new SpannerStruct
             {
                 { "x", SpannerDbType.Int64, 1 },

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/TransactionTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/TransactionTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// Copyright 2017 Google Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -120,10 +120,11 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             }
         }
 
-        [SkippableFact]
+        [Fact]
+        [Trait(Constants.SupportedOnEmulator, Constants.No)]
         public async Task AbortedThrownCorrectly()
         {
-            Skip.If(_fixture.RunningOnEmulator, "Requires multiple read/write transactions");
+            // Requires multiple read/write transactions which is not supported on the emulator.
             // connection 1 starts a transaction and reads
             // connection 2 starts a transaction and reads the same row
             // connection 1 writes and commits
@@ -558,10 +559,11 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             }
         }
 
-        [SkippableFact]
+        [Fact]
+        [Trait(Constants.SupportedOnEmulator, Constants.No)]
         public async Task ReturnCommitStats_ExplicitTransaction()
         {
-            Skip.If(_fixture.RunningOnEmulator, "Emulator does not yet support CommitStats");
+            // Emulator does not yet support CommitStats.
             CommitStatsCapturerLogger logger = new CommitStatsCapturerLogger();
             string key = IdGenerator.FromGuid();
             await RetryHelpers.ExecuteWithRetryAsync(async () =>
@@ -595,10 +597,11 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             });
         }
 
-        [SkippableFact]
+        [Fact]
+        [Trait(Constants.SupportedOnEmulator, Constants.No)]
         public async Task ReturnCommitStats_EphemeralTransaction()
         {
-            Skip.If(_fixture.RunningOnEmulator, "Emulator does not yet support CommitStats");
+            // Emulator does not yet support CommitStats.
             CommitStatsCapturerLogger logger = new CommitStatsCapturerLogger();
             string key = IdGenerator.FromGuid();
             await RetryHelpers.ExecuteWithRetryAsync(async () =>

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/V1/SessionPoolTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/V1/SessionPoolTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2018 Google LLC
+// Copyright 2018 Google LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 
 using Google.Api.Gax.Grpc;
 using Google.Cloud.Spanner.Data;
+using Google.Cloud.Spanner.Data.CommonTesting;
 using Google.Cloud.Spanner.Data.IntegrationTests;
 using Google.Cloud.Spanner.V1.Internal.Logging;
 using System;
@@ -90,10 +91,11 @@ namespace Google.Cloud.Spanner.V1.IntegrationTests
             }
         }
 
-        [SkippableFact]
+        [Fact]
+        [Trait(Constants.SupportedOnEmulator, Constants.No)]
         public async Task SessionLabels()
         {
-            Skip.If(_fixture.RunningOnEmulator, "Emulator does not support filtering by labels");
+            // Emulator does not support filtering by labels.
             string guid = Guid.NewGuid().ToString().ToLowerInvariant();
             var options = new SessionPoolOptions
             {

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/WriteTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/WriteTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// Copyright 2017 Google Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -381,10 +381,11 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             }
         }
 
-        [SkippableFact]
+        [Fact]
+        [Trait(Constants.SupportedOnEmulator, Constants.No)]
         public async Task CommandTimeout()
         {
-            Skip.If(_fixture.RunningOnEmulator, "The emulator returns too quickly to trigger timeout");
+            // The emulator returns too quickly to trigger timeout.
             var values = new SpannerParameterCollection
             {
                 {"StringValue", SpannerDbType.String, "abc"},

--- a/apis/Google.Cloud.Spanner.Data/run-emulator-tests.sh
+++ b/apis/Google.Cloud.Spanner.Data/run-emulator-tests.sh
@@ -30,5 +30,5 @@ EMULATOR_PID=$!
 trap "kill -15 $EMULATOR_PID; echo \"Cleaned up the emulator\";" EXIT
 
 # Run the tests.
-dotnet test -c Release Google.Cloud.Spanner.Data.IntegrationTests
+dotnet test -c Release Google.Cloud.Spanner.Data.IntegrationTests --filter SupportedOnEmulator\!=No
 dotnet test -c Release Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets


### PR DESCRIPTION
This PR contains just the xUnit Trait decorated on the tests that are not supported on the emulator and the corresponding changes to filter unsupported tests in the .yml and shell script. Incorporates feedback from #9140 and the design document. Please share your feedback.

I will raise a new PR for the PostgreSQL infrastructure and tests.

Thanks.