### PR TITLE
Release OS Login libraries

### DIFF
--- a/apis/Google.Cloud.OsLogin.Common/Google.Cloud.OsLogin.Common/Google.Cloud.OsLogin.Common.csproj
+++ b/apis/Google.Cloud.OsLogin.Common/Google.Cloud.OsLogin.Common/Google.Cloud.OsLogin.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0</Version>
+    <Version>3.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Version-agnostic types for the Google OS Login API.</Description>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.CommonProtos" Version="[2.6.0, 3.0.0)" />
-    <PackageReference Include="Google.Api.Gax" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.CommonProtos" Version="[2.7.0, 3.0.0)" />
+    <PackageReference Include="Google.Api.Gax" Version="[4.3.1, 5.0.0)" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.csproj
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0</Version>
+    <Version>3.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to manage OS login configuration for Google account users.</Description>
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.OsLogin.Common\Google.Cloud.OsLogin.Common\Google.Cloud.OsLogin.Common.csproj" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.OsLogin.V1/docs/history.md
+++ b/apis/Google.Cloud.OsLogin.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 3.1.0, released 2023-02-08
+
+### New features
+
+- Enable REST transport ([commit 46d4fe8](https://github.com/googleapis/google-cloud-dotnet/commit/46d4fe8461ac30e7666600e44e7bd16228768621))
+- Added CreateSshPublicKey RPC ([commit 910c4eb](https://github.com/googleapis/google-cloud-dotnet/commit/910c4eb6c506287acb500e7257144db280ed1fba))
+
 ## Version 3.0.0, released 2022-06-09
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.csproj
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0-beta01</Version>
+    <Version>3.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to manages OS login configuration for Google account users.</Description>
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.OsLogin.Common\Google.Cloud.OsLogin.Common\Google.Cloud.OsLogin.Common.csproj" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.OsLogin.V1Beta/docs/history.md
+++ b/apis/Google.Cloud.OsLogin.V1Beta/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 3.0.0-beta02, released 2023-02-08
+
+### New features
+
+- Enable REST transport ([commit 46d4fe8](https://github.com/googleapis/google-cloud-dotnet/commit/46d4fe8461ac30e7666600e44e7bd16228768621))
+- Added CreateSshPublicKey RPC ([commit ea76949](https://github.com/googleapis/google-cloud-dotnet/commit/ea76949ef04bdb3444666b5d79532f06cdc3d8c0))
+
 ## Version 3.0.0-beta01, released 2022-06-09
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3130,7 +3130,7 @@
       "id": "Google.Cloud.OsLogin.Common",
       "generator": "micro",
       "protoPath": "google/cloud/oslogin/common",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "type": "other",
       "targetFrameworks": "netstandard2.1;net462",
       "description": "Version-agnostic types for the Google OS Login API.",
@@ -3139,8 +3139,8 @@
         "Login"
       ],
       "dependencies": {
-        "Google.Api.CommonProtos": "2.6.0",
-        "Google.Api.Gax": "4.2.0"
+        "Google.Api.CommonProtos": "2.7.0",
+        "Google.Api.Gax": "4.3.1"
       },
       "noVersionHistory": true,
       "forceOwlBotRegeneration": "OsLogin Common proto is generated in the wrong place.",
@@ -3152,7 +3152,7 @@
       "protoPath": "google/cloud/oslogin/v1",
       "productName": "Google Cloud OS Login",
       "productUrl": "https://cloud.google.com/compute/docs/instances/managing-instance-access",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "type": "grpc",
       "description": "Recommended Google client library to manage OS login configuration for Google account users.",
       "tags": [
@@ -3160,9 +3160,9 @@
         "Login"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.2.0",
+        "Google.Api.Gax.Grpc": "4.3.1",
         "Google.Cloud.OsLogin.Common": "project",
-        "Grpc.Core": "2.46.3"
+        "Grpc.Core": "2.46.5"
       },
       "forceOwlBotRegeneration": "OsLogin Common proto is generated and copied when it shouldn't be.",
       "shortName": "oslogin",
@@ -3176,7 +3176,7 @@
       "protoPath": "google/cloud/oslogin/v1beta",
       "productName": "Google Cloud OS Login",
       "productUrl": "https://cloud.google.com/compute/docs/instances/managing-instance-access",
-      "version": "3.0.0-beta01",
+      "version": "3.0.0-beta02",
       "releaseLevelOverride": "preview",
       "type": "grpc",
       "description": "Recommended Google client library to manages OS login configuration for Google account users.",
@@ -3185,9 +3185,9 @@
         "Login"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.2.0",
+        "Google.Api.Gax.Grpc": "4.3.1",
         "Google.Cloud.OsLogin.Common": "project",
-        "Grpc.Core": "2.46.3"
+        "Grpc.Core": "2.46.5"
       },
       "forceOwlBotRegeneration": "OsLogin Common proto is generated and copied when it shouldn't be.",
       "shortName": "oslogin",


### PR DESCRIPTION

Changes in Google.Cloud.OsLogin.V1 version 3.1.0:

### New features

- Enable REST transport ([commit 46d4fe8](https://github.com/googleapis/google-cloud-dotnet/commit/46d4fe8461ac30e7666600e44e7bd16228768621))
- Added CreateSshPublicKey RPC ([commit 910c4eb](https://github.com/googleapis/google-cloud-dotnet/commit/910c4eb6c506287acb500e7257144db280ed1fba))

Changes in Google.Cloud.OsLogin.V1Beta version 3.0.0-beta02:

### New features

- Enable REST transport ([commit 46d4fe8](https://github.com/googleapis/google-cloud-dotnet/commit/46d4fe8461ac30e7666600e44e7bd16228768621))
- Added CreateSshPublicKey RPC ([commit ea76949](https://github.com/googleapis/google-cloud-dotnet/commit/ea76949ef04bdb3444666b5d79532f06cdc3d8c0))

Packages in this release:
- Release Google.Cloud.OsLogin.Common version 3.1.0
- Release Google.Cloud.OsLogin.V1 version 3.1.0
- Release Google.Cloud.OsLogin.V1Beta version 3.0.0-beta02
