### PR TITLE
Release Google.Cloud.ContactCenterInsights.V1 version 2.2.1

### DIFF
--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.csproj
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.2.0</Version>
+    <Version>2.2.1</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Contact Center AI Insights API, which helps users detect and visualize patterns in their contact center data. Understanding conversational data drives business value, improves operational efficiency, and provides a voice for customer feedback.</Description>

--- a/apis/Google.Cloud.ContactCenterInsights.V1/docs/history.md
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.2.1, released 2022-12-15
+
+Patch release due to a release failure in 2.2.0.
+This has the exact same code as 2.2.0 should have had, but rolling
+forward is simpler than trying to re-release 2.2.0.
+
 ## Version 2.2.0, released 2022-12-14
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1118,7 +1118,7 @@
     },
     {
       "id": "Google.Cloud.ContactCenterInsights.V1",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "type": "grpc",
       "productName": "Contact Center AI Insights",
       "productUrl": "https://cloud.google.com/contact-center/insights/docs",


### PR DESCRIPTION

Changes in this release:

Patch release due to a release failure in 2.2.0. This has the exact same code as 2.2.0 should have had, but rolling forward is simpler than trying to re-release 2.2.0.
