### PR TITLE
Release Google.Cloud.Container.V1 version 3.8.0

### DIFF
--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.7.0</Version>
+    <Version>3.8.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.</Description>

--- a/apis/Google.Cloud.Container.V1/docs/history.md
+++ b/apis/Google.Cloud.Container.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.8.0, released 2023-01-18
+
+### New features
+
+- Add support for viewing the subnet IPv6 CIDR and services IPv6 CIDR assigned to dual stack clusters ([commit f4ea790](https://github.com/googleapis/google-cloud-dotnet/commit/f4ea7907f39cdf76b88453e23809c43f2ab0beb5))
+
 ## Version 3.7.0, released 2023-01-16
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1152,7 +1152,7 @@
       "protoPath": "google/container/v1",
       "productName": "Google Kubernetes Engine",
       "productUrl": "https://cloud.google.com/kubernetes-engine/docs/reference/rest/",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Add support for viewing the subnet IPv6 CIDR and services IPv6 CIDR assigned to dual stack clusters ([commit f4ea790](https://github.com/googleapis/google-cloud-dotnet/commit/f4ea7907f39cdf76b88453e23809c43f2ab0beb5))
