### PR TITLE
Release Google.Cloud.Batch.V1 version 1.3.0

### DIFF
--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.csproj
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Batch API (v1), which allows you to manage the running of batch jobs on Google Cloud Platform.</Description>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />

--- a/apis/Google.Cloud.Batch.V1/docs/history.md
+++ b/apis/Google.Cloud.Batch.V1/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 1.3.0, released 2023-02-08
+
+### New features
+
+- Support custom scopes for service account in v1 ([commit 60d746a](https://github.com/googleapis/google-cloud-dotnet/commit/60d746a3bab5e93c406cbd1472ee683a8db7862e))
+- Add boot disk field in InstanceStatus ([commit 60d746a](https://github.com/googleapis/google-cloud-dotnet/commit/60d746a3bab5e93c406cbd1472ee683a8db7862e))
+- Add boot disk and image source fields to v1 InstancePolicy ([commit 60d746a](https://github.com/googleapis/google-cloud-dotnet/commit/60d746a3bab5e93c406cbd1472ee683a8db7862e))
+
 ## Version 1.2.0, released 2023-01-11
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -456,7 +456,7 @@
     },
     {
       "id": "Google.Cloud.Batch.V1",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "type": "grpc",
       "productName": "Batch",
       "productUrl": "https://cloud.google.com/batch/docs/",
@@ -465,7 +465,7 @@
         "batch"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.3.1",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",


### PR DESCRIPTION

Changes in this release:

### New features

- Support custom scopes for service account in v1 ([commit 60d746a](https://github.com/googleapis/google-cloud-dotnet/commit/60d746a3bab5e93c406cbd1472ee683a8db7862e))
- Add boot disk field in InstanceStatus ([commit 60d746a](https://github.com/googleapis/google-cloud-dotnet/commit/60d746a3bab5e93c406cbd1472ee683a8db7862e))
- Add boot disk and image source fields to v1 InstancePolicy ([commit 60d746a](https://github.com/googleapis/google-cloud-dotnet/commit/60d746a3bab5e93c406cbd1472ee683a8db7862e))
