### PR TITLE
Release Google.Cloud.Channel.V1 version 2.3.0

### DIFF
--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.csproj
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.2.0</Version>
+    <Version>2.3.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Channel API, which enables Google Cloud resellers and distributors to manage their customers, channel partners, entitlements and reports.</Description>

--- a/apis/Google.Cloud.Channel.V1/docs/history.md
+++ b/apis/Google.Cloud.Channel.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.3.0, released 2022-12-14
+
+### New features
+
+- Add support for granular repricing configurations via SkuGroups in Cloud Channel Repricing APIs ([commit fe238c6](https://github.com/googleapis/google-cloud-dotnet/commit/fe238c6dd1d6c47b9421ad53ae7a90b89b7c80e6))
+
 ## Version 2.2.0, released 2022-11-10
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1019,7 +1019,7 @@
     },
     {
       "id": "Google.Cloud.Channel.V1",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "type": "grpc",
       "productName": "Cloud Channel",
       "productUrl": "https://cloud.google.com/channel/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add support for granular repricing configurations via SkuGroups in Cloud Channel Repricing APIs ([commit fe238c6](https://github.com/googleapis/google-cloud-dotnet/commit/fe238c6dd1d6c47b9421ad53ae7a90b89b7c80e6))
