### PR TITLE
chore: Update the OwlBot Docker image lock file

### DIFF
--- a/.github/.OwlBot.lock.yaml
+++ b/.github/.OwlBot.lock.yaml
@@ -14,4 +14,4 @@
 
 docker:
     image: gcr.io/cloud-devrel-public-resources/owlbot-dotnet:latest
-    digest: sha256:c7c743f4b5ce7142fd072ccb04e51f4360db2160eb139424e06c612bf10a23c6
+    digest: sha256:83334d396a9d6c3eded74998ac00dc3020143efaebcd6130a847855e46aa96f6

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.402",
+    "version": "6.0.404",
     "allowPrerelease": false,
     "rollForward": "latestMinor"
   }


### PR DESCRIPTION
This also reverts global.json back to requiring SDK 6.0.404.

I'll make sure OwlBot runs on this PR, so we can check it's all okay.