### PR TITLE
Release Google.Cloud.Gaming.V1 version 2.1.0-beta01

### DIFF
--- a/apis/Google.Cloud.Gaming.V1/Google.Cloud.Gaming.V1/Google.Cloud.Gaming.V1.csproj
+++ b/apis/Google.Cloud.Gaming.V1/Google.Cloud.Gaming.V1/Google.Cloud.Gaming.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0-beta00</Version>
+    <Version>2.1.0-beta01</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client ilbrary to access the Google Cloud Gaming API version v1, which allows you to deploy and manage infrastructure for global multiplayer gaming experiences.</Description>

--- a/apis/Google.Cloud.Gaming.V1/docs/history.md
+++ b/apis/Google.Cloud.Gaming.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.1.0-beta01, released 2022-12-08
+
+### New features
+
+- Enable REST transport in selected APIs. Set GrpcAdapter=RestGrpcAdapter.Default in the client builder to use this transport ([commit 5008946](https://github.com/googleapis/google-cloud-dotnet/commit/500894667ba84ecc3d8e3e4ebc09ac0cd597100b))
+
 ## Version 2.0.0, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2057,7 +2057,7 @@
     },
     {
       "id": "Google.Cloud.Gaming.V1",
-      "version": "2.1.0-beta00",
+      "version": "2.1.0-beta01",
       "type": "grpc",
       "productName": "Game Services",
       "productUrl": "https://cloud.google.com/solutions/gaming",


### PR DESCRIPTION

Changes in this release:

### New features

- Enable REST transport in selected APIs. Set GrpcAdapter=RestGrpcAdapter.Default in the client builder to use this transport ([commit 5008946](https://github.com/googleapis/google-cloud-dotnet/commit/500894667ba84ecc3d8e3e4ebc09ac0cd597100b))
