### PR TITLE
Release Google.Cloud.CloudBuild.V1 version 2.1.0

### DIFF
--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.csproj
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Build API, which creates and manages builds on Google Cloud Platform.</Description>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.0.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.1.1, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>

--- a/apis/Google.Cloud.CloudBuild.V1/docs/history.md
+++ b/apis/Google.Cloud.CloudBuild.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 2.1.0, released 2022-11-02
+
+### New features
+
+- Integration of Cloud Build with Artifact Registry ([commit 6fb3a24](https://github.com/googleapis/google-cloud-dotnet/commit/6fb3a24d473518376fd5b7c039a8539dfd7d1f9c))
+- Add allow_failure, exit_code, and allow_exit_code to BuildStep message ([commit 7612013](https://github.com/googleapis/google-cloud-dotnet/commit/7612013d377a10dc35baba930ce30fe61ba77ad0))
+
 ## Version 2.0.0, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -979,7 +979,7 @@
     },
     {
       "id": "Google.Cloud.CloudBuild.V1",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "type": "grpc",
       "productName": "Cloud Build",
       "productUrl": "https://cloud.google.com/cloud-build",
@@ -989,7 +989,7 @@
         "cloudbuild"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.0.0",
+        "Google.Api.Gax.Grpc": "4.1.1",
         "Google.LongRunning": "3.0.0",
         "Grpc.Core": "2.46.3"
       },


### PR DESCRIPTION

Changes in this release:

### New features

- Integration of Cloud Build with Artifact Registry ([commit 6fb3a24](https://github.com/googleapis/google-cloud-dotnet/commit/6fb3a24d473518376fd5b7c039a8539dfd7d1f9c))
- Add allow_failure, exit_code, and allow_exit_code to BuildStep message ([commit 7612013](https://github.com/googleapis/google-cloud-dotnet/commit/7612013d377a10dc35baba930ce30fe61ba77ad0))
