### PR TITLE
Release Google.Cloud.NetworkConnectivity.V1 version 2.2.0

### DIFF
--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.csproj
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Network Connectivity API, which provides access to Network Connectivity Center.</Description>
@@ -9,10 +9,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.NetworkConnectivity.V1/docs/history.md
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 2.2.0, released 2023-01-25
+
+BREAKING CHANGE: This release removes some API aspects that were
+accidentally included earlier, but which were access-checked
+server-side. These RPCs would never have worked for customers, and
+the package has low usage, so we're performing a *minor* version
+bump on this occasion.
 ## Version 2.1.0, released 2022-11-02
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2849,7 +2849,7 @@
     },
     {
       "id": "Google.Cloud.NetworkConnectivity.V1",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "type": "grpc",
       "productName": "Network Connectivity",
       "productUrl": "https://cloud.google.com/network-connectivity/docs/",
@@ -2860,11 +2860,11 @@
         "vpc"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.2.0",
+        "Google.Api.Gax.Grpc": "4.3.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.3"
+        "Grpc.Core": "2.46.5"
       },
       "generator": "micro",
       "protoPath": "google/cloud/networkconnectivity/v1",


### PR DESCRIPTION

Changes in this release:

BREAKING CHANGE: This release removes some API aspects that were accidentally included earlier, but which were access-checked server-side. These RPCs would never have worked for customers, and the package has low usage, so we're performing a *minor* version bump on this occasion.
