### PR TITLE
Release Google.Analytics.Admin.V1Alpha version 2.0.0-alpha07

### DIFF
--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha06</Version>
+    <Version>2.0.0-alpha07</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Analytics Admin API (v1alpha)</Description>

--- a/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
+++ b/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
@@ -1,5 +1,18 @@
 # Version history
 
+## Version 2.0.0-alpha07, released 2023-03-27
+
+### New features
+
+- Add account-level binding for the`RunAccessReport` method (example: /v1alpha/accounts/1234567:runAccessReport) ([commit 94adeed](https://github.com/googleapis/google-cloud-dotnet/commit/94adeed8d5afba8d537ec2787f1bee54d7ab271f))
+- Add `GetEnhancedMeasurementSettings`, `UpdateEnhancedMeasurementSettings` methods to the Admin API v1alpha ([commit 94adeed](https://github.com/googleapis/google-cloud-dotnet/commit/94adeed8d5afba8d537ec2787f1bee54d7ab271f))
+- Add `CreateConnectedSiteTag`, `DeleteConnectedSiteTag`, `ListConnectedSiteTags` methods to the Admin API v1alpha ([commit 94adeed](https://github.com/googleapis/google-cloud-dotnet/commit/94adeed8d5afba8d537ec2787f1bee54d7ab271f))
+- Add `EnhancedMeasurementSettings`, `ConnectedSiteTag` resource types to the Admin API v1alpha ([commit 94adeed](https://github.com/googleapis/google-cloud-dotnet/commit/94adeed8d5afba8d537ec2787f1bee54d7ab271f))
+- Add `GetEnhancedMeasurementSettingsRequest`, ([commit 94adeed](https://github.com/googleapis/google-cloud-dotnet/commit/94adeed8d5afba8d537ec2787f1bee54d7ab271f))
+- Add `ENHANCED_MEASUREMENT_SETTINGS` option to the `ChangeHistoryResourceType` enum ([commit 94adeed](https://github.com/googleapis/google-cloud-dotnet/commit/94adeed8d5afba8d537ec2787f1bee54d7ab271f))
+- Add `enhanced_measurement_settings` option to the `ChangeHistoryResource.resource` oneof field ([commit 94adeed](https://github.com/googleapis/google-cloud-dotnet/commit/94adeed8d5afba8d537ec2787f1bee54d7ab271f))
+- Add `intraday_export_enabled` field to the `BigQueryLink` resource ([commit 94adeed](https://github.com/googleapis/google-cloud-dotnet/commit/94adeed8d5afba8d537ec2787f1bee54d7ab271f))
+
 ## Version 2.0.0-alpha06, released 2023-02-21
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2,7 +2,7 @@
   "apis": [
     {
       "id": "Google.Analytics.Admin.V1Alpha",
-      "version": "2.0.0-alpha06",
+      "version": "2.0.0-alpha07",
       "type": "grpc",
       "productName": "Analytics Admin",
       "productUrl": "https://developers.google.com/analytics",


### PR DESCRIPTION

Changes in this release:

### New features

- Add account-level binding for the`RunAccessReport` method (example: /v1alpha/accounts/1234567:runAccessReport) ([commit 94adeed](https://github.com/googleapis/google-cloud-dotnet/commit/94adeed8d5afba8d537ec2787f1bee54d7ab271f))
- Add `GetEnhancedMeasurementSettings`, `UpdateEnhancedMeasurementSettings` methods to the Admin API v1alpha ([commit 94adeed](https://github.com/googleapis/google-cloud-dotnet/commit/94adeed8d5afba8d537ec2787f1bee54d7ab271f))
- Add `CreateConnectedSiteTag`, `DeleteConnectedSiteTag`, `ListConnectedSiteTags` methods to the Admin API v1alpha ([commit 94adeed](https://github.com/googleapis/google-cloud-dotnet/commit/94adeed8d5afba8d537ec2787f1bee54d7ab271f))
- Add `EnhancedMeasurementSettings`, `ConnectedSiteTag` resource types to the Admin API v1alpha ([commit 94adeed](https://github.com/googleapis/google-cloud-dotnet/commit/94adeed8d5afba8d537ec2787f1bee54d7ab271f))
- Add `GetEnhancedMeasurementSettingsRequest`, ([commit 94adeed](https://github.com/googleapis/google-cloud-dotnet/commit/94adeed8d5afba8d537ec2787f1bee54d7ab271f))
- Add `ENHANCED_MEASUREMENT_SETTINGS` option to the `ChangeHistoryResourceType` enum ([commit 94adeed](https://github.com/googleapis/google-cloud-dotnet/commit/94adeed8d5afba8d537ec2787f1bee54d7ab271f))
- Add `enhanced_measurement_settings` option to the `ChangeHistoryResource.resource` oneof field ([commit 94adeed](https://github.com/googleapis/google-cloud-dotnet/commit/94adeed8d5afba8d537ec2787f1bee54d7ab271f))
- Add `intraday_export_enabled` field to the `BigQueryLink` resource ([commit 94adeed](https://github.com/googleapis/google-cloud-dotnet/commit/94adeed8d5afba8d537ec2787f1bee54d7ab271f))
