### PR TITLE
Release Google.Cloud.Notebooks.V1Beta1 version 2.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.csproj
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta01</Version>
+    <Version>2.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AI Platform Notebooks API (beta), which is used to manage notebook resources in Google Cloud.</Description>

--- a/apis/Google.Cloud.Notebooks.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/docs/history.md
@@ -1,5 +1,18 @@
 # Version history
 
+## Version 2.0.0-beta02, released 2022-12-01
+
+### Bug fixes
+
+- Deprecate AcceleratorType.NVIDIA_TESLA_K80 ([commit 3b439c4](https://github.com/googleapis/google-cloud-dotnet/commit/3b439c4ce6af9d491356e2c6984e123df2c7eb03))
+
+### New features
+
+- Added UpdateRuntime, UpgradeRuntime, DiagnoseRuntime, DiagnoseInstance to v1 API ([commit 3b439c4](https://github.com/googleapis/google-cloud-dotnet/commit/3b439c4ce6af9d491356e2c6984e123df2c7eb03))
+- Add Instance.reservation_affinity, nic_type, can_ip_forward to v1beta1 API ([commit 3b439c4](https://github.com/googleapis/google-cloud-dotnet/commit/3b439c4ce6af9d491356e2c6984e123df2c7eb03))
+- Add IsInstanceUpgradeableResponse.upgrade_image to v1beta1 API ([commit 3b439c4](https://github.com/googleapis/google-cloud-dotnet/commit/3b439c4ce6af9d491356e2c6984e123df2c7eb03))
+- Added Location and IAM methods ([commit 3b439c4](https://github.com/googleapis/google-cloud-dotnet/commit/3b439c4ce6af9d491356e2c6984e123df2c7eb03))
+
 ## Version 2.0.0-beta01, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2741,7 +2741,7 @@
     },
     {
       "id": "Google.Cloud.Notebooks.V1Beta1",
-      "version": "2.0.0-beta01",
+      "version": "2.0.0-beta02",
       "type": "grpc",
       "productName": "AI Platform Notebooks",
       "productUrl": "https://cloud.google.com/ai-platform-notebooks",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Deprecate AcceleratorType.NVIDIA_TESLA_K80 ([commit 3b439c4](https://github.com/googleapis/google-cloud-dotnet/commit/3b439c4ce6af9d491356e2c6984e123df2c7eb03))

### New features

- Added UpdateRuntime, UpgradeRuntime, DiagnoseRuntime, DiagnoseInstance to v1 API ([commit 3b439c4](https://github.com/googleapis/google-cloud-dotnet/commit/3b439c4ce6af9d491356e2c6984e123df2c7eb03))
- Add Instance.reservation_affinity, nic_type, can_ip_forward to v1beta1 API ([commit 3b439c4](https://github.com/googleapis/google-cloud-dotnet/commit/3b439c4ce6af9d491356e2c6984e123df2c7eb03))
- Add IsInstanceUpgradeableResponse.upgrade_image to v1beta1 API ([commit 3b439c4](https://github.com/googleapis/google-cloud-dotnet/commit/3b439c4ce6af9d491356e2c6984e123df2c7eb03))
- Added Location and IAM methods ([commit 3b439c4](https://github.com/googleapis/google-cloud-dotnet/commit/3b439c4ce6af9d491356e2c6984e123df2c7eb03))
