### PR TITLE
Release Firestore libraries version 3.1.0

### DIFF
--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.csproj
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0</Version>
+    <Version>3.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Low-level Google client library to access the Firestore API. Users are recommended to use the Google.Cloud.Firestore package instead.</Description>
@@ -9,9 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Firestore.V1/docs/history.md
+++ b/apis/Google.Cloud.Firestore.V1/docs/history.md
@@ -4,6 +4,16 @@ This package is primarily a dependency of Google.Cloud.Firestore. See the
 [Google.Cloud.Firestore version history](https://googleapis.dev/dotnet/Google.Cloud.Firestore/latest/history.html)
 for more details.
 
+## Version 3.1.0, released 2023-02-08
+
+### New features
+
+- Add Firestore aggregation query apis ([commit a93b264](https://github.com/googleapis/google-cloud-dotnet/commit/a93b264d6acbdcee46d61d22271187884709e04a))
+
+### Documentation improvements
+
+- Update query ordering documentation ([commit 16f4f35](https://github.com/googleapis/google-cloud-dotnet/commit/16f4f354a7713b193d95ce1937c9a17257cf524f))
+
 ## Version 3.0.0, released 2022-06-09
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/Google.Cloud.Firestore.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/Google.Cloud.Firestore.IntegrationTests.csproj
@@ -7,11 +7,11 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.2.0, 5.0.0)" />
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.3.1, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Firestore\Google.Cloud.Firestore.csproj" />
-    <PackageReference Include="Grpc.Core.Testing" Version="[2.46.3, 3.0.0)" />
+    <PackageReference Include="Grpc.Core.Testing" Version="[2.46.5, 3.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/Google.Cloud.Firestore.Snippets.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/Google.Cloud.Firestore.Snippets.csproj
@@ -7,11 +7,11 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.2.0, 5.0.0)" />
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.3.1, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Firestore\Google.Cloud.Firestore.csproj" />
-    <PackageReference Include="Grpc.Core.Testing" Version="[2.46.3, 3.0.0)" />
+    <PackageReference Include="Grpc.Core.Testing" Version="[2.46.5, 3.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Google.Cloud.Firestore.Tests.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Google.Cloud.Firestore.Tests.csproj
@@ -7,11 +7,11 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.2.0, 5.0.0)" />
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.3.1, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Firestore\Google.Cloud.Firestore.csproj" />
-    <PackageReference Include="Grpc.Core.Testing" Version="[2.46.3, 3.0.0)" />
+    <PackageReference Include="Grpc.Core.Testing" Version="[2.46.5, 3.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Google.Cloud.Firestore.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Google.Cloud.Firestore.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0</Version>
+    <Version>3.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Firestore API.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <ProjectReference Include="..\..\Google.Cloud.Firestore.V1\Google.Cloud.Firestore.V1\Google.Cloud.Firestore.V1.csproj" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>

--- a/apis/Google.Cloud.Firestore/docs/history.md
+++ b/apis/Google.Cloud.Firestore/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.1.0, released 2023-02-08
+
+### New features
+
+- Add support for count(*) aggregation query firestore ([commit 1df2774](https://github.com/googleapis/google-cloud-dotnet/commit/1df2774c6aa684012c9b53af287d6510f89bb968))
+
 ## Version 3.0.0, released 2022-06-09
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1999,7 +1999,7 @@
       "productName": "Firestore",
       "productUrl": "https://firebase.google.com/docs/firestore/",
       "listingDescription": "Firestore high-level library",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "type": "other",
       "metadataType": "GAPIC_MANUAL",
       "targetFrameworks": "netstandard2.1;net462",
@@ -2011,14 +2011,14 @@
       ],
       "dependencies": {
         "Google.Cloud.Firestore.V1": "project",
-        "Grpc.Core": "2.46.3",
+        "Grpc.Core": "2.46.5",
         "System.Collections.Immutable": "6.0.0",
         "System.Linq.Async": "6.0.1"
       },
       "testDependencies": {
-        "Google.Api.Gax.Grpc.Testing": "4.2.0",
-        "Google.Api.Gax.Testing": "4.2.0",
-        "Grpc.Core.Testing": "2.46.3",
+        "Google.Api.Gax.Grpc.Testing": "4.3.1",
+        "Google.Api.Gax.Testing": "4.3.1",
+        "Grpc.Core.Testing": "2.46.5",
         "System.ValueTuple": "4.5.0",
         "Xunit.Combinatorial": "1.4.1"
       },
@@ -2031,7 +2031,7 @@
       "productName": "Firestore",
       "productUrl": "https://firebase.google.com",
       "listingDescription": "Firestore low-level API access",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "type": "grpc",
       "targetFrameworks": "netstandard2.1;net462",
       "testTargetFrameworks": "net6.0;net462",
@@ -2041,10 +2041,10 @@
         "firebase"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.2.0",
+        "Google.Api.Gax.Grpc": "4.3.1",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.3"
+        "Grpc.Core": "2.46.5"
       },
       "shortName": "firestore",
       "serviceConfigFile": "firestore_v1.yaml",


### PR DESCRIPTION

Changes in Google.Cloud.Firestore version 3.1.0:

### New features

- Add support for count(*) aggregation query firestore ([commit 1df2774](https://github.com/googleapis/google-cloud-dotnet/commit/1df2774c6aa684012c9b53af287d6510f89bb968))

Changes in Google.Cloud.Firestore.V1 version 3.1.0:

### New features

- Add Firestore aggregation query apis ([commit a93b264](https://github.com/googleapis/google-cloud-dotnet/commit/a93b264d6acbdcee46d61d22271187884709e04a))

### Documentation improvements

- Update query ordering documentation ([commit 16f4f35](https://github.com/googleapis/google-cloud-dotnet/commit/16f4f354a7713b193d95ce1937c9a17257cf524f))

Packages in this release:
- Release Google.Cloud.Firestore version 3.1.0
- Release Google.Cloud.Firestore.V1 version 3.1.0
