### PR TITLE
Release Google.Cloud.DocumentAI.V1Beta3 version 2.0.0-beta08

### DIFF
--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.csproj
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta07</Version>
+    <Version>2.0.0-beta08</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Document AI API (v1beta3), which is a service to parse structured information from unstructured or semi-structured documents using state-of-the-art Google AI such as natural language, computer vision, translation, and AutoML.</Description>

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/docs/history.md
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 2.0.0-beta08, released 2023-02-08
+
+### New features
+
+- Added EvaluationReference to evaluation.proto ([commit a51e02c](https://github.com/googleapis/google-cloud-dotnet/commit/a51e02c698fe38b2c2f273af42f020532e14380e))
+- Added latest_evaluation to processor.proto ([commit a51e02c](https://github.com/googleapis/google-cloud-dotnet/commit/a51e02c698fe38b2c2f273af42f020532e14380e))
+- Added advanced_ocr_options field in OcrConfig ([commit e4901eb](https://github.com/googleapis/google-cloud-dotnet/commit/e4901eb6b5e35cebe1ca1b453da6901f17ec1e46))
+
+### Breaking changes
+
+- The TrainProcessorVersion parent was incorrectly annotated. ([commit a51e02c](https://github.com/googleapis/google-cloud-dotnet/commit/a51e02c698fe38b2c2f273af42f020532e14380e))
+
 ## Version 2.0.0-beta07, released 2023-01-20
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1776,7 +1776,7 @@
     },
     {
       "id": "Google.Cloud.DocumentAI.V1Beta3",
-      "version": "2.0.0-beta07",
+      "version": "2.0.0-beta08",
       "type": "grpc",
       "productName": "Cloud Document AI",
       "productUrl": "https://cloud.google.com/solutions/document-ai",


### PR DESCRIPTION

Changes in this release:

### New features

- Added EvaluationReference to evaluation.proto ([commit a51e02c](https://github.com/googleapis/google-cloud-dotnet/commit/a51e02c698fe38b2c2f273af42f020532e14380e))
- Added latest_evaluation to processor.proto ([commit a51e02c](https://github.com/googleapis/google-cloud-dotnet/commit/a51e02c698fe38b2c2f273af42f020532e14380e))
- Added advanced_ocr_options field in OcrConfig ([commit e4901eb](https://github.com/googleapis/google-cloud-dotnet/commit/e4901eb6b5e35cebe1ca1b453da6901f17ec1e46))

### Breaking changes

- The TrainProcessorVersion parent was incorrectly annotated. ([commit a51e02c](https://github.com/googleapis/google-cloud-dotnet/commit/a51e02c698fe38b2c2f273af42f020532e14380e))
