### PR TITLE
Release Google.Cloud.VMMigration.V1 version 2.2.0

### DIFF
--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.csproj
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the VM Migration API, which allows you to programmatically migrate workloads.</Description>
@@ -9,10 +9,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.VMMigration.V1/docs/history.md
+++ b/apis/Google.Cloud.VMMigration.V1/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 2.2.0, released 2023-01-16
+
+### New features
+
+- AWS as a source ([commit 8c6bdf0](https://github.com/googleapis/google-cloud-dotnet/commit/8c6bdf05056adb2f6f87045c4209838c00630a76))
+- Cycles history ([commit 8c6bdf0](https://github.com/googleapis/google-cloud-dotnet/commit/8c6bdf05056adb2f6f87045c4209838c00630a76))
+- Cycle\Clone\Cutover steps ([commit 8c6bdf0](https://github.com/googleapis/google-cloud-dotnet/commit/8c6bdf05056adb2f6f87045c4209838c00630a76))
+
 ## Version 2.1.0, released 2022-07-25
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4228,7 +4228,7 @@
     },
     {
       "id": "Google.Cloud.VMMigration.V1",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "type": "grpc",
       "productName": "VM Migration",
       "productUrl": "https://cloud.google.com/migrate/compute-engine/docs/",
@@ -4239,11 +4239,11 @@
         "virtual-machine"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.2.0",
+        "Google.Api.Gax.Grpc": "4.3.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.3"
+        "Grpc.Core": "2.46.5"
       },
       "generator": "micro",
       "protoPath": "google/cloud/vmmigration/v1",


### PR DESCRIPTION

Changes in this release:

### New features

- AWS as a source ([commit 8c6bdf0](https://github.com/googleapis/google-cloud-dotnet/commit/8c6bdf05056adb2f6f87045c4209838c00630a76))
- Cycles history ([commit 8c6bdf0](https://github.com/googleapis/google-cloud-dotnet/commit/8c6bdf05056adb2f6f87045c4209838c00630a76))
- Cycle\Clone\Cutover steps ([commit 8c6bdf0](https://github.com/googleapis/google-cloud-dotnet/commit/8c6bdf05056adb2f6f87045c4209838c00630a76))
