### PR TITLE
Release Google.Cloud.OrgPolicy.V2 version 2.2.0

### DIFF
--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.csproj
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Organization Policy API (v2), which allows users to configure governance rules on their GCP resources across the Cloud Resource Hierarchy.</Description>

--- a/apis/Google.Cloud.OrgPolicy.V2/docs/history.md
+++ b/apis/Google.Cloud.OrgPolicy.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.2.0, released 2023-01-19
+
+### New features
+
+- Support for OrgPolicy dry runs ([commit edfcb7b](https://github.com/googleapis/google-cloud-dotnet/commit/edfcb7b10fc124d1847e4208a68e7aa9b084c547))
+
 ## Version 2.1.0, released 2023-01-18
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2985,7 +2985,7 @@
     },
     {
       "id": "Google.Cloud.OrgPolicy.V2",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "type": "grpc",
       "productName": "Organization Policy",
       "productUrl": "https://cloud.google.com/resource-manager/docs/organization-policy/overview",


### PR DESCRIPTION

Changes in this release:

### New features

- Support for OrgPolicy dry runs ([commit edfcb7b](https://github.com/googleapis/google-cloud-dotnet/commit/edfcb7b10fc124d1847e4208a68e7aa9b084c547))
