### PR TITLE
Release Google.Cloud.Domains.V1 version 2.1.0

### DIFF
--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.csproj
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0-beta01</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Domains API v1, which enables management and configuration of domain names.</Description>
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0-beta01, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Domains.V1/docs/history.md
+++ b/apis/Google.Cloud.Domains.V1/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+## Version 2.1.0, released 2023-01-11
+
+This is primarily a promotion of the previous beta, which includes
+REST transport support. No API surface changes; just dependency updates.
+
 ## Version 2.1.0-beta01, released 2022-12-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1728,7 +1728,7 @@
     },
     {
       "id": "Google.Cloud.Domains.V1",
-      "version": "2.1.0-beta01",
+      "version": "2.1.0",
       "type": "grpc",
       "productName": "Cloud Domains",
       "productUrl": "https://cloud.google.com/domains/",
@@ -1737,9 +1737,9 @@
         "domains"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0-beta01",
+        "Google.Api.Gax.Grpc": "4.3.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.3"
+        "Grpc.Core": "2.46.5"
       },
       "generator": "micro",
       "protoPath": "google/cloud/domains/v1",


### PR DESCRIPTION

Changes in this release:

This is primarily a promotion of the previous beta, which includes REST transport support. No API surface changes; just dependency updates.
