### PR TITLE
Release Google.Cloud.ArtifactRegistry.V1 version 2.2.0

### DIFF
--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.csproj
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Artifact Registry API v1, which stores and manages build artifacts in a scalable and integrated service built on Google infrastructure.</Description>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />

--- a/apis/Google.Cloud.ArtifactRegistry.V1/docs/history.md
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/docs/history.md
@@ -1,5 +1,20 @@
 # Version history
 
+## Version 2.2.0, released 2023-02-08
+
+### Bug fixes
+
+- Make `GetFileRequest.name` and `ListFilesRequest.parent` required ([commit fdab706](https://github.com/googleapis/google-cloud-dotnet/commit/fdab7068c60f640d21113616cc77978578a3cf36))
+- Make `Package` a resource ([commit fdab706](https://github.com/googleapis/google-cloud-dotnet/commit/fdab7068c60f640d21113616cc77978578a3cf36))
+- Deprecate `REDIRECTION_FROM_GCR_IO_FINALIZED` ([commit fdab706](https://github.com/googleapis/google-cloud-dotnet/commit/fdab7068c60f640d21113616cc77978578a3cf36))
+
+### New features
+
+- Add format-specific resources `MavenArtifact`, `NpmPackage`, `KfpArtifact` and `PythonPackage` ([commit fdab706](https://github.com/googleapis/google-cloud-dotnet/commit/fdab7068c60f640d21113616cc77978578a3cf36))
+- Add `order_by` to `ListDockerImages` ([commit fdab706](https://github.com/googleapis/google-cloud-dotnet/commit/fdab7068c60f640d21113616cc77978578a3cf36))
+- Add an API to get and update VPCSC config ([commit fdab706](https://github.com/googleapis/google-cloud-dotnet/commit/fdab7068c60f640d21113616cc77978578a3cf36))
+- Add `BatchDeleteVersionMetadata` to return version that failed to delete ([commit fdab706](https://github.com/googleapis/google-cloud-dotnet/commit/fdab7068c60f640d21113616cc77978578a3cf36))
+
 ## Version 2.1.0, released 2023-01-16
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -268,7 +268,7 @@
     },
     {
       "id": "Google.Cloud.ArtifactRegistry.V1",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "type": "grpc",
       "productName": "Artifact Registry",
       "productUrl": "https://cloud.google.com/artifact-registry",
@@ -279,7 +279,7 @@
         "containers"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.3.1",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Make `GetFileRequest.name` and `ListFilesRequest.parent` required ([commit fdab706](https://github.com/googleapis/google-cloud-dotnet/commit/fdab7068c60f640d21113616cc77978578a3cf36))
- Make `Package` a resource ([commit fdab706](https://github.com/googleapis/google-cloud-dotnet/commit/fdab7068c60f640d21113616cc77978578a3cf36))
- Deprecate `REDIRECTION_FROM_GCR_IO_FINALIZED` ([commit fdab706](https://github.com/googleapis/google-cloud-dotnet/commit/fdab7068c60f640d21113616cc77978578a3cf36))

### New features

- Add format-specific resources `MavenArtifact`, `NpmPackage`, `KfpArtifact` and `PythonPackage` ([commit fdab706](https://github.com/googleapis/google-cloud-dotnet/commit/fdab7068c60f640d21113616cc77978578a3cf36))
- Add `order_by` to `ListDockerImages` ([commit fdab706](https://github.com/googleapis/google-cloud-dotnet/commit/fdab7068c60f640d21113616cc77978578a3cf36))
- Add an API to get and update VPCSC config ([commit fdab706](https://github.com/googleapis/google-cloud-dotnet/commit/fdab7068c60f640d21113616cc77978578a3cf36))
- Add `BatchDeleteVersionMetadata` to return version that failed to delete ([commit fdab706](https://github.com/googleapis/google-cloud-dotnet/commit/fdab7068c60f640d21113616cc77978578a3cf36))
