### PR TITLE
Release Google.Cloud.Run.V2 version 2.0.0

### DIFF
--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/Google.Cloud.Run.V2.csproj
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/Google.Cloud.Run.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta05</Version>
+    <Version>2.0.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Run Admin API (v2)</Description>

--- a/apis/Google.Cloud.Run.V2/docs/history.md
+++ b/apis/Google.Cloud.Run.V2/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 2.0.0, released 2023-03-27
+
+No API surface changes; just dependency updates and initial GA release.
+
 ## Version 2.0.0-beta05, released 2023-01-20
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3636,7 +3636,7 @@
     },
     {
       "id": "Google.Cloud.Run.V2",
-      "version": "2.0.0-beta05",
+      "version": "2.0.0",
       "type": "grpc",
       "productName": "Cloud Run Admin",
       "productUrl": "https://cloud.google.com/run/docs",
@@ -3646,9 +3646,11 @@
         "admin"
       ],
       "dependencies": {
+        "Google.Api.Gax.Grpc": "4.3.1",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
-        "Google.LongRunning": "3.0.0"
+        "Google.LongRunning": "3.0.0",
+        "Grpc.Core": "2.46.5"
       },
       "generator": "micro",
       "protoPath": "google/cloud/run/v2",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates and initial GA release.
