### PR TITLE
chore: Update Firestore code to follow editorconfig requirements

### DIFF
--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Benchmarks/Program.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Benchmarks/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2018 Google LLC
+// Copyright 2018 Google LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,11 +15,11 @@
 using BenchmarkDotNet.Running;
 using System.Reflection;
 
-namespace Google.Cloud.Firestore.Benchmarks
+namespace Google.Cloud.Firestore.Benchmark
 {
-    class Program
+    internal class Program
     {
-        static void Main(string[] args) =>
+        private static void Main(string[] args) =>
             new BenchmarkSwitcher(typeof(Program).GetTypeInfo().Assembly).Run(args);
     }
 }

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.CleanTestData/Program.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.CleanTestData/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2019, Google LLC
+// Copyright 2019, Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,9 +18,9 @@ using System.Threading.Tasks;
 
 namespace Google.Cloud.Firestore.CleanTestData
 {
-    class Program
+    internal class Program
     {
-        static async Task Main(string[] args)
+        private static async Task Main(string[] args)
         {
             string project = Environment.GetEnvironmentVariable("FIRESTORE_TEST_PROJECT");
             var db = FirestoreDb.Create(project);

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Converters/AttributedTimestampAssignerTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Converters/AttributedTimestampAssignerTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2019, Google LLC
+// Copyright 2019, Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -99,7 +99,7 @@ namespace Google.Cloud.Firestore.Tests.Converters
             /// A timestamp that isn't part of a snapshot. This is used to ensure we're actually setting properties
             /// rather than just leaving them.
             /// </summary>
-            private static Timestamp s_sampleOtherTimestamp = new Timestamp(-1, 123);
+            private static readonly Timestamp s_sampleOtherTimestamp = new Timestamp(-1, 123);
 
             [FirestoreDocumentCreateTimestamp] public DateTime CreateDateTime { get; set; } = s_sampleOtherTimestamp.ToDateTime();
             [FirestoreDocumentCreateTimestamp] public DateTimeOffset CreateDateTimeOffset { get; set; } = s_sampleOtherTimestamp.ToDateTimeOffset();

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Converters/ValueTupleConverterTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Converters/ValueTupleConverterTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2019, Google LLC
+// Copyright 2019, Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ namespace Google.Cloud.Firestore.Tests.Converters
     // are in ValueSerializerTest/ValueDeserializerTest via SerializationTestData.TupleModel
     public class ValueTupleConverterTest
     {
-        private static FirestoreDb s_db = new FirestoreDbBuilder
+        private static readonly FirestoreDb s_db = new FirestoreDbBuilder
         {
             CallInvoker = new ThrowingInvoker(),
             ConverterRegistry = new ConverterRegistry
@@ -40,7 +40,7 @@ namespace Google.Cloud.Firestore.Tests.Converters
         private static SerializationContext SerializationContext => s_db.SerializationContext;
         private static DeserializationContext DeserializationContext => new DeserializationContext(GetSampleSnapshot(s_db, "doc1"));
 
-        private static object[] s_sampleValuesByArity =
+        private static readonly object[] s_sampleValuesByArity =
         {
             null,
             null,

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/DocumentChangeTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/DocumentChangeTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2018, Google LLC
+// Copyright 2018, Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Cloud.ClientTesting;
 using Xunit;
 using static Google.Cloud.Firestore.Tests.DocumentSnapshotHelpers;
 
 namespace Google.Cloud.Firestore.Tests
 {
-    using Google.Cloud.ClientTesting;
-
     public class DocumentChangeTest
     {
         private static readonly FirestoreDb s_db = FirestoreDb.Create("proj", "db", new FakeFirestoreClient());

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/DocumentSetTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/DocumentSetTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2018, Google LLC
+// Copyright 2018, Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,15 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Cloud.Firestore.V1;
 using System.Collections.Generic;
+using System.Linq;
 using Xunit;
+using static Google.Cloud.Firestore.Tests.ProtoHelpers;
 
 namespace Google.Cloud.Firestore.Tests
 {
-    using Google.Cloud.Firestore.V1;
-    using System.Linq;
-    using static ProtoHelpers;
-
     public class DocumentSetTest
     {
         private static readonly FirestoreDb s_db = FirestoreDb.Create("proj", "db", new FakeFirestoreClient());

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/DocumentSnapshotHelpers.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/DocumentSnapshotHelpers.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2019, Google LLC
+// Copyright 2019, Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,11 +13,10 @@
 // limitations under the License.
 
 using Google.Cloud.Firestore.V1;
+using static Google.Cloud.Firestore.Tests.ProtoHelpers;
 
 namespace Google.Cloud.Firestore.Tests
 {
-    using static ProtoHelpers;
-
     /// <summary>
     /// Helpers to create sample document snapshots easily.
     /// </summary>

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/QueryTest.CreateDocumentSnapshotComparer.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/QueryTest.CreateDocumentSnapshotComparer.cs
@@ -13,15 +13,14 @@
 // limitations under the License.
 
 using Google.Cloud.Firestore.V1;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using static Google.Cloud.Firestore.Tests.ProtoHelpers;
 
 namespace Google.Cloud.Firestore.Tests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using Xunit;
-    using static ProtoHelpers;
-
     /// <summary>
     /// Tests for Query.CreateDocumentSnapshotComparer
     /// </summary>

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/SentinelValueTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/SentinelValueTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2018, Google LLC
+// Copyright 2018, Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,15 +13,11 @@
 // limitations under the License.
 
 using Google.Cloud.Firestore.V1;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Xunit;
+using static Google.Cloud.Firestore.Tests.ProtoHelpers;
 
 namespace Google.Cloud.Firestore.Tests
 {
-    using static ProtoHelpers;
-
     public class SentinelValueTest
     {
         [Fact]

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/ValueComparerTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/ValueComparerTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2018, Google LLC
+// Copyright 2018, Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,13 +14,12 @@
 
 using Google.Cloud.Firestore.V1;
 using System.Collections.Generic;
+using System.Linq;
 using Xunit;
+using static Google.Cloud.Firestore.Tests.ProtoHelpers;
 
 namespace Google.Cloud.Firestore.Tests
 {
-    using System.Linq;
-    using static ProtoHelpers;
-
     public class ValueComparerTest
     {
         // Taken from OrderTest.java, with a few extra tests.

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/WatchStreamTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/WatchStreamTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2018, Google LLC
+// Copyright 2018, Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -283,11 +283,11 @@ namespace Google.Cloud.Firestore.Tests
             /// </summary>
             private readonly TaskCompletionSource<int> _completionTaskSource = new TaskCompletionSource<int>();
             private readonly FakeScheduler _scheduler;
+            private readonly FakeWatchState _watchState;
 
+            private int _responseIndex;
             private FakeWatchStream _currentStream;
             private List<Func<ListenResponse>> _currentResponseList;
-            private FakeWatchState _watchState;
-            private int _responseIndex;
 
             internal WatchStream WatchStream { get; }
 
@@ -399,11 +399,12 @@ namespace Google.Cloud.Firestore.Tests
 
         private class FakeWatchState : IWatchState
         {
-            private List<(int index, ByteString token)> _resumeTokens = new List<(int, ByteString)> { (-1, null) };
-            private int _lastSeenIndex = -1;
+            private readonly List<(int index, ByteString token)> _resumeTokens = new List<(int, ByteString)> { (-1, null) };
             // Very primitive mocking; we can't use Moq due to the types being internal.
-            private Queue<Delegate> _expectedCalls = new Queue<Delegate>();
+            private readonly Queue<Delegate> _expectedCalls = new Queue<Delegate>();
             private readonly Action _hangingCallback;
+
+            private int _lastSeenIndex = -1;
 
             public ByteString ResumeToken => _resumeTokens.Last(tuple => tuple.index <= _lastSeenIndex).token;
 
@@ -536,10 +537,11 @@ namespace Google.Cloud.Firestore.Tests
         {
             private readonly FakeResponseList _responses;
             private readonly ListenRequest _expectedRequest;
+            private readonly AsyncDuplexStreamingCall<ListenRequest, ListenResponse> _grpcCall;
+
             internal bool Completed { get; private set; }
             internal bool Disposed { get; private set; }
             private bool _requestWritten = false;
-            private AsyncDuplexStreamingCall<ListenRequest, ListenResponse> _grpcCall;
 
             internal FakeWatchStream(ListenRequest expectedRequest, FakeResponseList responses)
             {

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Converters/AttributedTypeConverter.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Converters/AttributedTypeConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2018, Google LLC
+// Copyright 2018, Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -160,7 +160,7 @@ namespace Google.Cloud.Firestore.Converters
         private sealed class AttributedProperty
         {
             private readonly PropertyInfo _propertyInfo;
-            private SentinelValue _sentinelValue;
+            private readonly SentinelValue _sentinelValue;
             private readonly IFirestoreInternalConverter _converter;
 
             /// <summary>

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/FieldMask.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/FieldMask.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2018, Google LLC
+// Copyright 2018, Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ namespace Google.Cloud.Firestore
         {
         }
 
-        static IEnumerable<FieldPath> ConvertPaths(string[] paths)
+        private static IEnumerable<FieldPath> ConvertPaths(string[] paths)
         {
             GaxPreconditions.CheckNotNull(paths, nameof(paths));
             return paths.Select(path =>
@@ -61,7 +61,7 @@ namespace Google.Cloud.Firestore
         {
         }
 
-        static IEnumerable<FieldPath> CheckPaths(FieldPath[] paths)
+        private static IEnumerable<FieldPath> CheckPaths(FieldPath[] paths)
         {
             GaxPreconditions.CheckNotNull(paths, nameof(paths));
             GaxPreconditions.CheckArgument(!paths.Contains(null), nameof(paths), "Path array must not contain any null elements");

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/ValueComparer.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/ValueComparer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2018, Google LLC
+// Copyright 2018, Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ namespace Google.Cloud.Firestore
         }
 
         internal static ValueComparer Instance { get; } = new ValueComparer();
-        private static Dictionary<ValueTypeOneofCase, TypeOrder> s_typeMap = new Dictionary<ValueTypeOneofCase, TypeOrder>
+        private static readonly Dictionary<ValueTypeOneofCase, TypeOrder> s_typeMap = new Dictionary<ValueTypeOneofCase, TypeOrder>
         {
             { ValueTypeOneofCase.NullValue, TypeOrder.Null },
             { ValueTypeOneofCase.BooleanValue, TypeOrder.Boolean },


### PR DESCRIPTION
There are no semantically-significant changes here.

When making some fields readonly, I've sometimes reordered so that all the readonly fields appear before the non-readonly ones.