### PR TITLE
chore: Fix the line ending check

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -33,7 +33,7 @@ jobs:
 
     - name: Detect CRLF files
       run: |
-        ! git ls-files --eol | grep crlf
+        ! git ls-files --eol | grep -e i/crlf -e i/mixed
 
     - name: Build and test
       run: |


### PR DESCRIPTION
This checks that there are no mixed- or crlf-ending files in the index.