### PR TITLE
chore: Update OwlBot lockfile

### DIFF
--- a/.github/.OwlBot.lock.yaml
+++ b/.github/.OwlBot.lock.yaml
@@ -14,5 +14,4 @@
 
 docker:
     image: gcr.io/cloud-devrel-public-resources/owlbot-dotnet:latest
-    digest: sha256:4e1edae04428c531fb105c34cda668bd2fbded3de21271574b23948e113259f0
-  
+    digest: sha256:c7c743f4b5ce7142fd072ccb04e51f4360db2160eb139424e06c612bf10a23c6

--- a/owl-bot-post-processor/main.sh
+++ b/owl-bot-post-processor/main.sh
@@ -130,6 +130,10 @@ copy_one_api() {
   ./prepare-release.sh update-mixins $PACKAGE HEAD
 }
 
+# List the SDKs available, for diagnostic purposes
+echo ".NET SDKs:"
+dotnet --list-sdks
+
 # Avoid .NET complaining about submodules being missing
 git config --global --add safe.directory /repo
 git submodule update --init --recursive


### PR DESCRIPTION
(This would normally happen automatically.)

Additionally, list the .NET SDKs at the start of an OwlBot run for diagnostic purposes.