### PR TITLE
Release Google.Cloud.Compute.V1 version 2.5.0

### DIFF
--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.4.0</Version>
+    <Version>2.5.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Compute Engine API.</Description>

--- a/apis/Google.Cloud.Compute.V1/docs/history.md
+++ b/apis/Google.Cloud.Compute.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.5.0, released 2022-12-14
+
+### New features
+
+- Update Compute Engine API to revision 20221126 ([issue 757](https://github.com/googleapis/google-cloud-dotnet/issues/757)) ([commit da30e3a](https://github.com/googleapis/google-cloud-dotnet/commit/da30e3a14d3b633ca2b7ed77d6dbd296f4676a6a))
+
 ## Version 2.4.0, released 2022-12-01
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1098,7 +1098,7 @@
     },
     {
       "id": "Google.Cloud.Compute.V1",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "type": "regapic",
       "productName": "Compute Engine",
       "productUrl": "https://cloud.google.com/compute",


### PR DESCRIPTION

Changes in this release:

### New features

- Update Compute Engine API to revision 20221126 ([issue 757](https://github.com/googleapis/google-cloud-dotnet/issues/757)) ([commit da30e3a](https://github.com/googleapis/google-cloud-dotnet/commit/da30e3a14d3b633ca2b7ed77d6dbd296f4676a6a))
