### PR TITLE
chore: Update API catalog for Vmware Engine to include numeric enums

### DIFF
--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4338,6 +4338,7 @@
       },
       "generator": "micro",
       "protoPath": "google/cloud/vmwareengine/v1",
+      "restNumericEnums": true,
       "shortName": "vmwareengine",
       "serviceConfigFile": "vmwareengine_v1.yaml"
     },


### PR DESCRIPTION
(This was missed when the API was added. We should probably automate updating this information from the BUILD.bazel file...)