### PR TITLE
feat: Add JSON DB type support in BigQuery

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/BigQueryFixture.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/BigQueryFixture.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016 Google Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -234,6 +234,7 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
                 { "single_numeric", BigQueryDbType.Numeric },
                 { "single_big_numeric", BigQueryDbType.BigNumeric },
                 { "single_geography", BigQueryDbType.Geography },
+                { "single_json", BigQueryDbType.Json },
                 { "single_record", recordSchema },
                 
                 // Repeated fields
@@ -249,6 +250,7 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
                 { "array_numeric", BigQueryDbType.Numeric, BigQueryFieldMode.Repeated },
                 { "array_big_numeric", BigQueryDbType.BigNumeric, BigQueryFieldMode.Repeated },
                 { "array_geography", BigQueryDbType.Geography, BigQueryFieldMode.Repeated },
+                { "array_json", BigQueryDbType.Json, BigQueryFieldMode.Repeated },
                 { "array_record", recordSchema, BigQueryFieldMode.Repeated },                
             }.Build());
 

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/ExhaustiveTypesTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/ExhaustiveTypesTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// Copyright 2017 Google Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -69,6 +69,7 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             Assert.Equal(BigQueryNumeric.Parse("1234567890123456789012345678.123456789"), (BigQueryNumeric) row["single_numeric"]);
             Assert.Equal(BigQueryBigNumeric.Parse("123456789012345678901234567890123456789.12345678901234567890123456789012345678"), (BigQueryBigNumeric) row["single_big_numeric"]);
             Assert.Equal(BigQueryGeography.Parse("POINT(1 2)"), (BigQueryGeography) row["single_geography"]);
+            Assert.Equal("{\"x\":10,\"y\":\"text\"}", row["single_json"]);
 
             var singleRecord = (Dictionary<string, object>) row["single_record"];
             Assert.Equal("nested string", (string) singleRecord["single_string"]);
@@ -98,6 +99,7 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
                 (BigQueryBigNumeric[])row["array_big_numeric"]);
             Assert.Equal(new[] { BigQueryGeography.Parse("POINT(1 2)"), BigQueryGeography.Parse("POINT(1 3)") },
                 (BigQueryGeography[]) row["array_geography"]);
+            Assert.Equal(new[] { "{\"x\":10,\"y\":\"text1\"}", "{\"x\":20,\"y\":\"text2\"}" }, row["array_json"]);
 
             var arrayRecords = (Dictionary<string, object>[]) row["array_record"];
 
@@ -130,6 +132,7 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             AssertParameterRoundTrip(client, new BigQueryParameter(BigQueryDbType.Numeric, BigQueryNumeric.Parse("1234567890123456789012345678.123456789")));
             AssertParameterRoundTrip(client, new BigQueryParameter(BigQueryDbType.BigNumeric, BigQueryBigNumeric.Parse("123456789012345678901234567890123456789.12345678901234567890123456789012345678")));
             AssertParameterRoundTrip(client, new BigQueryParameter(BigQueryDbType.Geography, BigQueryGeography.Parse("POINT(1 2)")));
+            AssertParameterRoundTrip(client, new BigQueryParameter(BigQueryDbType.Json, "{\"x\":10,\"y\":\"text\"}"));
 
             AssertParameterRoundTrip(client, new BigQueryParameter(BigQueryDbType.Array, new[] { "foo", "bar" }));
             AssertParameterRoundTrip(client, new BigQueryParameter(BigQueryDbType.Array, new[] { true, false }));
@@ -154,6 +157,8 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
                 new[] { BigQueryBigNumeric.Parse("123456789012345678901234567890123456789.12345678901234567890123456789012345678"), BigQueryBigNumeric.Parse("123.456") }));
             AssertParameterRoundTrip(client, new BigQueryParameter(BigQueryDbType.Array,
                 new[] { BigQueryGeography.Parse("POINT(1 2)"), BigQueryGeography.Parse("POINT(1 3)") }));
+            AssertParameterRoundTrip(client, new BigQueryParameter(BigQueryDbType.Array,
+               new[] { "{\"x\": 10, \"y\": \"text1\"}", "{\"x\": 20, \"y\": \"text2\"}" }));
         }
 
         // Parameterized test to make it easy to add more test cases.
@@ -229,6 +234,7 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             ["single_numeric"] = BigQueryNumeric.Parse("1234567890123456789012345678.123456789"),
             ["single_big_numeric"] = BigQueryBigNumeric.Parse("123456789012345678901234567890123456789.12345678901234567890123456789012345678"),
             ["single_geography"] = BigQueryGeography.Parse("POINT(1 2)"),
+            ["single_json"] = "{\"x\":10,\"y\":\"text\"}",
             ["single_record"] = new BigQueryInsertRow
             {
                 ["single_string"] = "nested string",
@@ -248,6 +254,7 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             ["array_numeric"] = new[] { BigQueryNumeric.Parse("1234567890123456789012345678.123456789"), BigQueryNumeric.Parse("123.456") },
             ["array_big_numeric"] = new[] { BigQueryBigNumeric.Parse("123456789012345678901234567890123456789.12345678901234567890123456789012345678"), BigQueryBigNumeric.Parse("123.456") },
             ["array_geography"] = new[] { BigQueryGeography.Parse("POINT(1 2)"), BigQueryGeography.Parse("POINT(1 3)") },
+            ["array_json"] = new[] { "{\"x\":10,\"y\":\"text1\"}", "{\"x\":20,\"y\":\"text2\"}" },
             ["array_record"] = new[] {
                     new BigQueryInsertRow
                     {

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryInsertRowTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryInsertRowTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016 Google Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -144,6 +144,15 @@ namespace Google.Cloud.BigQuery.V2.Tests
             var row = new BigQueryInsertRow { { "field", value } };
             var rowData = row.ToRowsData(false);
             Assert.Equal("123.456", rowData.Json["field"]);
+        }
+
+        [Fact]
+        public void Json()
+        {
+            object value = "{\"x\": 10, \"y\": \"text\"}";
+            var row = new BigQueryInsertRow { { "field", value } };
+            var rowData = row.ToRowsData(false);
+            Assert.Equal(value.ToString(), rowData.Json["field"]);
         }
 
         [Fact]

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryParameterTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryParameterTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016 Google Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -145,6 +145,10 @@ namespace Google.Cloud.BigQuery.V2.Tests
             ScalarTest("Geogprahy parameter, string value", BigQueryDbType.Numeric, "POINT", "POINT"),
             ScalarTest("Geography parameter, null value", BigQueryDbType.Geography, null, null),
 
+            // Json
+            ScalarTest("Json parameter", BigQueryDbType.Json, "{\"foo\":\"bar\"}", "{\"foo\":\"bar\"}"),
+            ScalarTest("Json parameter, string value", BigQueryDbType.Json, "{\"foo\":\"bar\"}", "{\"foo\":\"bar\"}"),
+            ScalarTest("Json parameter, null value", BigQueryDbType.Json, null, null),
         };
 
         public static IEnumerable<object[]> InvalidParameterData => new[]

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryRowTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryRowTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016 Google Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
                 { "numeric", BigQueryDbType.Numeric },
                 { "bigNumeric", BigQueryDbType.BigNumeric },
                 { "geography", BigQueryDbType.Geography },
+                { "json", BigQueryDbType.Json },
                 { "struct", new TableSchemaBuilder { { "x", BigQueryDbType.Int64 }, { "y", BigQueryDbType.String } } }
             }.Build();
             var rawRow = new TableRow
@@ -58,6 +59,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
                     new TableCell { V = "1234567890123456789012345678.123456789" },
                     new TableCell { V = "123456789012345678901234567890123456789.12345678901234567890123456789012345678" },
                     new TableCell { V = "POINT(1 2)" },
+                    new TableCell { V = "{\"x\": 10, \"y\": \"text\"}" },
                     new TableCell { V = new JObject { ["f"] = new JArray {new JObject { ["v"] = "100" }, new JObject { ["v"] = "xyz" } } } }
                 }
             };
@@ -74,6 +76,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
             Assert.Equal(BigQueryNumeric.Parse("1234567890123456789012345678.123456789"), (BigQueryNumeric) row["numeric"]);
             Assert.Equal(BigQueryBigNumeric.Parse("123456789012345678901234567890123456789.12345678901234567890123456789012345678"), (BigQueryBigNumeric)row["bigNumeric"]);
             Assert.Equal(BigQueryGeography.Parse("POINT(1 2)"), (BigQueryGeography) row["geography"]);
+            Assert.Equal("{\"x\": 10, \"y\": \"text\"}", (string) row["json"]);
             Assert.Equal(new Dictionary<string, object> { { "x", 100L }, { "y", "xyz" } }, (Dictionary<string, object>)row["struct"]);
         }
 
@@ -94,6 +97,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
                 { "numeric", BigQueryDbType.Numeric, BigQueryFieldMode.Repeated },
                 { "bigNumeric", BigQueryDbType.BigNumeric, BigQueryFieldMode.Repeated },
                 { "geography", BigQueryDbType.Geography, BigQueryFieldMode.Repeated },
+                { "json", BigQueryDbType.Json, BigQueryFieldMode.Repeated },
                 { "struct", new TableSchemaBuilder { { "x", BigQueryDbType.Int64 }, { "y", BigQueryDbType.String } }, BigQueryFieldMode.Repeated }
             }.Build();
             var rawRow = new TableRow
@@ -112,6 +116,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
                     new TableCell { V = CreateArray("1234567890123456789012345678.123456789", "0.000000001") },
                     new TableCell { V = CreateArray("123456789012345678901234567890123456789.12345678901234567890123456789012345678", "0.00000000000000000000000000000000000001") },
                     new TableCell { V = CreateArray("POINT(1 3)", "POINT(2 4)") },
+                    new TableCell { V = CreateArray("{\"x\": 10, \"y\": \"text1\"}", "{\"x\": 11, \"y\": \"text2\"}") },
                     new TableCell { V = new JArray {
                         new JObject { ["v"] = new JObject { ["f"] = new JArray { new JObject { ["v"] = "100" }, new JObject { ["v"] = "xyz" } } } },
                         new JObject { ["v"] = new JObject { ["f"] = new JArray { new JObject { ["v"] = "200" }, new JObject { ["v"] = "abc" } } } }
@@ -134,6 +139,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
             Assert.Equal(new[] { BigQueryNumeric.Parse("1234567890123456789012345678.123456789"), BigQueryNumeric.Parse("0.000000001") }, (BigQueryNumeric[]) row["numeric"]);
             Assert.Equal(new[] { BigQueryBigNumeric.Parse("123456789012345678901234567890123456789.12345678901234567890123456789012345678"), BigQueryBigNumeric.Parse("0.00000000000000000000000000000000000001") }, (BigQueryBigNumeric[])row["bigNumeric"]);
             Assert.Equal(new[] { BigQueryGeography.Parse("POINT(1 3)"), BigQueryGeography.Parse("POINT(2 4)") }, (BigQueryGeography[]) row["geography"]);
+            Assert.Equal(new[] { "{\"x\": 10, \"y\": \"text1\"}", "{\"x\": 11, \"y\": \"text2\"}" }, (string[]) row["json"]);
             Assert.Equal(new[]
                 {
                     new Dictionary<string, object> { { "x", 100L }, { "y", "xyz" } },

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryDbType.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryDbType.cs
@@ -100,6 +100,10 @@ namespace Google.Cloud.BigQuery.V2
         /// and always 38 decimal places.
         /// </summary>
         BigNumeric,
+        /// <summary>
+        /// A JSON-formatted string as described in RFC 7159.
+        /// </summary>
+        Json,
     }
 
     internal static class BigQueryDbTypeExtensions
@@ -122,7 +126,8 @@ namespace Google.Cloud.BigQuery.V2
             { BigQueryDbType.Struct, "STRUCT" },
             { BigQueryDbType.Numeric, "NUMERIC" },
             { BigQueryDbType.Geography, "GEOGRAPHY" },
-            { BigQueryDbType.BigNumeric, "BIGNUMERIC" }
+            { BigQueryDbType.BigNumeric, "BIGNUMERIC" },
+            { BigQueryDbType.Json, "JSON" }
         };
 
         internal static string ToParameterApiType(this BigQueryDbType type) => s_typeToNameMapping[type];

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryParameter.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryParameter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016 Google Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -53,6 +53,7 @@ namespace Google.Cloud.BigQuery.V2
     ///   <item><description><c>Timestamp</c>: <c>System.DateTime</c>, <c>System.DateTimeOffset</c></description></item>
     ///   <item><description><c>Numeric</c>: <c>Google.Cloud.BigQuery.V1.BigQueryNumeric</c></description></item>
     ///   <item><description><c>Geography</c>: <c>Google.Cloud.BigQuery.V1.BigQueryGeography</c></description></item>
+    ///   <item><description><c>Json</c>: <c>System.String</c></description></item>
     ///   <item><description><c>Array</c>: An <c>IReadOnlyList&lt;T&gt;</c> of any of the above types corresponding to the <see cref="ArrayElementType"/>,
     ///   which will be inferred from the value's element type if not otherwise specified.</description></item>
     /// </list>
@@ -265,6 +266,7 @@ namespace Google.Cloud.BigQuery.V2
                         ?? parameter.PopulateScalar<string>(value, x => x)
                         ?? parameter.UseNullScalarOrThrow(value);
                 case BigQueryDbType.String:
+                case BigQueryDbType.Json:
                     return parameter.PopulateScalar<string>(value, x => x)
                         ?? parameter.UseNullScalarOrThrow(value);
                 case BigQueryDbType.Struct: throw new NotImplementedException("Struct parameters are not yet implemented");

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryRow.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryRow.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016 Google Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -112,6 +112,7 @@ namespace Google.Cloud.BigQuery.V2
                 switch (type)
                 {
                     case BigQueryDbType.String:
+                    case BigQueryDbType.Json:
                         return ConvertArray(array, StringConverter);
                     case BigQueryDbType.Int64:
                         return ConvertArray(array, Int64Converter);
@@ -144,6 +145,7 @@ namespace Google.Cloud.BigQuery.V2
             switch (type)
             {
                 case BigQueryDbType.String:
+                case BigQueryDbType.Json:
                     return StringConverter((string)rawValue);
                 case BigQueryDbType.Int64:
                     return Int64Converter((string)rawValue);


### PR DESCRIPTION
This isn't complete and ready yet. 

I am figuring out a whitespace behavior observed while testing.  When I call the ListRows API on the table, whitespace in JSON string between field and value seems to be preserved while they are lost when using the StandardQuery (Select * from {table}).

I will investigate this, document my findings and request the review tomorrow. Thanks.