### PR TITLE
Release Google.Cloud.Storage.V1 version 4.2.0

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/Google.Cloud.Storage.V1.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/Google.Cloud.Storage.V1.IntegrationTests.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.3.0, 5.0.0)" />
     <PackageReference Include="Google.Apis.Iam.v1" Version="[1.57.0.2702, 2.0.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\..\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1.csproj" />

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Snippets/Google.Cloud.Storage.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Snippets/Google.Cloud.Storage.V1.Snippets.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.3.0, 5.0.0)" />
     <PackageReference Include="Google.Apis.Iam.v1" Version="[1.57.0.2702, 2.0.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\..\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1.csproj" />

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/Google.Cloud.Storage.V1.Tests.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/Google.Cloud.Storage.V1.Tests.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.3.0, 5.0.0)" />
     <PackageReference Include="Google.Apis.Iam.v1" Version="[1.57.0.2702, 2.0.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\..\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1.csproj" />

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.2.0-beta00</Version>
+    <Version>4.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Storage API. It wraps the Google.Apis.Storage.v1 client library, making common operations simpler in client code. Google Cloud Storage stores and retrieves potentially large, immutable data objects.</Description>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Rest" Version="[4.3.0-beta01, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Rest" Version="[4.3.0, 5.0.0)" />
     <PackageReference Include="Google.Apis.Storage.v1" Version="[1.59.0.2742, 2.0.0.0)" />
   </ItemGroup>
   <ItemGroup>

--- a/apis/Google.Cloud.Storage.V1/docs/history.md
+++ b/apis/Google.Cloud.Storage.V1/docs/history.md
@@ -1,5 +1,20 @@
 # Version history
 
+## Version 4.2.0, released 2023-01-23
+
+### New features
+
+- Improve credential support for URL signing. ([commit d36a8dd](https://github.com/googleapis/google-cloud-dotnet/commit/d36a8dd4f3ccd91b70f4a454dfa7f1dd4317308b))
+- Add DownloadValidationMode.Automatic ([commit c9f2b19](https://github.com/googleapis/google-cloud-dotnet/commit/c9f2b19c2e624771df497a969a5b60d37c1bfec5))
+- Support HMAC URL signing. ([commit dfad68e](https://github.com/googleapis/google-cloud-dotnet/commit/dfad68e47ed7a72c9ef97b5676c59adec2f87aa2))
+- Enable self-signed JWTs for Storage and Translation clients ([commit 10d2787](https://github.com/googleapis/google-cloud-dotnet/commit/10d2787c9963b49199ffdf8d4ed69169142272fb))
+- Add invocation ID and attempt count in x-goog-api-client header. Fixes [issue 8881](https://github.com/googleapis/google-cloud-dotnet/issues/8881) ([commit 1ac6f68](https://github.com/googleapis/google-cloud-dotnet/commit/1ac6f6812d829081c096e3ae5da0de7972feb368))
+- Disabled default ExponentialBackOffPolicy in message handler via StorageClientBuilder ([commit 62aec51](https://github.com/googleapis/google-cloud-dotnet/commit/62aec51d17922857f260f32a9dc17099062c47a0))
+
+### Documentation improvements
+
+- Add commentary on accidentally-optional parameters ([commit 228bdfc](https://github.com/googleapis/google-cloud-dotnet/commit/228bdfcb90b62b40cf68591ee2c7b468964adcfa))
+
 ## Version 4.1.0, released 2022-07-22
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4055,15 +4055,15 @@
       "id": "Google.Cloud.Storage.V1",
       "productName": "Google Cloud Storage",
       "productUrl": "https://cloud.google.com/storage/",
-      "version": "4.2.0-beta00",
+      "version": "4.2.0",
       "type": "rest",
       "description": "Recommended Google client library to access the Google Cloud Storage API. It wraps the Google.Apis.Storage.v1 client library, making common operations simpler in client code. Google Cloud Storage stores and retrieves potentially large, immutable data objects.",
       "dependencies": {
-        "Google.Api.Gax.Rest": "4.3.0-beta01",
+        "Google.Api.Gax.Rest": "4.3.0",
         "Google.Apis.Storage.v1": "1.59.0.2742"
       },
       "testDependencies": {
-        "Google.Api.Gax.Testing": "4.2.0",
+        "Google.Api.Gax.Testing": "4.3.0",
         "Google.Apis.Iam.v1": "1.57.0.2702",
         "Google.Cloud.PubSub.V1": "project"
       },


### PR DESCRIPTION

Changes in this release:

### New features

- Improve credential support for URL signing. ([commit d36a8dd](https://github.com/googleapis/google-cloud-dotnet/commit/d36a8dd4f3ccd91b70f4a454dfa7f1dd4317308b))
- Add DownloadValidationMode.Automatic ([commit c9f2b19](https://github.com/googleapis/google-cloud-dotnet/commit/c9f2b19c2e624771df497a969a5b60d37c1bfec5))
- Support HMAC URL signing. ([commit dfad68e](https://github.com/googleapis/google-cloud-dotnet/commit/dfad68e47ed7a72c9ef97b5676c59adec2f87aa2))
- Enable self-signed JWTs for Storage and Translation clients ([commit 10d2787](https://github.com/googleapis/google-cloud-dotnet/commit/10d2787c9963b49199ffdf8d4ed69169142272fb))
- Add invocation ID and attempt count in x-goog-api-client header. Fixes [issue 8881](https://github.com/googleapis/google-cloud-dotnet/issues/8881) ([commit 1ac6f68](https://github.com/googleapis/google-cloud-dotnet/commit/1ac6f6812d829081c096e3ae5da0de7972feb368))
- Disabled default ExponentialBackOffPolicy in message handler via StorageClientBuilder ([commit 62aec51](https://github.com/googleapis/google-cloud-dotnet/commit/62aec51d17922857f260f32a9dc17099062c47a0))

### Documentation improvements

- Add commentary on accidentally-optional parameters ([commit 228bdfc](https://github.com/googleapis/google-cloud-dotnet/commit/228bdfcb90b62b40cf68591ee2c7b468964adcfa))
