### PR TITLE
Release Google.Analytics.Admin.V1Alpha version 2.0.0-alpha05

### DIFF
--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha04</Version>
+    <Version>2.0.0-alpha05</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Analytics Admin API (v1alpha)</Description>

--- a/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
+++ b/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
@@ -1,5 +1,22 @@
 # Version history
 
+## Version 2.0.0-alpha05, released 2023-02-08
+
+### Bug fixes
+
+- **BREAKING CHANGE** Remove `LESS_THAN_OR_EQUAL`, `GREATER_THAN_OR_EQUAL` values from NumericFilter.Operation enum ([commit 8f3fc34](https://github.com/googleapis/google-cloud-dotnet/commit/8f3fc3433185ee3f9b0f79f4c295b923e6796c1c))
+- **BREAKING CHANGE** Remove `PARTIAL_REGEXP` value from StringFilter.MatchType enum ([commit 8f3fc34](https://github.com/googleapis/google-cloud-dotnet/commit/8f3fc3433185ee3f9b0f79f4c295b923e6796c1c))
+
+### New features
+
+- Add `GetSearchAds360Link`, `ListSearchAds360Links`, `CreateSearchAds360Link`, `DeleteSearchAds360Link`, `UpdateSearchAds360Link` methods to the Admin API v1alpha ([commit 8f3fc34](https://github.com/googleapis/google-cloud-dotnet/commit/8f3fc3433185ee3f9b0f79f4c295b923e6796c1c))
+- Add `SetAutomatedGa4ConfigurationOptOut`, `FetchAutomatedGa4ConfigurationOptOut` methods to the Admin API v1alpha ([commit 8f3fc34](https://github.com/googleapis/google-cloud-dotnet/commit/8f3fc3433185ee3f9b0f79f4c295b923e6796c1c))
+- Add `GetBigQueryLink`, `ListBigQueryLinks` methods to the Admin API v1alpha ([commit 8f3fc34](https://github.com/googleapis/google-cloud-dotnet/commit/8f3fc3433185ee3f9b0f79f4c295b923e6796c1c))
+- Add `tokens_per_project_per_hour` field to `AccessQuota` type ([commit 8f3fc34](https://github.com/googleapis/google-cloud-dotnet/commit/8f3fc3433185ee3f9b0f79f4c295b923e6796c1c))
+- Add `EXPANDED_DATA_SET`, `CHANNEL_GROUP` values to `ChangeHistoryResourceType` enum ([commit 8f3fc34](https://github.com/googleapis/google-cloud-dotnet/commit/8f3fc3433185ee3f9b0f79f4c295b923e6796c1c))
+- Add `search_ads_360_link`, `expanded_data_set`, `bigquery_link` values to ChangeHistoryResource.resource oneof field ([commit 8f3fc34](https://github.com/googleapis/google-cloud-dotnet/commit/8f3fc3433185ee3f9b0f79f4c295b923e6796c1c))
+- Add `BigQueryLink`, `SearchAds360Link` resource types to the Admin API v1alpha ([commit 8f3fc34](https://github.com/googleapis/google-cloud-dotnet/commit/8f3fc3433185ee3f9b0f79f4c295b923e6796c1c))
+
 ## Version 2.0.0-alpha04, released 2023-01-19
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2,7 +2,7 @@
   "apis": [
     {
       "id": "Google.Analytics.Admin.V1Alpha",
-      "version": "2.0.0-alpha04",
+      "version": "2.0.0-alpha05",
       "type": "grpc",
       "productName": "Analytics Admin",
       "productUrl": "https://developers.google.com/analytics",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- **BREAKING CHANGE** Remove `LESS_THAN_OR_EQUAL`, `GREATER_THAN_OR_EQUAL` values from NumericFilter.Operation enum ([commit 8f3fc34](https://github.com/googleapis/google-cloud-dotnet/commit/8f3fc3433185ee3f9b0f79f4c295b923e6796c1c))
- **BREAKING CHANGE** Remove `PARTIAL_REGEXP` value from StringFilter.MatchType enum ([commit 8f3fc34](https://github.com/googleapis/google-cloud-dotnet/commit/8f3fc3433185ee3f9b0f79f4c295b923e6796c1c))

### New features

- Add `GetSearchAds360Link`, `ListSearchAds360Links`, `CreateSearchAds360Link`, `DeleteSearchAds360Link`, `UpdateSearchAds360Link` methods to the Admin API v1alpha ([commit 8f3fc34](https://github.com/googleapis/google-cloud-dotnet/commit/8f3fc3433185ee3f9b0f79f4c295b923e6796c1c))
- Add `SetAutomatedGa4ConfigurationOptOut`, `FetchAutomatedGa4ConfigurationOptOut` methods to the Admin API v1alpha ([commit 8f3fc34](https://github.com/googleapis/google-cloud-dotnet/commit/8f3fc3433185ee3f9b0f79f4c295b923e6796c1c))
- Add `GetBigQueryLink`, `ListBigQueryLinks` methods to the Admin API v1alpha ([commit 8f3fc34](https://github.com/googleapis/google-cloud-dotnet/commit/8f3fc3433185ee3f9b0f79f4c295b923e6796c1c))
- Add `tokens_per_project_per_hour` field to `AccessQuota` type ([commit 8f3fc34](https://github.com/googleapis/google-cloud-dotnet/commit/8f3fc3433185ee3f9b0f79f4c295b923e6796c1c))
- Add `EXPANDED_DATA_SET`, `CHANNEL_GROUP` values to `ChangeHistoryResourceType` enum ([commit 8f3fc34](https://github.com/googleapis/google-cloud-dotnet/commit/8f3fc3433185ee3f9b0f79f4c295b923e6796c1c))
- Add `search_ads_360_link`, `expanded_data_set`, `bigquery_link` values to ChangeHistoryResource.resource oneof field ([commit 8f3fc34](https://github.com/googleapis/google-cloud-dotnet/commit/8f3fc3433185ee3f9b0f79f4c295b923e6796c1c))
- Add `BigQueryLink`, `SearchAds360Link` resource types to the Admin API v1alpha ([commit 8f3fc34](https://github.com/googleapis/google-cloud-dotnet/commit/8f3fc3433185ee3f9b0f79f4c295b923e6796c1c))
