### PR TITLE
chore: Update OwlBot to use Ubuntu 22.04

### DIFF
--- a/owl-bot-post-processor/Dockerfile
+++ b/owl-bot-post-processor/Dockerfile
@@ -23,7 +23,7 @@
 # To launch a bash shell in the container, run:
 #   docker run --rm -it --entrypoint bash gcr.io/cloud-devrel-public-resources/owlbot-dotnet:latest
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0.408-focal
+FROM mcr.microsoft.com/dotnet/sdk:6.0.408-jammy
 
 # Additional tooling required to regenerate libraries and project files.
 


### PR DESCRIPTION
We're currently using focal, which is 20.04 - that's still supported, but I'm hoping that using a later version will reduce some of the reported vulnerabilities.