### PR TITLE
chore: Revert address validation release

### DIFF
--- a/apis/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1.csproj
+++ b/apis/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta03</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Maps Address Validation API, which allows developers to verify the accuracy of addresses. Given an address, it returns information about the correctness of the components of the parsed address, a geocode, and a verdict on the deliverability of the parsed address.</Description>

--- a/apis/Google.Maps.AddressValidation.V1/docs/history.md
+++ b/apis/Google.Maps.AddressValidation.V1/docs/history.md
@@ -1,15 +1,5 @@
 # Version history
 
-## Version 1.0.0-beta03, released 2023-01-16
-
-### New features
-
-- Enable REST transport in C# ([commit a6c4606](https://github.com/googleapis/google-cloud-dotnet/commit/a6c46063bd961a9dadc728a780d66de772f28e71))
-
-### Documentation improvements
-
-- Document that PREMISE_PROXIMITY is a valid value for an address granularity ([commit 174a1c0](https://github.com/googleapis/google-cloud-dotnet/commit/174a1c011fc45775ee62172425d46c441dc1feb5))
-
 ## Version 1.0.0-beta02, released 2022-11-10
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4666,7 +4666,7 @@
     },
     {
       "id": "Google.Maps.AddressValidation.V1",
-      "version": "1.0.0-beta03",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Address Validation",
       "productUrl": "https://developers.google.com/maps/documentation/address-validation/requests-validate-address",
@@ -4683,8 +4683,7 @@
       "protoPath": "google/maps/addressvalidation/v1",
       "shortName": "addressvalidation",
       "serviceConfigFile": "addressvalidation_v1.yaml",
-      "restNumericEnums": true,
-      "transport": "grpc+rest"
+      "restNumericEnums": true
     },
     {
       "id": "Google.Maps.Routing.V2",


### PR DESCRIPTION
It looks like this doesn't support the REST transport as-is (smoke test fails).