### PR TITLE
Release Google.Cloud.CertificateManager.V1 version 2.1.0

### DIFF
--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.csproj
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Certificate Manager API, which lets you acquire and manage TLS (SSL) certificates for use with Cloud Load Balancing</Description>

--- a/apis/Google.Cloud.CertificateManager.V1/docs/history.md
+++ b/apis/Google.Cloud.CertificateManager.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 2.1.0, released 2022-10-06
+
+### New features
+
+- Added support for Private Trust to Certificate Manager API ([commit 9722cb7](https://github.com/googleapis/google-cloud-dotnet/commit/9722cb7981d69eda8f759a01b0fd72dbd9c28819))
+
+### Documentation improvements
+
+- See https://cloud.google.com/certificate-manager/docs/deploy-google-managed-cas ([commit 9722cb7](https://github.com/googleapis/google-cloud-dotnet/commit/9722cb7981d69eda8f759a01b0fd72dbd9c28819))
+
 ## Version 2.0.0, released 2022-09-15
 
 No API surface changes; just dependency updates and promotion to GA.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -934,7 +934,7 @@
     },
     {
       "id": "Google.Cloud.CertificateManager.V1",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "type": "grpc",
       "productName": "Certificate Manager",
       "productUrl": "https://cloud.google.com/certificate-manager/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Added support for Private Trust to Certificate Manager API ([commit 9722cb7](https://github.com/googleapis/google-cloud-dotnet/commit/9722cb7981d69eda8f759a01b0fd72dbd9c28819))

### Documentation improvements

- See https://cloud.google.com/certificate-manager/docs/deploy-google-managed-cas ([commit 9722cb7](https://github.com/googleapis/google-cloud-dotnet/commit/9722cb7981d69eda8f759a01b0fd72dbd9c28819))
