### PR TITLE
Release Google.Cloud.Batch.V1 version 1.2.0

### DIFF
--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.csproj
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.2.0-beta01</Version>
+    <Version>1.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Batch API (v1), which allows you to manage the running of batch jobs on Google Cloud Platform.</Description>
@@ -9,10 +9,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0-beta01, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Batch.V1/docs/history.md
+++ b/apis/Google.Cloud.Batch.V1/docs/history.md
@@ -1,5 +1,19 @@
 # Version history
 
+## Version 1.2.0, released 2023-01-11
+
+### Bug fixes
+
+- Remove unsupported HTTP bindings for IAMPolicy RPCs ([commit 9ca7a4b](https://github.com/googleapis/google-cloud-dotnet/commit/9ca7a4b02bbfe33f395b3cdd7e5c09d723beb79e))
+
+### New features
+
+- Support secret and encrypted environment variables in v1 ([commit f527507](https://github.com/googleapis/google-cloud-dotnet/commit/f52750711320054e6d623eeb3423baa1694389b8))
+
+### Documentation improvements
+
+- Updated documentation for message NetworkInterface ([commit 7c2ce96](https://github.com/googleapis/google-cloud-dotnet/commit/7c2ce96828902581fc7c408628781bffb314230c))
+
 ## Version 1.2.0-beta01, released 2022-12-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -440,7 +440,7 @@
     },
     {
       "id": "Google.Cloud.Batch.V1",
-      "version": "1.2.0-beta01",
+      "version": "1.2.0",
       "type": "grpc",
       "productName": "Batch",
       "productUrl": "https://cloud.google.com/batch/docs/",
@@ -449,11 +449,11 @@
         "batch"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0-beta01",
+        "Google.Api.Gax.Grpc": "4.3.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.3"
+        "Grpc.Core": "2.46.5"
       },
       "generator": "micro",
       "protoPath": "google/cloud/batch/v1",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Remove unsupported HTTP bindings for IAMPolicy RPCs ([commit 9ca7a4b](https://github.com/googleapis/google-cloud-dotnet/commit/9ca7a4b02bbfe33f395b3cdd7e5c09d723beb79e))

### New features

- Support secret and encrypted environment variables in v1 ([commit f527507](https://github.com/googleapis/google-cloud-dotnet/commit/f52750711320054e6d623eeb3423baa1694389b8))

### Documentation improvements

- Updated documentation for message NetworkInterface ([commit 7c2ce96](https://github.com/googleapis/google-cloud-dotnet/commit/7c2ce96828902581fc7c408628781bffb314230c))
