### PR TITLE
Add ProviderAlias attribute to GoogleLoggerProvder

### DIFF
--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Logging/GoogleLoggerProvider.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Logging/GoogleLoggerProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2021 Google LLC
+// Copyright 2021 Google LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ namespace Google.Cloud.Diagnostics.Common
     /// <summary>
     /// <see cref="ILoggerProvider"/> for Google Cloud Logging.
     /// </summary>
+    [ProviderAlias("Google")]
     public sealed class GoogleLoggerProvider : ILoggerProvider
     {
         /// <summary>The consumer to push logs to.</summary>


### PR DESCRIPTION
By adding `ProviderAlias` attribute to `GoogleLoggerProvider` one is allowed to use a shorthand reference in "appsettings.json" (rather than using a cumbersome full type name).

This is what it used to look like:

```json
{
  "Logging": {
    "LogLevel": {
      "Default": "Debug",
      "Microsoft": "Warning"
    },
    "Google.Cloud.Diagnostics.Common.GoogleLoggerProvider": {
      "LogLevel": {
        "Microsoft": "Error"
      }
    }
  }
}
```

This is what it may look like after the change:

```json
{
  "Logging": {
    "LogLevel": {
      "Default": "Debug",
      "Microsoft": "Warning"
    },
    "Google": {
      "LogLevel": {
        "Microsoft": "Error"
      }
    }
  }
}
```

The `ProviderAlias` is used by all of the built-in logger providers (e.g. `Console`, `Debug`, `EventLog`, `EventSource`, `TraceSource`).