### PR TITLE
Release Google.Cloud.Container.V1 version 3.5.0

### DIFF
--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.4.0</Version>
+    <Version>3.5.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.</Description>

--- a/apis/Google.Cloud.Container.V1/docs/history.md
+++ b/apis/Google.Cloud.Container.V1/docs/history.md
@@ -1,5 +1,14 @@
 # Version history
 
+## Version 3.5.0, released 2022-11-10
+
+### New features
+
+- Add APIs for GKE Control Plane Logs ([commit 45f1266](https://github.com/googleapis/google-cloud-dotnet/commit/45f1266a6af8dc2f4247882d0815270c3a76c461))
+- GKE cluster's control plan/node-pool network isolation ([commit 45f1266](https://github.com/googleapis/google-cloud-dotnet/commit/45f1266a6af8dc2f4247882d0815270c3a76c461))
+- Add nodeconfig resource_labels api ([commit 45f1266](https://github.com/googleapis/google-cloud-dotnet/commit/45f1266a6af8dc2f4247882d0815270c3a76c461))
+- Add API to enable GKE Gateway controller ([commit 45f1266](https://github.com/googleapis/google-cloud-dotnet/commit/45f1266a6af8dc2f4247882d0815270c3a76c461))
+
 ## Version 3.4.0, released 2022-10-17
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1084,7 +1084,7 @@
       "protoPath": "google/container/v1",
       "productName": "Google Kubernetes Engine",
       "productUrl": "https://cloud.google.com/kubernetes-engine/docs/reference/rest/",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Add APIs for GKE Control Plane Logs ([commit 45f1266](https://github.com/googleapis/google-cloud-dotnet/commit/45f1266a6af8dc2f4247882d0815270c3a76c461))
- GKE cluster's control plan/node-pool network isolation ([commit 45f1266](https://github.com/googleapis/google-cloud-dotnet/commit/45f1266a6af8dc2f4247882d0815270c3a76c461))
- Add nodeconfig resource_labels api ([commit 45f1266](https://github.com/googleapis/google-cloud-dotnet/commit/45f1266a6af8dc2f4247882d0815270c3a76c461))
- Add API to enable GKE Gateway controller ([commit 45f1266](https://github.com/googleapis/google-cloud-dotnet/commit/45f1266a6af8dc2f4247882d0815270c3a76c461))
