### PR TITLE
chore: Upgrade to docfx 2.60.0, and use it as a dotnet tool

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "docfx": {
+      "version": "2.60.0",
+      "commands": [
+        "docfx"
+      ]
+    }
+  }
+}

--- a/docs/builddocs.sh
+++ b/docs/builddocs.sh
@@ -33,11 +33,11 @@ build_api_docs() {
     dotnet run --no-build --no-restore --project ../tools/Google.Cloud.Tools.GenerateDocfxSources -- $api
   fi
   cp filterConfig.yml output/$api
-  $DOCFX metadata --logLevel Warning -f output/$api/docfx.json | tee errors.txt | grep -v "Invalid file link"
+  dotnet docfx metadata --logLevel Warning -f output/$api/docfx.json | tee errors.txt | grep -v "Invalid file link"
   (! grep --quiet 'Build failed.' errors.txt)
 
   # Build metadata for devsite
-  $DOCFX metadata --logLevel Warning -f output/$api/docfx-devsite.json | tee errors.txt | grep -v "Invalid file link"
+  dotnet docfx metadata --logLevel Warning -f output/$api/docfx-devsite.json | tee errors.txt | grep -v "Invalid file link"
   (! grep --quiet 'Build failed.' errors.txt)
 
   # Unescape the metadata files for both devsite and googleapis.dev
@@ -49,7 +49,7 @@ build_api_docs() {
   
   # Build for googleapis.dev
   # Note that the devsite build will happen elsewhere.
-  $DOCFX build --logLevel Warning --disableGitFeatures output/$api/docfx.json | tee errors.txt | grep -v "Invalid file link"
+  dotnet docfx build --logLevel Warning --disableGitFeatures output/$api/docfx.json | tee errors.txt | grep -v "Invalid file link"
   (! grep --quiet 'Build failed.' errors.txt)
   
   # We need to make some changes to meet DevSite build expectations.

--- a/docs/generate-devsite-help.sh
+++ b/docs/generate-devsite-help.sh
@@ -65,6 +65,6 @@ cd ../..
 
 echo 'Building site for local debugging purposes'
 cp devsite-help-docfx.json output/devsite-help/docfx.json
-$DOCFX build --disableGitFeatures output/devsite-help/docfx.json
+dotnet docfx build --disableGitFeatures output/devsite-help/docfx.json
 
 echo 'Done'

--- a/docs/generate-devsite-utilities.sh
+++ b/docs/generate-devsite-utilities.sh
@@ -124,7 +124,7 @@ do
 done
 
 echo 'Running docfx metadata'
-$DOCFX metadata --logLevel Error -o output --property TargetFramework=$TARGET_FRAMEWORK $PROJECTS_TMP
+dotnet docfx metadata --logLevel Error -o output --property TargetFramework=$TARGET_FRAMEWORK $PROJECTS_TMP
 
 # This will have created an output/output directory. 
 # (For some reason docfx takes "output" and doubles it to output/output.)

--- a/toolversions.sh
+++ b/toolversions.sh
@@ -6,7 +6,6 @@
 declare -r REPO_ROOT=$(readlink -f $(dirname ${BASH_SOURCE}))
 declare -r TOOL_PACKAGES=$REPO_ROOT/packages
 
-declare -r DOCFX_VERSION=2.59.4
 declare -r DOTCOVER_VERSION=2019.3.4
 declare -r REPORTGENERATOR_VERSION=2.4.5.0
 declare -r PROTOC_VERSION=3.21.3
@@ -14,7 +13,6 @@ declare -r GRPC_VERSION=2.47.0
 declare -r GAPIC_GENERATOR_VERSION=1.4.9
 
 # Tools that only run under Windows (at the moment)
-declare -r DOCFX=$TOOL_PACKAGES/docfx.$DOCFX_VERSION/docfx.exe
 declare -r DOTCOVER=$TOOL_PACKAGES/JetBrains.dotCover.CommandLineTools.$DOTCOVER_VERSION/tools/dotCover.exe
 declare -r REPORTGENERATOR=$TOOL_PACKAGES/ReportGenerator.$REPORTGENERATOR_VERSION/tools/ReportGenerator.exe
 
@@ -139,18 +137,9 @@ install_grpc() {
 }
 
 install_docfx() {
-  if [[ ! -f $DOCFX ]]
-  then
-    (echo "Fetching docfx v${DOCFX_VERSION}";
-     mkdir -p $TOOL_PACKAGES;
-     cd $TOOL_PACKAGES;
-     mkdir docfx.$DOCFX_VERSION;
-     cd docfx.$DOCFX_VERSION;
-     curl -sSL https://github.com/dotnet/docfx/releases/download/v${DOCFX_VERSION}/docfx.zip -o tmp.zip;
-     unzip -q tmp.zip;
-     rm tmp.zip;
-     )
-  fi  
+  # Note that errors will still appear in stderr, but we don't need
+  # the banner of "here's how to invoke the tool" when installing
+  dotnet tool install docfx > /dev/null
 }
 
 # Logs to both stdout and a build timing log, allowing


### PR DESCRIPTION
Once we've made sure this works with all our existing processes, we can then start moving to use Linux in CI for docs building, and update other repos to do the same.