### PR TITLE
Release Google.Cloud.Batch.V1 version 1.0.0-beta03

### DIFF
--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.csproj
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Batch API (v1), which allows you to manage the running of batch jobs on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Batch.V1/docs/history.md
+++ b/apis/Google.Cloud.Batch.V1/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 1.0.0-beta03, released 2022-10-17
+
+### New features
+
+- Enable install_gpu_drivers flag in v1 proto ([commit 12c66f2](https://github.com/googleapis/google-cloud-dotnet/commit/12c66f2f8c16395132c5a19cb77616732876b8f6))
+
+### Documentation improvements
+
+- Refine GPU drivers installation proto description ([commit 12c66f2](https://github.com/googleapis/google-cloud-dotnet/commit/12c66f2f8c16395132c5a19cb77616732876b8f6))
+- Refine comments for deprecated proto fields ([commit 12c66f2](https://github.com/googleapis/google-cloud-dotnet/commit/12c66f2f8c16395132c5a19cb77616732876b8f6))
+- Update the API comments about the device_name ([commit 12c66f2](https://github.com/googleapis/google-cloud-dotnet/commit/12c66f2f8c16395132c5a19cb77616732876b8f6))
+
 ## Version 1.0.0-beta02, released 2022-08-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -420,7 +420,7 @@
     },
     {
       "id": "Google.Cloud.Batch.V1",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0-beta03",
       "type": "grpc",
       "productName": "Batch",
       "productUrl": "https://cloud.google.com/batch/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Enable install_gpu_drivers flag in v1 proto ([commit 12c66f2](https://github.com/googleapis/google-cloud-dotnet/commit/12c66f2f8c16395132c5a19cb77616732876b8f6))

### Documentation improvements

- Refine GPU drivers installation proto description ([commit 12c66f2](https://github.com/googleapis/google-cloud-dotnet/commit/12c66f2f8c16395132c5a19cb77616732876b8f6))
- Refine comments for deprecated proto fields ([commit 12c66f2](https://github.com/googleapis/google-cloud-dotnet/commit/12c66f2f8c16395132c5a19cb77616732876b8f6))
- Update the API comments about the device_name ([commit 12c66f2](https://github.com/googleapis/google-cloud-dotnet/commit/12c66f2f8c16395132c5a19cb77616732876b8f6))
