### PR TITLE
Release Google.Cloud.CloudBuild.V2 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.csproj
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Build API v2, which creates and manages builds on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.CloudBuild.V2/docs/history.md
+++ b/apis/Google.Cloud.CloudBuild.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2023-03-27
+
+### Bug fixes
+
+- (Java-only breaking change) Change java package of Cloud Build v2 ([commit e127aa9](https://github.com/googleapis/google-cloud-dotnet/commit/e127aa98cc0c63bae3dba34b5902436144c8f7e4))
+
 ## Version 1.0.0-beta01, released 2023-02-24
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1183,7 +1183,7 @@
     },
     {
       "id": "Google.Cloud.CloudBuild.V2",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Cloud Build",
       "description": "Recommended Google client library to access the Google Cloud Build API v2, which creates and manages builds on Google Cloud Platform.",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- (Java-only breaking change) Change java package of Cloud Build v2 ([commit e127aa9](https://github.com/googleapis/google-cloud-dotnet/commit/e127aa98cc0c63bae3dba34b5902436144c8f7e4))
