### PR TITLE
Release Google.Cloud.Container.V1 version 3.9.0

### DIFF
--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.8.0</Version>
+    <Version>3.9.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.</Description>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Container.V1/docs/history.md
+++ b/apis/Google.Cloud.Container.V1/docs/history.md
@@ -1,5 +1,21 @@
 # Version history
 
+## Version 3.9.0, released 2023-04-12
+
+### New features
+
+- Add support for updating additional pod IPv4 ranges for Standard and Autopilot clusters ([commit 217853b](https://github.com/googleapis/google-cloud-dotnet/commit/217853b8b06f699c6f064aef9ea9174860ed5a96))
+- Add support for disabling pod IP cidr overprovision ([commit 440c8ca](https://github.com/googleapis/google-cloud-dotnet/commit/440c8ca56d42a29dd1dd93db640e1b62e12de831))
+- Add a new fleet registration feature ([commit e6be97b](https://github.com/googleapis/google-cloud-dotnet/commit/e6be97b75027d9ad2a18e836e9312b2b77ab0b09))
+
+### Documentation improvements
+
+- Minor typo fix ([commit 891e898](https://github.com/googleapis/google-cloud-dotnet/commit/891e89876c6b91843d35c5143e63da5101c6c530))
+- Minor grammar improvements ([commit 2e674ee](https://github.com/googleapis/google-cloud-dotnet/commit/2e674ee00dc17ee64edeb9c053907fed53187a0c))
+- Add clarification on whether `NodePool.version` is a required field ([commit 50c4b0f](https://github.com/googleapis/google-cloud-dotnet/commit/50c4b0fc6005d326f500023267c797dbe39aa2db))
+- Clarified wording around the NodePoolUpdateStrategy default behavior ([commit beac7f8](https://github.com/googleapis/google-cloud-dotnet/commit/beac7f8fa14f7944a56bd5c99bc45740a130643b))
+- Add references for available node image types ([commit beac7f8](https://github.com/googleapis/google-cloud-dotnet/commit/beac7f8fa14f7944a56bd5c99bc45740a130643b))
+
 ## Version 3.8.0, released 2023-01-18
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1311,11 +1311,11 @@
       "protoPath": "google/container/v1",
       "productName": "Google Kubernetes Engine",
       "productUrl": "https://cloud.google.com/kubernetes-engine/docs/reference/rest/",
-      "version": "3.8.0",
+      "version": "3.9.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.",
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.3.1",
         "Grpc.Core": "2.46.5"
       },
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- Add support for updating additional pod IPv4 ranges for Standard and Autopilot clusters ([commit 217853b](https://github.com/googleapis/google-cloud-dotnet/commit/217853b8b06f699c6f064aef9ea9174860ed5a96))
- Add support for disabling pod IP cidr overprovision ([commit 440c8ca](https://github.com/googleapis/google-cloud-dotnet/commit/440c8ca56d42a29dd1dd93db640e1b62e12de831))
- Add a new fleet registration feature ([commit e6be97b](https://github.com/googleapis/google-cloud-dotnet/commit/e6be97b75027d9ad2a18e836e9312b2b77ab0b09))

### Documentation improvements

- Minor typo fix ([commit 891e898](https://github.com/googleapis/google-cloud-dotnet/commit/891e89876c6b91843d35c5143e63da5101c6c530))
- Minor grammar improvements ([commit 2e674ee](https://github.com/googleapis/google-cloud-dotnet/commit/2e674ee00dc17ee64edeb9c053907fed53187a0c))
- Add clarification on whether `NodePool.version` is a required field ([commit 50c4b0f](https://github.com/googleapis/google-cloud-dotnet/commit/50c4b0fc6005d326f500023267c797dbe39aa2db))
- Clarified wording around the NodePoolUpdateStrategy default behavior ([commit beac7f8](https://github.com/googleapis/google-cloud-dotnet/commit/beac7f8fa14f7944a56bd5c99bc45740a130643b))
- Add references for available node image types ([commit beac7f8](https://github.com/googleapis/google-cloud-dotnet/commit/beac7f8fa14f7944a56bd5c99bc45740a130643b))
