### PR TITLE
Release Google.Cloud.Speech.V2 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.csproj
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Speech-to-Text API (v2) which converts audio to text by applying powerful neural network models.</Description>

--- a/apis/Google.Cloud.Speech.V2/docs/history.md
+++ b/apis/Google.Cloud.Speech.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2022-10-17
+
+### Documentation improvements
+
+- Remove instructions for custom endpoint for Speech.V2
+
 ## Version 1.0.0-beta01, released 2022-09-30
 
 Initial release.

--- a/apis/Google.Cloud.Speech.V2/docs/index.md
+++ b/apis/Google.Cloud.Speech.V2/docs/index.md
@@ -4,10 +4,6 @@
 
 {{version}}
 
-Please note that Google.Cloud.Speech.V2 is currently in preview;
-for production purposes, please use Google.Cloud.Speech.V1 which has
-General Availability.
-
 {{installation}}
 
 {{auth}}
@@ -16,10 +12,4 @@ General Availability.
 
 {{client-classes}}
 
-Note that currently the end-point must be specified explicitly when
-constructing the client. The endpoint is of the form
-`{location}-speech.googleapis.com`, e.g.
-`global-documentai.googleapis.com`. The simplest way to specify the
-endpoint is to use `SpeechClientBuilder`:
-
-{{sample:SpeechClient.CustomEndpoint}}
+{{client-construction}}

--- a/apis/Google.Cloud.Speech.V2/smoketests.json
+++ b/apis/Google.Cloud.Speech.V2/smoketests.json
@@ -1,6 +1,6 @@
 [
   {
-    "endpoint": "global-speech.googleapis.com",
+    "endpoint": "speech.googleapis.com",
     "method": "ListCustomClasses",
     "client": "SpeechClient",
     "arguments": {
@@ -8,7 +8,7 @@
     }
   },
   {
-    "endpoint": "global-speech.googleapis.com",
+    "endpoint": "speech.googleapis.com",
     "method": "ListRecognizers",
     "client": "SpeechClient",
     "arguments": {
@@ -16,7 +16,7 @@
     }
   },
   {
-    "endpoint": "global-speech.googleapis.com",
+    "endpoint": "speech.googleapis.com",
     "method": "ListPhraseSets",
     "client": "SpeechClient",
     "arguments": {

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3636,7 +3636,7 @@
     },
     {
       "id": "Google.Cloud.Speech.V2",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Cloud Speech-to-Text",
       "productUrl": "https://cloud.google.com/speech",


### PR DESCRIPTION

Changes in this release:

### Documentation improvements

- Remove instructions for custom endpoint for Speech.V2
