### PR TITLE
Release Google.Cloud.Run.V2 version 2.0.0-beta05

### DIFF
--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/Google.Cloud.Run.V2.csproj
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/Google.Cloud.Run.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta04</Version>
+    <Version>2.0.0-beta05</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Run Admin API (v2)</Description>

--- a/apis/Google.Cloud.Run.V2/docs/history.md
+++ b/apis/Google.Cloud.Run.V2/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 2.0.0-beta05, released 2023-01-20
+
+### New features
+
+- Adding support for encryption_key_revocation_action and encryption_key_shutdown_duration for RevisionTemplate and ExecutionTemplate ([commit 1ba9bc3](https://github.com/googleapis/google-cloud-dotnet/commit/1ba9bc37c06b483268f38acedd0e71f1f9d494f4))
+
+### Documentation improvements
+
+- Documentation improvements, including clarification that v1 labels/annotations are rejected in v2 API ([commit 1ba9bc3](https://github.com/googleapis/google-cloud-dotnet/commit/1ba9bc37c06b483268f38acedd0e71f1f9d494f4))
+
 ## Version 2.0.0-beta04, released 2023-01-18
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3501,7 +3501,7 @@
     },
     {
       "id": "Google.Cloud.Run.V2",
-      "version": "2.0.0-beta04",
+      "version": "2.0.0-beta05",
       "type": "grpc",
       "productName": "Cloud Run Admin",
       "productUrl": "https://cloud.google.com/run/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Adding support for encryption_key_revocation_action and encryption_key_shutdown_duration for RevisionTemplate and ExecutionTemplate ([commit 1ba9bc3](https://github.com/googleapis/google-cloud-dotnet/commit/1ba9bc37c06b483268f38acedd0e71f1f9d494f4))

### Documentation improvements

- Documentation improvements, including clarification that v1 labels/annotations are rejected in v2 API ([commit 1ba9bc3](https://github.com/googleapis/google-cloud-dotnet/commit/1ba9bc37c06b483268f38acedd0e71f1f9d494f4))
