### PR TITLE
Release Google.Cloud.AIPlatform.V1 version 2.5.0

### DIFF
--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.4.0</Version>
+    <Version>2.5.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AI Platform API, which allows you to train high-quality custom machine learning models with minimal machine learning expertise and effort.</Description>

--- a/apis/Google.Cloud.AIPlatform.V1/docs/history.md
+++ b/apis/Google.Cloud.AIPlatform.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 2.5.0, released 2022-11-10
+
+### New features
+
+- Add annotation_labels to ImportDataConfig in aiplatform v1 dataset.proto ([commit f94d859](https://github.com/googleapis/google-cloud-dotnet/commit/f94d8598ffce8de96037023be374fef58e528061))
+- Add start_time to BatchReadFeatureValuesRequest in aiplatform v1 featurestore_service.proto ([commit f94d859](https://github.com/googleapis/google-cloud-dotnet/commit/f94d8598ffce8de96037023be374fef58e528061))
+- Add metadata_artifact to Model in aiplatform v1 model.proto ([commit f94d859](https://github.com/googleapis/google-cloud-dotnet/commit/f94d8598ffce8de96037023be374fef58e528061))
+- Add failed_main_jobs and failed_pre_caching_check_jobs to ContainerDetail in aiplatform v1 pipeline_job.proto ([commit f94d859](https://github.com/googleapis/google-cloud-dotnet/commit/f94d8598ffce8de96037023be374fef58e528061))
+- Add persist_ml_use_assignment to InputDataConfig in aiplatform v1 training_pipeline.proto ([commit f94d859](https://github.com/googleapis/google-cloud-dotnet/commit/f94d8598ffce8de96037023be374fef58e528061))
+
 ## Version 2.4.0, released 2022-10-03
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -121,7 +121,7 @@
     },
     {
       "id": "Google.Cloud.AIPlatform.V1",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "type": "grpc",
       "productName": "Cloud AI Platform",
       "productUrl": "https://cloud.google.com/ai-platform/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add annotation_labels to ImportDataConfig in aiplatform v1 dataset.proto ([commit f94d859](https://github.com/googleapis/google-cloud-dotnet/commit/f94d8598ffce8de96037023be374fef58e528061))
- Add start_time to BatchReadFeatureValuesRequest in aiplatform v1 featurestore_service.proto ([commit f94d859](https://github.com/googleapis/google-cloud-dotnet/commit/f94d8598ffce8de96037023be374fef58e528061))
- Add metadata_artifact to Model in aiplatform v1 model.proto ([commit f94d859](https://github.com/googleapis/google-cloud-dotnet/commit/f94d8598ffce8de96037023be374fef58e528061))
- Add failed_main_jobs and failed_pre_caching_check_jobs to ContainerDetail in aiplatform v1 pipeline_job.proto ([commit f94d859](https://github.com/googleapis/google-cloud-dotnet/commit/f94d8598ffce8de96037023be374fef58e528061))
- Add persist_ml_use_assignment to InputDataConfig in aiplatform v1 training_pipeline.proto ([commit f94d859](https://github.com/googleapis/google-cloud-dotnet/commit/f94d8598ffce8de96037023be374fef58e528061))
