### PR TITLE
Release Google.Cloud.Asset.V1 version 3.4.0

### DIFF
--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.csproj
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.3.0</Version>
+    <Version>3.4.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Asset Inventory API (v1).</Description>
@@ -9,13 +9,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.OrgPolicy.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.OsConfig.V1" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.Identity.AccessContextManager.Type" Version="[2.0.0, 3.0.0)" />
-    <PackageReference Include="Google.Identity.AccessContextManager.V1" Version="[2.0.0, 3.0.0)" />
+    <PackageReference Include="Google.Identity.AccessContextManager.V1" Version="[2.1.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Asset.V1/docs/history.md
+++ b/apis/Google.Cloud.Asset.V1/docs/history.md
@@ -1,5 +1,18 @@
 # Version history
 
+## Version 3.4.0, released 2023-01-16
+
+### New features
+
+- Enable REST transport in C# ([commit a6c4606](https://github.com/googleapis/google-cloud-dotnet/commit/a6c46063bd961a9dadc728a780d66de772f28e71))
+- Policy Analyzer for Organization Policy is publicly available ([commit ffb0726](https://github.com/googleapis/google-cloud-dotnet/commit/ffb07260788e807957a43ce951aa32ced725b889))
+
+### Documentation improvements
+
+- Brand and typo fixes ([commit ffb0726](https://github.com/googleapis/google-cloud-dotnet/commit/ffb07260788e807957a43ce951aa32ced725b889))
+- Small change for documentation ([commit 0927419](https://github.com/googleapis/google-cloud-dotnet/commit/0927419e9474930d4043e3a60d8b3c353e4fb8b5))
+- Small change for documentation ([commit e6fa780](https://github.com/googleapis/google-cloud-dotnet/commit/e6fa78083830d592eb72dd28ceaf79215ea04be4))
+
 ## Version 3.3.0, released 2022-10-17
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -314,18 +314,18 @@
       "protoPath": "google/cloud/asset/v1",
       "productName": "Google Cloud Asset Inventory",
       "productUrl": "https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Asset Inventory API (v1).",
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.2.0",
+        "Google.Api.Gax.Grpc": "4.3.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.OrgPolicy.V1": "3.0.0",
         "Google.Cloud.OsConfig.V1": "2.0.0",
         "Google.Identity.AccessContextManager.Type": "2.0.0",
-        "Google.Identity.AccessContextManager.V1": "2.0.0",
+        "Google.Identity.AccessContextManager.V1": "2.1.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.3"
+        "Grpc.Core": "2.46.5"
       },
       "tags": [
         "asset",


### PR DESCRIPTION

Changes in this release:

### New features

- Enable REST transport in C# ([commit a6c4606](https://github.com/googleapis/google-cloud-dotnet/commit/a6c46063bd961a9dadc728a780d66de772f28e71))
- Policy Analyzer for Organization Policy is publicly available ([commit ffb0726](https://github.com/googleapis/google-cloud-dotnet/commit/ffb07260788e807957a43ce951aa32ced725b889))

### Documentation improvements

- Brand and typo fixes ([commit ffb0726](https://github.com/googleapis/google-cloud-dotnet/commit/ffb07260788e807957a43ce951aa32ced725b889))
- Small change for documentation ([commit 0927419](https://github.com/googleapis/google-cloud-dotnet/commit/0927419e9474930d4043e3a60d8b3c353e4fb8b5))
- Small change for documentation ([commit e6fa780](https://github.com/googleapis/google-cloud-dotnet/commit/e6fa78083830d592eb72dd28ceaf79215ea04be4))
