### PR TITLE
chore: Update .NET SDK to 6.0.408

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.405",
+    "version": "6.0.408",
     "allowPrerelease": false,
     "rollForward": "latestMinor"
   }

--- a/owl-bot-post-processor/Dockerfile
+++ b/owl-bot-post-processor/Dockerfile
@@ -23,7 +23,7 @@
 # To launch a bash shell in the container, run:
 #   docker run --rm -it --entrypoint bash gcr.io/cloud-devrel-public-resources/owlbot-dotnet:latest
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0.405-focal
+FROM mcr.microsoft.com/dotnet/sdk:6.0.408-focal
 
 # Additional tooling required to regenerate libraries and project files.
 


### PR DESCRIPTION
(Once this is merged, we'll need another PR to update the OwlBot lockfile.)