### PR TITLE
Release Google.Cloud.Translation.V2 version 3.2.0

### DIFF
--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.csproj
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.2.0-beta01</Version>
+    <Version>3.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Translate v2 API. It wraps the Google.Apis.Translate.v2 client library, making common operations simpler in client code. The Translate API translates text from one language to another.</Description>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Rest" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Rest" Version="[4.3.1, 5.0.0)" />
     <PackageReference Include="Google.Apis.Translate.v2" Version="[1.60.0.875, 2.0.0.0)" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Translation.V2/docs/history.md
+++ b/apis/Google.Cloud.Translation.V2/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 3.2.0, released 2023-03-27
+
+No API surface changes; just dependency updates and a GA release for self-signed JWTs.
+
 ## Version 3.2.0-beta01, released 2023-01-16
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4438,11 +4438,11 @@
       "id": "Google.Cloud.Translation.V2",
       "productName": "Google Cloud Translation",
       "productUrl": "https://cloud.google.com/translate/",
-      "version": "3.2.0-beta01",
+      "version": "3.2.0",
       "type": "rest",
       "description": "Recommended Google client library to access the Translate v2 API. It wraps the Google.Apis.Translate.v2 client library, making common operations simpler in client code. The Translate API translates text from one language to another.",
       "dependencies": {
-        "Google.Api.Gax.Rest": "4.3.0",
+        "Google.Api.Gax.Rest": "4.3.1",
         "Google.Apis.Translate.v2": "1.60.0.875"
       },
       "tags": [


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates and a GA release for self-signed JWTs.
