### PR TITLE
Release Google.Cloud.AIPlatform.V1 version 2.10.0

### DIFF
--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.9.0</Version>
+    <Version>2.10.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AI Platform API, which allows you to train high-quality custom machine learning models with minimal machine learning expertise and effort.</Description>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />

--- a/apis/Google.Cloud.AIPlatform.V1/docs/history.md
+++ b/apis/Google.Cloud.AIPlatform.V1/docs/history.md
@@ -1,5 +1,18 @@
 # Version history
 
+## Version 2.10.0, released 2023-02-08
+
+### New features
+
+- Add service_networking.proto to aiplatform v1 ([commit 189dffe](https://github.com/googleapis/google-cloud-dotnet/commit/189dffeda7937d84a4397f89621157711b7b2b03))
+- Add private_service_connect_config to IndexEndpoint in aiplatform v1 index_endpoint.proto ([commit 189dffe](https://github.com/googleapis/google-cloud-dotnet/commit/189dffeda7937d84a4397f89621157711b7b2b03))
+- Add nas_job.proto to aiplatform v1 ([commit 189dffe](https://github.com/googleapis/google-cloud-dotnet/commit/189dffeda7937d84a4397f89621157711b7b2b03))
+- Add CreateNasJob, GetNasJob, ListNasJobs, DeleteNasJob, CancelNasJob, GetNasTrialDetail, ListNasTrialDetails RPCs to aiplatform v1 job_service.proto ([commit 189dffe](https://github.com/googleapis/google-cloud-dotnet/commit/189dffeda7937d84a4397f89621157711b7b2b03))
+- Add original_model_info to Model in aiplatform v1 model.proto ([commit 189dffe](https://github.com/googleapis/google-cloud-dotnet/commit/189dffeda7937d84a4397f89621157711b7b2b03))
+- Add CopyModel RPC to aiplatform v1 model_service.proto ([commit 189dffe](https://github.com/googleapis/google-cloud-dotnet/commit/189dffeda7937d84a4397f89621157711b7b2b03))
+- Add failed_jobs to CustomJobDetail to aiplatform v1 pipeline_job.proto ([commit 189dffe](https://github.com/googleapis/google-cloud-dotnet/commit/189dffeda7937d84a4397f89621157711b7b2b03))
+- Add safety_config to StudySpec in aiplatform v1 study.proto ([commit 189dffe](https://github.com/googleapis/google-cloud-dotnet/commit/189dffeda7937d84a4397f89621157711b7b2b03))
+
 ## Version 2.9.0, released 2023-01-18
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -133,7 +133,7 @@
     },
     {
       "id": "Google.Cloud.AIPlatform.V1",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "type": "grpc",
       "productName": "Cloud AI Platform",
       "productUrl": "https://cloud.google.com/ai-platform/docs/",
@@ -143,7 +143,7 @@
         "ml"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.3.1",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",


### PR DESCRIPTION

Changes in this release:

### New features

- Add service_networking.proto to aiplatform v1 ([commit 189dffe](https://github.com/googleapis/google-cloud-dotnet/commit/189dffeda7937d84a4397f89621157711b7b2b03))
- Add private_service_connect_config to IndexEndpoint in aiplatform v1 index_endpoint.proto ([commit 189dffe](https://github.com/googleapis/google-cloud-dotnet/commit/189dffeda7937d84a4397f89621157711b7b2b03))
- Add nas_job.proto to aiplatform v1 ([commit 189dffe](https://github.com/googleapis/google-cloud-dotnet/commit/189dffeda7937d84a4397f89621157711b7b2b03))
- Add CreateNasJob, GetNasJob, ListNasJobs, DeleteNasJob, CancelNasJob, GetNasTrialDetail, ListNasTrialDetails RPCs to aiplatform v1 job_service.proto ([commit 189dffe](https://github.com/googleapis/google-cloud-dotnet/commit/189dffeda7937d84a4397f89621157711b7b2b03))
- Add original_model_info to Model in aiplatform v1 model.proto ([commit 189dffe](https://github.com/googleapis/google-cloud-dotnet/commit/189dffeda7937d84a4397f89621157711b7b2b03))
- Add CopyModel RPC to aiplatform v1 model_service.proto ([commit 189dffe](https://github.com/googleapis/google-cloud-dotnet/commit/189dffeda7937d84a4397f89621157711b7b2b03))
- Add failed_jobs to CustomJobDetail to aiplatform v1 pipeline_job.proto ([commit 189dffe](https://github.com/googleapis/google-cloud-dotnet/commit/189dffeda7937d84a4397f89621157711b7b2b03))
- Add safety_config to StudySpec in aiplatform v1 study.proto ([commit 189dffe](https://github.com/googleapis/google-cloud-dotnet/commit/189dffeda7937d84a4397f89621157711b7b2b03))
