### PR TITLE
Release Google.Cloud.Vision.V1 version 3.3.0-beta01

### DIFF
--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.csproj
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.3.0-beta00</Version>
+    <Version>3.3.0-beta01</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Vision API, which integrates Google Vision features, including image labeling, face, logo, and landmark detection, optical character recognition (OCR), and detection of explicit content, into applications.</Description>

--- a/apis/Google.Cloud.Vision.V1/docs/history.md
+++ b/apis/Google.Cloud.Vision.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.3.0-beta01, released 2022-12-08
+
+### New features
+
+- Enable REST transport in selected APIs. Set GrpcAdapter=RestGrpcAdapter.Default in the client builder to use this transport ([commit 5008946](https://github.com/googleapis/google-cloud-dotnet/commit/500894667ba84ecc3d8e3e4ebc09ac0cd597100b))
+
 ## Version 3.2.0, released 2022-09-15
 
 ### Documentation improvements

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4299,7 +4299,7 @@
       "protoPath": "google/cloud/vision/v1",
       "productName": "Google Cloud Vision",
       "productUrl": "https://cloud.google.com/vision",
-      "version": "3.3.0-beta00",
+      "version": "3.3.0-beta01",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Vision API, which integrates Google Vision features, including image labeling, face, logo, and landmark detection, optical character recognition (OCR), and detection of explicit content, into applications.",


### PR DESCRIPTION

Changes in this release:

### New features

- Enable REST transport in selected APIs. Set GrpcAdapter=RestGrpcAdapter.Default in the client builder to use this transport ([commit 5008946](https://github.com/googleapis/google-cloud-dotnet/commit/500894667ba84ecc3d8e3e4ebc09ac0cd597100b))
