### PR TITLE
Release Google.Cloud.GkeMultiCloud.V1 version 2.1.0

### DIFF
--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.csproj
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Anthos Multi-Cloud API, which provides a way to manage Kubernetes clusters that run on AWS and Azure infrastructure using the Anthos Multi-Cloud API. Combined with Connect, you can manage Kubernetes clusters on Google Cloud, AWS, and Azure from the Google Cloud Console.  When you create a cluster with Anthos Multi-Cloud, Google creates the resources needed and brings up a cluster on your behalf. You can deploy workloads with the Anthos Multi-Cloud API or the gcloud and kubectl command-line tools.</Description>
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.GkeMultiCloud.V1/docs/history.md
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/docs/history.md
@@ -1,5 +1,14 @@
 # Version history
 
+## Version 2.1.0, released 2023-01-16
+
+### New features
+
+- Support AttachedClusters ([commit aee0849](https://github.com/googleapis/google-cloud-dotnet/commit/aee0849f0679a9557375d70887436926f6ec1c16))
+- Add errors output fields for cluster and nodepool resources ([commit aee0849](https://github.com/googleapis/google-cloud-dotnet/commit/aee0849f0679a9557375d70887436926f6ec1c16))
+- Add AWS Autoscaling Group metrics collection for AWS nodepools ([commit aee0849](https://github.com/googleapis/google-cloud-dotnet/commit/aee0849f0679a9557375d70887436926f6ec1c16))
+- Add monitoring config ([commit aee0849](https://github.com/googleapis/google-cloud-dotnet/commit/aee0849f0679a9557375d70887436926f6ec1c16))
+
 ## Version 2.0.0, released 2022-09-15
 
 No API surface changes; just dependency updates and promotion to GA.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2227,7 +2227,7 @@
     },
     {
       "id": "Google.Cloud.GkeMultiCloud.V1",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "type": "grpc",
       "productName": "Anthos Multi-Cloud",
       "productUrl": "https://cloud.google.com/anthos/clusters/docs/multi-cloud",
@@ -2240,9 +2240,9 @@
         "azure"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.2.0",
+        "Google.Api.Gax.Grpc": "4.3.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.3"
+        "Grpc.Core": "2.46.5"
       },
       "generator": "micro",
       "protoPath": "google/cloud/gkemulticloud/v1",


### PR DESCRIPTION

Changes in this release:

### New features

- Support AttachedClusters ([commit aee0849](https://github.com/googleapis/google-cloud-dotnet/commit/aee0849f0679a9557375d70887436926f6ec1c16))
- Add errors output fields for cluster and nodepool resources ([commit aee0849](https://github.com/googleapis/google-cloud-dotnet/commit/aee0849f0679a9557375d70887436926f6ec1c16))
- Add AWS Autoscaling Group metrics collection for AWS nodepools ([commit aee0849](https://github.com/googleapis/google-cloud-dotnet/commit/aee0849f0679a9557375d70887436926f6ec1c16))
- Add monitoring config ([commit aee0849](https://github.com/googleapis/google-cloud-dotnet/commit/aee0849f0679a9557375d70887436926f6ec1c16))
