### PR TITLE
Release Google.Cloud.Run.V2 version 2.0.0-beta04

### DIFF
--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/Google.Cloud.Run.V2.csproj
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/Google.Cloud.Run.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta03</Version>
+    <Version>2.0.0-beta04</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Run Admin API (v2)</Description>

--- a/apis/Google.Cloud.Run.V2/docs/history.md
+++ b/apis/Google.Cloud.Run.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.0.0-beta04, released 2023-01-18
+
+### New features
+
+- Enable REST transport in C# ([commit f9ccce7](https://github.com/googleapis/google-cloud-dotnet/commit/f9ccce7aa4e16a8049445724cf57e8e390c66bfc))
+
 ## Version 2.0.0-beta03, released 2022-11-10
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3414,7 +3414,7 @@
     },
     {
       "id": "Google.Cloud.Run.V2",
-      "version": "2.0.0-beta03",
+      "version": "2.0.0-beta04",
       "type": "grpc",
       "productName": "Cloud Run Admin",
       "productUrl": "https://cloud.google.com/run/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Enable REST transport in C# ([commit f9ccce7](https://github.com/googleapis/google-cloud-dotnet/commit/f9ccce7aa4e16a8049445724cf57e8e390c66bfc))
