### PR TITLE
Release Google.Cloud.Container.V1 version 3.6.0

### DIFF
--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.5.0</Version>
+    <Version>3.6.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.</Description>

--- a/apis/Google.Cloud.Container.V1/docs/history.md
+++ b/apis/Google.Cloud.Container.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 3.6.0, released 2022-12-01
+
+### New features
+
+- Add a FastSocket API ([commit ec6e15e](https://github.com/googleapis/google-cloud-dotnet/commit/ec6e15e877bc1bd77d2324be8180ac4e56bdfc3d))
+- Add compact placement feature for node pools ([commit 89213cc](https://github.com/googleapis/google-cloud-dotnet/commit/89213cc6e3484360c45cf980087c8c33d1c0b6e6))
+
 ## Version 3.5.0, released 2022-11-10
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1085,7 +1085,7 @@
       "protoPath": "google/container/v1",
       "productName": "Google Kubernetes Engine",
       "productUrl": "https://cloud.google.com/kubernetes-engine/docs/reference/rest/",
-      "version": "3.5.0",
+      "version": "3.6.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Add a FastSocket API ([commit ec6e15e](https://github.com/googleapis/google-cloud-dotnet/commit/ec6e15e877bc1bd77d2324be8180ac4e56bdfc3d))
- Add compact placement feature for node pools ([commit 89213cc](https://github.com/googleapis/google-cloud-dotnet/commit/89213cc6e3484360c45cf980087c8c33d1c0b6e6))
