### PR TITLE
Release Google.Cloud.Compute.V1 version 2.4.0

### DIFF
--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Compute Engine API.</Description>

--- a/apis/Google.Cloud.Compute.V1/docs/history.md
+++ b/apis/Google.Cloud.Compute.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.4.0, released 2022-12-01
+
+### New features
+
+- Update Compute Engine API to revision 20221101 ([issue 751](https://github.com/googleapis/google-cloud-dotnet/issues/751)) ([commit 83e6c11](https://github.com/googleapis/google-cloud-dotnet/commit/83e6c115e69a1d802022c6aa3be2eaebe4c09342))
+
 ## Version 2.3.0, released 2022-11-02
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1039,7 +1039,7 @@
     },
     {
       "id": "Google.Cloud.Compute.V1",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "type": "regapic",
       "productName": "Compute Engine",
       "productUrl": "https://cloud.google.com/compute",


### PR DESCRIPTION

Changes in this release:

### New features

- Update Compute Engine API to revision 20221101 ([issue 751](https://github.com/googleapis/google-cloud-dotnet/issues/751)) ([commit 83e6c11](https://github.com/googleapis/google-cloud-dotnet/commit/83e6c115e69a1d802022c6aa3be2eaebe4c09342))
