### PR TITLE
Release Google.Maps.AddressValidation.V1 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1.csproj
+++ b/apis/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Maps Address Validation API, which allows developers to verify the accuracy of addresses. Given an address, it returns information about the correctness of the components of the parsed address, a geocode, and a verdict on the deliverability of the parsed address.</Description>

--- a/apis/Google.Maps.AddressValidation.V1/docs/history.md
+++ b/apis/Google.Maps.AddressValidation.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2022-11-10
+
+### New features
+
+- **BREAKING CHANGE** Remove deprecated fields `highrise` and `multi_family` ([commit c654b96](https://github.com/googleapis/google-cloud-dotnet/commit/c654b960e578f1920f5ace0134702311eb0fe878))
+
+### Documentation improvements
+
+- Minor documentation updates ([commit c654b96](https://github.com/googleapis/google-cloud-dotnet/commit/c654b960e578f1920f5ace0134702311eb0fe878))
+
 ## Version 1.0.0-beta01, released 2022-10-27
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4384,7 +4384,7 @@
     },
     {
       "id": "Google.Maps.AddressValidation.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Address Validation",
       "productUrl": "https://developers.google.com/maps/documentation/address-validation/requests-validate-address",


### PR DESCRIPTION

Changes in this release:

### New features

- **BREAKING CHANGE** Remove deprecated fields `highrise` and `multi_family` ([commit c654b96](https://github.com/googleapis/google-cloud-dotnet/commit/c654b960e578f1920f5ace0134702311eb0fe878))

### Documentation improvements

- Minor documentation updates ([commit c654b96](https://github.com/googleapis/google-cloud-dotnet/commit/c654b960e578f1920f5ace0134702311eb0fe878))
