### PR TITLE
chore: Update docfx and move to Markdig

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "docfx": {
-      "version": "2.62.1",
+      "version": "2.62.2",
       "commands": [
         "docfx"
       ]

--- a/tools/Google.Cloud.Tools.GenerateDocfxSources/Program.cs
+++ b/tools/Google.Cloud.Tools.GenerateDocfxSources/Program.cs
@@ -117,11 +117,7 @@ namespace Google.Cloud.Tools.GenerateDocfxSources
                     },
                     ["template"] = new JArray { "default", "../../../third_party/docfx/templates/custom" },
                     ["overwrite"] = new JArray { "obj/snippets/*.md" },
-                    ["dest"] = "site",
-                    // As of 2.61.0, the default Markdown engine is markdig,
-                    // which fails to parse our overwrite files.
-                    // See https://github.com/dotnet/docfx/issues/8441
-                    ["markdownEngineName"] = "dfm"
+                    ["dest"] = "site"
                 }
             };
             File.WriteAllText(Path.Combine(outputDirectory, "docfx.json"), json.ToString());


### PR DESCRIPTION
(Markdig is the default Markdown engine in docfx now. We were only using dfm explicitly due to the previous Markdig integration not supporting overwrite files with multiple sections.)