### PR TITLE
docs: Add help documentation for using API keys with GAPIC libraries

### DIFF
--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.Snippets/LanguageServiceClientSnippets.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.Snippets/LanguageServiceClientSnippets.cs
@@ -129,6 +129,8 @@ namespace Google.Cloud.Language.V1.Snippets
             // End sample
         }
 
+        // Note: If you change this sample, please also change the sample
+        // in Google.Cloud.Docs.Snippets.
         [SkippableFact]
         public void ApiKey()
         {

--- a/docs/Google.Cloud.DocTools.sln
+++ b/docs/Google.Cloud.DocTools.sln
@@ -33,7 +33,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Tools.DocfxMet
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Tools.FetchDependencyXrefmaps", "..\tools\Google.Cloud.Tools.FetchDependencyXrefmaps\Google.Cloud.Tools.FetchDependencyXrefmaps.csproj", "{3734E267-99C5-4C80-9D73-D411B6773BC5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Tools.UnescapeDocfxMetadataXml", "..\tools\Google.Cloud.Tools.UnescapeDocfxMetadataXml\Google.Cloud.Tools.UnescapeDocfxMetadataXml.csproj", "{60920FE5-243D-4A75-9B42-D03DF86AA6AF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Tools.UnescapeDocfxMetadataXml", "..\tools\Google.Cloud.Tools.UnescapeDocfxMetadataXml\Google.Cloud.Tools.UnescapeDocfxMetadataXml.csproj", "{60920FE5-243D-4A75-9B42-D03DF86AA6AF}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Language.V1", "..\apis\Google.Cloud.Language.V1\Google.Cloud.Language.V1\Google.Cloud.Language.V1.csproj", "{33357DA1-7028-42CA-8798-28EC86EC32C1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -237,6 +239,18 @@ Global
 		{60920FE5-243D-4A75-9B42-D03DF86AA6AF}.Release|x64.Build.0 = Release|Any CPU
 		{60920FE5-243D-4A75-9B42-D03DF86AA6AF}.Release|x86.ActiveCfg = Release|Any CPU
 		{60920FE5-243D-4A75-9B42-D03DF86AA6AF}.Release|x86.Build.0 = Release|Any CPU
+		{33357DA1-7028-42CA-8798-28EC86EC32C1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{33357DA1-7028-42CA-8798-28EC86EC32C1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{33357DA1-7028-42CA-8798-28EC86EC32C1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{33357DA1-7028-42CA-8798-28EC86EC32C1}.Debug|x64.Build.0 = Debug|Any CPU
+		{33357DA1-7028-42CA-8798-28EC86EC32C1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{33357DA1-7028-42CA-8798-28EC86EC32C1}.Debug|x86.Build.0 = Debug|Any CPU
+		{33357DA1-7028-42CA-8798-28EC86EC32C1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{33357DA1-7028-42CA-8798-28EC86EC32C1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{33357DA1-7028-42CA-8798-28EC86EC32C1}.Release|x64.ActiveCfg = Release|Any CPU
+		{33357DA1-7028-42CA-8798-28EC86EC32C1}.Release|x64.Build.0 = Release|Any CPU
+		{33357DA1-7028-42CA-8798-28EC86EC32C1}.Release|x86.ActiveCfg = Release|Any CPU
+		{33357DA1-7028-42CA-8798-28EC86EC32C1}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/docs/devsite-help/client-configuration.md
+++ b/docs/devsite-help/client-configuration.md
@@ -52,6 +52,18 @@ represent "raw" credentials which are used exactly as they are provided, without
 applying any additional options such as scopes or a quota project. These are the most low-level
 properties, and are rarely as useful as the ones above.
 
+### API Keys
+
+Most Cloud APIs do not support API keys, instead requiring full credentials as described above. For this
+reason, the client libraries do not have *direct* support for API keys, but API keys can still be used
+for those APIs which support them. The API key should be specified in the `X-Goog-Api-Key` header on
+every request, and the gRPC channel should be built using `ChannelCredentials.SecureSsl`. For example,
+to create a client for the Language API using an API key, you could use the following code:
+
+[!code-cs[](../examples/help.Configuration.txt#ApiKey)]
+
+After building the client, it can be used like any other client.
+
 ## gRPC configuration
 
 ### GrpcAdapter

--- a/tools/Google.Cloud.Docs.Snippets/CallSettingsSnippets.cs
+++ b/tools/Google.Cloud.Docs.Snippets/CallSettingsSnippets.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -102,12 +102,12 @@ namespace Google.Cloud.Tools.Snippets
             // Sample: Overrides
             // Create a default PublisherServiceApiSettings, with customizations for CreateTopic RPCs:
             // * A custom "ClientVersion" header.
-            // * A custom 5-second timeout Timing.
+            // * A custom 15-second timeout.
             // * No cancellation token.
             PublisherServiceApiSettings publisherSettings = new PublisherServiceApiSettings();
             publisherSettings.CreateTopicSettings = publisherSettings.CreateTopicSettings
                 .WithCancellationToken(CancellationToken.None)
-                .WithTimeout(TimeSpan.FromSeconds(5))
+                .WithTimeout(TimeSpan.FromSeconds(15))
                 .WithHeader("ClientVersion", "1.0.0");
 
             // Override the above Timing and CancellationToken in the client-wide CallSettings;

--- a/tools/Google.Cloud.Docs.Snippets/ConfigurationSnippets.cs
+++ b/tools/Google.Cloud.Docs.Snippets/ConfigurationSnippets.cs
@@ -1,0 +1,52 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+using Google.Api.Gax.Grpc;
+using Google.Cloud.Language.V1;
+using Grpc.Core;
+using Xunit;
+
+namespace Google.Cloud.Docs.Snippets;
+
+public class ConfigurationSnippets
+{
+    // Note: If you change this sample, please also change the sample
+    // in Google.Cloud.Language.V1.Snippets.
+    [Fact]
+    public void LanguageApiKey()
+    {
+        string apiKey = "some-api-key";
+
+        // Sample: ApiKey
+        // Create a LanguageServiceSettings that applies the X-Goog-Api-Key
+        // header on every request
+        LanguageServiceSettings settings = new LanguageServiceSettings
+        {
+            CallSettings = CallSettings.FromHeader("X-Goog-Api-Key", apiKey)
+        };
+
+        // Create a LanguageServiceClient which uses the settings to apply
+        // the API key to every request. The ChannelCredentials are set to
+        // just SSL; we don't authenticate at the channel level when
+        // applying API keys.
+        LanguageServiceClient client = new LanguageServiceClientBuilder
+        {
+            ChannelCredentials = ChannelCredentials.SecureSsl,
+            Settings = settings
+        }.Build();
+        // End sample
+
+        Assert.NotNull(client);
+    }
+}

--- a/tools/Google.Cloud.Docs.Snippets/Google.Cloud.Docs.Snippets.csproj
+++ b/tools/Google.Cloud.Docs.Snippets/Google.Cloud.Docs.Snippets.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\apis\Google.Cloud.Language.V1\Google.Cloud.Language.V1\Google.Cloud.Language.V1.csproj" />
     <ProjectReference Include="..\..\apis\Google.Cloud.Scheduler.V1\Google.Cloud.Scheduler.V1\Google.Cloud.Scheduler.V1.csproj" />
     <ProjectReference Include="..\..\apis\Google.Cloud.Vision.V1\Google.Cloud.Vision.V1\Google.Cloud.Vision.V1.csproj" />
     <ProjectReference Include="..\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />


### PR DESCRIPTION
The change to the call settings override is just to make the test pass... it can easily take 5 seconds to create a topic...