### PR TITLE
Release Google.Cloud.Container.V1 version 3.4.0

### DIFF
--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.3.0</Version>
+    <Version>3.4.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.</Description>

--- a/apis/Google.Cloud.Container.V1/docs/history.md
+++ b/apis/Google.Cloud.Container.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.4.0, released 2022-10-17
+
+### New features
+
+- Launch GKE Cost Allocations configuration to the v1 GKE API ([commit c359c4a](https://github.com/googleapis/google-cloud-dotnet/commit/c359c4a17e2697da4219ef9176bd3b3b84792105))
+
 ## Version 3.3.0, released 2022-10-03
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1079,7 +1079,7 @@
       "protoPath": "google/container/v1",
       "productName": "Google Kubernetes Engine",
       "productUrl": "https://cloud.google.com/kubernetes-engine/docs/reference/rest/",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Launch GKE Cost Allocations configuration to the v1 GKE API ([commit c359c4a](https://github.com/googleapis/google-cloud-dotnet/commit/c359c4a17e2697da4219ef9176bd3b3b84792105))
