### PR TITLE
chore: Removed the [Fact] attribute from the sample.

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/SubscriberClientSnippets.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/SubscriberClientSnippets.cs
@@ -81,9 +81,8 @@ namespace Google.Cloud.PubSub.V1.Snippets
             services.AddHostedService<SubscriberService>();
             // End sample        
         }
-
-        [Fact]
-        public async Task UseSubscriberServiceInConsoleApp()
+                
+        internal async Task UseSubscriberServiceInConsoleApp()
         {            
             string projectId = "projectId";
             string subscriptionId = "subscriptionId";


### PR DESCRIPTION
This fixes the test failure introduced by the sample [here](https://fusion2.corp.google.com/ci/kokoro/prod:cloud-sharp%2Fgoogle-cloud-dotnet%2Fgcp_windows%2Fautorelease/activity/3f47390a-79c2-4dd9-87ef-509dd62e3cea/log)

I had to make the method internal as just removing the [Fact] attribute threw [xUnit1013](https://xunit.net/xunit.analyzers/rules/xUnit1013)

I have locally generated the documentation and verified that snippet is still resolved in the generated documentation.  