### PR TITLE
Release Google.Cloud.Translation.V2 version 3.2.0-beta01

### DIFF
--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.csproj
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.2.0-beta00</Version>
+    <Version>3.2.0-beta01</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Translate v2 API. It wraps the Google.Apis.Translate.v2 client library, making common operations simpler in client code. The Translate API translates text from one language to another.</Description>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Rest" Version="[4.3.0-beta01, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Rest" Version="[4.3.0, 5.0.0)" />
     <PackageReference Include="Google.Apis.Translate.v2" Version="[1.57.0.875, 2.0.0.0)" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Translation.V2/docs/history.md
+++ b/apis/Google.Cloud.Translation.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.2.0-beta01, released 2023-01-16
+
+### New features
+
+- Enable self-signed JWTs for Storage and Translation clients ([commit 10d2787](https://github.com/googleapis/google-cloud-dotnet/commit/10d2787c9963b49199ffdf8d4ed69169142272fb))
+
 ## Version 3.1.0, released 2022-07-25
 
 ## New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4213,11 +4213,11 @@
       "id": "Google.Cloud.Translation.V2",
       "productName": "Google Cloud Translation",
       "productUrl": "https://cloud.google.com/translate/",
-      "version": "3.2.0-beta00",
+      "version": "3.2.0-beta01",
       "type": "rest",
       "description": "Recommended Google client library to access the Translate v2 API. It wraps the Google.Apis.Translate.v2 client library, making common operations simpler in client code. The Translate API translates text from one language to another.",
       "dependencies": {
-        "Google.Api.Gax.Rest": "4.3.0-beta01",
+        "Google.Api.Gax.Rest": "4.3.0",
         "Google.Apis.Translate.v2": "1.57.0.875"
       },
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- Enable self-signed JWTs for Storage and Translation clients ([commit 10d2787](https://github.com/googleapis/google-cloud-dotnet/commit/10d2787c9963b49199ffdf8d4ed69169142272fb))
