### PR TITLE
Release Google.Cloud.Video.Transcoder.V1 version 2.2.0

### DIFF
--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.csproj
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Transcoder API version v1, which converts video files into formats suitable for consumer distribution.</Description>

--- a/apis/Google.Cloud.Video.Transcoder.V1/docs/history.md
+++ b/apis/Google.Cloud.Video.Transcoder.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 2.2.0, released 2022-12-01
+
+### New features
+
+- Add PreprocessingConfig.deinterlace ([commit f5af179](https://github.com/googleapis/google-cloud-dotnet/commit/f5af17911707975405b510b0408d747e441921cb))
+
+### Documentation improvements
+
+- Minor documentation changes ([commit f5af179](https://github.com/googleapis/google-cloud-dotnet/commit/f5af17911707975405b510b0408d747e441921cb))
+
 ## Version 2.1.0, released 2022-07-11
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4063,7 +4063,7 @@
     },
     {
       "id": "Google.Cloud.Video.Transcoder.V1",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "type": "grpc",
       "productName": "Transcoder",
       "productUrl": "https://cloud.google.com/transcoder/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Add PreprocessingConfig.deinterlace ([commit f5af179](https://github.com/googleapis/google-cloud-dotnet/commit/f5af17911707975405b510b0408d747e441921cb))

### Documentation improvements

- Minor documentation changes ([commit f5af179](https://github.com/googleapis/google-cloud-dotnet/commit/f5af17911707975405b510b0408d747e441921cb))
