### PR TITLE
Release Google.Cloud.Kms.V1 version 3.2.0

### DIFF
--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.csproj
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.1.0</Version>
+    <Version>3.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Key Management Service API, which manages encryption for your cloud services the same way you do on-premises. You can generate, use, rotate, and destroy AES256 encryption keys.</Description>

--- a/apis/Google.Cloud.Kms.V1/docs/history.md
+++ b/apis/Google.Cloud.Kms.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 3.2.0, released 2022-12-01
+
+### New features
+
+- Add SHA-2 import methods ([issue 9353](https://github.com/googleapis/google-cloud-dotnet/issues/9353)) ([commit df7a29e](https://github.com/googleapis/google-cloud-dotnet/commit/df7a29ea4d48c819d451a47e5d3e3d944a1ceb51))
+- Add support for additional HMAC algorithms ([issue 9327](https://github.com/googleapis/google-cloud-dotnet/issues/9327)) ([commit 26da664](https://github.com/googleapis/google-cloud-dotnet/commit/26da664a2c73758fedb9e527fa3562119719399d))
+
 ## Version 3.1.0, released 2022-11-02
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2271,7 +2271,7 @@
       "protoPath": "google/cloud/kms/v1",
       "productName": "Google Cloud Key Management Service",
       "productUrl": "https://cloud.google.com/kms/",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Key Management Service API, which manages encryption for your cloud services the same way you do on-premises. You can generate, use, rotate, and destroy AES256 encryption keys.",
       "tags": [


### PR DESCRIPTION
Changes in this release:

### New features

- Add SHA-2 import methods ([issue 9353](https://github.com/googleapis/google-cloud-dotnet/issues/9353)) ([commit df7a29e](https://github.com/googleapis/google-cloud-dotnet/commit/df7a29ea4d48c819d451a47e5d3e3d944a1ceb51))
- Add support for additional HMAC algorithms ([issue 9327](https://github.com/googleapis/google-cloud-dotnet/issues/9327)) ([commit 26da664](https://github.com/googleapis/google-cloud-dotnet/commit/26da664a2c73758fedb9e527fa3562119719399d))
