### PR TITLE
Release Google.Cloud.Datastore.V1 version 4.5.0

### DIFF
--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/Google.Cloud.Datastore.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/Google.Cloud.Datastore.V1.GeneratedSnippets.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.3.1, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Datastore.V1\Google.Cloud.Datastore.V1.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/Google.Cloud.Datastore.V1.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/Google.Cloud.Datastore.V1.IntegrationTests.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.3.1, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Datastore.V1\Google.Cloud.Datastore.V1.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/Google.Cloud.Datastore.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/Google.Cloud.Datastore.V1.Snippets.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.3.1, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Datastore.V1\Google.Cloud.Datastore.V1.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Tests/Google.Cloud.Datastore.V1.Tests.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Tests/Google.Cloud.Datastore.V1.Tests.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.3.1, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Datastore.V1\Google.Cloud.Datastore.V1.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.4.0</Version>
+    <Version>4.5.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Datastore API, which accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.</Description>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/apis/Google.Cloud.Datastore.V1/docs/history.md
+++ b/apis/Google.Cloud.Datastore.V1/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 4.5.0, released 2023-03-13
+
+### New features
+
+- Add Filter.Or static convenience methods ([issue 9946](https://github.com/googleapis/google-cloud-dotnet/issues/9946)) ([commit 00967cb](https://github.com/googleapis/google-cloud-dotnet/commit/00967cbe9cedd631dc6bbc3bd297db4a87e5d86b))
+- Add `OR` query support (underlying proto API) ([commit 603dee4](https://github.com/googleapis/google-cloud-dotnet/commit/603dee4be049456477c82c6cbd7a3f8e1c334dd6))
+- Add support for count(*) aggregation ([commit 8ee696d](https://github.com/googleapis/google-cloud-dotnet/commit/8ee696dfa57e0f5c80e8024d54ae536f2cd0ec00))
+
+### Documentation improvements
+
+- Minor documentation formatting and cleanup ([commit 603dee4](https://github.com/googleapis/google-cloud-dotnet/commit/603dee4be049456477c82c6cbd7a3f8e1c334dd6))
+
 ## Version 4.4.0, released 2023-01-16
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1526,7 +1526,7 @@
       "protoPath": "google/datastore/v1",
       "productName": "Google Cloud Datastore",
       "productUrl": "https://cloud.google.com/datastore/docs/concepts/overview",
-      "version": "4.4.0",
+      "version": "4.5.0",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Datastore API, which accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.",
@@ -1534,13 +1534,13 @@
         "Datastore"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.3.1",
         "Google.LongRunning": "3.0.0",
         "Grpc.Core": "2.46.5",
         "System.Linq.Async": "6.0.1"
       },
       "testDependencies": {
-        "Google.Api.Gax.Grpc.Testing": "4.3.0"
+        "Google.Api.Gax.Grpc.Testing": "4.3.1"
       },
       "shortName": "datastore",
       "serviceConfigFile": "datastore_v1.yaml",


### PR DESCRIPTION

Changes in this release:

### New features

- Add Filter.Or static convenience methods ([issue 9946](https://github.com/googleapis/google-cloud-dotnet/issues/9946)) ([commit 00967cb](https://github.com/googleapis/google-cloud-dotnet/commit/00967cbe9cedd631dc6bbc3bd297db4a87e5d86b))
- Add `OR` query support (underlying proto API) ([commit 603dee4](https://github.com/googleapis/google-cloud-dotnet/commit/603dee4be049456477c82c6cbd7a3f8e1c334dd6))
- Add support for count(*) aggregation ([commit 8ee696d](https://github.com/googleapis/google-cloud-dotnet/commit/8ee696dfa57e0f5c80e8024d54ae536f2cd0ec00))

### Documentation improvements

- Minor documentation formatting and cleanup ([commit 603dee4](https://github.com/googleapis/google-cloud-dotnet/commit/603dee4be049456477c82c6cbd7a3f8e1c334dd6))
