### PR TITLE
Release Google.Analytics.Admin.V1Beta version 1.0.0-beta03

### DIFF
--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.csproj
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Analytics Admin API (v1beta)</Description>

--- a/apis/Google.Analytics.Admin.V1Beta/docs/history.md
+++ b/apis/Google.Analytics.Admin.V1Beta/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 1.0.0-beta03, released 2023-03-27
+
+### New features
+
+- Add `RunAccessReport` method (with bindings for account and property resources) to the Admin API v1beta ([commit 2efaa1a](https://github.com/googleapis/google-cloud-dotnet/commit/2efaa1adc9e2c0c7c96f0696928dad011e0888c4))
+- Add `AccessDimension`, `AccessMetric`, `AccessDateRange`, `AccessFilterExpression`, `AccessFilterExpressionList`, `AccessFilter`, `AccessStringFilter`, `AccessInListFilter`, `AccessNumericFilter`, `AccessBetweenFilter`, `NumericValue`, `AccessOrderBy`, `AccessDimensionHeader`, `AccessMetricHeader`, `AccessRow`, `AccessDimensionValue`, `AccessMetricValue`, `AccessQuota`, `AccessQuotaStatus` types to the Admin API v1beta ([commit 2efaa1a](https://github.com/googleapis/google-cloud-dotnet/commit/2efaa1adc9e2c0c7c96f0696928dad011e0888c4))
+
 ## Version 1.0.0-beta02, released 2023-01-19
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -20,7 +20,7 @@
     },
     {
       "id": "Google.Analytics.Admin.V1Beta",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0-beta03",
       "type": "grpc",
       "productName": "Google Analytics Admin",
       "productUrl": "https://developers.google.com/analytics",


### PR DESCRIPTION

Changes in this release:

### New features

- Add `RunAccessReport` method (with bindings for account and property resources) to the Admin API v1beta ([commit 2efaa1a](https://github.com/googleapis/google-cloud-dotnet/commit/2efaa1adc9e2c0c7c96f0696928dad011e0888c4))
- Add `AccessDimension`, `AccessMetric`, `AccessDateRange`, `AccessFilterExpression`, `AccessFilterExpressionList`, `AccessFilter`, `AccessStringFilter`, `AccessInListFilter`, `AccessNumericFilter`, `AccessBetweenFilter`, `NumericValue`, `AccessOrderBy`, `AccessDimensionHeader`, `AccessMetricHeader`, `AccessRow`, `AccessDimensionValue`, `AccessMetricValue`, `AccessQuota`, `AccessQuotaStatus` types to the Admin API v1beta ([commit 2efaa1a](https://github.com/googleapis/google-cloud-dotnet/commit/2efaa1adc9e2c0c7c96f0696928dad011e0888c4))
