### PR TITLE
Release Google.Maps.Routing.V2 version 1.0.0-beta09

### DIFF
--- a/apis/Google.Maps.Routing.V2/Google.Maps.Routing.V2/Google.Maps.Routing.V2.csproj
+++ b/apis/Google.Maps.Routing.V2/Google.Maps.Routing.V2/Google.Maps.Routing.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta08</Version>
+    <Version>1.0.0-beta09</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Maps Routes Preferred API.</Description>

--- a/apis/Google.Maps.Routing.V2/docs/history.md
+++ b/apis/Google.Maps.Routing.V2/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 1.0.0-beta09, released 2023-03-27
+
+### New features
+
+- **BREAKING CHANGE** Moved speed in SpeedReadingInterval into a oneof speed_type, this is a breaking change for Go client libraries ([commit 9732e20](https://github.com/googleapis/google-cloud-dotnet/commit/9732e20cc7b62eb0a19b2f5ea5598c7f6fcbff6e))
+
+### Documentation improvements
+
+- Update proto comments to contain concrete references to other proto messages ([commit 9732e20](https://github.com/googleapis/google-cloud-dotnet/commit/9732e20cc7b62eb0a19b2f5ea5598c7f6fcbff6e))
+
 ## Version 1.0.0-beta08, released 2023-03-20
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4947,7 +4947,7 @@
     },
     {
       "id": "Google.Maps.Routing.V2",
-      "version": "1.0.0-beta08",
+      "version": "1.0.0-beta09",
       "type": "grpc",
       "productName": "Maps Routing",
       "productUrl": "https://developers.google.com/maps/documentation/routes_preferred",


### PR DESCRIPTION

Changes in this release:

### New features

- **BREAKING CHANGE** Moved speed in SpeedReadingInterval into a oneof speed_type, this is a breaking change for Go client libraries ([commit 9732e20](https://github.com/googleapis/google-cloud-dotnet/commit/9732e20cc7b62eb0a19b2f5ea5598c7f6fcbff6e))

### Documentation improvements

- Update proto comments to contain concrete references to other proto messages ([commit 9732e20](https://github.com/googleapis/google-cloud-dotnet/commit/9732e20cc7b62eb0a19b2f5ea5598c7f6fcbff6e))
