### PR TITLE
chore: Update packaging to use PackageLicenseExpression

### DIFF
--- a/apis/Directory.Build.props
+++ b/apis/Directory.Build.props
@@ -30,7 +30,7 @@
     <Copyright>Copyright $([System.DateTime]::UtcNow.ToString(yyyy)) Google LLC</Copyright>
     <PackageIcon>NuGetIcon.png</PackageIcon>
     <PackageIconUrl>https://cloud.google.com/images/gcp-icon-64x64.png</PackageIconUrl>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/googleapis/google-cloud-dotnet</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/googleapis/google-cloud-dotnet</RepositoryUrl>


### PR DESCRIPTION
We still include the license file within the package, so we continue to meet all obligations, but this is easier for customers to validate.

(Non-urgent to review.)