### PR TITLE
Release Google.Cloud.Storage.V1 version 4.4.0

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.3.0</Version>
+    <Version>4.4.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Storage API. It wraps the Google.Apis.Storage.v1 client library, making common operations simpler in client code. Google Cloud Storage stores and retrieves potentially large, immutable data objects.</Description>

--- a/apis/Google.Cloud.Storage.V1/docs/history.md
+++ b/apis/Google.Cloud.Storage.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 4.4.0, released 2023-02-21
+
+### New features
+
+- Improve exception thrown on failure to upload/download ([commit 4782e03](https://github.com/googleapis/google-cloud-dotnet/commit/4782e0302c8feb4a3f631e5d064aad3564fc55ee))
+- Update Google.Apis.Storage.v1 dependency to 1.60.0.2742
+
 ## Version 4.3.0, released 2023-02-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4055,7 +4055,7 @@
       "id": "Google.Cloud.Storage.V1",
       "productName": "Google Cloud Storage",
       "productUrl": "https://cloud.google.com/storage/",
-      "version": "4.3.0",
+      "version": "4.4.0",
       "type": "rest",
       "description": "Recommended Google client library to access the Google Cloud Storage API. It wraps the Google.Apis.Storage.v1 client library, making common operations simpler in client code. Google Cloud Storage stores and retrieves potentially large, immutable data objects.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Improve exception thrown on failure to upload/download ([commit 4782e03](https://github.com/googleapis/google-cloud-dotnet/commit/4782e0302c8feb4a3f631e5d064aad3564fc55ee))
- Update Google.Apis.Storage.v1 dependency to 1.60.0.2742
