### PR TITLE
Release Google.Cloud.AIPlatform.V1 version 2.4.0

### DIFF
--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AI Platform API, which allows you to train high-quality custom machine learning models with minimal machine learning expertise and effort.</Description>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.0.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.1.1, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />

--- a/apis/Google.Cloud.AIPlatform.V1/docs/history.md
+++ b/apis/Google.Cloud.AIPlatform.V1/docs/history.md
@@ -1,5 +1,14 @@
 # Version history
 
+## Version 2.4.0, released 2022-10-03
+
+### New features
+
+- Add model_source_info to Model in aiplatform v1 model.proto ([commit 52a99e7](https://github.com/googleapis/google-cloud-dotnet/commit/52a99e7720eb6eb1328746a500c1354ce48948fc))
+- Add timestamp_outside_retention_rows_count to ImportFeatureValuesResponse and ImportFeatureValuesOperationMetadata in aiplatform v1 featurestore_service.proto ([commit 093a3f1](https://github.com/googleapis/google-cloud-dotnet/commit/093a3f1a3ea1e44cdb2dc558113cee303208f2ff))
+- Add RemoveContextChildren rpc to aiplatform v1 metadata_service.proto ([commit 093a3f1](https://github.com/googleapis/google-cloud-dotnet/commit/093a3f1a3ea1e44cdb2dc558113cee303208f2ff))
+- Add order_by to ListArtifactsRequest, ListContextsRequest, and ListExecutionsRequest in aiplatform v1 metadata_service.proto ([commit 093a3f1](https://github.com/googleapis/google-cloud-dotnet/commit/093a3f1a3ea1e44cdb2dc558113cee303208f2ff))
+
 ## Version 2.3.0, released 2022-08-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -121,7 +121,7 @@
     },
     {
       "id": "Google.Cloud.AIPlatform.V1",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "type": "grpc",
       "productName": "Cloud AI Platform",
       "productUrl": "https://cloud.google.com/ai-platform/docs/",
@@ -131,7 +131,7 @@
         "ml"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.0.0",
+        "Google.Api.Gax.Grpc": "4.1.1",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",


### PR DESCRIPTION

Changes in this release:

### New features

- Add model_source_info to Model in aiplatform v1 model.proto ([commit 52a99e7](https://github.com/googleapis/google-cloud-dotnet/commit/52a99e7720eb6eb1328746a500c1354ce48948fc))
- Add timestamp_outside_retention_rows_count to ImportFeatureValuesResponse and ImportFeatureValuesOperationMetadata in aiplatform v1 featurestore_service.proto ([commit 093a3f1](https://github.com/googleapis/google-cloud-dotnet/commit/093a3f1a3ea1e44cdb2dc558113cee303208f2ff))
- Add RemoveContextChildren rpc to aiplatform v1 metadata_service.proto ([commit 093a3f1](https://github.com/googleapis/google-cloud-dotnet/commit/093a3f1a3ea1e44cdb2dc558113cee303208f2ff))
- Add order_by to ListArtifactsRequest, ListContextsRequest, and ListExecutionsRequest in aiplatform v1 metadata_service.proto ([commit 093a3f1](https://github.com/googleapis/google-cloud-dotnet/commit/093a3f1a3ea1e44cdb2dc558113cee303208f2ff))
