### PR TITLE
chore: Remove the hack that was in place for the previous round of releases

### DIFF
--- a/buildrelease.sh
+++ b/buildrelease.sh
@@ -58,9 +58,6 @@ else
   git checkout $commit
 fi
 
-# TODO: Remove this hack after a round of releases
-cp ../toolversions.sh .
-
 # Turn the multi-line output of git tag --points-at into space-separated list of projects
 projects=$(git tag --points-at $commit | sed 's/-.*//g' | awk -vORS=\  '{print $1}' | sed 's/ $//')
 


### PR DESCRIPTION
At some point it *may* be worth looking at times that we've needed something like this, and coming up with more of a framework - but I suspect the reasons vary too much.