### PR TITLE
Release Google.Cloud.PubSub.V1 version 3.4.0

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/Google.Cloud.PubSub.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/Google.Cloud.PubSub.V1.GeneratedSnippets.csproj
@@ -7,11 +7,13 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.3.1, 5.0.0)" />
     <PackageReference Include="Google.Apis.CloudResourceManager.v1" Version="[1.60.0.2950, 2.0.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1.csproj" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.IntegrationTests/Google.Cloud.PubSub.V1.IntegrationTests.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.IntegrationTests/Google.Cloud.PubSub.V1.IntegrationTests.csproj
@@ -7,11 +7,13 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.3.1, 5.0.0)" />
     <PackageReference Include="Google.Apis.CloudResourceManager.v1" Version="[1.60.0.2950, 2.0.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1.csproj" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/Google.Cloud.PubSub.V1.Snippets.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/Google.Cloud.PubSub.V1.Snippets.csproj
@@ -7,13 +7,13 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.3.1, 5.0.0)" />
     <PackageReference Include="Google.Apis.CloudResourceManager.v1" Version="[1.60.0.2950, 2.0.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1.csproj" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Tests/Google.Cloud.PubSub.V1.Tests.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Tests/Google.Cloud.PubSub.V1.Tests.csproj
@@ -7,11 +7,13 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.3.1, 5.0.0)" />
     <PackageReference Include="Google.Apis.CloudResourceManager.v1" Version="[1.60.0.2950, 2.0.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1.csproj" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.3.0</Version>
+    <Version>3.4.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.</Description>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>

--- a/apis/Google.Cloud.PubSub.V1/docs/history.md
+++ b/apis/Google.Cloud.PubSub.V1/docs/history.md
@@ -1,5 +1,31 @@
 # Version history
 
+## Version 3.4.0, released 2023-03-08
+
+### Bug fixes
+
+- Ack/ModAck failures in non exactly once delivery flow should not be retried. ([commit a0da1f5](https://github.com/googleapis/google-cloud-dotnet/commit/a0da1f50b682c0c6f2670c85ca6d0356187988be))
+
+### New features
+
+- Make INTERNAL a retryable error for Pull ([commit ad9963e](https://github.com/googleapis/google-cloud-dotnet/commit/ad9963ed3b4620fe205d58a8fbab90b4a3ab443f))
+- Add temporary_failed_ack_ids to ModifyAckDeadlineConfirmation ([commit 55fef61](https://github.com/googleapis/google-cloud-dotnet/commit/55fef61f57d98bb450d8f6a85a6d42a5e7d9ac56))
+- Add google.api.method.signature to update methods ([commit cf2f61a](https://github.com/googleapis/google-cloud-dotnet/commit/cf2f61aed8aa14479e85edda1e50d23d178e55b9))
+- Implemented IAsyncDisposable in PublisherClient and SubscriberClient ([commit 2ae9ab7](https://github.com/googleapis/google-cloud-dotnet/commit/2ae9ab78d14bede0542274f03dd439c95564db55))
+- Added IServiceCollection extension methods for PublisherClient and SubscriberClient ([commit fe942e0](https://github.com/googleapis/google-cloud-dotnet/commit/fe942e04efbec32afa3d45e48bf6d9bf2cbf186d))
+
+### Documentation improvements
+
+- Add x-ref for ordering messages ([commit 16a4ddc](https://github.com/googleapis/google-cloud-dotnet/commit/16a4ddc83ed06eda2956b3c5e7e865183289efe3))
+- Clarify subscription expiration policy ([commit 16a4ddc](https://github.com/googleapis/google-cloud-dotnet/commit/16a4ddc83ed06eda2956b3c5e7e865183289efe3))
+- Clarify BigQueryConfig PERMISSION_DENIED state ([commit 78feab7](https://github.com/googleapis/google-cloud-dotnet/commit/78feab77bc9b3f29a5d2409556c65dffc626b4ca))
+- Clarify subscription description ([commit 5d43a47](https://github.com/googleapis/google-cloud-dotnet/commit/5d43a47d1e985fd500518af652a33046f88b7d32))
+- Replacing HTML code with Markdown ([commit f9467b0](https://github.com/googleapis/google-cloud-dotnet/commit/f9467b0ef8da529c323f2edab5592083f9b8278f))
+- Fix PullResponse description ([commit f9467b0](https://github.com/googleapis/google-cloud-dotnet/commit/f9467b0ef8da529c323f2edab5592083f9b8278f))
+- Fix Pull description ([commit f9467b0](https://github.com/googleapis/google-cloud-dotnet/commit/f9467b0ef8da529c323f2edab5592083f9b8278f))
+- Update Pub/Sub topic retention limit from 7 days to 31 days ([commit 7281474](https://github.com/googleapis/google-cloud-dotnet/commit/7281474046db813b4f93d2c7449b803eb6ee287d))
+- Mark revision_id in CommitSchemaRevisionRequest deprecated ([commit 2a9ddbb](https://github.com/googleapis/google-cloud-dotnet/commit/2a9ddbb360a92a6b9736c6d87f732bf91d4be2b7))
+
 ## Version 3.3.0, released 2023-01-19
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3417,21 +3417,21 @@
       "protoPath": "google/pubsub/v1",
       "productName": "Cloud Pub/Sub",
       "productUrl": "https://cloud.google.com/pubsub/",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.",
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.3.1",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Grpc.Core": "2.46.5"
       },
       "testDependencies": {
-        "Google.Api.Gax.Testing": "4.3.0",
+        "Google.Api.Gax.Testing": "4.3.1",
         "Google.Apis.CloudResourceManager.v1": "1.60.0.2950",
         "Microsoft.Extensions.DependencyInjection": "6.0.0",
-        "Microsoft.Extensions.Hosting.Abstractions": "6.0.0",
         "Microsoft.Extensions.Hosting": "6.0.0",
+        "Microsoft.Extensions.Hosting.Abstractions": "6.0.0",
         "System.ValueTuple": "4.5.0",
         "Xunit.Combinatorial": "1.4.1"
       },


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Ack/ModAck failures in non exactly once delivery flow should not be retried. ([commit a0da1f5](https://github.com/googleapis/google-cloud-dotnet/commit/a0da1f50b682c0c6f2670c85ca6d0356187988be))

### New features

- Make INTERNAL a retryable error for Pull ([commit ad9963e](https://github.com/googleapis/google-cloud-dotnet/commit/ad9963ed3b4620fe205d58a8fbab90b4a3ab443f))
- Add temporary_failed_ack_ids to ModifyAckDeadlineConfirmation ([commit 55fef61](https://github.com/googleapis/google-cloud-dotnet/commit/55fef61f57d98bb450d8f6a85a6d42a5e7d9ac56))
- Add google.api.method.signature to update methods ([commit cf2f61a](https://github.com/googleapis/google-cloud-dotnet/commit/cf2f61aed8aa14479e85edda1e50d23d178e55b9))
- Implemented IAsyncDisposable in PublisherClient and SubscriberClient ([commit 2ae9ab7](https://github.com/googleapis/google-cloud-dotnet/commit/2ae9ab78d14bede0542274f03dd439c95564db55))
- Added IServiceCollection extension methods for PublisherClient and SubscriberClient ([commit fe942e0](https://github.com/googleapis/google-cloud-dotnet/commit/fe942e04efbec32afa3d45e48bf6d9bf2cbf186d))

### Documentation improvements

- Add x-ref for ordering messages ([commit 16a4ddc](https://github.com/googleapis/google-cloud-dotnet/commit/16a4ddc83ed06eda2956b3c5e7e865183289efe3))
- Clarify subscription expiration policy ([commit 16a4ddc](https://github.com/googleapis/google-cloud-dotnet/commit/16a4ddc83ed06eda2956b3c5e7e865183289efe3))
- Clarify BigQueryConfig PERMISSION_DENIED state ([commit 78feab7](https://github.com/googleapis/google-cloud-dotnet/commit/78feab77bc9b3f29a5d2409556c65dffc626b4ca))
- Clarify subscription description ([commit 5d43a47](https://github.com/googleapis/google-cloud-dotnet/commit/5d43a47d1e985fd500518af652a33046f88b7d32))
- Replacing HTML code with Markdown ([commit f9467b0](https://github.com/googleapis/google-cloud-dotnet/commit/f9467b0ef8da529c323f2edab5592083f9b8278f))
- Fix PullResponse description ([commit f9467b0](https://github.com/googleapis/google-cloud-dotnet/commit/f9467b0ef8da529c323f2edab5592083f9b8278f))
- Fix Pull description ([commit f9467b0](https://github.com/googleapis/google-cloud-dotnet/commit/f9467b0ef8da529c323f2edab5592083f9b8278f))
- Update Pub/Sub topic retention limit from 7 days to 31 days ([commit 7281474](https://github.com/googleapis/google-cloud-dotnet/commit/7281474046db813b4f93d2c7449b803eb6ee287d))
- Mark revision_id in CommitSchemaRevisionRequest deprecated ([commit 2a9ddbb](https://github.com/googleapis/google-cloud-dotnet/commit/2a9ddbb360a92a6b9736c6d87f732bf91d4be2b7))
