### PR TITLE
Release Google.Cloud.WebRisk.V1 version 2.2.0

### DIFF
--- a/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.csproj
+++ b/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Web Risk API v1, which lets client applications check URLs against Google's constantly updated lists of unsafe web resources.</Description>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.2.0, 5.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.WebRisk.V1/docs/history.md
+++ b/apis/Google.Cloud.WebRisk.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.2.0, released 2023-01-17
+
+### New features
+
+- Enable REST transport in C# ([commit cdb518c](https://github.com/googleapis/google-cloud-dotnet/commit/cdb518c3524106ea73f0e546557a0180589ca3b0))
+
 ## Version 2.1.0, released 2022-10-17
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4412,7 +4412,7 @@
       "protoPath": "google/cloud/webrisk/v1",
       "productName": "Google Cloud Web Risk",
       "productUrl": "https://cloud.google.com/web-risk/",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Web Risk API v1, which lets client applications check URLs against Google's constantly updated lists of unsafe web resources.",
       "tags": [
@@ -4424,8 +4424,8 @@
         "url"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.2.0",
-        "Grpc.Core": "2.46.3"
+        "Google.Api.Gax.Grpc": "4.3.0",
+        "Grpc.Core": "2.46.5"
       },
       "shortName": "webrisk",
       "serviceConfigFile": "webrisk_v1.yaml",


### PR DESCRIPTION

Changes in this release:

### New features

- Enable REST transport in C# ([commit cdb518c](https://github.com/googleapis/google-cloud-dotnet/commit/cdb518c3524106ea73f0e546557a0180589ca3b0))
