### PR TITLE
feat: Support dependency injection of SpannerConnection

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/Google.Cloud.Spanner.Data.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/Google.Cloud.Spanner.Data.IntegrationTests.csproj
@@ -15,6 +15,8 @@
     <PackageReference Include="Google.Api.Gax.Testing" Version="[4.1.1, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Spanner.Data\Google.Cloud.Spanner.Data.csproj" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/Google.Cloud.Spanner.Data.Snippets.csproj
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/Google.Cloud.Spanner.Data.Snippets.csproj
@@ -12,6 +12,8 @@
     <PackageReference Include="Google.Api.Gax.Testing" Version="[4.1.1, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Spanner.Data\Google.Cloud.Spanner.Data.csproj" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/SpannerConnectionSnippets.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/SpannerConnectionSnippets.cs
@@ -15,6 +15,7 @@
 using Google.Cloud.ClientTesting;
 using Google.Cloud.Spanner.Data.CommonTesting;
 using Google.Cloud.Spanner.V1;
+using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
 using System.Data;
@@ -479,6 +480,15 @@ namespace Google.Cloud.Spanner.Data.Snippets
                 }
                 // End sample
             });
+        }
+
+        [Fact]
+        public void DependencyInjection()
+        {
+            IServiceCollection services = new ServiceCollection();
+            // Sample: DependencyInjection
+            services.AddSpannerConnection("SpannerDb");
+            // End sample
         }
     }
 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/Google.Cloud.Spanner.Data.Tests.csproj
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/Google.Cloud.Spanner.Data.Tests.csproj
@@ -12,6 +12,8 @@
     <PackageReference Include="Google.Api.Gax.Testing" Version="[4.1.1, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Spanner.Data\Google.Cloud.Spanner.Data.csproj" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/ServiceCollectionExtensionsTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,136 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+using Google.Apis.Auth.OAuth2;
+using Grpc.Auth;
+using Grpc.Core;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Google.Cloud.Spanner.Data.Tests;
+
+public class ServiceCollectionExtensionsTests
+{
+    private const string SampleDataSource = "projects/x/instances/y";
+
+    [Fact]
+    public void AddSpannerConnection_NoConfiguration()
+    {
+        IServiceCollection serviceCollection = new ServiceCollection();
+        serviceCollection.AddSpannerConnection("MyConnectionString");
+        var provider = serviceCollection.BuildServiceProvider();
+        Assert.Throws<InvalidOperationException>(() => provider.GetRequiredService<SpannerConnection>());
+    }
+
+    [Fact]
+    public void AddSpannerConnection_NoConnectionStringsSection()
+    {
+        IServiceCollection serviceCollection = new ServiceCollection();
+        AddConfiguration(serviceCollection);
+        serviceCollection.AddSpannerConnection("MyConnectionString");
+        var provider = serviceCollection.BuildServiceProvider();
+
+        Assert.Throws<ArgumentException>(() => provider.GetRequiredService<SpannerConnection>());
+    }
+
+    [Fact]
+    public void AddSpannerConnection_ConnectionStringMissing()
+    {
+        IServiceCollection serviceCollection = new ServiceCollection();
+        AddConfiguration(serviceCollection, $"ConnectionStrings:OtherConnectionString=Data Source={SampleDataSource}");
+        serviceCollection.AddSpannerConnection("MyConnectionString");
+        var provider = serviceCollection.BuildServiceProvider();
+
+        Assert.Throws<ArgumentException>(() => provider.GetRequiredService<SpannerConnection>());
+    }
+
+    [Fact]
+    public void AddSpannerConnection_NoCredentials()
+    {
+        IServiceCollection serviceCollection = new ServiceCollection();
+        AddConfiguration(serviceCollection, $"ConnectionStrings:MyConnectionString=Data Source={SampleDataSource}");
+        serviceCollection.AddSpannerConnection("MyConnectionString");
+        var provider = serviceCollection.BuildServiceProvider();
+
+        using var connection = provider.GetRequiredService<SpannerConnection>();
+        Assert.Null(connection.Builder.GoogleCredential);
+        Assert.Null(connection.Builder.CredentialOverride);
+        Assert.Equal(SampleDataSource, connection.DataSource);
+    }
+
+    [Fact]
+    public void AddSpannerConnection_ChannelCredentials()
+    {
+        var channelCredentials = GoogleCredential.FromAccessToken("token").ToChannelCredentials();
+        IServiceCollection serviceCollection = new ServiceCollection();
+        AddConfiguration(serviceCollection, $"ConnectionStrings:MyConnectionString=Data Source={SampleDataSource}");
+        serviceCollection.AddSpannerConnection("MyConnectionString");
+        serviceCollection.AddSingleton(channelCredentials);
+        var provider = serviceCollection.BuildServiceProvider();
+
+        using var connection = provider.GetRequiredService<SpannerConnection>();
+        Assert.Null(connection.Builder.GoogleCredential);
+        Assert.Same(channelCredentials, connection.Builder.CredentialOverride);
+        Assert.Equal(SampleDataSource, connection.DataSource);
+    }
+
+    [Fact]
+    public void AddSpannerConnection_GoogleCredential()
+    {
+        var googleCredential = GoogleCredential.FromAccessToken("token");
+        IServiceCollection serviceCollection = new ServiceCollection();
+        AddConfiguration(serviceCollection, $"ConnectionStrings:MyConnectionString=Data Source={SampleDataSource}");
+        serviceCollection.AddSpannerConnection("MyConnectionString");
+        serviceCollection.AddSingleton(googleCredential);
+        var provider = serviceCollection.BuildServiceProvider();
+
+        using var connection = provider.GetRequiredService<SpannerConnection>();
+        Assert.Same(googleCredential, connection.Builder.GoogleCredential);
+        Assert.Null(connection.Builder.CredentialOverride);
+        Assert.Equal(SampleDataSource, connection.DataSource);
+    }
+
+    [Fact]
+    public void AddSpannerConnection_ChannelCredentialsAndGoogleCredential_ChannelCredentialsTakePriority()
+    {
+        var channelCredentials = GoogleCredential.FromAccessToken("token").ToChannelCredentials();
+        var googleCredential = GoogleCredential.FromAccessToken("token");
+        IServiceCollection serviceCollection = new ServiceCollection();
+        AddConfiguration(serviceCollection, $"ConnectionStrings:MyConnectionString=Data Source={SampleDataSource}");
+        serviceCollection.AddSpannerConnection("MyConnectionString");
+        serviceCollection.AddSingleton(googleCredential);
+        serviceCollection.AddSingleton(channelCredentials);
+        var provider = serviceCollection.BuildServiceProvider();
+
+        using var connection = provider.GetRequiredService<SpannerConnection>();
+        Assert.Null(connection.Builder.GoogleCredential);
+        Assert.Same(channelCredentials, connection.Builder.CredentialOverride);
+        Assert.Equal(SampleDataSource, connection.DataSource);
+    }
+
+    /// <summary>
+    /// Adds configuration to the service collection, with configuration pairs in the form key=value.
+    /// </summary>
+    private static void AddConfiguration(IServiceCollection collection, params string[] pairs)
+    {
+        var configurationManager = new ConfigurationManager();
+        var keyValuePairs = pairs.Select(pair => new KeyValuePair<string, string>(pair.Split('=')[0], pair.Split(new[] { '=' }, 2)[1]));
+        configurationManager.AddInMemoryCollection(keyValuePairs);
+        collection.AddSingleton<IConfiguration>(configurationManager);
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.csproj
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.csproj
@@ -14,6 +14,7 @@
     <ProjectReference Include="..\..\Google.Cloud.Spanner.Admin.Instance.V1\Google.Cloud.Spanner.Admin.Instance.V1\Google.Cloud.Spanner.Admin.Instance.V1.csproj" />
     <ProjectReference Include="..\..\Google.Cloud.Spanner.V1\Google.Cloud.Spanner.V1\Google.Cloud.Spanner.V1.csproj" />
     <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Reference Include="System.Transactions" />

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/ServiceCollectionExtensions.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/ServiceCollectionExtensions.cs
@@ -1,0 +1,60 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using Google.Apis.Auth.OAuth2;
+using Google.Cloud.Spanner.Data;
+using Grpc.Core;
+using Microsoft.Extensions.Configuration;
+using System;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Provides extension methods to configure dependency injection with Spanner.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds a transient service providing a <see cref="SpannerConnection"/> using the ConnectionStrings
+    /// section of the configuration. If the container providers a <see cref="ChannelCredentials"/> or
+    /// <see cref="GoogleCredential"/>, this will be used for the connection (with <see cref="ChannelCredentials"/> taking precedence).
+    /// </summary>
+    /// <param name="services">The service collection to add the transient dependency to.</param>
+    /// <param name="connectionStringName">The name of the the connection string within the ConnectionStrings section of the configuration.
+    /// Must not be null or empty.</param>
+    /// <returns>The same service collection (<paramref name="services"/>), for method chaining.</returns>
+    public static IServiceCollection AddSpannerConnection(this IServiceCollection services, string connectionStringName)
+    {
+        GaxPreconditions.CheckNotNullOrEmpty(connectionStringName, nameof(connectionStringName));
+        return services.AddTransient(provider =>
+        {
+            var config = provider.GetRequiredService<IConfiguration>();
+            string connectionString = config.GetConnectionString(connectionStringName);
+            if (connectionString is null)
+            {
+                throw new ArgumentException($"Connection string '{connectionStringName}' is not present in the configuration.");
+            }
+
+            var channelCredentials = provider.GetService<ChannelCredentials>();
+            if (channelCredentials is not null)
+            {
+                return new SpannerConnection(connectionString, channelCredentials);
+            }
+
+            var googleCredential = provider.GetService<GoogleCredential>();
+            return new SpannerConnection(connectionString, googleCredential);
+        });
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/docs/index.md
+++ b/apis/Google.Cloud.Spanner.Data/docs/index.md
@@ -32,6 +32,39 @@ If you need to provide other credentials, there are three alternatives:
 - Pass a `ChannelCredentials` into the constructor of `SpannerConnection`
   or `SpannerConnectionStringBuilder`.
 
+## SpannerConnection and Dependency Injection
+
+A `SpannerConnection` can be provided via dependency injection based
+on the ConnectionStrings section of the application configuration,
+via the `AddSpannerConnection` extension method. For example, 
+consider an application configured with `appsettings.json` file like this:
+
+```json
+{
+  "ConnectionStrings": {
+    "SpannerDb": "Data Source=projects/my-project/instances/my-instance"
+  }
+}
+```
+
+The `SpannerConnection` can be configured on the service collection
+as shown below:
+
+{{sample:SpannerConnection.DependencyInjection}}
+
+The dependency is registered as a transient dependency (as a new
+`SpannerConnection` should be created for each request), and is
+automatically disposed by the dependency injection infrastructure.
+
+If the dependency injection container has been configured with
+`ChannelCredentials` or `GoogleCredential` values, those are used
+automatically by `AddSpannerConnection`. (If both are specified,
+`ChannelCredentials` takes priority.) Note that this means any
+`CredentialsFile` specified in the connection string is ignored when
+the connection is obtained via dependency injection and a
+`ChannelCredentials` or `GoogleCredential` is available from the
+same container.
+
 ## Sample code
 
 Once you have created your Google Cloud Project and Spanner Instance using the web console,

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3540,12 +3540,15 @@
         "Google.Cloud.Spanner.Admin.Database.V1": "project",
         "Google.Cloud.Spanner.Admin.Instance.V1": "project",
         "Google.Cloud.Spanner.V1": "project",
-        "Grpc.Core": "2.46.3"
+        "Grpc.Core": "2.46.3",
+        "Microsoft.Extensions.Configuration.Abstractions": "6.0.0"
       },
       "testDependencies": {
         "CoreCompat.EnterpriseLibrary.TransientFaultHandling": "6.0.1304-r3",
         "Google.Api.Gax.Grpc.Testing": "4.1.1",
         "Google.Api.Gax.Testing": "4.1.1",
+        "Microsoft.Extensions.Configuration": "6.0.0",
+        "Microsoft.Extensions.DependencyInjection": "6.0.0",
         "Xunit.Combinatorial": "1.4.1"
       }
     },


### PR DESCRIPTION
Currently there's no way of saying "Ignore the GoogleCredential/ChannelCredentials in DI, use the ADC or the CredentialsPath in the connection string" - we can add that functionality if it becomes a problem.

Fixes #8909