### PR TITLE
Release Google.Cloud.Batch.V1Alpha version 1.0.0-alpha06

### DIFF
--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.csproj
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha05</Version>
+    <Version>1.0.0-alpha06</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Batch API (v1alpha), which allows you to manage the running of batch jobs on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Batch.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.Batch.V1Alpha/docs/history.md
@@ -1,5 +1,20 @@
 # Version history
 
+## Version 1.0.0-alpha06, released 2023-01-16
+
+### Bug fixes
+
+- ServiceAccount.scopes is no longer deprecated ([commit d15829b](https://github.com/googleapis/google-cloud-dotnet/commit/d15829bc37938440697302acc3ffc0816da8b6be))
+- Removed unused endpoints for IAM methods ([commit d15829b](https://github.com/googleapis/google-cloud-dotnet/commit/d15829bc37938440697302acc3ffc0816da8b6be))
+
+### New features
+
+- Add InstancePolicy.boot_disk ([commit d15829b](https://github.com/googleapis/google-cloud-dotnet/commit/d15829bc37938440697302acc3ffc0816da8b6be))
+
+### Documentation improvements
+
+- Updated documentation for message NetworkInterface ([commit acb6f8f](https://github.com/googleapis/google-cloud-dotnet/commit/acb6f8f8618ee8eb33249e09fd3edc84665c4c6b))
+
 ## Version 1.0.0-alpha05, released 2022-12-01
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -468,7 +468,7 @@
     },
     {
       "id": "Google.Cloud.Batch.V1Alpha",
-      "version": "1.0.0-alpha05",
+      "version": "1.0.0-alpha06",
       "type": "grpc",
       "productName": "Batch",
       "productUrl": "https://cloud.google.com/batch/docs/",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- ServiceAccount.scopes is no longer deprecated ([commit d15829b](https://github.com/googleapis/google-cloud-dotnet/commit/d15829bc37938440697302acc3ffc0816da8b6be))
- Removed unused endpoints for IAM methods ([commit d15829b](https://github.com/googleapis/google-cloud-dotnet/commit/d15829bc37938440697302acc3ffc0816da8b6be))

### New features

- Add InstancePolicy.boot_disk ([commit d15829b](https://github.com/googleapis/google-cloud-dotnet/commit/d15829bc37938440697302acc3ffc0816da8b6be))

### Documentation improvements

- Updated documentation for message NetworkInterface ([commit acb6f8f](https://github.com/googleapis/google-cloud-dotnet/commit/acb6f8f8618ee8eb33249e09fd3edc84665c4c6b))
