### PR TITLE
chore: Add skipped smoke test for Maps Platform Datasets

### DIFF
--- a/apis/Google.Maps.MapsPlatformDatasets.V1Alpha/smoketests.json
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1Alpha/smoketests.json
@@ -1,0 +1,10 @@
+[
+  {
+    "skip": "Requires project ID support",
+    "method": "ListDatasets",
+    "client": "MapsPlatformDatasetsV1AlphaClient",
+    "arguments": {
+      "parent": "projects/${PROJECT_ID}"
+    }
+  }
+]


### PR DESCRIPTION
We should be able to unskip this soon.