### PR TITLE
Release Google.Cloud.Metastore.V1Alpha version 2.0.0-alpha03

### DIFF
--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.csproj
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha02</Version>
+    <Version>2.0.0-alpha03</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Dataproc Metastore API (v1alpha) which is used to manage the lifecycle and configuration of metastore services.</Description>

--- a/apis/Google.Cloud.Metastore.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.Metastore.V1Alpha/docs/history.md
@@ -1,5 +1,14 @@
 # Version history
 
+## Version 2.0.0-alpha03, released 2023-01-16
+
+### New features
+
+- Added RemoveIamPolicy API ([commit 7844ed8](https://github.com/googleapis/google-cloud-dotnet/commit/7844ed8ed245c704f85d9de72423e8eb6d761a1f))
+- Added QueryMetadata API ([commit 7844ed8](https://github.com/googleapis/google-cloud-dotnet/commit/7844ed8ed245c704f85d9de72423e8eb6d761a1f))
+- Added MoveTableToDatabase API ([commit 7844ed8](https://github.com/googleapis/google-cloud-dotnet/commit/7844ed8ed245c704f85d9de72423e8eb6d761a1f))
+- Added AlterMetadataResourceLocation API ([commit 7844ed8](https://github.com/googleapis/google-cloud-dotnet/commit/7844ed8ed245c704f85d9de72423e8eb6d761a1f))
+
 ## Version 2.0.0-alpha02, released 2022-12-01
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2717,7 +2717,7 @@
     },
     {
       "id": "Google.Cloud.Metastore.V1Alpha",
-      "version": "2.0.0-alpha02",
+      "version": "2.0.0-alpha03",
       "type": "grpc",
       "productName": "Dataproc Metastore",
       "productUrl": "https://cloud.google.com/dataproc-metastore/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Added RemoveIamPolicy API ([commit 7844ed8](https://github.com/googleapis/google-cloud-dotnet/commit/7844ed8ed245c704f85d9de72423e8eb6d761a1f))
- Added QueryMetadata API ([commit 7844ed8](https://github.com/googleapis/google-cloud-dotnet/commit/7844ed8ed245c704f85d9de72423e8eb6d761a1f))
- Added MoveTableToDatabase API ([commit 7844ed8](https://github.com/googleapis/google-cloud-dotnet/commit/7844ed8ed245c704f85d9de72423e8eb6d761a1f))
- Added AlterMetadataResourceLocation API ([commit 7844ed8](https://github.com/googleapis/google-cloud-dotnet/commit/7844ed8ed245c704f85d9de72423e8eb6d761a1f))
