### PR TITLE
Release Google.Cloud.BigQuery.DataPolicies.V1 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.BigQuery.DataPolicies.V1",
-  "release_level": "preview",
+  "release_level": "stable",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.BigQuery.DataPolicies.V1/latest",
   "library_type": "GAPIC_AUTO",
   "api_shortname": "bigquerydatapolicy"

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery DataPolicies API (v1), which allows users to manage BigQuery data policies.</Description>

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0, released 2023-03-27
+
+No API surface changes; just dependency updates and initial GA release.
+
 ## Version 1.0.0-beta02, released 2023-01-19
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -770,7 +770,7 @@
     },
     {
       "id": "Google.Cloud.BigQuery.DataPolicies.V1",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "BigQuery Data Policy",
       "productUrl": "https://cloud.google.com/bigquery/docs/data-governance",
@@ -780,7 +780,9 @@
         "policies"
       ],
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.0.0"
+        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Cloud.Iam.V1": "3.0.0",
+        "Grpc.Core": "2.46.5"
       },
       "generator": "micro",
       "protoPath": "google/cloud/bigquery/datapolicies/v1",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates and initial GA release.
