### PR TITLE
Release Google.Cloud.DataCatalog.Lineage.V1 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.DataCatalog.Lineage.V1",
-  "release_level": "preview",
+  "release_level": "stable",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.DataCatalog.Lineage.V1/latest",
   "library_type": "GAPIC_AUTO",
   "api_shortname": "datalineage"

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.csproj
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Dataplex Data Lineage API</Description>

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/docs/history.md
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/docs/history.md
@@ -1,5 +1,14 @@
 # Version history
 
+## Version 1.0.0, released 2023-03-27
+
+Initial GA release.
+
+### Documentation improvements
+
+- Fixed formatting for several literal expressions ([commit 3b8cbd7](https://github.com/googleapis/google-cloud-dotnet/commit/3b8cbd7b18f4b092d4b2e3103fba245c8966d5c5))
+- Update proto comments for better explanation of parent parameter ([commit 60870a1](https://github.com/googleapis/google-cloud-dotnet/commit/60870a18c75835a5fe482c0c16abcb7ba81060f7))
+
 ## Version 1.0.0-beta02, released 2023-01-19
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1303,7 +1303,7 @@
     },
     {
       "id": "Google.Cloud.DataCatalog.Lineage.V1",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Data Lineage",
       "productUrl": "https://cloud.google.com/data-catalog/docs/concepts/about-data-lineage",
@@ -1314,7 +1314,9 @@
         "data"
       ],
       "dependencies": {
-        "Google.LongRunning": "3.0.0"
+        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.LongRunning": "3.0.0",
+        "Grpc.Core": "2.46.5"
       },
       "generator": "micro",
       "protoPath": "google/cloud/datacatalog/lineage/v1",


### PR DESCRIPTION

Changes in this release:

Initial GA release.

### Documentation improvements

- Fixed formatting for several literal expressions ([commit 3b8cbd7](https://github.com/googleapis/google-cloud-dotnet/commit/3b8cbd7b18f4b092d4b2e3103fba245c8966d5c5))
- Update proto comments for better explanation of parent parameter ([commit 60870a1](https://github.com/googleapis/google-cloud-dotnet/commit/60870a18c75835a5fe482c0c16abcb7ba81060f7))
