### PR TITLE
Release Google.Cloud.Monitoring.V3 version 3.2.0

### DIFF
--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.csproj
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.1.0</Version>
+    <Version>3.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Monitoring API, which manages your Google Cloud Monitoring data and configurations.</Description>
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Monitoring.V3/docs/history.md
+++ b/apis/Google.Cloud.Monitoring.V3/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.2.0, released 2023-01-16
+
+### New features
+
+- Added Snooze API support ([commit e68a83e](https://github.com/googleapis/google-cloud-dotnet/commit/e68a83ef1b5633f4ebe196bbdb0f7efdc5b751c8))
+
 ## Version 3.1.0, released 2022-08-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2765,7 +2765,7 @@
       "protoPath": "google/monitoring/v3",
       "productName": "Google Cloud Monitoring",
       "productUrl": "https://cloud.google.com/monitoring/api/v3/",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Monitoring API, which manages your Google Cloud Monitoring data and configurations.",
       "tags": [
@@ -2773,9 +2773,9 @@
         "Stackdriver"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.2.0",
+        "Google.Api.Gax.Grpc": "4.3.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.3"
+        "Grpc.Core": "2.46.5"
       },
       "shortName": "monitoring",
       "serviceConfigFile": "monitoring.yaml",


### PR DESCRIPTION

Changes in this release:

### New features

- Added Snooze API support ([commit e68a83e](https://github.com/googleapis/google-cloud-dotnet/commit/e68a83ef1b5633f4ebe196bbdb0f7efdc5b751c8))
