### PR TITLE
Release Google.Analytics.Data.V1Beta version 2.0.0-beta02

### DIFF
--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.csproj
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta01</Version>
+    <Version>2.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Analytics Data API (v1beta)</Description>

--- a/apis/Google.Analytics.Data.V1Beta/docs/history.md
+++ b/apis/Google.Analytics.Data.V1Beta/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 2.0.0-beta02, released 2022-10-17
+
+### New features
+
+- Add `subject_to_thresholding` field to `ResponseMetadata` type ([commit 5be9430](https://github.com/googleapis/google-cloud-dotnet/commit/5be9430f582a6fadedcd2f3ccc3aa45dcf0a0253))
+- Add `tokens_per_project_per_hour` field to `PropertyQuota` type ([commit 5be9430](https://github.com/googleapis/google-cloud-dotnet/commit/5be9430f582a6fadedcd2f3ccc3aa45dcf0a0253))
+
 ## Version 2.0.0-beta01, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -34,7 +34,7 @@
     },
     {
       "id": "Google.Analytics.Data.V1Beta",
-      "version": "2.0.0-beta01",
+      "version": "2.0.0-beta02",
       "type": "grpc",
       "productName": "Google Analytics Data",
       "productUrl": "https://developers.google.com/analytics",


### PR DESCRIPTION

Changes in this release:

### New features

- Add `subject_to_thresholding` field to `ResponseMetadata` type ([commit 5be9430](https://github.com/googleapis/google-cloud-dotnet/commit/5be9430f582a6fadedcd2f3ccc3aa45dcf0a0253))
- Add `tokens_per_project_per_hour` field to `PropertyQuota` type ([commit 5be9430](https://github.com/googleapis/google-cloud-dotnet/commit/5be9430f582a6fadedcd2f3ccc3aa45dcf0a0253))
