### PR TITLE
Release Google.Cloud.Security.PublicCA.V1Beta1 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.Security.PublicCA.V1Beta1/Google.Cloud.Security.PublicCA.V1Beta1/Google.Cloud.Security.PublicCA.V1Beta1.csproj
+++ b/apis/Google.Cloud.Security.PublicCA.V1Beta1/Google.Cloud.Security.PublicCA.V1Beta1/Google.Cloud.Security.PublicCA.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Public Certificate Authority API, which may be used to create and manage ACME external account binding keys associated with Google Trust Services' publicly trusted certificate authority.</Description>

--- a/apis/Google.Cloud.Security.PublicCA.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.Security.PublicCA.V1Beta1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2023-01-19
+
+### New features
+
+- Enable REST transport in C# ([commit f6a1c3e](https://github.com/googleapis/google-cloud-dotnet/commit/f6a1c3e8930f0e8209a079352765be3bb9039be2))
+
 ## Version 1.0.0-beta01, released 2022-09-16
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3641,7 +3641,7 @@
     },
     {
       "id": "Google.Cloud.Security.PublicCA.V1Beta1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Public Certificate Authority",
       "productUrl": "cloud.google.com/certificate-manager/docs/public-ca/",


### PR DESCRIPTION

Changes in this release:

### New features

- Enable REST transport in C# ([commit f6a1c3e](https://github.com/googleapis/google-cloud-dotnet/commit/f6a1c3e8930f0e8209a079352765be3bb9039be2))
