### PR TITLE
Release Google.Cloud.Dialogflow.V2 version 4.3.0

### DIFF
--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.csproj
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.2.0</Version>
+    <Version>4.3.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Dialogflow API (v2).</Description>

--- a/apis/Google.Cloud.Dialogflow.V2/docs/history.md
+++ b/apis/Google.Cloud.Dialogflow.V2/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 4.3.0, released 2022-10-17
+
+### New features
+
+- Include conversation dataset name to be created with dataset creation metadata ([commit 293e1ff](https://github.com/googleapis/google-cloud-dotnet/commit/293e1ff997ea8ccedf5812dda0392089cfbe8228))
+
+### Documentation improvements
+
+- Clarify SuggestionFeature enums which are specific to chat agents ([commit 293e1ff](https://github.com/googleapis/google-cloud-dotnet/commit/293e1ff997ea8ccedf5812dda0392089cfbe8228))
+
 ## Version 4.2.0, released 2022-09-15
 
 ### Documentation improvements

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1510,7 +1510,7 @@
       "protoPath": "google/cloud/dialogflow/v2",
       "productName": "Google Cloud Dialogflow",
       "productUrl": "https://cloud.google.com/dialogflow-enterprise/",
-      "version": "4.2.0",
+      "version": "4.3.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Dialogflow API (v2).",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- Include conversation dataset name to be created with dataset creation metadata ([commit 293e1ff](https://github.com/googleapis/google-cloud-dotnet/commit/293e1ff997ea8ccedf5812dda0392089cfbe8228))

### Documentation improvements

- Clarify SuggestionFeature enums which are specific to chat agents ([commit 293e1ff](https://github.com/googleapis/google-cloud-dotnet/commit/293e1ff997ea8ccedf5812dda0392089cfbe8228))
