### PR TITLE
Release Google.Cloud.Compute.V1 version 2.8.0

### DIFF
--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.7.0</Version>
+    <Version>2.8.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Compute Engine API.</Description>

--- a/apis/Google.Cloud.Compute.V1/docs/history.md
+++ b/apis/Google.Cloud.Compute.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.8.0, released 2023-03-20
+
+### New features
+
+- Update Compute Engine API to revision 20230307 ([issue 770](https://github.com/googleapis/google-cloud-dotnet/issues/770)) ([commit 0497f75](https://github.com/googleapis/google-cloud-dotnet/commit/0497f75cb6372e1c72d4302211894c8146335f70))
+
 ## Version 2.7.0, released 2023-02-08
 
 ### New features

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Google.Cloud.Firestore.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Google.Cloud.Firestore.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Filter.*.cs">
-        <DependentUpon>Filter.cs</DependentUpon>
+      <DependentUpon>Filter.cs</DependentUpon>
     </Compile>
   </ItemGroup>
 </Project>

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1239,7 +1239,7 @@
     },
     {
       "id": "Google.Cloud.Compute.V1",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "type": "regapic",
       "productName": "Compute Engine",
       "productUrl": "https://cloud.google.com/compute",


### PR DESCRIPTION

Changes in this release:

### New features

- Update Compute Engine API to revision 20230307 ([issue 770](https://github.com/googleapis/google-cloud-dotnet/issues/770)) ([commit 0497f75](https://github.com/googleapis/google-cloud-dotnet/commit/0497f75cb6372e1c72d4302211894c8146335f70))
