### PR TITLE
docs: Fix building docs with the latest version of docfx

### DIFF
--- a/tools/Google.Cloud.Tools.GenerateDocfxSources/Program.cs
+++ b/tools/Google.Cloud.Tools.GenerateDocfxSources/Program.cs
@@ -81,11 +81,6 @@ namespace Google.Cloud.Tools.GenerateDocfxSources
                 });
             }
 
-            // Pick whichever framework is listed first. (This could cause problems if a dependency
-            // doesn't target the given framework, but that seems unlikely.)
-            // Default to netstandard2.1 if nothing is listed.
-            string targetFramework = rootApi.TargetFrameworks?.Split(';').First() ?? "netstandard2.1";
-
             var json = new JObject
             {
                 ["metadata"] = new JArray {
@@ -94,7 +89,6 @@ namespace Google.Cloud.Tools.GenerateDocfxSources
                         ["src"] = src,
                         ["dest"] = "obj/api",
                         ["filter"] = "filterConfig.yml",
-                        ["properties"] = new JObject { ["TargetFramework"] = targetFramework }
                     }
                 },
                 ["build"] = new JObject {


### PR DESCRIPTION
When we specify a target framework, the metadata extraction fails if any of the projects don't support that target - which happens for Diagnostics.

It *looks* like it's okay to just not specify it. (That used to be a problem, but appears not to be now.)

Fixes #9924.