### PR TITLE
Release Google.Cloud.Dialogflow.Cx.V3 version 2.2.0

### DIFF
--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.csproj
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Builds conversational interfaces (for example, chatbots, and voice-powered apps and devices).</Description>

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/docs/history.md
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/docs/history.md
@@ -1,5 +1,14 @@
 # Version history
 
+## Version 2.2.0, released 2022-12-01
+
+### Documentation improvements
+
+- Clarified Agent Assist max retention is 30 days ([commit 8ebde4f](https://github.com/googleapis/google-cloud-dotnet/commit/8ebde4f5eceb04d7833acb0890df634d8b0d2501))
+- Clarified TTL as time-to-live ([commit 8aa3a16](https://github.com/googleapis/google-cloud-dotnet/commit/8aa3a16cf991d8ab13004ce85fbbb418be652573))
+- Removed pre-GA disclaimer from Interaction Logging (has been GA for awhile) ([commit 8aa3a16](https://github.com/googleapis/google-cloud-dotnet/commit/8aa3a16cf991d8ab13004ce85fbbb418be652573))
+- Clarified gcs_bucket field of the SecuritySettings message ([commit 4888598](https://github.com/googleapis/google-cloud-dotnet/commit/488859889ab68c0fcf4e0bcff00b203ca0641b39))
+
 ## Version 2.1.0, released 2022-07-11
 
 ### Documentation improvements

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1489,7 +1489,7 @@
     },
     {
       "id": "Google.Cloud.Dialogflow.Cx.V3",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "type": "grpc",
       "productName": "Dialogflow",
       "productUrl": "https://cloud.google.com/dialogflow/cx/docs",


### PR DESCRIPTION

Changes in this release:

### Documentation improvements

- Clarified Agent Assist max retention is 30 days ([commit 8ebde4f](https://github.com/googleapis/google-cloud-dotnet/commit/8ebde4f5eceb04d7833acb0890df634d8b0d2501))
- Clarified TTL as time-to-live ([commit 8aa3a16](https://github.com/googleapis/google-cloud-dotnet/commit/8aa3a16cf991d8ab13004ce85fbbb418be652573))
- Removed pre-GA disclaimer from Interaction Logging (has been GA for awhile) ([commit 8aa3a16](https://github.com/googleapis/google-cloud-dotnet/commit/8aa3a16cf991d8ab13004ce85fbbb418be652573))
- Clarified gcs_bucket field of the SecuritySettings message ([commit 4888598](https://github.com/googleapis/google-cloud-dotnet/commit/488859889ab68c0fcf4e0bcff00b203ca0641b39))
