### PR TITLE
Release diagnostics libraries version 5.1.0

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>5.0.0</Version>
+    <Version>5.1.0</Version>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core 3.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <ProjectReference Include="..\..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.csproj" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/apis/Google.Cloud.Diagnostics.AspNetCore3/docs/history.md
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore3/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 5.1.0, released 2023-02-08
+
+No API surface changes; just dependency updates.
+
 ## Version 5.0.0, released 2022-06-09
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Google.Cloud.Diagnostics.Common.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Google.Cloud.Diagnostics.Common.IntegrationTests.csproj
@@ -13,10 +13,10 @@
     <DebugType Condition="'$(TargetFramework)' == 'net6.0'">portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.3.1, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.csproj" />
-    <PackageReference Include="Google.Cloud.ErrorReporting.V1Beta1" Version="[3.0.0-beta01, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.ErrorReporting.V1Beta1" Version="[3.0.0-beta02, 4.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="Moq" Version="4.18.4" />

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Snippets/Google.Cloud.Diagnostics.Common.Snippets.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Snippets/Google.Cloud.Diagnostics.Common.Snippets.csproj
@@ -13,10 +13,10 @@
     <DebugType Condition="'$(TargetFramework)' == 'net6.0'">portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.3.1, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.csproj" />
-    <PackageReference Include="Google.Cloud.ErrorReporting.V1Beta1" Version="[3.0.0-beta01, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.ErrorReporting.V1Beta1" Version="[3.0.0-beta02, 4.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="Moq" Version="4.18.4" />

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Google.Cloud.Diagnostics.Common.Tests.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Google.Cloud.Diagnostics.Common.Tests.csproj
@@ -7,10 +7,10 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.3.1, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.csproj" />
-    <PackageReference Include="Google.Cloud.ErrorReporting.V1Beta1" Version="[3.0.0-beta01, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.ErrorReporting.V1Beta1" Version="[3.0.0-beta02, 4.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="Moq" Version="4.18.4" />

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>5.0.0</Version>
+    <Version>5.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries Common Components.</Description>
@@ -9,9 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Logging.V2" Version="[4.0.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Trace.V1" Version="[3.0.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Trace.V1" Version="[3.1.0, 4.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
   </ItemGroup>

--- a/apis/Google.Cloud.Diagnostics.Common/docs/history.md
+++ b/apis/Google.Cloud.Diagnostics.Common/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 5.1.0, released 2023-02-08
+
+### New features
+
+- Allow handling of timer thread exceptions in timed buffers. ([commit 957f4b4](https://github.com/googleapis/google-cloud-dotnet/commit/957f4b43914a8063a8af1fa6013f3533f1712da1))
+- Adds a ProviderAlias attribute to GoogleLoggerProvider ([commit a6f9e7c](https://github.com/googleapis/google-cloud-dotnet/commit/a6f9e7c5e76813874a07f449f0333beeebe89aa7))
+
 ## Version 5.0.0, released 2022-06-09
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1578,7 +1578,7 @@
     },
     {
       "id": "Google.Cloud.Diagnostics.AspNetCore3",
-      "version": "5.0.0",
+      "version": "5.1.0",
       "type": "other",
       "metadataType": "INTEGRATION",
       "targetFrameworks": "netcoreapp3.1",
@@ -1594,7 +1594,7 @@
       ],
       "dependencies": {
         "Google.Cloud.Diagnostics.Common": "project",
-        "Grpc.Core": "2.46.3"
+        "Grpc.Core": "2.46.5"
       },
       "testDependencies": {
         "Google.Cloud.Diagnostics.Common.IntegrationTests": "project",
@@ -1603,7 +1603,7 @@
     },
     {
       "id": "Google.Cloud.Diagnostics.Common",
-      "version": "5.0.0",
+      "version": "5.1.0",
       "type": "other",
       "targetFrameworks": "netstandard2.1;net462",
       "testTargetFrameworks": "net6.0;net462",
@@ -1617,15 +1617,15 @@
         "Diagnostics"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.2.0",
+        "Google.Api.Gax.Grpc": "4.3.1",
         "Google.Cloud.Logging.V2": "4.0.0",
-        "Google.Cloud.Trace.V1": "3.0.0",
+        "Google.Cloud.Trace.V1": "3.1.0",
         "Microsoft.Extensions.Http": "6.0.0",
         "System.Diagnostics.StackTrace": "4.3.0"
       },
       "testDependencies": {
-        "Google.Api.Gax.Testing": "4.2.0",
-        "Google.Cloud.ErrorReporting.V1Beta1": "3.0.0-beta01",
+        "Google.Api.Gax.Testing": "4.3.1",
+        "Google.Cloud.ErrorReporting.V1Beta1": "3.0.0-beta02",
         "Microsoft.Extensions.Hosting": "6.0.0"
       }
     },


### PR DESCRIPTION

Changes in Google.Cloud.Diagnostics.AspNetCore3 version 5.1.0:

No API surface changes; just dependency updates.

Changes in Google.Cloud.Diagnostics.Common version 5.1.0:

### New features

- Allow handling of timer thread exceptions in timed buffers. ([commit 957f4b4](https://github.com/googleapis/google-cloud-dotnet/commit/957f4b43914a8063a8af1fa6013f3533f1712da1))
- Adds a ProviderAlias attribute to GoogleLoggerProvider ([commit a6f9e7c](https://github.com/googleapis/google-cloud-dotnet/commit/a6f9e7c5e76813874a07f449f0333beeebe89aa7))

Packages in this release:
- Release Google.Cloud.Diagnostics.AspNetCore3 version 5.1.0
- Release Google.Cloud.Diagnostics.Common version 5.1.0
