### PR TITLE
tests: Rollback job's labels test changes from #9552

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/JobsTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/JobsTest.cs
@@ -310,11 +310,9 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
         internal static void VerifyJobLabels(IDictionary<string, string> actual)
         {
             Assert.NotNull(actual);
-            Assert.Equal(3, actual.Count);
+            Assert.Equal(2, actual.Count);
             Assert.Equal("label_value_2", actual["another-label-2"]);
             Assert.Equal("", actual["yet_another_label"]);
-            // Even though we set "one_label" => null, we get back "one_label" => "".
-            Assert.Equal("", actual["one_label"]);
         }
     }
 }


### PR DESCRIPTION
The change has been rollbacked on the backend. In local also I'm seeing the previous behaviour.