### PR TITLE
chore: Only generate metadata for the API we're creating docs for

### DIFF
--- a/docs/builddocs.sh
+++ b/docs/builddocs.sh
@@ -34,11 +34,6 @@ build_api_docs() {
   fi
   cp filterConfig.yml output/$api
   
-  # Make sure all dependencies are built. Even if the target package refers to a
-  # dependency in this repo by NuGet version rather than as a project reference,
-  # we need it for googleapis.dev
-  (cd ..; ./build.sh --notests $(cat docs/output/$api/dependencies.txt))
-  
   dotnet docfx metadata --logLevel Warning output/$api/docfx.json | tee errors.txt | grep -v "Invalid file link"
   (! grep --quiet 'Build failed.' errors.txt)
 


### PR DESCRIPTION
This only changes the customer-facing result for non-Cloud APIs (which still have docs hosted on googleapis.dev), and only when they have other dependencies within this repo. We can live with that at the moment, and it avoids rebuilding things for no good reason.

Towards #9939