### PR TITLE
tests: Flatten Storage retry conformance tests

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.RetryConformanceTests/RetryTestCase.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.RetryConformanceTests/RetryTestCase.cs
@@ -1,0 +1,48 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+using Google.Cloud.Storage.V1.Tests.Conformance;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Google.Cloud.Storage.V1.RetryConformanceTests;
+
+/// <summary>
+/// A single retry test case, created from a <see cref="RetryTest"/> but for
+/// a single <see cref="Tests.Conformance.InstructionList"/> and <see cref="Tests.Conformance.Method"/> combination.
+/// </summary>
+public class RetryTestCase
+{
+    public RetryTest Test { get; }
+    public InstructionList InstructionList { get; }
+    public Method Method { get; }
+
+    private RetryTestCase(RetryTest test, Method method, InstructionList instructionList)
+    {
+        Test = test;
+        InstructionList = instructionList;
+        Method = method;
+    }
+
+    public override string ToString() =>
+        $"Test={Test.Id}:{Test.Description}; Method={Method.Name}; Instructions={string.Join(", ", InstructionList.Instructions)}";
+
+    /// <summary>
+    /// Flattens the given test into its constituent test cases.
+    /// </summary>
+    public static IEnumerable<RetryTestCase> Flatten(RetryTest test) =>
+        from method in test.Methods
+        from instructionList in test.Cases
+        select new RetryTestCase(test, method, instructionList);
+}

--- a/tools/Google.Cloud.ClientTesting/ConformanceTestData.cs
+++ b/tools/Google.Cloud.ClientTesting/ConformanceTestData.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2019 Google LLC
+// Copyright 2019 Google LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 using Google.Protobuf;
-using Google.Protobuf.Collections;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Xunit;
@@ -89,7 +89,7 @@ namespace Google.Cloud.ClientTesting
         /// <summary>
         /// Convenience method to create a TheoryData for a given test subset.
         /// </summary>
-        public TheoryData<TTest> GetTheoryData<TTest>(Func<T, RepeatedField<TTest>> testExtractor)
+        public TheoryData<TTest> GetTheoryData<TTest>(Func<T, IEnumerable<TTest>> testExtractor)
         {
             var ret = new TheoryData<TTest>();
             foreach (var test in testExtractor(MergedTests))


### PR DESCRIPTION
This creates a separate XUnit test case for each actual test we'll be running, making it much easier to diagnose issues.

We *could* move the skipping to RetryTestCase.Flatten (just by not reporting them), but the current approach makes it clear how many tests we *are* skipping. Currently we're running 110 tests and skipping 204.