### PR TITLE
Release Google.Cloud.AssuredWorkloads.V1 version 2.2.0

### DIFF
--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.csproj
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Assured Workloads API (v1)</Description>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.0.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.1.1, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>

--- a/apis/Google.Cloud.AssuredWorkloads.V1/docs/history.md
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 2.2.0, released 2022-10-17
+
+### New features
+
+- Add new field for exception audit log link ([commit f22a43e](https://github.com/googleapis/google-cloud-dotnet/commit/f22a43e19787024d703416e584dcbf53373f401c))
+- Add support of new compliance regime for regions and new partner T systems ([commit f22a43e](https://github.com/googleapis/google-cloud-dotnet/commit/f22a43e19787024d703416e584dcbf53373f401c))
+- Add apis for AssuredWorkload monitoring feature and to restrict allowed resources ([commit 982ac1c](https://github.com/googleapis/google-cloud-dotnet/commit/982ac1c2add600cf357e6feb5e5c94e33715fd30))
+
+### Documentation improvements
+
+- Fix some typos in documentation ([commit f22a43e](https://github.com/googleapis/google-cloud-dotnet/commit/f22a43e19787024d703416e584dcbf53373f401c))
+
 ## Version 2.1.0, released 2022-07-11
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -319,7 +319,7 @@
     },
     {
       "id": "Google.Cloud.AssuredWorkloads.V1",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "type": "grpc",
       "productName": "Assured Workloads",
       "productUrl": "https://cloud.google.com/assured-workloads/docs",
@@ -329,7 +329,7 @@
         "compilance"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.0.0",
+        "Google.Api.Gax.Grpc": "4.1.1",
         "Google.LongRunning": "3.0.0",
         "Grpc.Core": "2.46.3"
       },


### PR DESCRIPTION

Changes in this release:

### New features

- Add new field for exception audit log link ([commit f22a43e](https://github.com/googleapis/google-cloud-dotnet/commit/f22a43e19787024d703416e584dcbf53373f401c))
- Add support of new compliance regime for regions and new partner T systems ([commit f22a43e](https://github.com/googleapis/google-cloud-dotnet/commit/f22a43e19787024d703416e584dcbf53373f401c))
- Add apis for AssuredWorkload monitoring feature and to restrict allowed resources ([commit 982ac1c](https://github.com/googleapis/google-cloud-dotnet/commit/982ac1c2add600cf357e6feb5e5c94e33715fd30))

### Documentation improvements

- Fix some typos in documentation ([commit f22a43e](https://github.com/googleapis/google-cloud-dotnet/commit/f22a43e19787024d703416e584dcbf53373f401c))
