### PR TITLE
feat: Add DownloadValidationMode.Automatic

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/DownloadObjectTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/DownloadObjectTest.cs
@@ -347,6 +347,25 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
             Assert.Equal(expected, actual);
         }
 
+        [SkippableFact]
+        public void DownloadGzippedFile_NoClientDecompression_AutomaticValidationMode()
+        {
+            TestEnvironment.SkipIfVpcSc();
+
+            var service = new StorageService(new BaseClientService.Initializer
+            {
+                HttpClientInitializer = _fixture.Client.Service.HttpClientInitializer,
+                GZipEnabled = false
+            });
+            var client = new StorageClientImpl(service);
+            var stream = new MemoryStream();
+            client.DownloadObject(StorageFixture.CrossLanguageTestBucket, "gzipped-text.txt", stream,
+                new DownloadObjectOptions { DownloadValidationMode = DownloadValidationMode.Automatic });
+            var expected = Encoding.UTF8.GetBytes("hello world");
+            var actual = stream.ToArray();
+            Assert.Equal(expected, actual);
+        }
+
         [Fact]
         public void InvalidDownloadValidationMode()
         {

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/DownloadObjectOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/DownloadObjectOptions.cs
@@ -16,10 +16,8 @@ using Google.Apis.Download;
 using Google.Apis.Requests;
 using Google.Apis.Util;
 using System;
-using System.Diagnostics;
 using System.Globalization;
 using System.Net.Http.Headers;
-using System.Text;
 
 namespace Google.Cloud.Storage.V1
 {
@@ -81,10 +79,18 @@ namespace Google.Cloud.Storage.V1
         /// the hash will always be validated.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// This is effectively an escape hatch for situations where hash validation fails.
         /// See https://github.com/googleapis/google-cloud-dotnet/issues/1641 for background
-        /// on this option. It is recommended that you leave this option unset unless you are knowingly
+        /// on this option. It is recommended that you leave this option unset (or use
+        /// <see cref="DownloadValidationMode.Automatic"/>) unless you are knowingly
         /// downloading data for an object where hashing will fail.
+        /// </para>
+        /// <para>
+        /// The current implementation defaults to <see cref="DownloadValidationMode.Always"/>; in a future
+        /// major version the default will change to <see cref="DownloadValidationMode.Automatic"/> which will
+        /// automatically ignore the hash where validation is expected to fail (even with valid data).
+        /// </para>
         /// </remarks>
         public DownloadValidationMode? DownloadValidationMode { get; set; }
 

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/DownloadValidationMode.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/DownloadValidationMode.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// Copyright 2017 Google Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,6 +28,14 @@ namespace Google.Cloud.Storage.V1
         /// The hash is never validated; data integrity errors may still be exposed
         /// via other network layers, but there is a risk of data loss.
         /// </summary>
-        Never = 1
+        Never = 1,
+
+        /// <summary>
+        /// The hash is validated if the library can detect that validation should
+        /// be feasible. If response headers provide information to indicate that
+        /// hash validation will fail (even in the face of correct data), the hash
+        /// is not validated.
+        /// </summary>
+        Automatic = 2
     }
 }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/HashValidatingDownloader.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/HashValidatingDownloader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016 Google Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,52 +24,78 @@ using System.Net.Http;
 namespace Google.Cloud.Storage.V1
 {
     /// <summary>
-    /// Subclass of <see cref="MediaDownloader"/> which validates the data it receives
+    /// Subclass of <see cref="MediaDownloader"/> which (potentially) validates the data it receives
     /// against a CRC32c hash set in the header.
     /// </summary>
     internal sealed class HashValidatingDownloader : ContentMetadataRecordingMediaDownloader
     {
-        private string crc32cHashBase64;
-        private Crc32c hasher;
+        internal const string StoredContentEncodingHeaderName = "x-goog-stored-content-encoding";
+
+        private readonly DownloadValidationMode _mode;
+        private string _crc32cHashBase64;
+        private Crc32c _hasher;
 
         /// <summary>Constructs a new downloader with the given client service.</summary>
-        internal HashValidatingDownloader(Object metadata, IClientService service) : base(metadata, service)
+        internal HashValidatingDownloader(Object metadata, IClientService service, DownloadValidationMode mode) : base(metadata, service)
         {
+            _mode = mode;
             ResponseStreamInterceptorProvider = CreateInterceptor;
         }
 
         private StreamInterceptor CreateInterceptor(HttpResponseMessage response)
         {
-            crc32cHashBase64 = null;
-            hasher = null;
+            _crc32cHashBase64 = null;
+            _hasher = null;
 
-            IEnumerable<string> values;
-            if (response.Headers.TryGetValues(Crc32c.HashHeaderName, out values))
+            switch (_mode)
             {
-                string prefix = Crc32c.HashName + "=";
-                foreach (var value in values.SelectMany(v => v.Split(',')))
+                case DownloadValidationMode.Always:
+                    return PrepareForHashing();
+                case DownloadValidationMode.Never:
+                    return null;
+                case DownloadValidationMode.Automatic:
+                    bool decompressedByServer =
+                        response.Headers.TryGetValues(StoredContentEncodingHeaderName, out var storedContentEncoding) &&
+                        storedContentEncoding.FirstOrDefault() == "gzip" &&
+                        response.Content?.Headers?.ContentEncoding?.FirstOrDefault() != "gzip";                        
+                    return decompressedByServer ? null : PrepareForHashing();
+                default:
+                    return null;
+            }
+
+            StreamInterceptor PrepareForHashing()
+            {
+                IEnumerable<string> values;
+                if (response.Headers.TryGetValues(Crc32c.HashHeaderName, out values))
                 {
-                    if (value.StartsWith(prefix))
+                    string prefix = Crc32c.HashName + "=";
+                    foreach (var value in values.SelectMany(v => v.Split(',')))
                     {
-                        hasher = new Crc32c();
-                        crc32cHashBase64 = value.Substring(prefix.Length);
-                        return hasher.UpdateHash;
+                        if (value.StartsWith(prefix))
+                        {
+                            _hasher = new Crc32c();
+                            _crc32cHashBase64 = value.Substring(prefix.Length);
+                            return _hasher.UpdateHash;
+                        }
                     }
                 }
+                // The mode indicates that we'd like to validate the hash, but we don't have one to validate.
+                // (We could potentially have a mode of "fail if there isn't a hash to validate", in the future,
+                // but for the moment we just ignore it.)
+                return null;
             }
-            return null;
         }
 
         protected override void OnDownloadCompleted()
         {
             base.OnDownloadCompleted();
 
-            if (crc32cHashBase64 != null)
+            if (_crc32cHashBase64 != null)
             {
-                string actualHash = System.Convert.ToBase64String(hasher.GetHash());
-                if (actualHash != crc32cHashBase64)
+                string actualHash = System.Convert.ToBase64String(_hasher.GetHash());
+                if (actualHash != _crc32cHashBase64)
                 {
-                    throw new IOException($"Incorrect hash: expected '{crc32cHashBase64}' (base64), was '{actualHash}' (base64)");
+                    throw new IOException($"Incorrect hash: expected '{_crc32cHashBase64}' (base64), was '{actualHash}' (base64)");
                 }
             }
         }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.DownloadObject.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.DownloadObject.cs
@@ -173,8 +173,7 @@ namespace Google.Cloud.Storage.V1
             DownloadValidationMode mode = options?.DownloadValidationMode ?? DownloadValidationMode.Always;
             GaxPreconditions.CheckEnumValue(mode, nameof(DownloadObjectOptions.DownloadValidationMode));
 
-            var downloader = mode == DownloadValidationMode.Never
-                ? new ContentMetadataRecordingMediaDownloader(metadata, Service) : new HashValidatingDownloader(metadata, Service);
+            var downloader = new HashValidatingDownloader(metadata, Service, mode);
             options?.ModifyDownloader(downloader);
             ApplyEncryptionKey(options?.EncryptionKey, downloader);
             return downloader;


### PR DESCRIPTION
Fixes #9507 (modulo the change to default in the next majro version)

This detects if the x-goog-stored-content-encoding header is set to gzip, but the actual content encoding of the response is non-gzip, and disables validation in that specific case - while validating in the same way as normal for everything else.

We will make this the default in the next major version. (This is recorded in the internal document.)

Implementation note: this now *always* creates a HashValidatingDownloader, and puts that in control of whether validation is actually performed or not. That's simpler than the previous split of the choice being in StorageClientImpl.DownloadObject.cs with the hashing in HashValidatingDownloader.