### PR TITLE
Release Google.Cloud.Deploy.V1 version 2.3.0

### DIFF
--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.csproj
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.2.0</Version>
+    <Version>2.3.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Deploy API, which automates delivery of your applications to a series of target environments in a defined sequence.</Description>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />

--- a/apis/Google.Cloud.Deploy.V1/docs/history.md
+++ b/apis/Google.Cloud.Deploy.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 2.3.0, released 2023-03-27
+
+### New features
+
+- Added supported for Cloud Deploy Progressive Deployment Strategy ([commit 1b6adf3](https://github.com/googleapis/google-cloud-dotnet/commit/1b6adf30328422af2ebbf0a20d9b583d845a4915))
+
+### Deprecations
+
+- TYPE_RENDER_STATUSES_CHANGE is deprecated, use RELEASE_RENDER log type instead ([commit 1b6adf3](https://github.com/googleapis/google-cloud-dotnet/commit/1b6adf30328422af2ebbf0a20d9b583d845a4915))
+
 ## Version 2.2.0, released 2023-01-19
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1620,7 +1620,7 @@
     },
     {
       "id": "Google.Cloud.Deploy.V1",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "type": "grpc",
       "productName": "Google Cloud Deploy",
       "productUrl": "https://cloud.google.com/deploy/",
@@ -1634,7 +1634,7 @@
         "kubernetes"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.3.1",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",


### PR DESCRIPTION

Changes in this release:

### New features

- Added supported for Cloud Deploy Progressive Deployment Strategy ([commit 1b6adf3](https://github.com/googleapis/google-cloud-dotnet/commit/1b6adf30328422af2ebbf0a20d9b583d845a4915))

### Deprecations

- TYPE_RENDER_STATUSES_CHANGE is deprecated, use RELEASE_RENDER log type instead ([commit 1b6adf3](https://github.com/googleapis/google-cloud-dotnet/commit/1b6adf30328422af2ebbf0a20d9b583d845a4915))
