### PR TITLE
Release Google.Cloud.OrgPolicy.V2 version 2.1.0

### DIFF
--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.csproj
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Organization Policy API (v2), which allows users to configure governance rules on their GCP resources across the Cloud Resource Hierarchy.</Description>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.2.0, 5.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.OrgPolicy.V2/docs/history.md
+++ b/apis/Google.Cloud.OrgPolicy.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.1.0, released 2023-01-18
+
+### New features
+
+- Enable REST transport in C# ([commit 0f8560c](https://github.com/googleapis/google-cloud-dotnet/commit/0f8560c840725bf41bc060c8beecafc7d99f38eb))
+
 ## Version 2.0.0, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2985,7 +2985,7 @@
     },
     {
       "id": "Google.Cloud.OrgPolicy.V2",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "type": "grpc",
       "productName": "Organization Policy",
       "productUrl": "https://cloud.google.com/resource-manager/docs/organization-policy/overview",
@@ -2996,8 +2996,8 @@
         "governance"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.2.0",
-        "Grpc.Core": "2.46.3"
+        "Google.Api.Gax.Grpc": "4.3.0",
+        "Grpc.Core": "2.46.5"
       },
       "generator": "micro",
       "protoPath": "google/cloud/orgpolicy/v2",


### PR DESCRIPTION

Changes in this release:

### New features

- Enable REST transport in C# ([commit 0f8560c](https://github.com/googleapis/google-cloud-dotnet/commit/0f8560c840725bf41bc060c8beecafc7d99f38eb))
