### PR TITLE
Release Google.Cloud.Iap.V1 version 2.1.0

### DIFF
--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.csproj
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud IAP API, which controls access to cloud applications running on Google Cloud Platform.</Description>
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Iap.V1/docs/history.md
+++ b/apis/Google.Cloud.Iap.V1/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 2.1.0, released 2023-01-16
+
+### New features
+
+- Add AllowedDomainSettings to the UpdateIapSettingsRequest ([commit 5b5c678](https://github.com/googleapis/google-cloud-dotnet/commit/5b5c678d67d38c53653a33e981a7f438f1278aa3))
+- Add AttributePropagationSettings to the UpdateIapSettingsRequest ([commit 5b5c678](https://github.com/googleapis/google-cloud-dotnet/commit/5b5c678d67d38c53653a33e981a7f438f1278aa3))
+- Add remediation_token_generation_enabled to the CsmSettings ([commit 5b5c678](https://github.com/googleapis/google-cloud-dotnet/commit/5b5c678d67d38c53653a33e981a7f438f1278aa3))
+
 ## Version 2.0.0, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2343,7 +2343,7 @@
     },
     {
       "id": "Google.Cloud.Iap.V1",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "type": "grpc",
       "productName": "Cloud Identity-Aware Proxy",
       "productUrl": "https://cloud.google.com/iap/docs/",
@@ -2354,9 +2354,9 @@
         "access"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.2.0",
+        "Google.Api.Gax.Grpc": "4.3.0",
         "Google.Cloud.Iam.V1": "3.0.0",
-        "Grpc.Core": "2.46.3"
+        "Grpc.Core": "2.46.5"
       },
       "generator": "micro",
       "protoPath": "google/cloud/iap/v1",


### PR DESCRIPTION

Changes in this release:

### New features

- Add AllowedDomainSettings to the UpdateIapSettingsRequest ([commit 5b5c678](https://github.com/googleapis/google-cloud-dotnet/commit/5b5c678d67d38c53653a33e981a7f438f1278aa3))
- Add AttributePropagationSettings to the UpdateIapSettingsRequest ([commit 5b5c678](https://github.com/googleapis/google-cloud-dotnet/commit/5b5c678d67d38c53653a33e981a7f438f1278aa3))
- Add remediation_token_generation_enabled to the CsmSettings ([commit 5b5c678](https://github.com/googleapis/google-cloud-dotnet/commit/5b5c678d67d38c53653a33e981a7f438f1278aa3))
