### PR TITLE
chore: Update SecretManager to support REGAPIC

### DIFF
--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3438,7 +3438,8 @@
       ],
       "shortName": "secretmanager",
       "serviceConfigFile": "secretmanager_v1.yaml",
-      "restNumericEnums": true
+      "restNumericEnums": true,
+      "transport": "grpc+rest"
     },
     {
       "id": "Google.Cloud.SecretManager.V1Beta1",


### PR DESCRIPTION
(This was accidentally done in BUILD.bazel, but there's no reason not to include it here.)

This makes generation from Bazel consistent with local generation.