### PR TITLE
Release Google.Cloud.Video.Stitcher.V1 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.csproj
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Video Stitcher API, which helps you generate dynamic content for delivery to client devices. </Description>

--- a/apis/Google.Cloud.Video.Stitcher.V1/docs/history.md
+++ b/apis/Google.Cloud.Video.Stitcher.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.1.0, released 2022-11-02
+
+### New features
+
+- Add support for Media CDN ([commit b01726a](https://github.com/googleapis/google-cloud-dotnet/commit/b01726adc197f0b04aa9b2e24762b905732f3d1c))
+
 ## Version 1.0.0, released 2022-09-15
 
 No API surface changes; just dependency updates and promotion to GA.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4016,7 +4016,7 @@
     },
     {
       "id": "Google.Cloud.Video.Stitcher.V1",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "grpc",
       "productName": "Video Stitcher",
       "productUrl": "https://cloud.google.com/video-stitcher/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Add support for Media CDN ([commit b01726a](https://github.com/googleapis/google-cloud-dotnet/commit/b01726adc197f0b04aa9b2e24762b905732f3d1c))
