### PR TITLE
Release Google.Cloud.Orchestration.Airflow.Service.V1 version 2.1.0

### DIFF
--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.csproj
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Cloud Composer API, which manages Apache Airflow environments on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/docs/history.md
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 2.1.0, released 2022-12-14
+
+### New features
+
+- Added LoadSnapshot, SaveSnapshot RPCs ([commit c84f55a](https://github.com/googleapis/google-cloud-dotnet/commit/c84f55a6901a487e1f9494ac73a7ce0dcaf9dfa4))
+- Added fields maintenance_window, workloads_config, environment_size, master_authorized_networks_config, recovery_config to EnvironmentConfig ([commit c84f55a](https://github.com/googleapis/google-cloud-dotnet/commit/c84f55a6901a487e1f9494ac73a7ce0dcaf9dfa4))
+- Added field scheduler_count to SoftwareConfig ([commit c84f55a](https://github.com/googleapis/google-cloud-dotnet/commit/c84f55a6901a487e1f9494ac73a7ce0dcaf9dfa4))
+- Added field enable_ip_masq_agent to NodeConfig ([commit c84f55a](https://github.com/googleapis/google-cloud-dotnet/commit/c84f55a6901a487e1f9494ac73a7ce0dcaf9dfa4))
+- Added fields cloud_composer_network_ipv4_cidr_block, cloud_composer_network_ipv4_reserved_range, enable_privately_used_public_ips, cloud_composer_connection_subnetwork, networking_config to PrivateEnvironmentConfig ([commit c84f55a](https://github.com/googleapis/google-cloud-dotnet/commit/c84f55a6901a487e1f9494ac73a7ce0dcaf9dfa4))
+
 ## Version 2.0.0, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2908,7 +2908,7 @@
     },
     {
       "id": "Google.Cloud.Orchestration.Airflow.Service.V1",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "type": "grpc",
       "productName": "Cloud Composer",
       "productUrl": "https://cloud.google.com/composer/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Added LoadSnapshot, SaveSnapshot RPCs ([commit c84f55a](https://github.com/googleapis/google-cloud-dotnet/commit/c84f55a6901a487e1f9494ac73a7ce0dcaf9dfa4))
- Added fields maintenance_window, workloads_config, environment_size, master_authorized_networks_config, recovery_config to EnvironmentConfig ([commit c84f55a](https://github.com/googleapis/google-cloud-dotnet/commit/c84f55a6901a487e1f9494ac73a7ce0dcaf9dfa4))
- Added field scheduler_count to SoftwareConfig ([commit c84f55a](https://github.com/googleapis/google-cloud-dotnet/commit/c84f55a6901a487e1f9494ac73a7ce0dcaf9dfa4))
- Added field enable_ip_masq_agent to NodeConfig ([commit c84f55a](https://github.com/googleapis/google-cloud-dotnet/commit/c84f55a6901a487e1f9494ac73a7ce0dcaf9dfa4))
- Added fields cloud_composer_network_ipv4_cidr_block, cloud_composer_network_ipv4_reserved_range, enable_privately_used_public_ips, cloud_composer_connection_subnetwork, networking_config to PrivateEnvironmentConfig ([commit c84f55a](https://github.com/googleapis/google-cloud-dotnet/commit/c84f55a6901a487e1f9494ac73a7ce0dcaf9dfa4))
