### PR TITLE
Release Google.Cloud.Trace.V2 version 3.3.0

### DIFF
--- a/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.csproj
+++ b/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.2.0</Version>
+    <Version>3.3.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Trace V2 API, which sends and retrieves trace data from Google Cloud Trace. Data is generated and available by default for all App Engine applications. Data from other applications can be written to Cloud Trace for display, reporting, and analysis.</Description>

--- a/apis/Google.Cloud.Trace.V2/docs/history.md
+++ b/apis/Google.Cloud.Trace.V2/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 3.3.0, released 2023-01-25
+
+### New features
+
+- Add Cloud Trace v2 retry defaults for BatchWriteSpans ([commit be4bdf1](https://github.com/googleapis/google-cloud-dotnet/commit/be4bdf14bdb2dbfeff2eb3a747c07c1b952a3ec5))
+
+### Documentation improvements
+
+- Remove html formatting (cleanup) ([commit 8b31e3d](https://github.com/googleapis/google-cloud-dotnet/commit/8b31e3d4fe7aaf88e25aa933a66586d22b088e03))
+
 ## Version 3.2.0, released 2023-01-19
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4280,7 +4280,7 @@
       "protoPath": "google/devtools/cloudtrace/v2",
       "productName": "Google Cloud Trace",
       "productUrl": "https://cloud.google.com/trace/",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Trace V2 API, which sends and retrieves trace data from Google Cloud Trace. Data is generated and available by default for all App Engine applications. Data from other applications can be written to Cloud Trace for display, reporting, and analysis.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Add Cloud Trace v2 retry defaults for BatchWriteSpans ([commit be4bdf1](https://github.com/googleapis/google-cloud-dotnet/commit/be4bdf14bdb2dbfeff2eb3a747c07c1b952a3ec5))

### Documentation improvements

- Remove html formatting (cleanup) ([commit 8b31e3d](https://github.com/googleapis/google-cloud-dotnet/commit/8b31e3d4fe7aaf88e25aa933a66586d22b088e03))
