### PR TITLE
tools: Improve "release-all" flow

### DIFF
--- a/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/ReleaseAllCriterion.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/ReleaseAllCriterion.cs
@@ -63,7 +63,7 @@ namespace Google.Cloud.Tools.ReleaseManager.BatchRelease
                 {
                     if (!commits.Any(c => c.GetReleaseNoteElements().Any(note => note.PublishInReleaseNotes)))
                     {
-                        Console.WriteLine($"Skipping {api} which has {commits.Count} commits, but none generate release notes:");
+                        Console.WriteLine($"Skipping {api.Id} which has {commits.Count} commit(s), but none generate release notes:");
                         foreach (var commit in commits)
                         {
                             string truncatedTitle = commit.Title.Substring(0, Math.Min(commit.Title.Length, 60));

--- a/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/ReleaseAllCriterion.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/ReleaseAllCriterion.cs
@@ -32,6 +32,12 @@ namespace Google.Cloud.Tools.ReleaseManager.BatchRelease
         /// </summary>
         public bool SkipIfNoReleaseNotes { get; set; }
 
+        /// <summary>
+        /// If this is set to true, any APIs which would only generate
+        /// release notes related to documentation are skipped.
+        /// </summary>
+        public bool SkipDocumentationOnly { get; set; }
+
         IEnumerable<ReleaseProposal> IBatchCriterion.GetProposals(ApiCatalog catalog, Func<string, StructuredVersion, StructuredVersion> versionIncrementer, string defaultMessage)
         {
             var root = DirectoryLayout.DetermineRootDirectory();
@@ -69,6 +75,16 @@ namespace Google.Cloud.Tools.ReleaseManager.BatchRelease
                             string truncatedTitle = commit.Title.Substring(0, Math.Min(commit.Title.Length, 60));
                             Console.WriteLine($"  {commit.HashPrefix}: {truncatedTitle}");
                         }
+                        Console.WriteLine();
+                        continue;
+                    }
+                }
+
+                if (SkipDocumentationOnly)
+                {
+                    if (!commits.Any(c => c.GetReleaseNoteElements().Any(note => note.PublishInReleaseNotes && note.Type != History.ReleaseNoteElementType.Docs)))
+                    {
+                        Console.WriteLine($"Skipping {api.Id} which only contains documentation/trivial changes");
                         Console.WriteLine();
                         continue;
                     }

--- a/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/ReleaseProposal.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/ReleaseProposal.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2021 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ namespace Google.Cloud.Tools.ReleaseManager.BatchRelease
     /// </summary>
     internal class ReleaseProposal
     {
-        private ApiMetadata api;
+        private readonly ApiMetadata api;
         public string Id => api.Id;
         public StructuredVersion OldVersion { get; }
         public StructuredVersion NewVersion { get; }

--- a/tools/Google.Cloud.Tools.ReleaseManager/GitHelpers.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/GitHelpers.cs
@@ -107,6 +107,10 @@ namespace Google.Cloud.Tools.ReleaseManager
             var allTags = repo.Tags.OrderByDescending(GetDate).ToList();
             return catalog.Apis.ToDictionary(api => api, api => GetPendingChanges(api));
 
+            // TODO: Optimize this; it's pretty slow due to checking lots of paths all the time.
+            // We can probably find the oldest commit we care about, and work out all the APIs that have changed on
+            // a per-commit basis after that. But it gets complex quite quickly...
+
             Release GetPendingChanges(ApiMetadata api)
             {
                 string expectedTagPrefix = $"{api.Id}-";

--- a/tools/Google.Cloud.Tools.ReleaseManager/History/HistoryFile.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/History/HistoryFile.cs
@@ -156,8 +156,8 @@ namespace Google.Cloud.Tools.ReleaseManager.History
             internal IEnumerable<string> GetNotesFromCommits(IReadOnlyList<GitCommit> commits) =>
                 commits
                     .SelectMany(c => c.GetReleaseNoteElements())
+                    .Where(c => c.PublishInReleaseNotes)
                     .ToLookup(e => e.Type)
-                    .Where(g => g.Key != ReleaseNoteElementType.Chore)
                     .OrderBy(g => g.Key)
                     .Select(GetNotesFromElement)
                     .SelectMany(line => line);

--- a/tools/Google.Cloud.Tools.ReleaseManager/History/ReleaseNoteElement.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/History/ReleaseNoteElement.cs
@@ -22,6 +22,12 @@ namespace Google.Cloud.Tools.ReleaseManager.History
     internal sealed class ReleaseNoteElement
     {
         /// <summary>
+        /// Whether or not we should actually include this note in the published
+        /// release notes.
+        /// </summary>
+        public bool PublishInReleaseNotes => Type != ReleaseNoteElementType.Chore;
+
+        /// <summary>
         /// The commit within google-cloud-dotnet responsible for the change.
         /// </summary>
         public string CommitHash { get; }

--- a/tools/Google.Cloud.Tools.ReleaseManager/History/overrides.json
+++ b/tools/Google.Cloud.Tools.ReleaseManager/History/overrides.json
@@ -41,4 +41,6 @@
   // This is the commit message from the previous commit, but our change detection ignores changes to apis.json.
   // This is the message we want in the release notes for the REGAPIC-enabled packages.
   "5008946": "feat: Enable REST transport in selected APIs. Set GrpcAdapter=RestGrpcAdapter.Default in the client builder to use this transport",
+  "aa471c9": "skip", // Enable requesting numeric enums
+  "3927b62": "skip", // Regenerate all APIs with new generator; no user-significant API changes
 }


### PR DESCRIPTION
I normally have to manually skip a bunch of APIs which don't have "interesting" changes. This just automates that.