### PR TITLE
Release Google.Analytics.Admin.V1Alpha version 2.0.0-alpha06

### DIFF
--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha05</Version>
+    <Version>2.0.0-alpha06</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Analytics Admin API (v1alpha)</Description>

--- a/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
+++ b/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 2.0.0-alpha06, released 2023-02-21
+
+### New features
+
+- Add `CreateAccessBinding`, `GetAccessBinding`, `UpdateAccessBinding`, `DeleteAccessBinding`, `ListAccessBindings`, `BatchCreateAccessBindings`, `BatchGetAccessBindings`, `BatchUpdateAccessBindings`, `BatchDeleteAccessBindings` methods to the Admin API v1alpha ([commit 60827e8](https://github.com/googleapis/google-cloud-dotnet/commit/60827e81ee3eed5a4c92b26070385b7e46451172))
+- Add `GetExpandedDataSet`, `ListExpandedDataSets`, `CreateExpandedDataSet`, `UpdateExpandedDataSet`, `DeleteExpandedDataSet` methods to the Admin API v1alpha ([commit 60827e8](https://github.com/googleapis/google-cloud-dotnet/commit/60827e81ee3eed5a4c92b26070385b7e46451172))
+- Add `AccessBinding`, `ExpandedDataSet`, `ExpandedDataSetFilter`, `ExpandedDataSetFilterExpression`, `ExpandedDataSetFilterExpressionList` resource types to the Admin API v1alpha ([commit 60827e8](https://github.com/googleapis/google-cloud-dotnet/commit/60827e81ee3eed5a4c92b26070385b7e46451172))
+
 ## Version 2.0.0-alpha05, released 2023-02-08
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2,7 +2,7 @@
   "apis": [
     {
       "id": "Google.Analytics.Admin.V1Alpha",
-      "version": "2.0.0-alpha05",
+      "version": "2.0.0-alpha06",
       "type": "grpc",
       "productName": "Analytics Admin",
       "productUrl": "https://developers.google.com/analytics",


### PR DESCRIPTION

Changes in this release:

### New features

- Add `CreateAccessBinding`, `GetAccessBinding`, `UpdateAccessBinding`, `DeleteAccessBinding`, `ListAccessBindings`, `BatchCreateAccessBindings`, `BatchGetAccessBindings`, `BatchUpdateAccessBindings`, `BatchDeleteAccessBindings` methods to the Admin API v1alpha ([commit 60827e8](https://github.com/googleapis/google-cloud-dotnet/commit/60827e81ee3eed5a4c92b26070385b7e46451172))
- Add `GetExpandedDataSet`, `ListExpandedDataSets`, `CreateExpandedDataSet`, `UpdateExpandedDataSet`, `DeleteExpandedDataSet` methods to the Admin API v1alpha ([commit 60827e8](https://github.com/googleapis/google-cloud-dotnet/commit/60827e81ee3eed5a4c92b26070385b7e46451172))
- Add `AccessBinding`, `ExpandedDataSet`, `ExpandedDataSetFilter`, `ExpandedDataSetFilterExpression`, `ExpandedDataSetFilterExpressionList` resource types to the Admin API v1alpha ([commit 60827e8](https://github.com/googleapis/google-cloud-dotnet/commit/60827e81ee3eed5a4c92b26070385b7e46451172))
