### PR TITLE
Release Google.Cloud.Domains.V1Beta1 version 2.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.csproj
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta01</Version>
+    <Version>2.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Domains API v1beta1, which enables management and configuration of domain names.</Description>

--- a/apis/Google.Cloud.Domains.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.Domains.V1Beta1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.0.0-beta02, released 2023-01-19
+
+### New features
+
+- Enable REST transport in C# ([commit 496c8ab](https://github.com/googleapis/google-cloud-dotnet/commit/496c8abe53e80646e5dd5a6d4a2231b11b36969a))
+
 ## Version 2.0.0-beta01, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1783,7 +1783,7 @@
     },
     {
       "id": "Google.Cloud.Domains.V1Beta1",
-      "version": "2.0.0-beta01",
+      "version": "2.0.0-beta02",
       "type": "grpc",
       "productName": "Cloud Domains",
       "productUrl": "https://cloud.google.com/domains/",


### PR DESCRIPTION

Changes in this release:

### New features

- Enable REST transport in C# ([commit 496c8ab](https://github.com/googleapis/google-cloud-dotnet/commit/496c8abe53e80646e5dd5a6d4a2231b11b36969a))
