### PR TITLE
Release GSuite Add-Ons libraries version 2.1.0

### DIFF
--- a/apis/Google.Apps.Script.Type/Google.Apps.Script.Type/Google.Apps.Script.Type.csproj
+++ b/apis/Google.Apps.Script.Type/Google.Apps.Script.Type/Google.Apps.Script.Type.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Version-agnostic types for Apps Script APIs.</Description>
@@ -9,6 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.CommonProtos" Version="[2.6.0, 3.0.0)" />
+    <PackageReference Include="Google.Api.CommonProtos" Version="[2.7.0, 3.0.0)" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Apps.Script.Type/docs/history.md
+++ b/apis/Google.Apps.Script.Type/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 2.1.0, released 2023-03-06
+
+No API surface changes; just dependency updates.
+
 ## Version 2.0.0, released 2022-06-09
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.csproj
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Workspace Add-ons API</Description>
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
     <ProjectReference Include="..\..\Google.Apps.Script.Type\Google.Apps.Script.Type\Google.Apps.Script.Type.csproj" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.GSuiteAddOns.V1/docs/history.md
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.1.0, released 2023-03-06
+
+### New features
+
+- Enable REST transport in C# ([commit cdb518c](https://github.com/googleapis/google-cloud-dotnet/commit/cdb518c3524106ea73f0e546557a0180589ca3b0))
+
 ## Version 2.0.0, released 2022-06-09
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -56,7 +56,7 @@
     },
     {
       "id": "Google.Apps.Script.Type",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "targetFrameworks": "netstandard2.1;net462",
       "type": "other",
       "description": "Version-agnostic types for Apps Script APIs.",
@@ -64,7 +64,7 @@
         "gsuite"
       ],
       "dependencies": {
-        "Google.Api.CommonProtos": "2.6.0"
+        "Google.Api.CommonProtos": "2.7.0"
       },
       "generator": "proto",
       "protoPath": "google/apps/script/type"
@@ -2232,7 +2232,7 @@
     },
     {
       "id": "Google.Cloud.GSuiteAddOns.V1",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "type": "grpc",
       "productName": "Google Workspace Add-ons",
       "productUrl": "https://developers.google.com/gsuite/add-ons/overview",
@@ -2243,9 +2243,9 @@
         "add-ons"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.2.0",
+        "Google.Api.Gax.Grpc": "4.3.1",
         "Google.Apps.Script.Type": "project",
-        "Grpc.Core": "2.46.3"
+        "Grpc.Core": "2.46.5"
       },
       "generator": "micro",
       "protoPath": "google/cloud/gsuiteaddons/v1",


### PR DESCRIPTION

Changes in Google.Apps.Script.Type version 2.1.0:

No API surface changes; just dependency updates.

Changes in Google.Cloud.GSuiteAddOns.V1 version 2.1.0:

### New features

- Enable REST transport in C# ([commit cdb518c](https://github.com/googleapis/google-cloud-dotnet/commit/cdb518c3524106ea73f0e546557a0180589ca3b0))

Packages in this release:
- Release Google.Apps.Script.Type version 2.1.0
- Release Google.Cloud.GSuiteAddOns.V1 version 2.1.0
