### PR TITLE
Release Google.Cloud.Dialogflow.Cx.V3 version 2.6.0

### DIFF
--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.csproj
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.5.0</Version>
+    <Version>2.6.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Builds conversational interfaces (for example, chatbots, and voice-powered apps and devices).</Description>

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/docs/history.md
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.6.0, released 2023-03-06
+
+### New features
+
+- Added persist_parameter_changes field from `query_params` to MatchIntentRequest ([commit 3798668](https://github.com/googleapis/google-cloud-dotnet/commit/3798668f292c995ca023d2c03d236c6e7d60b00c))
+
 ## Version 2.5.0, released 2023-02-22
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1742,7 +1742,7 @@
     },
     {
       "id": "Google.Cloud.Dialogflow.Cx.V3",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "type": "grpc",
       "productName": "Dialogflow",
       "productUrl": "https://cloud.google.com/dialogflow/cx/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Added persist_parameter_changes field from `query_params` to MatchIntentRequest ([commit 3798668](https://github.com/googleapis/google-cloud-dotnet/commit/3798668f292c995ca023d2c03d236c6e7d60b00c))
