### PR TITLE
Release Google.Cloud.Redis.V1Beta1 version 3.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.csproj
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0-beta01</Version>
+    <Version>3.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to administer Cloud Memorystore for Redis (V1 Beta 1 API).</Description>

--- a/apis/Google.Cloud.Redis.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.Redis.V1Beta1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.0.0-beta02, released 2023-01-19
+
+### New features
+
+- Enable REST transport in C# ([commit e04406f](https://github.com/googleapis/google-cloud-dotnet/commit/e04406fbc8700134ab6955e5244a5f2924a16a0a))
+
 ## Version 3.0.0-beta01, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3332,7 +3332,7 @@
       "protoPath": "google/cloud/redis/v1beta1",
       "productName": "Google Cloud Memorystore for Redis",
       "productUrl": "https://cloud.google.com/memorystore/",
-      "version": "3.0.0-beta01",
+      "version": "3.0.0-beta02",
       "releaseLevelOverride": "preview",
       "type": "grpc",
       "description": "Recommended Google client library to administer Cloud Memorystore for Redis (V1 Beta 1 API).",


### PR DESCRIPTION

Changes in this release:

### New features

- Enable REST transport in C# ([commit e04406f](https://github.com/googleapis/google-cloud-dotnet/commit/e04406fbc8700134ab6955e5244a5f2924a16a0a))
