### PR TITLE
Release Google.Cloud.Speech.V2 version 1.0.0-beta03

### DIFF
--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.csproj
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Speech-to-Text API (v2) which converts audio to text by applying powerful neural network models.</Description>

--- a/apis/Google.Cloud.Speech.V2/docs/history.md
+++ b/apis/Google.Cloud.Speech.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta03, released 2023-01-19
+
+### New features
+
+- Enable REST transport in C# ([commit e04406f](https://github.com/googleapis/google-cloud-dotnet/commit/e04406fbc8700134ab6955e5244a5f2924a16a0a))
+
 ## Version 1.0.0-beta02, released 2022-10-17
 
 ### Documentation improvements

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3929,7 +3929,7 @@
     },
     {
       "id": "Google.Cloud.Speech.V2",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0-beta03",
       "type": "grpc",
       "productName": "Cloud Speech-to-Text",
       "productUrl": "https://cloud.google.com/speech",


### PR DESCRIPTION

Changes in this release:

### New features

- Enable REST transport in C# ([commit e04406f](https://github.com/googleapis/google-cloud-dotnet/commit/e04406fbc8700134ab6955e5244a5f2924a16a0a))
