### PR TITLE
Release Google.Area120.Tables.V1Alpha1 version 2.0.0-alpha02

### DIFF
--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.csproj
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha01</Version>
+    <Version>2.0.0-alpha02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Area 120 Tables API</Description>

--- a/apis/Google.Area120.Tables.V1Alpha1/docs/history.md
+++ b/apis/Google.Area120.Tables.V1Alpha1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.0.0-alpha02, released 2023-01-17
+
+### New features
+
+- Enable REST transport in C# ([commit cdb518c](https://github.com/googleapis/google-cloud-dotnet/commit/cdb518c3524106ea73f0e546557a0180589ca3b0))
+
 ## Version 2.0.0-alpha01, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -68,7 +68,7 @@
     },
     {
       "id": "Google.Area120.Tables.V1Alpha1",
-      "version": "2.0.0-alpha01",
+      "version": "2.0.0-alpha02",
       "type": "grpc",
       "productName": "Google Area 120 Tables",
       "description": "Recommended Google client library to access the Area 120 Tables API",


### PR DESCRIPTION

Changes in this release:

### New features

- Enable REST transport in C# ([commit cdb518c](https://github.com/googleapis/google-cloud-dotnet/commit/cdb518c3524106ea73f0e546557a0180589ca3b0))
