### PR TITLE
Release Google.Cloud.Video.LiveStream.V1 version 1.2.0

### DIFF
--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.csproj
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Live Stream API, which transcodes mezzanine live signals into direct-to-consumer streaming formats.</Description>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />

--- a/apis/Google.Cloud.Video.LiveStream.V1/docs/history.md
+++ b/apis/Google.Cloud.Video.LiveStream.V1/docs/history.md
@@ -1,5 +1,19 @@
 # Version history
 
+## Version 1.2.0, released 2023-03-27
+
+### New features
+
+- Added TimecodeConfig for specifying the source of timecode used in media workflow synchronization ([commit f7c5a13](https://github.com/googleapis/google-cloud-dotnet/commit/f7c5a134ba3ed60c6fb67e001ce430bc95724815))
+- Added Encryption for enabling output encryption with DRM systems ([commit f7c5a13](https://github.com/googleapis/google-cloud-dotnet/commit/f7c5a134ba3ed60c6fb67e001ce430bc95724815))
+- Added InputConfig to allow enabling/disabling automatic failover ([commit f7c5a13](https://github.com/googleapis/google-cloud-dotnet/commit/f7c5a134ba3ed60c6fb67e001ce430bc95724815))
+- Added new tasks to Event: inputSwitch, returnToProgram, mute, unmute ([commit f7c5a13](https://github.com/googleapis/google-cloud-dotnet/commit/f7c5a134ba3ed60c6fb67e001ce430bc95724815))
+- Added support for audio normalization and audio gain ([commit f7c5a13](https://github.com/googleapis/google-cloud-dotnet/commit/f7c5a134ba3ed60c6fb67e001ce430bc95724815))
+
+### Documentation improvements
+
+- Clarify behavior when update_mask is omitted in PATCH requests ([commit f7c5a13](https://github.com/googleapis/google-cloud-dotnet/commit/f7c5a134ba3ed60c6fb67e001ce430bc95724815))
+
 ## Version 1.1.0, released 2023-01-19
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4479,7 +4479,7 @@
     },
     {
       "id": "Google.Cloud.Video.LiveStream.V1",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "type": "grpc",
       "productName": "Live Stream",
       "productUrl": "https://cloud.google.com/livestream/docs/",
@@ -4490,7 +4490,7 @@
         "transcoding"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.3.1",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
         "Grpc.Core": "2.46.5"


### PR DESCRIPTION

Changes in this release:

### New features

- Added TimecodeConfig for specifying the source of timecode used in media workflow synchronization ([commit f7c5a13](https://github.com/googleapis/google-cloud-dotnet/commit/f7c5a134ba3ed60c6fb67e001ce430bc95724815))
- Added Encryption for enabling output encryption with DRM systems ([commit f7c5a13](https://github.com/googleapis/google-cloud-dotnet/commit/f7c5a134ba3ed60c6fb67e001ce430bc95724815))
- Added InputConfig to allow enabling/disabling automatic failover ([commit f7c5a13](https://github.com/googleapis/google-cloud-dotnet/commit/f7c5a134ba3ed60c6fb67e001ce430bc95724815))
- Added new tasks to Event: inputSwitch, returnToProgram, mute, unmute ([commit f7c5a13](https://github.com/googleapis/google-cloud-dotnet/commit/f7c5a134ba3ed60c6fb67e001ce430bc95724815))
- Added support for audio normalization and audio gain ([commit f7c5a13](https://github.com/googleapis/google-cloud-dotnet/commit/f7c5a134ba3ed60c6fb67e001ce430bc95724815))

### Documentation improvements

- Clarify behavior when update_mask is omitted in PATCH requests ([commit f7c5a13](https://github.com/googleapis/google-cloud-dotnet/commit/f7c5a134ba3ed60c6fb67e001ce430bc95724815))
