### PR TITLE
Release Google.Maps.AddressValidation.V1 version 1.0.0-beta03

### DIFF
--- a/apis/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1.csproj
+++ b/apis/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Maps Address Validation API, which allows developers to verify the accuracy of addresses. Given an address, it returns information about the correctness of the components of the parsed address, a geocode, and a verdict on the deliverability of the parsed address.</Description>

--- a/apis/Google.Maps.AddressValidation.V1/docs/history.md
+++ b/apis/Google.Maps.AddressValidation.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta03, released 2023-01-20
+
+### Documentation improvements
+
+- Document that PREMISE_PROXIMITY is a valid value for an address granularity ([commit 174a1c0](https://github.com/googleapis/google-cloud-dotnet/commit/174a1c011fc45775ee62172425d46c441dc1feb5))
+
 ## Version 1.0.0-beta02, released 2022-11-10
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4788,7 +4788,7 @@
     },
     {
       "id": "Google.Maps.AddressValidation.V1",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0-beta03",
       "type": "grpc",
       "productName": "Address Validation",
       "productUrl": "https://developers.google.com/maps/documentation/address-validation/requests-validate-address",


### PR DESCRIPTION

Changes in this release:

### Documentation improvements

- Document that PREMISE_PROXIMITY is a valid value for an address granularity ([commit 174a1c0](https://github.com/googleapis/google-cloud-dotnet/commit/174a1c011fc45775ee62172425d46c441dc1feb5))
