### PR TITLE
Release Google.Cloud.GkeBackup.V1 version 2.0.0

### DIFF
--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.csproj
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta01</Version>
+    <Version>2.0.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Backup for GKE API, which is a managed Kubernetes workload backup and restore service for GKE clusters.</Description>

--- a/apis/Google.Cloud.GkeBackup.V1/docs/history.md
+++ b/apis/Google.Cloud.GkeBackup.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 2.0.0, released 2022-11-02
+
+No API surface changes; just dependency updates and promotion to general availability.
+
 ## Version 2.0.0-beta01, released 2022-06-09
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1992,7 +1992,7 @@
     },
     {
       "id": "Google.Cloud.GkeBackup.V1",
-      "version": "2.0.0-beta01",
+      "version": "2.0.0",
       "type": "grpc",
       "productName": "Backup for GKE",
       "productUrl": "https://cloud.google.com/kubernetes-engine/docs/add-on/backup-for-gke",
@@ -2003,7 +2003,9 @@
         "backup"
       ],
       "dependencies": {
-        "Google.LongRunning": "3.0.0"
+        "Google.Api.Gax.Grpc": "4.1.1",
+        "Google.LongRunning": "3.0.0",
+        "Grpc.Core": "2.46.3"
       },
       "generator": "micro",
       "protoPath": "google/cloud/gkebackup/v1",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates and promotion to general availability.
