### PR TITLE
Release Google.Cloud.DataCatalog.V1 version 2.3.0

### DIFF
--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.csproj
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.2.0</Version>
+    <Version>2.3.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Data Catalog API. Data Catalog is a fully managed and highly scalable data discovery and metadata management service.</Description>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />

--- a/apis/Google.Cloud.DataCatalog.V1/docs/history.md
+++ b/apis/Google.Cloud.DataCatalog.V1/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 2.3.0, released 2023-03-20
+
+### New features
+
+- Add support for new ImportEntries() API, including format of the dump ([commit 2628c55](https://github.com/googleapis/google-cloud-dotnet/commit/2628c5527cfedb6b775e3858a1ce38aad7920d72))
+- Add support for entries associated with Looker and CloudSQL ([commit 2628c55](https://github.com/googleapis/google-cloud-dotnet/commit/2628c5527cfedb6b775e3858a1ce38aad7920d72))
+- Add support for a ReconcileTags() API method ([commit 2628c55](https://github.com/googleapis/google-cloud-dotnet/commit/2628c5527cfedb6b775e3858a1ce38aad7920d72))
+
 ## Version 2.2.0, released 2023-01-16
 
 ### New features

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Google.Cloud.Firestore.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Google.Cloud.Firestore.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Filter.*.cs">
-        <DependentUpon>Filter.cs</DependentUpon>
+      <DependentUpon>Filter.cs</DependentUpon>
     </Compile>
   </ItemGroup>
 </Project>

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1329,7 +1329,7 @@
       "protoPath": "google/cloud/datacatalog/v1",
       "productName": "Data Catalog",
       "productUrl": "https://cloud.google.com/data-catalog/docs",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Data Catalog API. Data Catalog is a fully managed and highly scalable data discovery and metadata management service.",
       "tags": [
@@ -1337,7 +1337,7 @@
         "metadata"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.3.1",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.LongRunning": "3.0.0",
         "Grpc.Core": "2.46.5"


### PR DESCRIPTION

Changes in this release:

### New features

- Add support for new ImportEntries() API, including format of the dump ([commit 2628c55](https://github.com/googleapis/google-cloud-dotnet/commit/2628c5527cfedb6b775e3858a1ce38aad7920d72))
- Add support for entries associated with Looker and CloudSQL ([commit 2628c55](https://github.com/googleapis/google-cloud-dotnet/commit/2628c5527cfedb6b775e3858a1ce38aad7920d72))
- Add support for a ReconcileTags() API method ([commit 2628c55](https://github.com/googleapis/google-cloud-dotnet/commit/2628c5527cfedb6b775e3858a1ce38aad7920d72))
