### PR TITLE
Release Google.Cloud.Dialogflow.V2 version 4.5.0

### DIFF
--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.csproj
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.4.0</Version>
+    <Version>4.5.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Dialogflow API (v2).</Description>

--- a/apis/Google.Cloud.Dialogflow.V2/docs/history.md
+++ b/apis/Google.Cloud.Dialogflow.V2/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 4.5.0, released 2022-12-01
+
+### New features
+
+- Added cx_current_page field to AutomatedAgentReply ([commit 2e15dd1](https://github.com/googleapis/google-cloud-dotnet/commit/2e15dd164b6552055ea6c9f2ba23f8b9e75959f3))
+
+### Documentation improvements
+
+- Clarified docs for Sentiment ([commit 2e15dd1](https://github.com/googleapis/google-cloud-dotnet/commit/2e15dd164b6552055ea6c9f2ba23f8b9e75959f3))
+
 ## Version 4.4.0, released 2022-11-02
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1516,7 +1516,7 @@
       "protoPath": "google/cloud/dialogflow/v2",
       "productName": "Google Cloud Dialogflow",
       "productUrl": "https://cloud.google.com/dialogflow-enterprise/",
-      "version": "4.4.0",
+      "version": "4.5.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Dialogflow API (v2).",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- Added cx_current_page field to AutomatedAgentReply ([commit 2e15dd1](https://github.com/googleapis/google-cloud-dotnet/commit/2e15dd164b6552055ea6c9f2ba23f8b9e75959f3))

### Documentation improvements

- Clarified docs for Sentiment ([commit 2e15dd1](https://github.com/googleapis/google-cloud-dotnet/commit/2e15dd164b6552055ea6c9f2ba23f8b9e75959f3))
