### PR TITLE
Release Google.Cloud.Metastore.V1Alpha version 2.0.0-alpha02

### DIFF
--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.csproj
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha01</Version>
+    <Version>2.0.0-alpha02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Dataproc Metastore API (v1alpha) which is used to manage the lifecycle and configuration of metastore services.</Description>

--- a/apis/Google.Cloud.Metastore.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.Metastore.V1Alpha/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 2.0.0-alpha02, released 2022-12-01
+
+### New features
+
+- Added federation API ([commit 08fe5f7](https://github.com/googleapis/google-cloud-dotnet/commit/08fe5f76045f0a237bc23f1f0d54639e7fd150c3))
+- Added EncryptionConfig field ([commit 08fe5f7](https://github.com/googleapis/google-cloud-dotnet/commit/08fe5f76045f0a237bc23f1f0d54639e7fd150c3))
+- Added NetworkConfig field ([commit 08fe5f7](https://github.com/googleapis/google-cloud-dotnet/commit/08fe5f76045f0a237bc23f1f0d54639e7fd150c3))
+- Added DatabaseType field ([commit 08fe5f7](https://github.com/googleapis/google-cloud-dotnet/commit/08fe5f76045f0a237bc23f1f0d54639e7fd150c3))
+- Added TelemetryConfiguration field ([commit 08fe5f7](https://github.com/googleapis/google-cloud-dotnet/commit/08fe5f76045f0a237bc23f1f0d54639e7fd150c3))
+
 ## Version 2.0.0-alpha01, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2560,7 +2560,7 @@
     },
     {
       "id": "Google.Cloud.Metastore.V1Alpha",
-      "version": "2.0.0-alpha01",
+      "version": "2.0.0-alpha02",
       "type": "grpc",
       "productName": "Dataproc Metastore",
       "productUrl": "https://cloud.google.com/dataproc-metastore/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Added federation API ([commit 08fe5f7](https://github.com/googleapis/google-cloud-dotnet/commit/08fe5f76045f0a237bc23f1f0d54639e7fd150c3))
- Added EncryptionConfig field ([commit 08fe5f7](https://github.com/googleapis/google-cloud-dotnet/commit/08fe5f76045f0a237bc23f1f0d54639e7fd150c3))
- Added NetworkConfig field ([commit 08fe5f7](https://github.com/googleapis/google-cloud-dotnet/commit/08fe5f76045f0a237bc23f1f0d54639e7fd150c3))
- Added DatabaseType field ([commit 08fe5f7](https://github.com/googleapis/google-cloud-dotnet/commit/08fe5f76045f0a237bc23f1f0d54639e7fd150c3))
- Added TelemetryConfiguration field ([commit 08fe5f7](https://github.com/googleapis/google-cloud-dotnet/commit/08fe5f76045f0a237bc23f1f0d54639e7fd150c3))
