### PR TITLE
Release Google.Cloud.Metastore.V1Beta version 2.0.0-beta03

### DIFF
--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.csproj
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta02</Version>
+    <Version>2.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Dataproc Metastore API (v1beta) which is used to manage the lifecycle and configuration of metastore services.</Description>

--- a/apis/Google.Cloud.Metastore.V1Beta/docs/history.md
+++ b/apis/Google.Cloud.Metastore.V1Beta/docs/history.md
@@ -1,5 +1,18 @@
 # Version history
 
+## Version 2.0.0-beta03, released 2023-01-16
+
+### New features
+
+- Added RemoveIamPolicy API ([commit d87bbd9](https://github.com/googleapis/google-cloud-dotnet/commit/d87bbd98854765b5fe797745a308b7a795ca7fda))
+- Added QueryMetadata API ([commit d87bbd9](https://github.com/googleapis/google-cloud-dotnet/commit/d87bbd98854765b5fe797745a308b7a795ca7fda))
+- Added MoveTableToDatabase API ([commit d87bbd9](https://github.com/googleapis/google-cloud-dotnet/commit/d87bbd98854765b5fe797745a308b7a795ca7fda))
+- Added AlterMetadataResourceLocation API ([commit d87bbd9](https://github.com/googleapis/google-cloud-dotnet/commit/d87bbd98854765b5fe797745a308b7a795ca7fda))
+
+### Documentation improvements
+
+- Fix formatting for subnetwork field pattern ([commit b86e735](https://github.com/googleapis/google-cloud-dotnet/commit/b86e73590f171a4656f4ffca9fda332b50c3315c))
+
 ## Version 2.0.0-beta02, released 2022-12-01
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2739,7 +2739,7 @@
     },
     {
       "id": "Google.Cloud.Metastore.V1Beta",
-      "version": "2.0.0-beta02",
+      "version": "2.0.0-beta03",
       "type": "grpc",
       "productName": "Dataproc Metastore",
       "productUrl": "https://cloud.google.com/dataproc-metastore/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Added RemoveIamPolicy API ([commit d87bbd9](https://github.com/googleapis/google-cloud-dotnet/commit/d87bbd98854765b5fe797745a308b7a795ca7fda))
- Added QueryMetadata API ([commit d87bbd9](https://github.com/googleapis/google-cloud-dotnet/commit/d87bbd98854765b5fe797745a308b7a795ca7fda))
- Added MoveTableToDatabase API ([commit d87bbd9](https://github.com/googleapis/google-cloud-dotnet/commit/d87bbd98854765b5fe797745a308b7a795ca7fda))
- Added AlterMetadataResourceLocation API ([commit d87bbd9](https://github.com/googleapis/google-cloud-dotnet/commit/d87bbd98854765b5fe797745a308b7a795ca7fda))

### Documentation improvements

- Fix formatting for subnetwork field pattern ([commit b86e735](https://github.com/googleapis/google-cloud-dotnet/commit/b86e73590f171a4656f4ffca9fda332b50c3315c))
