### PR TITLE
feat: Enable self-signed JWTs for Storage and Translation clients

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.1.0</Version>
+    <Version>4.2.0-beta00</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Storage API. It wraps the Google.Apis.Storage.v1 client library, making common operations simpler in client code. Google Cloud Storage stores and retrieves potentially large, immutable data objects.</Description>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Rest" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Rest" Version="[4.3.0-beta01, 5.0.0)" />
     <PackageReference Include="Google.Apis.Storage.v1" Version="[1.57.0.2742, 2.0.0.0)" />
   </ItemGroup>
   <ItemGroup>

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientBuilder.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientBuilder.cs
@@ -44,6 +44,14 @@ namespace Google.Cloud.Storage.V1
         /// </summary>
         internal bool GZipEnabled { get; set; } = true;
 
+        /// <summary>
+        /// Creates a new builder with default settings.
+        /// </summary>
+        public StorageClientBuilder()
+        {
+            UseJwtAccessWithScopes = true;
+        }
+
         /// <inheritdoc />
         public override StorageClient Build()
         {

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/AdvancedTranslationClientBuilder.cs
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/AdvancedTranslationClientBuilder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2019 Google LLC
+// Copyright 2019 Google LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,6 +28,14 @@ namespace Google.Cloud.Translation.V2
         /// The translation model to use.
         /// </summary>
         public string Model { get; set; }
+
+        /// <summary>
+        /// Creates a new builder with default settings.
+        /// </summary>
+        public AdvancedTranslationClientBuilder()
+        {
+            UseJwtAccessWithScopes = true;
+        }
 
         /// <inheritdoc />
         public override AdvancedTranslationClient Build()

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.csproj
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.1.0</Version>
+    <Version>3.2.0-beta00</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Translate v2 API. It wraps the Google.Apis.Translate.v2 client library, making common operations simpler in client code. The Translate API translates text from one language to another.</Description>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Rest" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Rest" Version="[4.3.0-beta01, 5.0.0)" />
     <PackageReference Include="Google.Apis.Translate.v2" Version="[1.57.0.875, 2.0.0.0)" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/TranslationClientBuilder.cs
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/TranslationClientBuilder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2019 Google LLC
+// Copyright 2019 Google LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,6 +28,14 @@ namespace Google.Cloud.Translation.V2
         /// The translation model to use, defaulting to <see cref="TranslationModel.ServiceDefault"/>.
         /// </summary>
         public TranslationModel TranslationModel { get; set; } = TranslationModel.ServiceDefault;
+
+        /// <summary>
+        /// Creates a new builder with default settings.
+        /// </summary>
+        public TranslationClientBuilder()
+        {
+            UseJwtAccessWithScopes = true;
+        }
 
         /// <inheritdoc />
         public override TranslationClient Build()

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3902,11 +3902,11 @@
       "id": "Google.Cloud.Storage.V1",
       "productName": "Google Cloud Storage",
       "productUrl": "https://cloud.google.com/storage/",
-      "version": "4.1.0",
+      "version": "4.2.0-beta00",
       "type": "rest",
       "description": "Recommended Google client library to access the Google Cloud Storage API. It wraps the Google.Apis.Storage.v1 client library, making common operations simpler in client code. Google Cloud Storage stores and retrieves potentially large, immutable data objects.",
       "dependencies": {
-        "Google.Api.Gax.Rest": "4.2.0",
+        "Google.Api.Gax.Rest": "4.3.0-beta01",
         "Google.Apis.Storage.v1": "1.57.0.2742"
       },
       "testDependencies": {
@@ -4160,11 +4160,11 @@
       "id": "Google.Cloud.Translation.V2",
       "productName": "Google Cloud Translation",
       "productUrl": "https://cloud.google.com/translate/",
-      "version": "3.1.0",
+      "version": "3.2.0-beta00",
       "type": "rest",
       "description": "Recommended Google client library to access the Translate v2 API. It wraps the Google.Apis.Translate.v2 client library, making common operations simpler in client code. The Translate API translates text from one language to another.",
       "dependencies": {
-        "Google.Api.Gax.Rest": "4.2.0",
+        "Google.Api.Gax.Rest": "4.3.0-beta01",
         "Google.Apis.Translate.v2": "1.57.0.875"
       },
       "tags": [


### PR DESCRIPTION
This requires GAX 4.3.0-beta01; if we need to do a GA release of Storage or Translation before GAX 4.3.0 is released, we'll need to comment out the line in each builder.

Fixes #9326