### PR TITLE
Release Google.Cloud.BigQuery.V2 version 3.2.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.1.0</Version>
+    <Version>3.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery API. It wraps the Google.Apis.Bigquery.v2 client library, making common operations simpler in client code. BigQuery is a data platform for customers to create, manage, share and query data.</Description>

--- a/apis/Google.Cloud.BigQuery.V2/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.2.0, released 2022-11-16
+
+### New features
+
+- Add JSON DB type support in BigQuery ([commit afa19c1](https://github.com/googleapis/google-cloud-dotnet/commit/afa19c179ae8fde5e78655041c72915bc6a0afaa))
+
 ## Version 3.1.0, released 2022-07-25
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -733,7 +733,7 @@
       "id": "Google.Cloud.BigQuery.V2",
       "productName": "Google BigQuery",
       "productUrl": "https://cloud.google.com/bigquery/",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "type": "rest",
       "description": "Recommended Google client library to access the BigQuery API. It wraps the Google.Apis.Bigquery.v2 client library, making common operations simpler in client code. BigQuery is a data platform for customers to create, manage, share and query data.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Add JSON DB type support in BigQuery ([commit afa19c1](https://github.com/googleapis/google-cloud-dotnet/commit/afa19c179ae8fde5e78655041c72915bc6a0afaa))
