### PR TITLE
docs: Fix support guide example

### DIFF
--- a/docs/devsite-help/support.md
+++ b/docs/devsite-help/support.md
@@ -223,4 +223,5 @@ Google.GoogleApiException: The service bigquery has thrown an exception. HttpSta
 ```
 
 If I set `UseJwtAccessWithScopes = false` when building the client, this code works fine. Why does `UseJwtAccessWithScopes = true` cause a failure?
+
 ---


### PR DESCRIPTION
The horizontal rule is coming out as a heading for the line above, due to the lack of a linebreak.