### PR TITLE
Release Google.Cloud.RecommendationEngine.V1Beta1 version 2.0.0-beta03

### DIFF
--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.csproj
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta02</Version>
+    <Version>2.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library for the Recommendations AI service, which enables customers to build end-to-end personalized recommendation systems without requiring a high level of expertise in machine learning, recommendation system, or Google Cloud.</Description>

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 2.0.0-beta03, released 2023-01-19
+
+### New features
+
+- Enable REST transport in C# ([commit 31e55cd](https://github.com/googleapis/google-cloud-dotnet/commit/31e55cdbafe12bfae68e28a75a1b75ceb445684f))
+
+### Documentation improvements
+
+- Fix minor docstring formatting ([commit fda6528](https://github.com/googleapis/google-cloud-dotnet/commit/fda6528eb5dfdfa5b99238fd21a85ec660efde14))
+
 ## Version 2.0.0-beta02, released 2022-09-15
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3346,7 +3346,7 @@
     },
     {
       "id": "Google.Cloud.RecommendationEngine.V1Beta1",
-      "version": "2.0.0-beta02",
+      "version": "2.0.0-beta03",
       "type": "grpc",
       "productName": "Recommendations AI",
       "productUrl": "https://cloud.google.com/recommendations",


### PR DESCRIPTION

Changes in this release:

### New features

- Enable REST transport in C# ([commit 31e55cd](https://github.com/googleapis/google-cloud-dotnet/commit/31e55cdbafe12bfae68e28a75a1b75ceb445684f))

### Documentation improvements

- Fix minor docstring formatting ([commit fda6528](https://github.com/googleapis/google-cloud-dotnet/commit/fda6528eb5dfdfa5b99238fd21a85ec660efde14))
