### PR TITLE
Release Google.Cloud.BigQuery.Storage.V1 version 3.5.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.4.0</Version>
+    <Version>3.5.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery Storage API.</Description>

--- a/apis/Google.Cloud.BigQuery.Storage.V1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.5.0, released 2022-12-14
+
+### New features
+
+- Add estimated number of rows to CreateReadSession response ([commit 2ac8ed0](https://github.com/googleapis/google-cloud-dotnet/commit/2ac8ed0add87367717aa7593a5013153d374d328))
+
 ## Version 3.4.0, released 2022-12-01
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -804,7 +804,7 @@
       "protoPath": "google/cloud/bigquery/storage/v1",
       "productName": "Google BigQuery Storage",
       "productUrl": "https://cloud.google.com/bigquery/docs/reference/storage/",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the BigQuery Storage API.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Add estimated number of rows to CreateReadSession response ([commit 2ac8ed0](https://github.com/googleapis/google-cloud-dotnet/commit/2ac8ed0add87367717aa7593a5013153d374d328))
