### PR TITLE
Release Cloud Workflows V1Beta libraries version 2.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.Workflows.Common.V1Beta/Google.Cloud.Workflows.Common.V1Beta/Google.Cloud.Workflows.Common.V1Beta.csproj
+++ b/apis/Google.Cloud.Workflows.Common.V1Beta/Google.Cloud.Workflows.Common.V1Beta/Google.Cloud.Workflows.Common.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta01</Version>
+    <Version>2.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Common resource names used by all Workflows V1Beta APIs</Description>
@@ -9,6 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax" Version="[4.3.1, 5.0.0)" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.csproj
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta01</Version>
+    <Version>2.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Workflow Executions API v1beta, used to manage user-provided workflows.</Description>

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/docs/history.md
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 2.0.0-beta02, released 2023-02-08
+
+No API surface changes; just dependency updates.
+
 ## Version 2.0.0-beta01, released 2022-06-09
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.csproj
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta01</Version>
+    <Version>2.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Workflows API v1beta.</Description>

--- a/apis/Google.Cloud.Workflows.V1Beta/docs/history.md
+++ b/apis/Google.Cloud.Workflows.V1Beta/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.0.0-beta02, released 2023-02-08
+
+### New features
+
+- Enable REST transport ([commit 46d4fe8](https://github.com/googleapis/google-cloud-dotnet/commit/46d4fe8461ac30e7666600e44e7bd16228768621))
+
 ## Version 2.0.0-beta01, released 2022-06-09
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4611,13 +4611,13 @@
       "id": "Google.Cloud.Workflows.Common.V1Beta",
       "type": "other",
       "targetFrameworks": "netstandard2.1;net462",
-      "version": "2.0.0-beta01",
+      "version": "2.0.0-beta02",
       "description": "Common resource names used by all Workflows V1Beta APIs",
       "tags": [
         "Spanner"
       ],
       "dependencies": {
-        "Google.Api.Gax": "4.2.0"
+        "Google.Api.Gax": "4.3.1"
       },
       "noVersionHistory": true
     },
@@ -4644,7 +4644,7 @@
     },
     {
       "id": "Google.Cloud.Workflows.Executions.V1Beta",
-      "version": "2.0.0-beta01",
+      "version": "2.0.0-beta02",
       "commonResourcesConfig": "apis/Google.Cloud.Workflows.Common.V1Beta/CommonResourcesConfig.json",
       "type": "grpc",
       "productName": "Workflow Executions",
@@ -4687,7 +4687,7 @@
     },
     {
       "id": "Google.Cloud.Workflows.V1Beta",
-      "version": "2.0.0-beta01",
+      "version": "2.0.0-beta02",
       "commonResourcesConfig": "apis/Google.Cloud.Workflows.Common.V1Beta/CommonResourcesConfig.json",
       "type": "grpc",
       "productName": "Workflows",


### PR DESCRIPTION

Changes in Google.Cloud.Workflows.Executions.V1Beta version 2.0.0-beta02:

No API surface changes; just dependency updates.

Changes in Google.Cloud.Workflows.V1Beta version 2.0.0-beta02:

### New features

- Enable REST transport ([commit 46d4fe8](https://github.com/googleapis/google-cloud-dotnet/commit/46d4fe8461ac30e7666600e44e7bd16228768621))

Packages in this release:
- Release Google.Cloud.Workflows.Common.V1Beta version 2.0.0-beta02
- Release Google.Cloud.Workflows.Executions.V1Beta version 2.0.0-beta02
- Release Google.Cloud.Workflows.V1Beta version 2.0.0-beta02
