### PR TITLE
Release Google.Cloud.Batch.V1 version 2.0.0

### DIFF
--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.csproj
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.3.0</Version>
+    <Version>2.0.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Batch API (v1), which allows you to manage the running of batch jobs on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Batch.V1/docs/history.md
+++ b/apis/Google.Cloud.Batch.V1/docs/history.md
@@ -1,5 +1,21 @@
 # Version history
 
+## Version 2.0.0, released 2023-03-09
+
+### BREAKING CHANGE
+
+BatchServiceClient no longer exposes an IAMPolicyClient. This was
+only exposed unintentionally, and has never worked. However, this is
+still a breaking change as application code may have referred to it.
+
+### New features
+
+- Added StatusEvent.task_state ([commit 25463ba](https://github.com/googleapis/google-cloud-dotnet/commit/25463baadfe8e1c958371757fe800df85d9b8542))
+
+### Documentation improvements
+
+- Updated comments ([commit 25463ba](https://github.com/googleapis/google-cloud-dotnet/commit/25463baadfe8e1c958371757fe800df85d9b8542))
+
 ## Version 1.3.0, released 2023-02-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -545,7 +545,7 @@
     },
     {
       "id": "Google.Cloud.Batch.V1",
-      "version": "1.3.0",
+      "version": "2.0.0",
       "type": "grpc",
       "productName": "Batch",
       "productUrl": "https://cloud.google.com/batch/docs/",


### PR DESCRIPTION

Changes in this release:

### BREAKING CHANGE

BatchServiceClient no longer exposes an IAMPolicyClient. This was only exposed unintentionally, and has never worked. However, this is still a breaking change as application code may have referred to it.

### New features

- Added StatusEvent.task_state ([commit 25463ba](https://github.com/googleapis/google-cloud-dotnet/commit/25463baadfe8e1c958371757fe800df85d9b8542))

### Documentation improvements

- Updated comments ([commit 25463ba](https://github.com/googleapis/google-cloud-dotnet/commit/25463baadfe8e1c958371757fe800df85d9b8542))
