### PR TITLE
Release Google.Cloud.Translate.V3 version 3.1.0

### DIFF
--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.csproj
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0</Version>
+    <Version>3.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Translate v3 API. The Translate API translates text from one language to another.</Description>
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Translate.V3/docs/history.md
+++ b/apis/Google.Cloud.Translate.V3/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 3.1.0, released 2023-01-17
+
+### New features
+
+- Enable REST transport in C# ([commit cdb518c](https://github.com/googleapis/google-cloud-dotnet/commit/cdb518c3524106ea73f0e546557a0180589ca3b0))
+
+### Documentation improvements
+
+- Fix minor docstring formatting ([commit b68a90c](https://github.com/googleapis/google-cloud-dotnet/commit/b68a90c9efa01d58ff7672de43eb770d7223b9f9))
+
 ## Version 3.0.0, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4193,13 +4193,13 @@
       "productUrl": "https://cloud.google.com/translate/",
       "generator": "micro",
       "protoPath": "google/cloud/translate/v3",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Translate v3 API. The Translate API translates text from one language to another.",
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.2.0",
+        "Google.Api.Gax.Grpc": "4.3.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.3"
+        "Grpc.Core": "2.46.5"
       },
       "tags": [
         "Translate",


### PR DESCRIPTION

Changes in this release:

### New features

- Enable REST transport in C# ([commit cdb518c](https://github.com/googleapis/google-cloud-dotnet/commit/cdb518c3524106ea73f0e546557a0180589ca3b0))

### Documentation improvements

- Fix minor docstring formatting ([commit b68a90c](https://github.com/googleapis/google-cloud-dotnet/commit/b68a90c9efa01d58ff7672de43eb770d7223b9f9))
