### PR TITLE
Release Google.Cloud.Asset.V1 version 3.3.0

### DIFF
--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.csproj
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.2.0</Version>
+    <Version>3.3.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Asset Inventory API (v1).</Description>

--- a/apis/Google.Cloud.Asset.V1/docs/history.md
+++ b/apis/Google.Cloud.Asset.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 3.3.0, released 2022-10-17
+
+### Bug fixes
+
+- Deprecate searchable field kmsKey ([commit 73d79e8](https://github.com/googleapis/google-cloud-dotnet/commit/73d79e81c1a3fb91bd07bec02b60bd105994e580))
+
+### New features
+
+- Add a new searchable field kmsKeys ([commit 73d79e8](https://github.com/googleapis/google-cloud-dotnet/commit/73d79e81c1a3fb91bd07bec02b60bd105994e580))
+
 ## Version 3.2.0, released 2022-10-03
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -296,7 +296,7 @@
       "protoPath": "google/cloud/asset/v1",
       "productName": "Google Cloud Asset Inventory",
       "productUrl": "https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Asset Inventory API (v1).",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Deprecate searchable field kmsKey ([commit 73d79e8](https://github.com/googleapis/google-cloud-dotnet/commit/73d79e81c1a3fb91bd07bec02b60bd105994e580))

### New features

- Add a new searchable field kmsKeys ([commit 73d79e8](https://github.com/googleapis/google-cloud-dotnet/commit/73d79e81c1a3fb91bd07bec02b60bd105994e580))
