### PR TITLE
Release Google.Cloud.Batch.V1 version 1.2.0-beta01

### DIFF
--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.csproj
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.2.0-beta00</Version>
+    <Version>1.2.0-beta01</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Batch API (v1), which allows you to manage the running of batch jobs on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Batch.V1/docs/history.md
+++ b/apis/Google.Cloud.Batch.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.2.0-beta01, released 2022-12-08
+
+### New features
+
+- Enable REST transport in selected APIs. Set GrpcAdapter=RestGrpcAdapter.Default in the client builder to use this transport ([commit 5008946](https://github.com/googleapis/google-cloud-dotnet/commit/500894667ba84ecc3d8e3e4ebc09ac0cd597100b))
+
 ## Version 1.1.0, released 2022-12-01
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -438,7 +438,7 @@
     },
     {
       "id": "Google.Cloud.Batch.V1",
-      "version": "1.2.0-beta00",
+      "version": "1.2.0-beta01",
       "type": "grpc",
       "productName": "Batch",
       "productUrl": "https://cloud.google.com/batch/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Enable REST transport in selected APIs. Set GrpcAdapter=RestGrpcAdapter.Default in the client builder to use this transport ([commit 5008946](https://github.com/googleapis/google-cloud-dotnet/commit/500894667ba84ecc3d8e3e4ebc09ac0cd597100b))
