### PR TITLE
chore: Update pip requirements again

### DIFF
--- a/.kokoro/README.md
+++ b/.kokoro/README.md
@@ -14,12 +14,10 @@ distribution.
 `pip-compile` is used to generate the hashes. Install that first,
 manually, using a hash from pypi.org.
 
-Edit the requirements.txt file to specify the version of the
+Edit the requirements.in file to specify the version of the
 dependency you want, then run:
 
 ```sh
-grep == requirements.txt | sed 's/ \\//g' > requirements.in
 rm requirements.txt
 pip-compile --generate-hashes requirements.in
-rm requirements.in
 ```

--- a/.kokoro/requirements.in
+++ b/.kokoro/requirements.in
@@ -1,0 +1,4 @@
+gcp-releasetool==1.10.5
+gcp-docuploader==0.6.4
+typing-extensions==4.5.0
+importlib-resources==5.12.0

--- a/.kokoro/requirements.txt
+++ b/.kokoro/requirements.txt
@@ -329,6 +329,10 @@ importlib-metadata==6.0.0 \
     --hash=sha256:7efb448ec9a5e313a57655d35aa54cd3e01b7e1fbcf72dce1bf06119420f5bad \
     --hash=sha256:e354bedeb60efa6affdcc8ae121b73544a7aa74156d047311948f6d711cd378d
     # via keyring
+importlib-resources==5.12.0 \
+    --hash=sha256:4be82589bf5c1d7999aedf2a45159d10cb3ca4f19b2271f8792bc8e6da7b22f6 \
+    --hash=sha256:7b1deeebbf351c7578e09bf2f63fa2ce8b5ffec296e0d349139d43cca061a81a
+    # via -r requirements.in
 jaraco-classes==3.2.3 \
     --hash=sha256:2353de3288bc6b82120752201c6b1c1a14b058267fa424ed5ce5984e3b922158 \
     --hash=sha256:89559fa5c1d3c34eff6f631ad80bb21f378dbcbb35dd161fd2c6b93f5be2f98a
@@ -486,4 +490,6 @@ urllib3==1.26.14 \
 zipp==3.14.0 \
     --hash=sha256:188834565033387710d046e3fe96acfc9b5e86cbca7f39ff69cf21a4128198b7 \
     --hash=sha256:9e5421e176ef5ab4c0ad896624e87a7b2f07aca746c9b2aa305952800cb8eecb
-    # via importlib-metadata
+    # via
+    #   importlib-metadata
+    #   importlib-resources


### PR DESCRIPTION
This time, let's keep requirements.in, so that's easier to modify directly.