### PR TITLE
Release Google.Cloud.DocumentAI.V1Beta3 version 2.0.0-beta06

### DIFF
--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.csproj
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta05</Version>
+    <Version>2.0.0-beta06</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Document AI API (v1beta3), which is a service to parse structured information from unstructured or semi-structured documents using state-of-the-art Google AI such as natural language, computer vision, translation, and AutoML.</Description>

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/docs/history.md
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.0.0-beta06, released 2023-01-18
+
+### New features
+
+- Exposed GetProcessorType to v1beta3 ([commit a1b1e1a](https://github.com/googleapis/google-cloud-dotnet/commit/a1b1e1a83942009f96189e75df8f8b5c9b6280ff))
+
 ## Version 2.0.0-beta05, released 2023-01-16
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1736,7 +1736,7 @@
     },
     {
       "id": "Google.Cloud.DocumentAI.V1Beta3",
-      "version": "2.0.0-beta05",
+      "version": "2.0.0-beta06",
       "type": "grpc",
       "productName": "Cloud Document AI",
       "productUrl": "https://cloud.google.com/solutions/document-ai",


### PR DESCRIPTION

Changes in this release:

### New features

- Exposed GetProcessorType to v1beta3 ([commit a1b1e1a](https://github.com/googleapis/google-cloud-dotnet/commit/a1b1e1a83942009f96189e75df8f8b5c9b6280ff))
