### PR TITLE
chore: Temporarily skip smoke tests for Google.Cloud.Security.PrivateCA.V1Beta1

### DIFF
--- a/apis/Google.Cloud.Security.PrivateCA.V1Beta1/smoketests.json
+++ b/apis/Google.Cloud.Security.PrivateCA.V1Beta1/smoketests.json
@@ -2,6 +2,7 @@
   {
     "method": "ListReusableConfigs",
     "client": "CertificateAuthorityServiceClient",
+    "skip": "https://github.com/googleapis/google-cloud-dotnet/issues/9833",
     "arguments": {
       "parent": "projects/${PROJECT_ID}/locations/us-east1"
     }
@@ -9,6 +10,7 @@
   {
     "method": "ListCertificateAuthorities",
     "client": "CertificateAuthorityServiceClient",
+    "skip": "https://github.com/googleapis/google-cloud-dotnet/issues/9833",
     "arguments": {
       "parent": "projects/${PROJECT_ID}/locations/us-east1"
     }


### PR DESCRIPTION
Fixes integration tests while we investigate #9833