### PR TITLE
Release Google.Cloud.DiscoveryEngine.V1Beta version 1.0.0-beta03

### DIFF
--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.csproj
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Discovery Engine API (v1beta). Discovery Engine powers high-quality content recommendations on your digital properties for Discovery for Media.</Description>

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/docs/history.md
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 1.0.0-beta03, released 2023-03-27
+
+### New features
+
+- Add additional resource path with collections ([commit 923b23d](https://github.com/googleapis/google-cloud-dotnet/commit/923b23d794ebae1ddbcb5118e6f6261c2776c7c8))
+- Document schema id is no longer required ([commit 923b23d](https://github.com/googleapis/google-cloud-dotnet/commit/923b23d794ebae1ddbcb5118e6f6261c2776c7c8))
+
+### Documentation improvements
+
+- Keep the API doc up-to-date with recent changes ([commit 923b23d](https://github.com/googleapis/google-cloud-dotnet/commit/923b23d794ebae1ddbcb5118e6f6261c2776c7c8))
+
 ## Version 1.0.0-beta02, released 2023-01-18
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1813,7 +1813,7 @@
     },
     {
       "id": "Google.Cloud.DiscoveryEngine.V1Beta",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0-beta03",
       "type": "grpc",
       "productName": "Discovery Engine",
       "productUrl": "https://cloud.google.com/discovery-engine/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Add additional resource path with collections ([commit 923b23d](https://github.com/googleapis/google-cloud-dotnet/commit/923b23d794ebae1ddbcb5118e6f6261c2776c7c8))
- Document schema id is no longer required ([commit 923b23d](https://github.com/googleapis/google-cloud-dotnet/commit/923b23d794ebae1ddbcb5118e6f6261c2776c7c8))

### Documentation improvements

- Keep the API doc up-to-date with recent changes ([commit 923b23d](https://github.com/googleapis/google-cloud-dotnet/commit/923b23d794ebae1ddbcb5118e6f6261c2776c7c8))
