### PR TITLE
Release Google.Cloud.Metastore.V1Beta version 2.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.csproj
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta01</Version>
+    <Version>2.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Dataproc Metastore API (v1beta) which is used to manage the lifecycle and configuration of metastore services.</Description>

--- a/apis/Google.Cloud.Metastore.V1Beta/docs/history.md
+++ b/apis/Google.Cloud.Metastore.V1Beta/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 2.0.0-beta02, released 2022-12-01
+
+### New features
+
+- Added federation API ([commit a361045](https://github.com/googleapis/google-cloud-dotnet/commit/a361045b4e61362de9e580d870803b297dc8f9e1))
+- Added EncryptionConfig field ([commit a361045](https://github.com/googleapis/google-cloud-dotnet/commit/a361045b4e61362de9e580d870803b297dc8f9e1))
+- Added NetworkConfig field ([commit a361045](https://github.com/googleapis/google-cloud-dotnet/commit/a361045b4e61362de9e580d870803b297dc8f9e1))
+- Added DatabaseType field ([commit a361045](https://github.com/googleapis/google-cloud-dotnet/commit/a361045b4e61362de9e580d870803b297dc8f9e1))
+- Added TelemetryConfiguration field ([commit a361045](https://github.com/googleapis/google-cloud-dotnet/commit/a361045b4e61362de9e580d870803b297dc8f9e1))
+
 ## Version 2.0.0-beta01, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2581,7 +2581,7 @@
     },
     {
       "id": "Google.Cloud.Metastore.V1Beta",
-      "version": "2.0.0-beta01",
+      "version": "2.0.0-beta02",
       "type": "grpc",
       "productName": "Dataproc Metastore",
       "productUrl": "https://cloud.google.com/dataproc-metastore/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Added federation API ([commit a361045](https://github.com/googleapis/google-cloud-dotnet/commit/a361045b4e61362de9e580d870803b297dc8f9e1))
- Added EncryptionConfig field ([commit a361045](https://github.com/googleapis/google-cloud-dotnet/commit/a361045b4e61362de9e580d870803b297dc8f9e1))
- Added NetworkConfig field ([commit a361045](https://github.com/googleapis/google-cloud-dotnet/commit/a361045b4e61362de9e580d870803b297dc8f9e1))
- Added DatabaseType field ([commit a361045](https://github.com/googleapis/google-cloud-dotnet/commit/a361045b4e61362de9e580d870803b297dc8f9e1))
- Added TelemetryConfiguration field ([commit a361045](https://github.com/googleapis/google-cloud-dotnet/commit/a361045b4e61362de9e580d870803b297dc8f9e1))
