### PR TITLE
Release Google.Cloud.Dialogflow.V2Beta1 version 1.0.0-beta03

### DIFF
--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.csproj
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Dialogflow API (v2beta1).</Description>

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/docs/history.md
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 1.0.0-beta03, released 2022-12-14
+
+### New features
+
+- Added cx_current_page field to AutomatedAgentReply ([commit bdd8fb5](https://github.com/googleapis/google-cloud-dotnet/commit/bdd8fb514ebbee57c57b9770f101e132b60efded))
+
+### Documentation improvements
+
+- Clarified docs for Sentiment ([commit bdd8fb5](https://github.com/googleapis/google-cloud-dotnet/commit/bdd8fb514ebbee57c57b9770f101e132b60efded))
+
 ## Version 1.0.0-beta02, released 2022-10-03
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1613,7 +1613,7 @@
     },
     {
       "id": "Google.Cloud.Dialogflow.V2Beta1",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0-beta03",
       "type": "grpc",
       "productName": "Google Cloud Dialogflow",
       "productUrl": "https://cloud.google.com/dialogflow-enterprise/",


### PR DESCRIPTION

Changes in this release:

### New features

- Added cx_current_page field to AutomatedAgentReply ([commit bdd8fb5](https://github.com/googleapis/google-cloud-dotnet/commit/bdd8fb514ebbee57c57b9770f101e132b60efded))

### Documentation improvements

- Clarified docs for Sentiment ([commit bdd8fb5](https://github.com/googleapis/google-cloud-dotnet/commit/bdd8fb514ebbee57c57b9770f101e132b60efded))
