### PR TITLE
Release Google.Cloud.BigQuery.Storage.V1 version 3.4.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.3.0</Version>
+    <Version>3.4.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery Storage API.</Description>

--- a/apis/Google.Cloud.BigQuery.Storage.V1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 3.4.0, released 2022-12-01
+
+### New features
+
+- Add missing_value_interpretations to AppendRowsRequest ([commit 13e3cd7](https://github.com/googleapis/google-cloud-dotnet/commit/13e3cd7ffc5e3ab283b9934470a9cb0729dbe102))
+
+### Documentation improvements
+
+- Remove stale header guidance for AppendRows ([commit b934a52](https://github.com/googleapis/google-cloud-dotnet/commit/b934a529b6cc89898e143ff3865dde5ceb3f4fa9))
+
 ## Version 3.3.0, released 2022-09-15
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -756,7 +756,7 @@
       "protoPath": "google/cloud/bigquery/storage/v1",
       "productName": "Google BigQuery Storage",
       "productUrl": "https://cloud.google.com/bigquery/docs/reference/storage/",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the BigQuery Storage API.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Add missing_value_interpretations to AppendRowsRequest ([commit 13e3cd7](https://github.com/googleapis/google-cloud-dotnet/commit/13e3cd7ffc5e3ab283b9934470a9cb0729dbe102))

### Documentation improvements

- Remove stale header guidance for AppendRows ([commit b934a52](https://github.com/googleapis/google-cloud-dotnet/commit/b934a529b6cc89898e143ff3865dde5ceb3f4fa9))
