### PR TITLE
Release Google.Cloud.BigQuery.Connection.V1 version 2.4.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery connection API, which allows users to manage BigQuery connections to external data sources.</Description>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>

--- a/apis/Google.Cloud.BigQuery.Connection.V1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 2.4.0, released 2023-03-06
+
+### New features
+
+- Add cloud spanner connection properties - serverless analytics ([commit 3b22371](https://github.com/googleapis/google-cloud-dotnet/commit/3b2237128775b97a17af15651000139bedc94375))
+- Add cloud spanner connection properties - database role ([commit 3b22371](https://github.com/googleapis/google-cloud-dotnet/commit/3b2237128775b97a17af15651000139bedc94375))
+
 ## Version 2.3.0, released 2023-01-19
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -727,7 +727,7 @@
     },
     {
       "id": "Google.Cloud.BigQuery.Connection.V1",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "type": "grpc",
       "productName": "BigQuery Connection",
       "productUrl": "https://cloud.google.com/bigquery/docs/reference/bigqueryconnection",
@@ -737,7 +737,7 @@
         "connection"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.3.1",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Grpc.Core": "2.46.5"
       },


### PR DESCRIPTION

Changes in this release:

### New features

- Add cloud spanner connection properties - serverless analytics ([commit 3b22371](https://github.com/googleapis/google-cloud-dotnet/commit/3b2237128775b97a17af15651000139bedc94375))
- Add cloud spanner connection properties - database role ([commit 3b22371](https://github.com/googleapis/google-cloud-dotnet/commit/3b2237128775b97a17af15651000139bedc94375))
