### PR TITLE
Release Google.Cloud.Audit version 2.1.0

### DIFF
--- a/apis/Google.Cloud.Audit/Google.Cloud.Audit/Google.Cloud.Audit.csproj
+++ b/apis/Google.Cloud.Audit/Google.Cloud.Audit/Google.Cloud.Audit.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Protobuf messages for Google Cloud audit logs.</Description>

--- a/apis/Google.Cloud.Audit/docs/history.md
+++ b/apis/Google.Cloud.Audit/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 2.1.0, released 2022-10-17
+
+### New features
+
+- Add PolicyViolation to the AuditLog proto, this will only be present when access is denied due to Organization Policy. It describes why access is denied ([commit 4123c0e](https://github.com/googleapis/google-cloud-dotnet/commit/4123c0e7cf10ff042930277cfd9fd8a5496f61e4))
+- Add FirstPartyAppMetadata to the BigQueryAuditMetadata proto, it contains metadata about requests originating from Google apps, such as Google Sheets ([commit 4123c0e](https://github.com/googleapis/google-cloud-dotnet/commit/4123c0e7cf10ff042930277cfd9fd8a5496f61e4))
+- Added new events to BigQueryAuditMetadata such as UnlinkDataset and RowAccessPolicyCreation ([commit 4123c0e](https://github.com/googleapis/google-cloud-dotnet/commit/4123c0e7cf10ff042930277cfd9fd8a5496f61e4))
+
+### Documentation improvements
+
+- Updated multiple comments ([commit 4123c0e](https://github.com/googleapis/google-cloud-dotnet/commit/4123c0e7cf10ff042930277cfd9fd8a5496f61e4))
+
 ## Version 2.0.0, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -359,7 +359,7 @@
     },
     {
       "id": "Google.Cloud.Audit",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "targetFrameworks": "netstandard2.1;net462",
       "productName": "Google Cloud Audit",
       "productUrl": "https://cloud.google.com/logging/docs/audit",


### PR DESCRIPTION

Changes in this release:

### New features

- Add PolicyViolation to the AuditLog proto, this will only be present when access is denied due to Organization Policy. It describes why access is denied ([commit 4123c0e](https://github.com/googleapis/google-cloud-dotnet/commit/4123c0e7cf10ff042930277cfd9fd8a5496f61e4))
- Add FirstPartyAppMetadata to the BigQueryAuditMetadata proto, it contains metadata about requests originating from Google apps, such as Google Sheets ([commit 4123c0e](https://github.com/googleapis/google-cloud-dotnet/commit/4123c0e7cf10ff042930277cfd9fd8a5496f61e4))
- Added new events to BigQueryAuditMetadata such as UnlinkDataset and RowAccessPolicyCreation ([commit 4123c0e](https://github.com/googleapis/google-cloud-dotnet/commit/4123c0e7cf10ff042930277cfd9fd8a5496f61e4))

### Documentation improvements

- Updated multiple comments ([commit 4123c0e](https://github.com/googleapis/google-cloud-dotnet/commit/4123c0e7cf10ff042930277cfd9fd8a5496f61e4))
