### PR TITLE
Release Google.Cloud.CertificateManager.V1 version 2.2.0

### DIFF
--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.csproj
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Certificate Manager API, which lets you acquire and manage TLS (SSL) certificates for use with Cloud Load Balancing</Description>
@@ -9,9 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.CertificateManager.V1/docs/history.md
+++ b/apis/Google.Cloud.CertificateManager.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.2.0, released 2023-01-18
+
+### New features
+
+- Enable REST transport in C# ([commit 0f8560c](https://github.com/googleapis/google-cloud-dotnet/commit/0f8560c840725bf41bc060c8beecafc7d99f38eb))
+
 ## Version 2.1.0, released 2022-10-06
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1002,7 +1002,7 @@
     },
     {
       "id": "Google.Cloud.CertificateManager.V1",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "type": "grpc",
       "productName": "Certificate Manager",
       "productUrl": "https://cloud.google.com/certificate-manager/docs",
@@ -1013,10 +1013,10 @@
         "certificates"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.2.0",
+        "Google.Api.Gax.Grpc": "4.3.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.3"
+        "Grpc.Core": "2.46.5"
       },
       "generator": "micro",
       "protoPath": "google/cloud/certificatemanager/v1",


### PR DESCRIPTION

Changes in this release:

### New features

- Enable REST transport in C# ([commit 0f8560c](https://github.com/googleapis/google-cloud-dotnet/commit/0f8560c840725bf41bc060c8beecafc7d99f38eb))
