### PR TITLE
chore: Remove the grouping for GSuite APIs

### DIFF
--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5036,14 +5036,6 @@
       ]
     },
     {
-      "id": "Google.Cloud.GSuite",
-      "displayName": "GSuite Add-Ons",
-      "packageIds": [
-        "Google.Apps.Script.Type",
-        "Google.Cloud.GSuiteAddOns.V1"
-      ]
-    },
-    {
       "id": "Google.Cloud.OsLogin",
       "displayName": "OS Login",
       "packageIds": [


### PR DESCRIPTION
Now that everything's been released, there's no need for this to be a group.