### PR TITLE
Release Google.Cloud.CertificateManager.V1 version 2.3.0

### DIFF
--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.csproj
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.2.0</Version>
+    <Version>2.3.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Certificate Manager API, which lets you acquire and manage TLS (SSL) certificates for use with Cloud Load Balancing</Description>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />

--- a/apis/Google.Cloud.CertificateManager.V1/docs/history.md
+++ b/apis/Google.Cloud.CertificateManager.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 2.3.0, released 2023-03-06
+
+### Bug fixes
+
+- Workaround crashes in gRPC for C++ ([commit edf4bda](https://github.com/googleapis/google-cloud-dotnet/commit/edf4bda298867ba6bfce2927e14732f90260e65e))
+
+### Documentation improvements
+
+- Corrected information about the limit of certificates that can be attached to a Certificate Map Entry ([commit 7219d64](https://github.com/googleapis/google-cloud-dotnet/commit/7219d645951e1c29a9f73376de8c1a3e39cf1737))
+
 ## Version 2.2.0, released 2023-01-18
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1112,7 +1112,7 @@
     },
     {
       "id": "Google.Cloud.CertificateManager.V1",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "type": "grpc",
       "productName": "Certificate Manager",
       "productUrl": "https://cloud.google.com/certificate-manager/docs",
@@ -1123,7 +1123,7 @@
         "certificates"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.3.1",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
         "Grpc.Core": "2.46.5"


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Workaround crashes in gRPC for C++ ([commit edf4bda](https://github.com/googleapis/google-cloud-dotnet/commit/edf4bda298867ba6bfce2927e14732f90260e65e))

### Documentation improvements

- Corrected information about the limit of certificates that can be attached to a Certificate Map Entry ([commit 7219d64](https://github.com/googleapis/google-cloud-dotnet/commit/7219d645951e1c29a9f73376de8c1a3e39cf1737))
