### PR TITLE
Release Google.Cloud.AIPlatform.V1 version 2.6.0

### DIFF
--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.5.0</Version>
+    <Version>2.6.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AI Platform API, which allows you to train high-quality custom machine learning models with minimal machine learning expertise and effort.</Description>

--- a/apis/Google.Cloud.AIPlatform.V1/docs/history.md
+++ b/apis/Google.Cloud.AIPlatform.V1/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 2.6.0, released 2022-12-01
+
+### New features
+
+- Add metadata_artifact to Dataset in aiplatform v1 dataset.proto ([commit 7f369da](https://github.com/googleapis/google-cloud-dotnet/commit/7f369dafdab8345660654a36e08ecfb53664518a))
+- Add WriteFeatureValues rpc to FeaturestoreOnlineServingService in aiplatform v1 featurestore_online_service.proto ([commit 7f369da](https://github.com/googleapis/google-cloud-dotnet/commit/7f369dafdab8345660654a36e08ecfb53664518a))
+- Add service_account to batch_prediction_job in aiplatform v1 batch_prediction_job.proto ([commit 047a19c](https://github.com/googleapis/google-cloud-dotnet/commit/047a19c79d0d9ef0c63d596aa0088bac4f9f5a58))
+
 ## Version 2.5.0, released 2022-11-10
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -121,7 +121,7 @@
     },
     {
       "id": "Google.Cloud.AIPlatform.V1",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "type": "grpc",
       "productName": "Cloud AI Platform",
       "productUrl": "https://cloud.google.com/ai-platform/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add metadata_artifact to Dataset in aiplatform v1 dataset.proto ([commit 7f369da](https://github.com/googleapis/google-cloud-dotnet/commit/7f369dafdab8345660654a36e08ecfb53664518a))
- Add WriteFeatureValues rpc to FeaturestoreOnlineServingService in aiplatform v1 featurestore_online_service.proto ([commit 7f369da](https://github.com/googleapis/google-cloud-dotnet/commit/7f369dafdab8345660654a36e08ecfb53664518a))
- Add service_account to batch_prediction_job in aiplatform v1 batch_prediction_job.proto ([commit 047a19c](https://github.com/googleapis/google-cloud-dotnet/commit/047a19c79d0d9ef0c63d596aa0088bac4f9f5a58))
