### PR TITLE
Release Google.Cloud.Tasks.V2 version 3.1.0

### DIFF
--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.csproj
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.1.0-beta01</Version>
+    <Version>3.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Tasks API (v2), which manages the execution of large numbers of distributed requests.</Description>
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0-beta01, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Tasks.V2/docs/history.md
+++ b/apis/Google.Cloud.Tasks.V2/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+## Version 3.1.0, released 2023-01-11
+
+This is primarily a promotion of the previous beta, which includes
+REST transport support. No API surface changes; just dependency updates.
+
 ## Version 3.1.0-beta01, released 2022-12-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4002,16 +4002,16 @@
       "protoPath": "google/cloud/tasks/v2",
       "productName": "Google Cloud Tasks",
       "productUrl": "https://cloud.google.com/tasks/",
-      "version": "3.1.0-beta01",
+      "version": "3.1.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Tasks API (v2), which manages the execution of large numbers of distributed requests.",
       "tags": [
         "Tasks"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0-beta01",
+        "Google.Api.Gax.Grpc": "4.3.0",
         "Google.Cloud.Iam.V1": "3.0.0",
-        "Grpc.Core": "2.46.3"
+        "Grpc.Core": "2.46.5"
       },
       "shortName": "cloudtasks",
       "serviceConfigFile": "cloudtasks_v2.yaml",


### PR DESCRIPTION

Changes in this release:

This is primarily a promotion of the previous beta, which includes REST transport support. No API surface changes; just dependency updates.
