### PR TITLE
Release Google.Cloud.Talent.V4 version 2.2.0

### DIFF
--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.csproj
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Talent solution API (v4) which provides the capability to create, read, update, and delete job postings, as well as search jobs based on keywords and filters.</Description>
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Talent.V4/docs/history.md
+++ b/apis/Google.Cloud.Talent.V4/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 2.2.0, released 2023-01-20
+
+### New features
+
+- Enable REST transport ([commit 46d4fe8](https://github.com/googleapis/google-cloud-dotnet/commit/46d4fe8461ac30e7666600e44e7bd16228768621))
+
+### Documentation improvements
+
+- Marking keyword_searchable_job_custom_attributes on the company object as deprecated ([commit 30e9c09](https://github.com/googleapis/google-cloud-dotnet/commit/30e9c09203c5238c48dffcdc7742504428234bfe))
+- Marking company_size histogram facet as deprecated ([commit 30e9c09](https://github.com/googleapis/google-cloud-dotnet/commit/30e9c09203c5238c48dffcdc7742504428234bfe))
+
 ## Version 2.1.0, released 2022-09-15
 
 No API surface changes, just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4099,7 +4099,7 @@
     },
     {
       "id": "Google.Cloud.Talent.V4",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "type": "grpc",
       "productName": "Google Cloud Talent Solution",
       "productUrl": "https://cloud.google.com/talent-solution/",
@@ -4109,9 +4109,9 @@
         "Jobs"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.2.0",
+        "Google.Api.Gax.Grpc": "4.3.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.3"
+        "Grpc.Core": "2.46.5"
       },
       "generator": "micro",
       "protoPath": "google/cloud/talent/v4",


### PR DESCRIPTION

Changes in this release:

### New features

- Enable REST transport ([commit 46d4fe8](https://github.com/googleapis/google-cloud-dotnet/commit/46d4fe8461ac30e7666600e44e7bd16228768621))

### Documentation improvements

- Marking keyword_searchable_job_custom_attributes on the company object as deprecated ([commit 30e9c09](https://github.com/googleapis/google-cloud-dotnet/commit/30e9c09203c5238c48dffcdc7742504428234bfe))
- Marking company_size histogram facet as deprecated ([commit 30e9c09](https://github.com/googleapis/google-cloud-dotnet/commit/30e9c09203c5238c48dffcdc7742504428234bfe))
