### PR TITLE
Release Google.Cloud.Talent.V4Beta1 version 3.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.csproj
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0-beta01</Version>
+    <Version>3.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Talent solution API (v4 beta1) which provides the capability to create, read, update, and delete job postings, as well as search jobs based on keywords and filters.</Description>

--- a/apis/Google.Cloud.Talent.V4Beta1/docs/history.md
+++ b/apis/Google.Cloud.Talent.V4Beta1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 3.0.0-beta02, released 2023-01-19
+
+### New features
+
+- Enable REST transport in C# ([commit 6ce3faf](https://github.com/googleapis/google-cloud-dotnet/commit/6ce3faf6f74ea6c63e14ee4c77627a6774fb807f))
+
+### Documentation improvements
+
+- Marking keyword_searchable_job_custom_attributes on the company object as deprecated ([commit b8dc192](https://github.com/googleapis/google-cloud-dotnet/commit/b8dc1922c3c190d26afc1fa2f1ac33424a49ecbd))
+- Marking company_size histogram facet as deprecated ([commit b8dc192](https://github.com/googleapis/google-cloud-dotnet/commit/b8dc1922c3c190d26afc1fa2f1ac33424a49ecbd))
+
 ## Version 3.0.0-beta01, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4022,7 +4022,7 @@
       "protoPath": "google/cloud/talent/v4beta1",
       "productName": "Google Cloud Talent Solution",
       "productUrl": "https://cloud.google.com/talent-solution/",
-      "version": "3.0.0-beta01",
+      "version": "3.0.0-beta02",
       "releaseLevelOverride": "preview",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Talent solution API (v4 beta1) which provides the capability to create, read, update, and delete job postings, as well as search jobs based on keywords and filters.",


### PR DESCRIPTION

Changes in this release:

### New features

- Enable REST transport in C# ([commit 6ce3faf](https://github.com/googleapis/google-cloud-dotnet/commit/6ce3faf6f74ea6c63e14ee4c77627a6774fb807f))

### Documentation improvements

- Marking keyword_searchable_job_custom_attributes on the company object as deprecated ([commit b8dc192](https://github.com/googleapis/google-cloud-dotnet/commit/b8dc1922c3c190d26afc1fa2f1ac33424a49ecbd))
- Marking company_size histogram facet as deprecated ([commit b8dc192](https://github.com/googleapis/google-cloud-dotnet/commit/b8dc1922c3c190d26afc1fa2f1ac33424a49ecbd))
