### PR TITLE
Release Google.Cloud.ApigeeRegistry.V1 version 1.0.0-beta04

### DIFF
--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.csproj
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta03</Version>
+    <Version>1.0.0-beta04</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Apigee Registry API which allows teams to upload and share machine-readable descriptions of APIs that are in use and in development.</Description>

--- a/apis/Google.Cloud.ApigeeRegistry.V1/docs/history.md
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta04, released 2023-01-17
+
+### New features
+
+- Enable REST transport in C# ([commit cdb518c](https://github.com/googleapis/google-cloud-dotnet/commit/cdb518c3524106ea73f0e546557a0180589ca3b0))
+
 ## Version 1.0.0-beta03, released 2022-09-05
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -196,7 +196,7 @@
     },
     {
       "id": "Google.Cloud.ApigeeRegistry.V1",
-      "version": "1.0.0-beta03",
+      "version": "1.0.0-beta04",
       "type": "grpc",
       "productName": "Apigee Registry",
       "description": "Recommended Google client library to access the Apigee Registry API which allows teams to upload and share machine-readable descriptions of APIs that are in use and in development.",


### PR DESCRIPTION

Changes in this release:

### New features

- Enable REST transport in C# ([commit cdb518c](https://github.com/googleapis/google-cloud-dotnet/commit/cdb518c3524106ea73f0e546557a0180589ca3b0))
