### PR TITLE
Release Google.Cloud.Eventarc.Publishing.V1 version 2.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1.csproj
+++ b/apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta01</Version>
+    <Version>2.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Eventarc Publishing API</Description>

--- a/apis/Google.Cloud.Eventarc.Publishing.V1/docs/history.md
+++ b/apis/Google.Cloud.Eventarc.Publishing.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.0.0-beta02, released 2022-11-10
+
+### New features
+
+- Introduce the event publishing using JSON representation of CloudEvents ([commit 9e59b13](https://github.com/googleapis/google-cloud-dotnet/commit/9e59b13261111da71197061589a8716f0fb4cd4d))
+
 ## Version 2.0.0-beta01, released 2022-06-09
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1737,7 +1737,7 @@
     },
     {
       "id": "Google.Cloud.Eventarc.Publishing.V1",
-      "version": "2.0.0-beta01",
+      "version": "2.0.0-beta02",
       "type": "grpc",
       "productName": "Eventarc Publishing",
       "productUrl": "https://cloud.google.com/eventarc/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Introduce the event publishing using JSON representation of CloudEvents ([commit 9e59b13](https://github.com/googleapis/google-cloud-dotnet/commit/9e59b13261111da71197061589a8716f0fb4cd4d))
