### PR TITLE
Release Google.Cloud.Asset.V1 version 3.2.0

### DIFF
--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.csproj
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.1.0</Version>
+    <Version>3.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Asset Inventory API (v1).</Description>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.0.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.1.1, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.OrgPolicy.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.OsConfig.V1" Version="[2.0.0, 3.0.0)" />

--- a/apis/Google.Cloud.Asset.V1/docs/history.md
+++ b/apis/Google.Cloud.Asset.V1/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+## Version 3.2.0, released 2022-10-03
+
+### New features
+
+- Add support for AssetService v1 SavedQuery APIs ([commit c747312](https://github.com/googleapis/google-cloud-dotnet/commit/c7473122b2db4f2b8499efb0a375c2fb2ed5025c))
 ## Version 3.1.0, released 2022-08-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -296,11 +296,11 @@
       "protoPath": "google/cloud/asset/v1",
       "productName": "Google Cloud Asset Inventory",
       "productUrl": "https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Asset Inventory API (v1).",
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.0.0",
+        "Google.Api.Gax.Grpc": "4.1.1",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.OrgPolicy.V1": "3.0.0",
         "Google.Cloud.OsConfig.V1": "2.0.0",


### PR DESCRIPTION

Changes in this release:

### New features

- Add support for AssetService v1 SavedQuery APIs ([commit c747312](https://github.com/googleapis/google-cloud-dotnet/commit/c7473122b2db4f2b8499efb0a375c2fb2ed5025c))
