### PR TITLE
Release Google.Cloud.CloudBuild.V1 version 2.2.0

### DIFF
--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.csproj
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Build API, which creates and manages builds on Google Cloud Platform.</Description>
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.CloudBuild.V1/docs/history.md
+++ b/apis/Google.Cloud.CloudBuild.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.2.0, released 2023-01-19
+
+### New features
+
+- Enable REST transport in C# ([commit 31e55cd](https://github.com/googleapis/google-cloud-dotnet/commit/31e55cdbafe12bfae68e28a75a1b75ceb445684f))
+
 ## Version 2.1.0, released 2022-11-02
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1071,7 +1071,7 @@
     },
     {
       "id": "Google.Cloud.CloudBuild.V1",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "type": "grpc",
       "productName": "Cloud Build",
       "productUrl": "https://cloud.google.com/cloud-build",
@@ -1081,9 +1081,9 @@
         "cloudbuild"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.2.0",
+        "Google.Api.Gax.Grpc": "4.3.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.3"
+        "Grpc.Core": "2.46.5"
       },
       "generator": "micro",
       "protoPath": "google/devtools/cloudbuild/v1",


### PR DESCRIPTION

Changes in this release:

### New features

- Enable REST transport in C# ([commit 31e55cd](https://github.com/googleapis/google-cloud-dotnet/commit/31e55cdbafe12bfae68e28a75a1b75ceb445684f))
