### PR TITLE
Release Google.Cloud.Compute.V1 version 2.3.0

### DIFF
--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.2.0</Version>
+    <Version>2.3.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Compute Engine API.</Description>

--- a/apis/Google.Cloud.Compute.V1/docs/history.md
+++ b/apis/Google.Cloud.Compute.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.3.0, released 2022-11-02
+
+### New features
+
+- Update Compute Engine API to revision 20221011 ([issue 736](https://github.com/googleapis/google-cloud-dotnet/issues/736)) ([commit 3d53a41](https://github.com/googleapis/google-cloud-dotnet/commit/3d53a41b073b4286f4fa7ab1d33748eb7f0e1147))
+
 ## Version 2.2.0, released 2022-09-15
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1034,7 +1034,7 @@
     },
     {
       "id": "Google.Cloud.Compute.V1",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "type": "regapic",
       "productName": "Compute Engine",
       "productUrl": "https://cloud.google.com/compute",


### PR DESCRIPTION

Changes in this release:

### New features

- Update Compute Engine API to revision 20221011 ([issue 736](https://github.com/googleapis/google-cloud-dotnet/issues/736)) ([commit 3d53a41](https://github.com/googleapis/google-cloud-dotnet/commit/3d53a41b073b4286f4fa7ab1d33748eb7f0e1147))
