### PR TITLE
chore: Modify the Dockerfile for the OwlBot postprocessor

### DIFF
--- a/owl-bot-post-processor/Dockerfile
+++ b/owl-bot-post-processor/Dockerfile
@@ -22,7 +22,8 @@
 #   docker build -t gcr.io/cloud-devrel-public-resources/owlbot-dotnet .
 # To launch a bash shell in the container, run:
 #   docker run --rm -it --entrypoint bash gcr.io/cloud-devrel-public-resources/owlbot-dotnet:latest
-FROM mcr.microsoft.com/dotnet/sdk:6.0-focal
+
+FROM mcr.microsoft.com/dotnet/sdk:6.0.404-focal
 
 # Additional tooling required to regenerate libraries and project files.
 


### PR DESCRIPTION
Once this is merged, a new Docker image should show up and we should get a PR updating the lockfile. (If the image shows up but no lockfile PR, we can just create that manually.)