### PR TITLE
chore: Fix OwlBot post processor to permit file-scoped namespaces

### DIFF
--- a/owl-bot-post-processor/main.sh
+++ b/owl-bot-post-processor/main.sh
@@ -113,7 +113,8 @@ copy_one_api() {
     (cd $PACKAGE_DIR; ./postgeneration.sh)
   fi
 
-  if [[ $(grep -E "^namespace" apis/$1/$1/*.cs | grep -v "namespace Microsoft.Extensions.DependencyInjection" | grep -Ev "namespace ${1}[[:space:]{]*\$") ]]; then
+  if [[ $(grep -E "^namespace" apis/$1/$1/*.cs | grep -v "namespace Microsoft.Extensions.DependencyInjection" | grep -Ev "namespace ${1}[[:space:]{]*;?\$") ]]
+  then
     # We know Google.LongRunning contains a proto in Google.Cloud.
     if [[ $1 == "Google.LongRunning" ]]; then
       echo "Ignoring broken namespaces in $1"


### PR DESCRIPTION
(Basically the "broken namespace" check is too picky at the moment.)