### PR TITLE
Release Google.Cloud.ArtifactRegistry.V1Beta2 version 2.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.csproj
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta01</Version>
+    <Version>2.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Artifact Registry API v1beta2, which stores and manages build artifacts in a scalable and integrated service built on Google infrastructure.</Description>

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/docs/history.md
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 2.0.0-beta02, released 2023-01-16
+
+### New features
+
+- Enable REST transport in C# ([commit a6c4606](https://github.com/googleapis/google-cloud-dotnet/commit/a6c46063bd961a9dadc728a780d66de772f28e71))
+- Add location methods ([commit 4c5f1de](https://github.com/googleapis/google-cloud-dotnet/commit/4c5f1deedbab60585fb109ab6ec0fafc86f0bcff))
+
 ## Version 2.0.0-beta01, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -286,7 +286,7 @@
     },
     {
       "id": "Google.Cloud.ArtifactRegistry.V1Beta2",
-      "version": "2.0.0-beta01",
+      "version": "2.0.0-beta02",
       "type": "grpc",
       "productName": "Artifact Registry",
       "productUrl": "https://cloud.google.com/artifact-registry",


### PR DESCRIPTION

Changes in this release:

### New features

- Enable REST transport in C# ([commit a6c4606](https://github.com/googleapis/google-cloud-dotnet/commit/a6c46063bd961a9dadc728a780d66de772f28e71))
- Add location methods ([commit 4c5f1de](https://github.com/googleapis/google-cloud-dotnet/commit/4c5f1deedbab60585fb109ab6ec0fafc86f0bcff))
