### PR TITLE
Release Google.Cloud.DocumentAI.V1Beta3 version 2.0.0-beta04

### DIFF
--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.csproj
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta03</Version>
+    <Version>2.0.0-beta04</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Document AI API (v1beta3), which is a service to parse structured information from unstructured or semi-structured documents using state-of-the-art Google AI such as natural language, computer vision, translation, and AutoML.</Description>

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/docs/history.md
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.0.0-beta04, released 2022-12-14
+
+### New features
+
+- Added sharding_config field in DocumentOutputConfig.GcsOutputConfig in document_io.proto ([commit 7b33720](https://github.com/googleapis/google-cloud-dotnet/commit/7b337209ed7a9195fa894eead83072aa7ebfd81d))
+
 ## Version 2.0.0-beta03, released 2022-11-16
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1701,7 +1701,7 @@
     },
     {
       "id": "Google.Cloud.DocumentAI.V1Beta3",
-      "version": "2.0.0-beta03",
+      "version": "2.0.0-beta04",
       "type": "grpc",
       "productName": "Cloud Document AI",
       "productUrl": "https://cloud.google.com/solutions/document-ai",


### PR DESCRIPTION

Changes in this release:

### New features

- Added sharding_config field in DocumentOutputConfig.GcsOutputConfig in document_io.proto ([commit 7b33720](https://github.com/googleapis/google-cloud-dotnet/commit/7b337209ed7a9195fa894eead83072aa7ebfd81d))
