### PR TITLE
Release Google.Cloud.Compute.V1 version 2.6.0

### DIFF
--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.5.0</Version>
+    <Version>2.6.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Compute Engine API.</Description>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Compute.V1/docs/history.md
+++ b/apis/Google.Cloud.Compute.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.6.0, released 2023-01-20
+
+### New features
+
+- Update Compute Engine API to revision 20221224 ([issue 760](https://github.com/googleapis/google-cloud-dotnet/issues/760)) ([commit 5889030](https://github.com/googleapis/google-cloud-dotnet/commit/58890304e5fbda3f09289695aa356a9d3adc27d2))
+
 ## Version 2.5.0, released 2022-12-14
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1129,7 +1129,7 @@
     },
     {
       "id": "Google.Cloud.Compute.V1",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "type": "regapic",
       "productName": "Compute Engine",
       "productUrl": "https://cloud.google.com/compute",
@@ -1138,7 +1138,7 @@
         "compute"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.2.0",
+        "Google.Api.Gax.Grpc": "4.3.0",
         "Google.LongRunning": "3.0.0"
       },
       "generator": "micro",


### PR DESCRIPTION

Changes in this release:

### New features

- Update Compute Engine API to revision 20221224 ([issue 760](https://github.com/googleapis/google-cloud-dotnet/issues/760)) ([commit 5889030](https://github.com/googleapis/google-cloud-dotnet/commit/58890304e5fbda3f09289695aa356a9d3adc27d2))
