### PR TITLE
Release Google.Cloud.Container.V1 version 3.7.0

### DIFF
--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.6.0</Version>
+    <Version>3.7.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.</Description>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.2.0, 5.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Container.V1/docs/history.md
+++ b/apis/Google.Cloud.Container.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 3.7.0, released 2023-01-16
+
+### New features
+
+- Add etags for cluster and node pool update operations ([commit 04b4db4](https://github.com/googleapis/google-cloud-dotnet/commit/04b4db4faaeb16f14e51206aa51dd3e557a10282))
+- Release GKE CloudDNS Cluster Scope ([commit 7d1eafe](https://github.com/googleapis/google-cloud-dotnet/commit/7d1eafef6b4479c9672e51498b71ce8b7218d702))
+- Add WindowsNodeConfig field to v1alpha1, v1beta1, v1 ([commit 7d1eafe](https://github.com/googleapis/google-cloud-dotnet/commit/7d1eafef6b4479c9672e51498b71ce8b7218d702))
+- Add EphemeralStorageLocalSsdConfig and LocalNvmeSsdBlockConfig APIs to v1alpha1, v1beta1, v1 ([commit 7d1eafe](https://github.com/googleapis/google-cloud-dotnet/commit/7d1eafef6b4479c9672e51498b71ce8b7218d702))
+- Add support for specifying stack type for clusters. This will allow clusters to be created as dual stack or toggled between IPV4 and dual stack ([commit 1cb1704](https://github.com/googleapis/google-cloud-dotnet/commit/1cb170400140ed79feec2dbee05e3113d5ec4e63))
+
 ## Version 3.6.0, released 2022-12-01
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1152,12 +1152,12 @@
       "protoPath": "google/container/v1",
       "productName": "Google Kubernetes Engine",
       "productUrl": "https://cloud.google.com/kubernetes-engine/docs/reference/rest/",
-      "version": "3.6.0",
+      "version": "3.7.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.",
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.2.0",
-        "Grpc.Core": "2.46.3"
+        "Google.Api.Gax.Grpc": "4.3.0",
+        "Grpc.Core": "2.46.5"
       },
       "tags": [
         "Kubernetes"


### PR DESCRIPTION

Changes in this release:

### New features

- Add etags for cluster and node pool update operations ([commit 04b4db4](https://github.com/googleapis/google-cloud-dotnet/commit/04b4db4faaeb16f14e51206aa51dd3e557a10282))
- Release GKE CloudDNS Cluster Scope ([commit 7d1eafe](https://github.com/googleapis/google-cloud-dotnet/commit/7d1eafef6b4479c9672e51498b71ce8b7218d702))
- Add WindowsNodeConfig field to v1alpha1, v1beta1, v1 ([commit 7d1eafe](https://github.com/googleapis/google-cloud-dotnet/commit/7d1eafef6b4479c9672e51498b71ce8b7218d702))
- Add EphemeralStorageLocalSsdConfig and LocalNvmeSsdBlockConfig APIs to v1alpha1, v1beta1, v1 ([commit 7d1eafe](https://github.com/googleapis/google-cloud-dotnet/commit/7d1eafef6b4479c9672e51498b71ce8b7218d702))
- Add support for specifying stack type for clusters. This will allow clusters to be created as dual stack or toggled between IPV4 and dual stack ([commit 1cb1704](https://github.com/googleapis/google-cloud-dotnet/commit/1cb170400140ed79feec2dbee05e3113d5ec4e63))
