### PR TITLE
Release Google.Maps.Routing.V2 version 1.0.0-beta08

### DIFF
--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Google.Cloud.Firestore.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Google.Cloud.Firestore.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Filter.*.cs">
-        <DependentUpon>Filter.cs</DependentUpon>
+      <DependentUpon>Filter.cs</DependentUpon>
     </Compile>
   </ItemGroup>
 </Project>

--- a/apis/Google.Maps.Routing.V2/Google.Maps.Routing.V2/Google.Maps.Routing.V2.csproj
+++ b/apis/Google.Maps.Routing.V2/Google.Maps.Routing.V2/Google.Maps.Routing.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta07</Version>
+    <Version>1.0.0-beta08</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Maps Routes Preferred API.</Description>

--- a/apis/Google.Maps.Routing.V2/docs/history.md
+++ b/apis/Google.Maps.Routing.V2/docs/history.md
@@ -1,5 +1,18 @@
 # Version history
 
+## Version 1.0.0-beta08, released 2023-03-20
+
+### New features
+
+- Adds support for specifying region_code in the ComputeRoutesRequest ([commit 2866cf6](https://github.com/googleapis/google-cloud-dotnet/commit/2866cf6abf8448febc94497de0f63bdc670bb3de))
+- Adds support for specifying region_code and language_code in the ComputeRouteMatrixRequest ([commit 2866cf6](https://github.com/googleapis/google-cloud-dotnet/commit/2866cf6abf8448febc94497de0f63bdc670bb3de))
+- Added support for specifying waypoints as addresses ([commit e18325e](https://github.com/googleapis/google-cloud-dotnet/commit/e18325e60d65b1435cbc3a7c8cd132ed4c82774a))
+
+### Documentation improvements
+
+- Clarify usage of compute_alternative_routes in proto comment ([commit 76c84a0](https://github.com/googleapis/google-cloud-dotnet/commit/76c84a0df10661ed5eea54e0bb3fd7642f5503cb))
+- Clarified usage of RouteLegStepTravelAdvisory in comment ([commit e18325e](https://github.com/googleapis/google-cloud-dotnet/commit/e18325e60d65b1435cbc3a7c8cd132ed4c82774a))
+
 ## Version 1.0.0-beta07, released 2023-01-19
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4944,7 +4944,7 @@
     },
     {
       "id": "Google.Maps.Routing.V2",
-      "version": "1.0.0-beta07",
+      "version": "1.0.0-beta08",
       "type": "grpc",
       "productName": "Maps Routing",
       "productUrl": "https://developers.google.com/maps/documentation/routes_preferred",


### PR DESCRIPTION

Changes in this release:

### New features

- Adds support for specifying region_code in the ComputeRoutesRequest ([commit 2866cf6](https://github.com/googleapis/google-cloud-dotnet/commit/2866cf6abf8448febc94497de0f63bdc670bb3de))
- Adds support for specifying region_code and language_code in the ComputeRouteMatrixRequest ([commit 2866cf6](https://github.com/googleapis/google-cloud-dotnet/commit/2866cf6abf8448febc94497de0f63bdc670bb3de))
- Added support for specifying waypoints as addresses ([commit e18325e](https://github.com/googleapis/google-cloud-dotnet/commit/e18325e60d65b1435cbc3a7c8cd132ed4c82774a))

### Documentation improvements

- Clarify usage of compute_alternative_routes in proto comment ([commit 76c84a0](https://github.com/googleapis/google-cloud-dotnet/commit/76c84a0df10661ed5eea54e0bb3fd7642f5503cb))
- Clarified usage of RouteLegStepTravelAdvisory in comment ([commit e18325e](https://github.com/googleapis/google-cloud-dotnet/commit/e18325e60d65b1435cbc3a7c8cd132ed4c82774a))
