### PR TITLE
Release Google.Cloud.Notebooks.V1 version 2.2.0-beta01

### DIFF
--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.csproj
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.2.0-beta00</Version>
+    <Version>2.2.0-beta01</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AI Platform Notebooks API (v1), which is used to manage notebook resources in Google Cloud.</Description>

--- a/apis/Google.Cloud.Notebooks.V1/docs/history.md
+++ b/apis/Google.Cloud.Notebooks.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.2.0-beta01, released 2022-12-08
+
+### New features
+
+- Enable REST transport in selected APIs. Set GrpcAdapter=RestGrpcAdapter.Default in the client builder to use this transport ([commit 5008946](https://github.com/googleapis/google-cloud-dotnet/commit/500894667ba84ecc3d8e3e4ebc09ac0cd597100b))
+
 ## Version 2.1.0, released 2022-12-01
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2841,7 +2841,7 @@
     },
     {
       "id": "Google.Cloud.Notebooks.V1",
-      "version": "2.2.0-beta00",
+      "version": "2.2.0-beta01",
       "type": "grpc",
       "productName": "AI Platform Notebooks",
       "productUrl": "https://cloud.google.com/ai-platform-notebooks",


### PR DESCRIPTION

Changes in this release:

### New features

- Enable REST transport in selected APIs. Set GrpcAdapter=RestGrpcAdapter.Default in the client builder to use this transport ([commit 5008946](https://github.com/googleapis/google-cloud-dotnet/commit/500894667ba84ecc3d8e3e4ebc09ac0cd597100b))
