### PR TITLE
Release Google.Cloud.VmwareEngine.V1 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.csproj
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google VMware Engine API, which lets you programmatically manage VMware environments.</Description>

--- a/apis/Google.Cloud.VmwareEngine.V1/docs/history.md
+++ b/apis/Google.Cloud.VmwareEngine.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2023-01-19
+
+### New features
+
+- Enable REST transport in C# ([commit 6ce3faf](https://github.com/googleapis/google-cloud-dotnet/commit/6ce3faf6f74ea6c63e14ee4c77627a6774fb807f))
+
+### Documentation improvements
+
+- Update location in docstrings to use `us-central1` ([commit 3ec2110](https://github.com/googleapis/google-cloud-dotnet/commit/3ec2110e9600ef474d2939749d3981f4eb13e40b))
+
 ## Version 1.0.0-beta01, released 2022-12-08
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4365,7 +4365,7 @@
     },
     {
       "id": "Google.Cloud.VmwareEngine.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "VMware Engine",
       "productUrl": "https://cloud.google.com/vmware-engine/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Enable REST transport in C# ([commit 6ce3faf](https://github.com/googleapis/google-cloud-dotnet/commit/6ce3faf6f74ea6c63e14ee4c77627a6774fb807f))

### Documentation improvements

- Update location in docstrings to use `us-central1` ([commit 3ec2110](https://github.com/googleapis/google-cloud-dotnet/commit/3ec2110e9600ef474d2939749d3981f4eb13e40b))
