### PR TITLE
Release Google.Cloud.Dialogflow.V2Beta1 version 1.0.0-beta04

### DIFF
--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.csproj
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta03</Version>
+    <Version>1.0.0-beta04</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Dialogflow API (v2beta1).</Description>

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/docs/history.md
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta04, released 2023-01-20
+
+### New features
+
+- Enable REST transport ([commit 46d4fe8](https://github.com/googleapis/google-cloud-dotnet/commit/46d4fe8461ac30e7666600e44e7bd16228768621))
+
 ## Version 1.0.0-beta03, released 2022-12-14
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1683,7 +1683,7 @@
     },
     {
       "id": "Google.Cloud.Dialogflow.V2Beta1",
-      "version": "1.0.0-beta03",
+      "version": "1.0.0-beta04",
       "type": "grpc",
       "productName": "Google Cloud Dialogflow",
       "productUrl": "https://cloud.google.com/dialogflow-enterprise/",


### PR DESCRIPTION

Changes in this release:

### New features

- Enable REST transport ([commit 46d4fe8](https://github.com/googleapis/google-cloud-dotnet/commit/46d4fe8461ac30e7666600e44e7bd16228768621))
