### PR TITLE
Release Google.Cloud.AIPlatform.V1 version 2.8.0

### DIFF
--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.7.0</Version>
+    <Version>2.8.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AI Platform API, which allows you to train high-quality custom machine learning models with minimal machine learning expertise and effort.</Description>
@@ -9,10 +9,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.AIPlatform.V1/docs/history.md
+++ b/apis/Google.Cloud.AIPlatform.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 2.8.0, released 2023-01-16
+
+### New features
+
+- Add instance_config to BatchPredictionJob in aiplatform v1 batch_prediction_job.proto ([commit f868bc8](https://github.com/googleapis/google-cloud-dotnet/commit/f868bc8f601d12499c7212b0b992ea205fe310f3))
+- Add saved_queries to Dataset in aiplatform v1 dataset.proto ([commit e7acad2](https://github.com/googleapis/google-cloud-dotnet/commit/e7acad20e505522f02023821ee133cc48ad8205c))
+- Add order_by to ListModelVersionRequest in aiplatform v1 model_service.proto ([commit e7acad2](https://github.com/googleapis/google-cloud-dotnet/commit/e7acad20e505522f02023821ee133cc48ad8205c))
+- Add update_all_stopped_trials to ConvexAutomatedStoppingSpec in aiplatform v1 study.proto ([commit e7acad2](https://github.com/googleapis/google-cloud-dotnet/commit/e7acad20e505522f02023821ee133cc48ad8205c))
+- Add ReadTensorboardUsage rpc in aiplatform v1 tensorboard_service.proto ([commit e7acad2](https://github.com/googleapis/google-cloud-dotnet/commit/e7acad20e505522f02023821ee133cc48ad8205c))
+
 ## Version 2.7.0, released 2022-12-14
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -128,7 +128,7 @@
     },
     {
       "id": "Google.Cloud.AIPlatform.V1",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "type": "grpc",
       "productName": "Cloud AI Platform",
       "productUrl": "https://cloud.google.com/ai-platform/docs/",
@@ -138,11 +138,11 @@
         "ml"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.2.0",
+        "Google.Api.Gax.Grpc": "4.3.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.3"
+        "Grpc.Core": "2.46.5"
       },
       "generator": "micro",
       "protoPath": "google/cloud/aiplatform/v1",


### PR DESCRIPTION

Changes in this release:

### New features

- Add instance_config to BatchPredictionJob in aiplatform v1 batch_prediction_job.proto ([commit f868bc8](https://github.com/googleapis/google-cloud-dotnet/commit/f868bc8f601d12499c7212b0b992ea205fe310f3))
- Add saved_queries to Dataset in aiplatform v1 dataset.proto ([commit e7acad2](https://github.com/googleapis/google-cloud-dotnet/commit/e7acad20e505522f02023821ee133cc48ad8205c))
- Add order_by to ListModelVersionRequest in aiplatform v1 model_service.proto ([commit e7acad2](https://github.com/googleapis/google-cloud-dotnet/commit/e7acad20e505522f02023821ee133cc48ad8205c))
- Add update_all_stopped_trials to ConvexAutomatedStoppingSpec in aiplatform v1 study.proto ([commit e7acad2](https://github.com/googleapis/google-cloud-dotnet/commit/e7acad20e505522f02023821ee133cc48ad8205c))
- Add ReadTensorboardUsage rpc in aiplatform v1 tensorboard_service.proto ([commit e7acad2](https://github.com/googleapis/google-cloud-dotnet/commit/e7acad20e505522f02023821ee133cc48ad8205c))
