### PR TITLE
Release Google.Cloud.DocumentAI.V1Beta3 version 2.0.0-beta03

### DIFF
--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.csproj
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta02</Version>
+    <Version>2.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Document AI API (v1beta3), which is a service to parse structured information from unstructured or semi-structured documents using state-of-the-art Google AI such as natural language, computer vision, translation, and AutoML.</Description>

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/docs/history.md
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 2.0.0-beta03, released 2022-11-16
+
+### New features
+
+- Added field_mask field in DocumentOutputConfig.GcsOutputConfig in document_io.proto ([commit a4e2380](https://github.com/googleapis/google-cloud-dotnet/commit/a4e238091d9633f85c8ddbd6fe369d96db4b8390))
+- Added TrainProcessorVersion, EvaluateProcessorVersion, GetEvaluation, and ListEvaluations v1beta3 APIs ([commit cbd4d22](https://github.com/googleapis/google-cloud-dotnet/commit/cbd4d2277958fe365c1615e34a98990573e01d27))
+- Added evaluation.proto ([commit cbd4d22](https://github.com/googleapis/google-cloud-dotnet/commit/cbd4d2277958fe365c1615e34a98990573e01d27))
+- Added document_schema field in ProcessorVersion processor.proto ([commit cbd4d22](https://github.com/googleapis/google-cloud-dotnet/commit/cbd4d2277958fe365c1615e34a98990573e01d27))
+- Added image_quality_scores field in Document.Page in document.proto ([commit cbd4d22](https://github.com/googleapis/google-cloud-dotnet/commit/cbd4d2277958fe365c1615e34a98990573e01d27))
+- Added font_family field in Document.Style in document.proto ([commit cbd4d22](https://github.com/googleapis/google-cloud-dotnet/commit/cbd4d2277958fe365c1615e34a98990573e01d27))
+
 ## Version 2.0.0-beta02, released 2022-08-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1621,7 +1621,7 @@
     },
     {
       "id": "Google.Cloud.DocumentAI.V1Beta3",
-      "version": "2.0.0-beta02",
+      "version": "2.0.0-beta03",
       "type": "grpc",
       "productName": "Cloud Document AI",
       "productUrl": "https://cloud.google.com/solutions/document-ai",


### PR DESCRIPTION

Changes in this release:

### New features

- Added field_mask field in DocumentOutputConfig.GcsOutputConfig in document_io.proto ([commit a4e2380](https://github.com/googleapis/google-cloud-dotnet/commit/a4e238091d9633f85c8ddbd6fe369d96db4b8390))
- Added TrainProcessorVersion, EvaluateProcessorVersion, GetEvaluation, and ListEvaluations v1beta3 APIs ([commit cbd4d22](https://github.com/googleapis/google-cloud-dotnet/commit/cbd4d2277958fe365c1615e34a98990573e01d27))
- Added evaluation.proto ([commit cbd4d22](https://github.com/googleapis/google-cloud-dotnet/commit/cbd4d2277958fe365c1615e34a98990573e01d27))
- Added document_schema field in ProcessorVersion processor.proto ([commit cbd4d22](https://github.com/googleapis/google-cloud-dotnet/commit/cbd4d2277958fe365c1615e34a98990573e01d27))
- Added image_quality_scores field in Document.Page in document.proto ([commit cbd4d22](https://github.com/googleapis/google-cloud-dotnet/commit/cbd4d2277958fe365c1615e34a98990573e01d27))
- Added font_family field in Document.Style in document.proto ([commit cbd4d22](https://github.com/googleapis/google-cloud-dotnet/commit/cbd4d2277958fe365c1615e34a98990573e01d27))
