### PR TITLE
Release Google.Cloud.Video.Transcoder.V1 version 2.4.0

### DIFF
--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.csproj
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Transcoder API version v1, which converts video files into formats suitable for consumer distribution.</Description>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Video.Transcoder.V1/docs/history.md
+++ b/apis/Google.Cloud.Video.Transcoder.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.4.0, released 2023-03-06
+
+### New features
+
+- Specifying language code and display name for text and audio streams is now supported ([commit 5802f24](https://github.com/googleapis/google-cloud-dotnet/commit/5802f24a38927568ffbe807f85013f420a28cb96))
+
 ## Version 2.3.0, released 2023-01-19
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4522,7 +4522,7 @@
     },
     {
       "id": "Google.Cloud.Video.Transcoder.V1",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "type": "grpc",
       "productName": "Transcoder",
       "productUrl": "https://cloud.google.com/transcoder/docs",
@@ -4533,7 +4533,7 @@
         "transcoding"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.3.1",
         "Grpc.Core": "2.46.5"
       },
       "generator": "micro",


### PR DESCRIPTION

Changes in this release:

### New features

- Specifying language code and display name for text and audio streams is now supported ([commit 5802f24](https://github.com/googleapis/google-cloud-dotnet/commit/5802f24a38927568ffbe807f85013f420a28cb96))
