### PR TITLE
Release Google.Cloud.Language.V1 version 3.1.0

### DIFF
--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/Google.Cloud.Language.V1.csproj
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/Google.Cloud.Language.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0</Version>
+    <Version>3.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Natural Language API, which provides natural language understanding technologies to developers. Examples include sentiment analysis, entity recognition, and text annotations.</Description>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.0.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.1.1, 5.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Language.V1/docs/history.md
+++ b/apis/Google.Cloud.Language.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 3.1.0, released 2022-10-03
+
+### New features
+
+- Add support for V1 and V2 classification models for the V1 API ([commit 634b207](https://github.com/googleapis/google-cloud-dotnet/commit/634b2072cc348f300932f94bf59a4ef9c0304c70))
+
+### Documentation improvements
+
+- Fix docstring formatting ([commit 191e5de](https://github.com/googleapis/google-cloud-dotnet/commit/191e5de258816094a26dc2ae42c1b2a846039912))
+
 ## Version 3.0.0, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2227,11 +2227,11 @@
       "protoPath": "google/cloud/language/v1",
       "productName": "Google Cloud Natural Language",
       "productUrl": "https://cloud.google.com/natural-language",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Natural Language API, which provides natural language understanding technologies to developers. Examples include sentiment analysis, entity recognition, and text annotations.",
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.0.0",
+        "Google.Api.Gax.Grpc": "4.1.1",
         "Grpc.Core": "2.46.3"
       },
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- Add support for V1 and V2 classification models for the V1 API ([commit 634b207](https://github.com/googleapis/google-cloud-dotnet/commit/634b2072cc348f300932f94bf59a4ef9c0304c70))

### Documentation improvements

- Fix docstring formatting ([commit 191e5de](https://github.com/googleapis/google-cloud-dotnet/commit/191e5de258816094a26dc2ae42c1b2a846039912))
