### PR TITLE
Release Google.Cloud.NetworkConnectivity.V1 version 2.3.0

### DIFF
--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.csproj
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.2.0</Version>
+    <Version>2.3.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Network Connectivity API, which provides access to Network Connectivity Center.</Description>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />

--- a/apis/Google.Cloud.NetworkConnectivity.V1/docs/history.md
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/docs/history.md
@@ -1,5 +1,20 @@
 # Version history
 
+## Version 2.3.0, released 2023-02-08
+
+### Bug fixes
+
+- **BREAKING CHANGE** Remove HTTP bindings for serviceConnectionMaps, serviceConnectionPolicies, serviceClasses ([commit 42415ac](https://github.com/googleapis/google-cloud-dotnet/commit/42415ac34613365778af5f8ec2cd68208e6b171f))
+- **BREAKING CHANGE** Remove policy based routing API ([commit 7ed1508](https://github.com/googleapis/google-cloud-dotnet/commit/7ed15089ab0972c8b267f3249df1d0502ecdb335))
+
+Note that these features would not have worked for customers anyway
+(as they were behind an allow-list), so we are not increasing the
+major version.
+
+### New features
+
+- Update Hub API ([commit 49cf881](https://github.com/googleapis/google-cloud-dotnet/commit/49cf881c481b0519656aaae9f9d85016d61d30bb))
+
 ## Version 2.2.0, released 2023-01-25
 
 BREAKING CHANGE: This release removes some API aspects that were

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2849,7 +2849,7 @@
     },
     {
       "id": "Google.Cloud.NetworkConnectivity.V1",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "type": "grpc",
       "productName": "Network Connectivity",
       "productUrl": "https://cloud.google.com/network-connectivity/docs/",
@@ -2860,7 +2860,7 @@
         "vpc"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.3.1",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- **BREAKING CHANGE** Remove HTTP bindings for serviceConnectionMaps, serviceConnectionPolicies, serviceClasses ([commit 42415ac](https://github.com/googleapis/google-cloud-dotnet/commit/42415ac34613365778af5f8ec2cd68208e6b171f))
- **BREAKING CHANGE** Remove policy based routing API ([commit 7ed1508](https://github.com/googleapis/google-cloud-dotnet/commit/7ed15089ab0972c8b267f3249df1d0502ecdb335))

Note that these features would not have worked for customers anyway (as they were behind an allow-list), so we are not increasing the major version.

### New features

- Update Hub API ([commit 49cf881](https://github.com/googleapis/google-cloud-dotnet/commit/49cf881c481b0519656aaae9f9d85016d61d30bb))
