### PR TITLE
Release Google.Cloud.AIPlatform.V1 version 2.7.0

### DIFF
--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AI Platform API, which allows you to train high-quality custom machine learning models with minimal machine learning expertise and effort.</Description>

--- a/apis/Google.Cloud.AIPlatform.V1/docs/history.md
+++ b/apis/Google.Cloud.AIPlatform.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 2.7.0, released 2022-12-14
+
+### New features
+
+- Add service_account to UploadModelRequest in aiplatform v1 model_service.proto ([commit d2f3215](https://github.com/googleapis/google-cloud-dotnet/commit/d2f32151d16303b4684188ca44e19ba6c115ee5d))
+- Add SearchDataItems RPC in aiplatform version v1 and v1beta1 dataset_service.proto ([commit c44d0dc](https://github.com/googleapis/google-cloud-dotnet/commit/c44d0dc34e3d22c26c2edd1eef2df32ea7f6d4e9))
+
 ## Version 2.6.0, released 2022-12-01
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -128,7 +128,7 @@
     },
     {
       "id": "Google.Cloud.AIPlatform.V1",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "type": "grpc",
       "productName": "Cloud AI Platform",
       "productUrl": "https://cloud.google.com/ai-platform/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add service_account to UploadModelRequest in aiplatform v1 model_service.proto ([commit d2f3215](https://github.com/googleapis/google-cloud-dotnet/commit/d2f32151d16303b4684188ca44e19ba6c115ee5d))
- Add SearchDataItems RPC in aiplatform version v1 and v1beta1 dataset_service.proto ([commit c44d0dc](https://github.com/googleapis/google-cloud-dotnet/commit/c44d0dc34e3d22c26c2edd1eef2df32ea7f6d4e9))
