### PR TITLE
Release Google.Cloud.NetworkConnectivity.V1 version 2.1.0

### DIFF
--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.csproj
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Network Connectivity API, which provides access to Network Connectivity Center.</Description>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.0.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.1.1, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />

--- a/apis/Google.Cloud.NetworkConnectivity.V1/docs/history.md
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.1.0, released 2022-11-02
+
+### New features
+
+- Add policy based routing ([commit 518e25b](https://github.com/googleapis/google-cloud-dotnet/commit/518e25be69cc8df4c04b5de0aca043818d50c795))
+
 ## Version 2.0.0, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2602,7 +2602,7 @@
     },
     {
       "id": "Google.Cloud.NetworkConnectivity.V1",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "type": "grpc",
       "productName": "Network Connectivity",
       "productUrl": "https://cloud.google.com/network-connectivity/docs/",
@@ -2613,7 +2613,7 @@
         "vpc"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.0.0",
+        "Google.Api.Gax.Grpc": "4.1.1",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",


### PR DESCRIPTION

Changes in this release:

### New features

- Add policy based routing ([commit 518e25b](https://github.com/googleapis/google-cloud-dotnet/commit/518e25be69cc8df4c04b5de0aca043818d50c795))
