### PR TITLE
Release Google.Cloud.Batch.V1Alpha version 1.0.0-alpha09

### DIFF
--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.csproj
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha08</Version>
+    <Version>1.0.0-alpha09</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Batch API (v1alpha), which allows you to manage the running of batch jobs on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Batch.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.Batch.V1Alpha/docs/history.md
@@ -1,5 +1,22 @@
 # Version history
 
+## Version 1.0.0-alpha09, released 2023-03-09
+
+### BREAKING CHANGE
+
+`BatchServiceClient` no longer exposes an `IAMPolicyClient`. This
+was only exposed unintentionally, and has never worked. However, this
+is still a breaking change as application code may have referred to
+it.
+
+### New features
+
+- Resource usage ([commit 80fe952](https://github.com/googleapis/google-cloud-dotnet/commit/80fe952729cd338837f752fefe7f94a0573b5368))
+
+### Documentation improvements
+
+- Update comments ([commit 80fe952](https://github.com/googleapis/google-cloud-dotnet/commit/80fe952729cd338837f752fefe7f94a0573b5368))
+
 ## Version 1.0.0-alpha08, released 2023-02-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -569,7 +569,7 @@
     },
     {
       "id": "Google.Cloud.Batch.V1Alpha",
-      "version": "1.0.0-alpha08",
+      "version": "1.0.0-alpha09",
       "type": "grpc",
       "productName": "Batch",
       "productUrl": "https://cloud.google.com/batch/docs/",


### PR DESCRIPTION

Changes in this release:

### BREAKING CHANGE

`BatchServiceClient` no longer exposes an `IAMPolicyClient`. This was only exposed unintentionally, and has never worked. However, this is still a breaking change as application code may have referred to it.

### New features

- Resource usage ([commit 80fe952](https://github.com/googleapis/google-cloud-dotnet/commit/80fe952729cd338837f752fefe7f94a0573b5368))

### Documentation improvements

- Update comments ([commit 80fe952](https://github.com/googleapis/google-cloud-dotnet/commit/80fe952729cd338837f752fefe7f94a0573b5368))
