### PR TITLE
Release Google.Cloud.ApiKeys.V2 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.csproj
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the API Keys API (v2), which manages the API keys associated with developer projects.</Description>
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ApiKeys.V2/docs/history.md
+++ b/apis/Google.Cloud.ApiKeys.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.1.0, released 2023-01-16
+
+### New features
+
+- Enable REST transport in C# ([commit a6c4606](https://github.com/googleapis/google-cloud-dotnet/commit/a6c46063bd961a9dadc728a780d66de772f28e71))
+
 ## Version 1.0.0, released 2022-09-15
 
 No API surface changes; just dependency updates and promotion to GA.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -151,7 +151,7 @@
     },
     {
       "id": "Google.Cloud.ApiKeys.V2",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "grpc",
       "productName": "API Keys",
       "productUrl": "https://cloud.google.com/api-keys/docs",
@@ -161,9 +161,9 @@
         "authorization"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.2.0",
+        "Google.Api.Gax.Grpc": "4.3.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.3"
+        "Grpc.Core": "2.46.5"
       },
       "generator": "micro",
       "protoPath": "google/api/apikeys/v2",


### PR DESCRIPTION

Changes in this release:

### New features

- Enable REST transport in C# ([commit a6c4606](https://github.com/googleapis/google-cloud-dotnet/commit/a6c46063bd961a9dadc728a780d66de772f28e71))
