### PR TITLE
Release Google.Cloud.Shell.V1 version 2.1.0

### DIFF
--- a/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.csproj
+++ b/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Cloud Shell API, which allows users to start, configure, and connect to interactive shell sessions running in the cloud.</Description>

--- a/apis/Google.Cloud.Shell.V1/docs/history.md
+++ b/apis/Google.Cloud.Shell.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.1.0, released 2022-12-01
+
+### New features
+
+- Add CloudShellErrorCode.ENVIRONMENT_UNAVAILABLE enum value ([commit 0b4f620](https://github.com/googleapis/google-cloud-dotnet/commit/0b4f620ad580d4fd32873bcd08057b71fcb58536))
+
 ## Version 2.0.0, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3541,7 +3541,7 @@
     },
     {
       "id": "Google.Cloud.Shell.V1",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "type": "grpc",
       "productName": "Cloud Shell",
       "productUrl": "https://cloud.google.com/shell/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add CloudShellErrorCode.ENVIRONMENT_UNAVAILABLE enum value ([commit 0b4f620](https://github.com/googleapis/google-cloud-dotnet/commit/0b4f620ad580d4fd32873bcd08057b71fcb58536))
