### PR TITLE
Release Google.Cloud.AIPlatform.V1 version 2.12.0

### DIFF
--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.11.0</Version>
+    <Version>2.12.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AI Platform API, which allows you to train high-quality custom machine learning models with minimal machine learning expertise and effort.</Description>

--- a/apis/Google.Cloud.AIPlatform.V1/docs/history.md
+++ b/apis/Google.Cloud.AIPlatform.V1/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 2.12.0, released 2023-04-12
+
+### New features
+
+- Add public_endpoint_enabled and publid_endpoint_domain_name to IndexEndpoint ([commit 6456df3](https://github.com/googleapis/google-cloud-dotnet/commit/6456df3710bf03715fd60988726c5fc75e76747d))
+- Add ModelSourceType.MODEL_GARDEN enum to ModelSourceInfo ([commit 6456df3](https://github.com/googleapis/google-cloud-dotnet/commit/6456df3710bf03715fd60988726c5fc75e76747d))
+- Add copy to ModelSourceInfo ([commit 6456df3](https://github.com/googleapis/google-cloud-dotnet/commit/6456df3710bf03715fd60988726c5fc75e76747d))
+
 ## Version 2.11.0, released 2023-03-06
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -222,7 +222,7 @@
     },
     {
       "id": "Google.Cloud.AIPlatform.V1",
-      "version": "2.11.0",
+      "version": "2.12.0",
       "type": "grpc",
       "productName": "Cloud AI Platform",
       "productUrl": "https://cloud.google.com/ai-platform/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add public_endpoint_enabled and publid_endpoint_domain_name to IndexEndpoint ([commit 6456df3](https://github.com/googleapis/google-cloud-dotnet/commit/6456df3710bf03715fd60988726c5fc75e76747d))
- Add ModelSourceType.MODEL_GARDEN enum to ModelSourceInfo ([commit 6456df3](https://github.com/googleapis/google-cloud-dotnet/commit/6456df3710bf03715fd60988726c5fc75e76747d))
- Add copy to ModelSourceInfo ([commit 6456df3](https://github.com/googleapis/google-cloud-dotnet/commit/6456df3710bf03715fd60988726c5fc75e76747d))
