### PR TITLE
Release Google.Cloud.NetworkSecurity.V1Beta1 version 2.0.0-beta03

### DIFF
--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.csproj
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta02</Version>
+    <Version>2.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Network Security API version v1beta1, which provides security management for Traffic Director.</Description>

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.0.0-beta03, released 2023-01-17
+
+### New features
+
+- Enable REST transport in C# ([commit cdb518c](https://github.com/googleapis/google-cloud-dotnet/commit/cdb518c3524106ea73f0e546557a0180589ca3b0))
+
 ## Version 2.0.0-beta02, released 2022-07-25
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2854,7 +2854,7 @@
     },
     {
       "id": "Google.Cloud.NetworkSecurity.V1Beta1",
-      "version": "2.0.0-beta02",
+      "version": "2.0.0-beta03",
       "type": "grpc",
       "productName": "Network Security",
       "productUrl": "https://cloud.google.com/traffic-director/docs/security-overview",


### PR DESCRIPTION

Changes in this release:

### New features

- Enable REST transport in C# ([commit cdb518c](https://github.com/googleapis/google-cloud-dotnet/commit/cdb518c3524106ea73f0e546557a0180589ca3b0))
