### PR TITLE
Release Google.Cloud.Metastore.V1 version 2.1.0

### DIFF
--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.csproj
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Dataproc Metastore API which is used to manage the lifecycle and configuration of metastore services.</Description>

--- a/apis/Google.Cloud.Metastore.V1/docs/history.md
+++ b/apis/Google.Cloud.Metastore.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 2.1.0, released 2022-12-01
+
+### New features
+
+- Added federation API ([commit 31c802d](https://github.com/googleapis/google-cloud-dotnet/commit/31c802d35e428ca28039f9af3f2aca4398b2517b))
+- Added EncryptionConfig field ([commit 31c802d](https://github.com/googleapis/google-cloud-dotnet/commit/31c802d35e428ca28039f9af3f2aca4398b2517b))
+- Added NetworkConfig field ([commit 31c802d](https://github.com/googleapis/google-cloud-dotnet/commit/31c802d35e428ca28039f9af3f2aca4398b2517b))
+- Added DatabaseType field ([commit 31c802d](https://github.com/googleapis/google-cloud-dotnet/commit/31c802d35e428ca28039f9af3f2aca4398b2517b))
+- Added TelemetryConfiguration field ([commit 31c802d](https://github.com/googleapis/google-cloud-dotnet/commit/31c802d35e428ca28039f9af3f2aca4398b2517b))
+
 ## Version 2.0.0, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2537,7 +2537,7 @@
     },
     {
       "id": "Google.Cloud.Metastore.V1",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "type": "grpc",
       "productName": "Dataproc Metastore",
       "productUrl": "https://cloud.google.com/dataproc-metastore/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Added federation API ([commit 31c802d](https://github.com/googleapis/google-cloud-dotnet/commit/31c802d35e428ca28039f9af3f2aca4398b2517b))
- Added EncryptionConfig field ([commit 31c802d](https://github.com/googleapis/google-cloud-dotnet/commit/31c802d35e428ca28039f9af3f2aca4398b2517b))
- Added NetworkConfig field ([commit 31c802d](https://github.com/googleapis/google-cloud-dotnet/commit/31c802d35e428ca28039f9af3f2aca4398b2517b))
- Added DatabaseType field ([commit 31c802d](https://github.com/googleapis/google-cloud-dotnet/commit/31c802d35e428ca28039f9af3f2aca4398b2517b))
- Added TelemetryConfiguration field ([commit 31c802d](https://github.com/googleapis/google-cloud-dotnet/commit/31c802d35e428ca28039f9af3f2aca4398b2517b))
