### PR TITLE
Release Google.Cloud.Batch.V1 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.Batch.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.Batch.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.Batch.V1",
-  "release_level": "preview",
+  "release_level": "stable",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Batch.V1/latest",
   "library_type": "GAPIC_AUTO",
   "api_shortname": "batch"

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.csproj
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta03</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Batch API (v1), which allows you to manage the running of batch jobs on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Batch.V1/docs/history.md
+++ b/apis/Google.Cloud.Batch.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0, released 2022-11-02
+
+No API surface changes; just dependency updates and promotion to general availability.
+
 ## Version 1.0.0-beta03, released 2022-10-17
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -420,7 +420,7 @@
     },
     {
       "id": "Google.Cloud.Batch.V1",
-      "version": "1.0.0-beta03",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Batch",
       "productUrl": "https://cloud.google.com/batch/docs/",
@@ -429,9 +429,11 @@
         "batch"
       ],
       "dependencies": {
+        "Google.Api.Gax.Grpc": "4.1.1",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
-        "Google.LongRunning": "3.0.0"
+        "Google.LongRunning": "3.0.0",
+        "Grpc.Core": "2.46.3"
       },
       "generator": "micro",
       "protoPath": "google/cloud/batch/v1",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates and promotion to general availability.
