### PR TITLE
chore: Remove mid-generation renaming in Bigtable

### DIFF
--- a/apis/Google.Cloud.Bigtable.V2/.OwlBot-ForceRegeneration.txt
+++ b/apis/Google.Cloud.Bigtable.V2/.OwlBot-ForceRegeneration.txt
@@ -1,2 +1,1 @@
-API requires pre/mid-generation tweaks.
 API uses a custom resources configuration.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.CheckAndMutateRow1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.CheckAndMutateRow1AsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_CheckAndMutateRow_async_flattened1]
+    // [START bigtable_v2_generated_Bigtable_CheckAndMutateRow_async_flattened1]
     using Google.Cloud.Bigtable.V2;
     using Google.Protobuf;
     using System.Collections.Generic;
@@ -46,5 +46,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             CheckAndMutateRowResponse response = await bigtableServiceApiClient.CheckAndMutateRowAsync(tableName, rowKey, predicateFilter, trueMutations, falseMutations);
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_CheckAndMutateRow_async_flattened1]
+    // [END bigtable_v2_generated_Bigtable_CheckAndMutateRow_async_flattened1]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.CheckAndMutateRow1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.CheckAndMutateRow1ResourceNamesAsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_CheckAndMutateRow_async_flattened1_resourceNames]
+    // [START bigtable_v2_generated_Bigtable_CheckAndMutateRow_async_flattened1_resourceNames]
     using Google.Cloud.Bigtable.Common.V2;
     using Google.Cloud.Bigtable.V2;
     using Google.Protobuf;
@@ -47,5 +47,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             CheckAndMutateRowResponse response = await bigtableServiceApiClient.CheckAndMutateRowAsync(tableName, rowKey, predicateFilter, trueMutations, falseMutations);
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_CheckAndMutateRow_async_flattened1_resourceNames]
+    // [END bigtable_v2_generated_Bigtable_CheckAndMutateRow_async_flattened1_resourceNames]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.CheckAndMutateRow1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.CheckAndMutateRow1ResourceNamesSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_CheckAndMutateRow_sync_flattened1_resourceNames]
+    // [START bigtable_v2_generated_Bigtable_CheckAndMutateRow_sync_flattened1_resourceNames]
     using Google.Cloud.Bigtable.Common.V2;
     using Google.Cloud.Bigtable.V2;
     using Google.Protobuf;
@@ -46,5 +46,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             CheckAndMutateRowResponse response = bigtableServiceApiClient.CheckAndMutateRow(tableName, rowKey, predicateFilter, trueMutations, falseMutations);
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_CheckAndMutateRow_sync_flattened1_resourceNames]
+    // [END bigtable_v2_generated_Bigtable_CheckAndMutateRow_sync_flattened1_resourceNames]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.CheckAndMutateRow1Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.CheckAndMutateRow1Snippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_CheckAndMutateRow_sync_flattened1]
+    // [START bigtable_v2_generated_Bigtable_CheckAndMutateRow_sync_flattened1]
     using Google.Cloud.Bigtable.V2;
     using Google.Protobuf;
     using System.Collections.Generic;
@@ -45,5 +45,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             CheckAndMutateRowResponse response = bigtableServiceApiClient.CheckAndMutateRow(tableName, rowKey, predicateFilter, trueMutations, falseMutations);
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_CheckAndMutateRow_sync_flattened1]
+    // [END bigtable_v2_generated_Bigtable_CheckAndMutateRow_sync_flattened1]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.CheckAndMutateRow2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.CheckAndMutateRow2AsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_CheckAndMutateRow_async_flattened2]
+    // [START bigtable_v2_generated_Bigtable_CheckAndMutateRow_async_flattened2]
     using Google.Cloud.Bigtable.V2;
     using Google.Protobuf;
     using System.Collections.Generic;
@@ -47,5 +47,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             CheckAndMutateRowResponse response = await bigtableServiceApiClient.CheckAndMutateRowAsync(tableName, rowKey, predicateFilter, trueMutations, falseMutations, appProfileId);
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_CheckAndMutateRow_async_flattened2]
+    // [END bigtable_v2_generated_Bigtable_CheckAndMutateRow_async_flattened2]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.CheckAndMutateRow2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.CheckAndMutateRow2ResourceNamesAsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_CheckAndMutateRow_async_flattened2_resourceNames]
+    // [START bigtable_v2_generated_Bigtable_CheckAndMutateRow_async_flattened2_resourceNames]
     using Google.Cloud.Bigtable.Common.V2;
     using Google.Cloud.Bigtable.V2;
     using Google.Protobuf;
@@ -48,5 +48,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             CheckAndMutateRowResponse response = await bigtableServiceApiClient.CheckAndMutateRowAsync(tableName, rowKey, predicateFilter, trueMutations, falseMutations, appProfileId);
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_CheckAndMutateRow_async_flattened2_resourceNames]
+    // [END bigtable_v2_generated_Bigtable_CheckAndMutateRow_async_flattened2_resourceNames]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.CheckAndMutateRow2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.CheckAndMutateRow2ResourceNamesSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_CheckAndMutateRow_sync_flattened2_resourceNames]
+    // [START bigtable_v2_generated_Bigtable_CheckAndMutateRow_sync_flattened2_resourceNames]
     using Google.Cloud.Bigtable.Common.V2;
     using Google.Cloud.Bigtable.V2;
     using Google.Protobuf;
@@ -47,5 +47,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             CheckAndMutateRowResponse response = bigtableServiceApiClient.CheckAndMutateRow(tableName, rowKey, predicateFilter, trueMutations, falseMutations, appProfileId);
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_CheckAndMutateRow_sync_flattened2_resourceNames]
+    // [END bigtable_v2_generated_Bigtable_CheckAndMutateRow_sync_flattened2_resourceNames]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.CheckAndMutateRow2Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.CheckAndMutateRow2Snippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_CheckAndMutateRow_sync_flattened2]
+    // [START bigtable_v2_generated_Bigtable_CheckAndMutateRow_sync_flattened2]
     using Google.Cloud.Bigtable.V2;
     using Google.Protobuf;
     using System.Collections.Generic;
@@ -46,5 +46,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             CheckAndMutateRowResponse response = bigtableServiceApiClient.CheckAndMutateRow(tableName, rowKey, predicateFilter, trueMutations, falseMutations, appProfileId);
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_CheckAndMutateRow_sync_flattened2]
+    // [END bigtable_v2_generated_Bigtable_CheckAndMutateRow_sync_flattened2]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.CheckAndMutateRowRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.CheckAndMutateRowRequestObjectAsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_CheckAndMutateRow_async]
+    // [START bigtable_v2_generated_Bigtable_CheckAndMutateRow_async]
     using Google.Cloud.Bigtable.Common.V2;
     using Google.Cloud.Bigtable.V2;
     using Google.Protobuf;
@@ -50,5 +50,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             CheckAndMutateRowResponse response = await bigtableServiceApiClient.CheckAndMutateRowAsync(request);
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_CheckAndMutateRow_async]
+    // [END bigtable_v2_generated_Bigtable_CheckAndMutateRow_async]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.CheckAndMutateRowRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.CheckAndMutateRowRequestObjectSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_CheckAndMutateRow_sync]
+    // [START bigtable_v2_generated_Bigtable_CheckAndMutateRow_sync]
     using Google.Cloud.Bigtable.Common.V2;
     using Google.Cloud.Bigtable.V2;
     using Google.Protobuf;
@@ -49,5 +49,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             CheckAndMutateRowResponse response = bigtableServiceApiClient.CheckAndMutateRow(request);
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_CheckAndMutateRow_sync]
+    // [END bigtable_v2_generated_Bigtable_CheckAndMutateRow_sync]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.GenerateInitialChangeStreamPartitions1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.GenerateInitialChangeStreamPartitions1ResourceNamesSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_GenerateInitialChangeStreamPartitions_sync_flattened1_resourceNames]
+    // [START bigtable_v2_generated_Bigtable_GenerateInitialChangeStreamPartitions_sync_flattened1_resourceNames]
     using Google.Api.Gax.Grpc;
     using Google.Cloud.Bigtable.Common.V2;
     using Google.Cloud.Bigtable.V2;
@@ -52,5 +52,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             // The response stream has completed
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_GenerateInitialChangeStreamPartitions_sync_flattened1_resourceNames]
+    // [END bigtable_v2_generated_Bigtable_GenerateInitialChangeStreamPartitions_sync_flattened1_resourceNames]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.GenerateInitialChangeStreamPartitions1Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.GenerateInitialChangeStreamPartitions1Snippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_GenerateInitialChangeStreamPartitions_sync_flattened1]
+    // [START bigtable_v2_generated_Bigtable_GenerateInitialChangeStreamPartitions_sync_flattened1]
     using Google.Api.Gax.Grpc;
     using Google.Cloud.Bigtable.V2;
     using System.Threading.Tasks;
@@ -51,5 +51,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             // The response stream has completed
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_GenerateInitialChangeStreamPartitions_sync_flattened1]
+    // [END bigtable_v2_generated_Bigtable_GenerateInitialChangeStreamPartitions_sync_flattened1]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.GenerateInitialChangeStreamPartitions2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.GenerateInitialChangeStreamPartitions2ResourceNamesSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_GenerateInitialChangeStreamPartitions_sync_flattened2_resourceNames]
+    // [START bigtable_v2_generated_Bigtable_GenerateInitialChangeStreamPartitions_sync_flattened2_resourceNames]
     using Google.Api.Gax.Grpc;
     using Google.Cloud.Bigtable.Common.V2;
     using Google.Cloud.Bigtable.V2;
@@ -53,5 +53,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             // The response stream has completed
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_GenerateInitialChangeStreamPartitions_sync_flattened2_resourceNames]
+    // [END bigtable_v2_generated_Bigtable_GenerateInitialChangeStreamPartitions_sync_flattened2_resourceNames]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.GenerateInitialChangeStreamPartitions2Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.GenerateInitialChangeStreamPartitions2Snippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_GenerateInitialChangeStreamPartitions_sync_flattened2]
+    // [START bigtable_v2_generated_Bigtable_GenerateInitialChangeStreamPartitions_sync_flattened2]
     using Google.Api.Gax.Grpc;
     using Google.Cloud.Bigtable.V2;
     using System.Threading.Tasks;
@@ -52,5 +52,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             // The response stream has completed
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_GenerateInitialChangeStreamPartitions_sync_flattened2]
+    // [END bigtable_v2_generated_Bigtable_GenerateInitialChangeStreamPartitions_sync_flattened2]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.GenerateInitialChangeStreamPartitionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.GenerateInitialChangeStreamPartitionsRequestObjectSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_GenerateInitialChangeStreamPartitions_sync]
+    // [START bigtable_v2_generated_Bigtable_GenerateInitialChangeStreamPartitions_sync]
     using Google.Api.Gax.Grpc;
     using Google.Cloud.Bigtable.Common.V2;
     using Google.Cloud.Bigtable.V2;
@@ -56,5 +56,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             // The response stream has completed
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_GenerateInitialChangeStreamPartitions_sync]
+    // [END bigtable_v2_generated_Bigtable_GenerateInitialChangeStreamPartitions_sync]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRow1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRow1AsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_MutateRow_async_flattened1]
+    // [START bigtable_v2_generated_Bigtable_MutateRow_async_flattened1]
     using Google.Cloud.Bigtable.V2;
     using Google.Protobuf;
     using System.Collections.Generic;
@@ -44,5 +44,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             MutateRowResponse response = await bigtableServiceApiClient.MutateRowAsync(tableName, rowKey, mutations);
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_MutateRow_async_flattened1]
+    // [END bigtable_v2_generated_Bigtable_MutateRow_async_flattened1]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRow1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRow1ResourceNamesAsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_MutateRow_async_flattened1_resourceNames]
+    // [START bigtable_v2_generated_Bigtable_MutateRow_async_flattened1_resourceNames]
     using Google.Cloud.Bigtable.Common.V2;
     using Google.Cloud.Bigtable.V2;
     using Google.Protobuf;
@@ -45,5 +45,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             MutateRowResponse response = await bigtableServiceApiClient.MutateRowAsync(tableName, rowKey, mutations);
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_MutateRow_async_flattened1_resourceNames]
+    // [END bigtable_v2_generated_Bigtable_MutateRow_async_flattened1_resourceNames]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRow1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRow1ResourceNamesSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_MutateRow_sync_flattened1_resourceNames]
+    // [START bigtable_v2_generated_Bigtable_MutateRow_sync_flattened1_resourceNames]
     using Google.Cloud.Bigtable.Common.V2;
     using Google.Cloud.Bigtable.V2;
     using Google.Protobuf;
@@ -44,5 +44,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             MutateRowResponse response = bigtableServiceApiClient.MutateRow(tableName, rowKey, mutations);
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_MutateRow_sync_flattened1_resourceNames]
+    // [END bigtable_v2_generated_Bigtable_MutateRow_sync_flattened1_resourceNames]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRow1Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRow1Snippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_MutateRow_sync_flattened1]
+    // [START bigtable_v2_generated_Bigtable_MutateRow_sync_flattened1]
     using Google.Cloud.Bigtable.V2;
     using Google.Protobuf;
     using System.Collections.Generic;
@@ -43,5 +43,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             MutateRowResponse response = bigtableServiceApiClient.MutateRow(tableName, rowKey, mutations);
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_MutateRow_sync_flattened1]
+    // [END bigtable_v2_generated_Bigtable_MutateRow_sync_flattened1]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRow2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRow2AsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_MutateRow_async_flattened2]
+    // [START bigtable_v2_generated_Bigtable_MutateRow_async_flattened2]
     using Google.Cloud.Bigtable.V2;
     using Google.Protobuf;
     using System.Collections.Generic;
@@ -45,5 +45,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             MutateRowResponse response = await bigtableServiceApiClient.MutateRowAsync(tableName, rowKey, mutations, appProfileId);
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_MutateRow_async_flattened2]
+    // [END bigtable_v2_generated_Bigtable_MutateRow_async_flattened2]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRow2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRow2ResourceNamesAsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_MutateRow_async_flattened2_resourceNames]
+    // [START bigtable_v2_generated_Bigtable_MutateRow_async_flattened2_resourceNames]
     using Google.Cloud.Bigtable.Common.V2;
     using Google.Cloud.Bigtable.V2;
     using Google.Protobuf;
@@ -46,5 +46,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             MutateRowResponse response = await bigtableServiceApiClient.MutateRowAsync(tableName, rowKey, mutations, appProfileId);
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_MutateRow_async_flattened2_resourceNames]
+    // [END bigtable_v2_generated_Bigtable_MutateRow_async_flattened2_resourceNames]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRow2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRow2ResourceNamesSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_MutateRow_sync_flattened2_resourceNames]
+    // [START bigtable_v2_generated_Bigtable_MutateRow_sync_flattened2_resourceNames]
     using Google.Cloud.Bigtable.Common.V2;
     using Google.Cloud.Bigtable.V2;
     using Google.Protobuf;
@@ -45,5 +45,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             MutateRowResponse response = bigtableServiceApiClient.MutateRow(tableName, rowKey, mutations, appProfileId);
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_MutateRow_sync_flattened2_resourceNames]
+    // [END bigtable_v2_generated_Bigtable_MutateRow_sync_flattened2_resourceNames]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRow2Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRow2Snippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_MutateRow_sync_flattened2]
+    // [START bigtable_v2_generated_Bigtable_MutateRow_sync_flattened2]
     using Google.Cloud.Bigtable.V2;
     using Google.Protobuf;
     using System.Collections.Generic;
@@ -44,5 +44,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             MutateRowResponse response = bigtableServiceApiClient.MutateRow(tableName, rowKey, mutations, appProfileId);
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_MutateRow_sync_flattened2]
+    // [END bigtable_v2_generated_Bigtable_MutateRow_sync_flattened2]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRowRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRowRequestObjectAsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_MutateRow_async]
+    // [START bigtable_v2_generated_Bigtable_MutateRow_async]
     using Google.Cloud.Bigtable.Common.V2;
     using Google.Cloud.Bigtable.V2;
     using Google.Protobuf;
@@ -48,5 +48,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             MutateRowResponse response = await bigtableServiceApiClient.MutateRowAsync(request);
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_MutateRow_async]
+    // [END bigtable_v2_generated_Bigtable_MutateRow_async]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRowRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRowRequestObjectSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_MutateRow_sync]
+    // [START bigtable_v2_generated_Bigtable_MutateRow_sync]
     using Google.Cloud.Bigtable.Common.V2;
     using Google.Cloud.Bigtable.V2;
     using Google.Protobuf;
@@ -47,5 +47,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             MutateRowResponse response = bigtableServiceApiClient.MutateRow(request);
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_MutateRow_sync]
+    // [END bigtable_v2_generated_Bigtable_MutateRow_sync]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRows1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRows1ResourceNamesSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_MutateRows_sync_flattened1_resourceNames]
+    // [START bigtable_v2_generated_Bigtable_MutateRows_sync_flattened1_resourceNames]
     using Google.Api.Gax.Grpc;
     using Google.Cloud.Bigtable.Common.V2;
     using Google.Cloud.Bigtable.V2;
@@ -57,5 +57,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             // The response stream has completed
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_MutateRows_sync_flattened1_resourceNames]
+    // [END bigtable_v2_generated_Bigtable_MutateRows_sync_flattened1_resourceNames]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRows1Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRows1Snippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_MutateRows_sync_flattened1]
+    // [START bigtable_v2_generated_Bigtable_MutateRows_sync_flattened1]
     using Google.Api.Gax.Grpc;
     using Google.Cloud.Bigtable.V2;
     using System.Collections.Generic;
@@ -56,5 +56,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             // The response stream has completed
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_MutateRows_sync_flattened1]
+    // [END bigtable_v2_generated_Bigtable_MutateRows_sync_flattened1]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRows2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRows2ResourceNamesSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_MutateRows_sync_flattened2_resourceNames]
+    // [START bigtable_v2_generated_Bigtable_MutateRows_sync_flattened2_resourceNames]
     using Google.Api.Gax.Grpc;
     using Google.Cloud.Bigtable.Common.V2;
     using Google.Cloud.Bigtable.V2;
@@ -58,5 +58,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             // The response stream has completed
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_MutateRows_sync_flattened2_resourceNames]
+    // [END bigtable_v2_generated_Bigtable_MutateRows_sync_flattened2_resourceNames]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRows2Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRows2Snippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_MutateRows_sync_flattened2]
+    // [START bigtable_v2_generated_Bigtable_MutateRows_sync_flattened2]
     using Google.Api.Gax.Grpc;
     using Google.Cloud.Bigtable.V2;
     using System.Collections.Generic;
@@ -57,5 +57,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             // The response stream has completed
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_MutateRows_sync_flattened2]
+    // [END bigtable_v2_generated_Bigtable_MutateRows_sync_flattened2]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRowsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRowsRequestObjectSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_MutateRows_sync]
+    // [START bigtable_v2_generated_Bigtable_MutateRows_sync]
     using Google.Api.Gax.Grpc;
     using Google.Cloud.Bigtable.Common.V2;
     using Google.Cloud.Bigtable.V2;
@@ -60,5 +60,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             // The response stream has completed
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_MutateRows_sync]
+    // [END bigtable_v2_generated_Bigtable_MutateRows_sync]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PingAndWarm1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PingAndWarm1AsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_PingAndWarm_async_flattened1]
+    // [START bigtable_v2_generated_Bigtable_PingAndWarm_async_flattened1]
     using Google.Cloud.Bigtable.V2;
     using System.Threading.Tasks;
 
@@ -40,5 +40,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             PingAndWarmResponse response = await bigtableServiceApiClient.PingAndWarmAsync(name);
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_PingAndWarm_async_flattened1]
+    // [END bigtable_v2_generated_Bigtable_PingAndWarm_async_flattened1]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PingAndWarm1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PingAndWarm1ResourceNamesAsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_PingAndWarm_async_flattened1_resourceNames]
+    // [START bigtable_v2_generated_Bigtable_PingAndWarm_async_flattened1_resourceNames]
     using Google.Cloud.Bigtable.Common.V2;
     using Google.Cloud.Bigtable.V2;
     using System.Threading.Tasks;
@@ -41,5 +41,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             PingAndWarmResponse response = await bigtableServiceApiClient.PingAndWarmAsync(name);
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_PingAndWarm_async_flattened1_resourceNames]
+    // [END bigtable_v2_generated_Bigtable_PingAndWarm_async_flattened1_resourceNames]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PingAndWarm1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PingAndWarm1ResourceNamesSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_PingAndWarm_sync_flattened1_resourceNames]
+    // [START bigtable_v2_generated_Bigtable_PingAndWarm_sync_flattened1_resourceNames]
     using Google.Cloud.Bigtable.Common.V2;
     using Google.Cloud.Bigtable.V2;
 
@@ -40,5 +40,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             PingAndWarmResponse response = bigtableServiceApiClient.PingAndWarm(name);
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_PingAndWarm_sync_flattened1_resourceNames]
+    // [END bigtable_v2_generated_Bigtable_PingAndWarm_sync_flattened1_resourceNames]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PingAndWarm1Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PingAndWarm1Snippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_PingAndWarm_sync_flattened1]
+    // [START bigtable_v2_generated_Bigtable_PingAndWarm_sync_flattened1]
     using Google.Cloud.Bigtable.V2;
 
     public sealed partial class GeneratedBigtableServiceApiClientSnippets
@@ -39,5 +39,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             PingAndWarmResponse response = bigtableServiceApiClient.PingAndWarm(name);
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_PingAndWarm_sync_flattened1]
+    // [END bigtable_v2_generated_Bigtable_PingAndWarm_sync_flattened1]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PingAndWarm2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PingAndWarm2AsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_PingAndWarm_async_flattened2]
+    // [START bigtable_v2_generated_Bigtable_PingAndWarm_async_flattened2]
     using Google.Cloud.Bigtable.V2;
     using System.Threading.Tasks;
 
@@ -41,5 +41,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             PingAndWarmResponse response = await bigtableServiceApiClient.PingAndWarmAsync(name, appProfileId);
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_PingAndWarm_async_flattened2]
+    // [END bigtable_v2_generated_Bigtable_PingAndWarm_async_flattened2]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PingAndWarm2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PingAndWarm2ResourceNamesAsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_PingAndWarm_async_flattened2_resourceNames]
+    // [START bigtable_v2_generated_Bigtable_PingAndWarm_async_flattened2_resourceNames]
     using Google.Cloud.Bigtable.Common.V2;
     using Google.Cloud.Bigtable.V2;
     using System.Threading.Tasks;
@@ -42,5 +42,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             PingAndWarmResponse response = await bigtableServiceApiClient.PingAndWarmAsync(name, appProfileId);
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_PingAndWarm_async_flattened2_resourceNames]
+    // [END bigtable_v2_generated_Bigtable_PingAndWarm_async_flattened2_resourceNames]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PingAndWarm2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PingAndWarm2ResourceNamesSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_PingAndWarm_sync_flattened2_resourceNames]
+    // [START bigtable_v2_generated_Bigtable_PingAndWarm_sync_flattened2_resourceNames]
     using Google.Cloud.Bigtable.Common.V2;
     using Google.Cloud.Bigtable.V2;
 
@@ -41,5 +41,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             PingAndWarmResponse response = bigtableServiceApiClient.PingAndWarm(name, appProfileId);
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_PingAndWarm_sync_flattened2_resourceNames]
+    // [END bigtable_v2_generated_Bigtable_PingAndWarm_sync_flattened2_resourceNames]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PingAndWarm2Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PingAndWarm2Snippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_PingAndWarm_sync_flattened2]
+    // [START bigtable_v2_generated_Bigtable_PingAndWarm_sync_flattened2]
     using Google.Cloud.Bigtable.V2;
 
     public sealed partial class GeneratedBigtableServiceApiClientSnippets
@@ -40,5 +40,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             PingAndWarmResponse response = bigtableServiceApiClient.PingAndWarm(name, appProfileId);
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_PingAndWarm_sync_flattened2]
+    // [END bigtable_v2_generated_Bigtable_PingAndWarm_sync_flattened2]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PingAndWarmRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PingAndWarmRequestObjectAsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_PingAndWarm_async]
+    // [START bigtable_v2_generated_Bigtable_PingAndWarm_async]
     using Google.Cloud.Bigtable.Common.V2;
     using Google.Cloud.Bigtable.V2;
     using System.Threading.Tasks;
@@ -45,5 +45,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             PingAndWarmResponse response = await bigtableServiceApiClient.PingAndWarmAsync(request);
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_PingAndWarm_async]
+    // [END bigtable_v2_generated_Bigtable_PingAndWarm_async]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PingAndWarmRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PingAndWarmRequestObjectSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_PingAndWarm_sync]
+    // [START bigtable_v2_generated_Bigtable_PingAndWarm_sync]
     using Google.Cloud.Bigtable.Common.V2;
     using Google.Cloud.Bigtable.V2;
 
@@ -44,5 +44,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             PingAndWarmResponse response = bigtableServiceApiClient.PingAndWarm(request);
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_PingAndWarm_sync]
+    // [END bigtable_v2_generated_Bigtable_PingAndWarm_sync]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadChangeStream1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadChangeStream1ResourceNamesSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_ReadChangeStream_sync_flattened1_resourceNames]
+    // [START bigtable_v2_generated_Bigtable_ReadChangeStream_sync_flattened1_resourceNames]
     using Google.Api.Gax.Grpc;
     using Google.Cloud.Bigtable.Common.V2;
     using Google.Cloud.Bigtable.V2;
@@ -52,5 +52,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             // The response stream has completed
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_ReadChangeStream_sync_flattened1_resourceNames]
+    // [END bigtable_v2_generated_Bigtable_ReadChangeStream_sync_flattened1_resourceNames]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadChangeStream1Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadChangeStream1Snippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_ReadChangeStream_sync_flattened1]
+    // [START bigtable_v2_generated_Bigtable_ReadChangeStream_sync_flattened1]
     using Google.Api.Gax.Grpc;
     using Google.Cloud.Bigtable.V2;
     using System.Threading.Tasks;
@@ -51,5 +51,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             // The response stream has completed
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_ReadChangeStream_sync_flattened1]
+    // [END bigtable_v2_generated_Bigtable_ReadChangeStream_sync_flattened1]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadChangeStream2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadChangeStream2ResourceNamesSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_ReadChangeStream_sync_flattened2_resourceNames]
+    // [START bigtable_v2_generated_Bigtable_ReadChangeStream_sync_flattened2_resourceNames]
     using Google.Api.Gax.Grpc;
     using Google.Cloud.Bigtable.Common.V2;
     using Google.Cloud.Bigtable.V2;
@@ -53,5 +53,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             // The response stream has completed
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_ReadChangeStream_sync_flattened2_resourceNames]
+    // [END bigtable_v2_generated_Bigtable_ReadChangeStream_sync_flattened2_resourceNames]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadChangeStream2Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadChangeStream2Snippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_ReadChangeStream_sync_flattened2]
+    // [START bigtable_v2_generated_Bigtable_ReadChangeStream_sync_flattened2]
     using Google.Api.Gax.Grpc;
     using Google.Cloud.Bigtable.V2;
     using System.Threading.Tasks;
@@ -52,5 +52,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             // The response stream has completed
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_ReadChangeStream_sync_flattened2]
+    // [END bigtable_v2_generated_Bigtable_ReadChangeStream_sync_flattened2]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadChangeStreamRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadChangeStreamRequestObjectSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_ReadChangeStream_sync]
+    // [START bigtable_v2_generated_Bigtable_ReadChangeStream_sync]
     using Google.Api.Gax.Grpc;
     using Google.Cloud.Bigtable.Common.V2;
     using Google.Cloud.Bigtable.V2;
@@ -61,5 +61,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             // The response stream has completed
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_ReadChangeStream_sync]
+    // [END bigtable_v2_generated_Bigtable_ReadChangeStream_sync]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadModifyWriteRow1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadModifyWriteRow1AsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_ReadModifyWriteRow_async_flattened1]
+    // [START bigtable_v2_generated_Bigtable_ReadModifyWriteRow_async_flattened1]
     using Google.Cloud.Bigtable.V2;
     using Google.Protobuf;
     using System.Collections.Generic;
@@ -47,5 +47,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             ReadModifyWriteRowResponse response = await bigtableServiceApiClient.ReadModifyWriteRowAsync(tableName, rowKey, rules);
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_ReadModifyWriteRow_async_flattened1]
+    // [END bigtable_v2_generated_Bigtable_ReadModifyWriteRow_async_flattened1]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadModifyWriteRow1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadModifyWriteRow1ResourceNamesAsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_ReadModifyWriteRow_async_flattened1_resourceNames]
+    // [START bigtable_v2_generated_Bigtable_ReadModifyWriteRow_async_flattened1_resourceNames]
     using Google.Cloud.Bigtable.Common.V2;
     using Google.Cloud.Bigtable.V2;
     using Google.Protobuf;
@@ -48,5 +48,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             ReadModifyWriteRowResponse response = await bigtableServiceApiClient.ReadModifyWriteRowAsync(tableName, rowKey, rules);
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_ReadModifyWriteRow_async_flattened1_resourceNames]
+    // [END bigtable_v2_generated_Bigtable_ReadModifyWriteRow_async_flattened1_resourceNames]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadModifyWriteRow1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadModifyWriteRow1ResourceNamesSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_ReadModifyWriteRow_sync_flattened1_resourceNames]
+    // [START bigtable_v2_generated_Bigtable_ReadModifyWriteRow_sync_flattened1_resourceNames]
     using Google.Cloud.Bigtable.Common.V2;
     using Google.Cloud.Bigtable.V2;
     using Google.Protobuf;
@@ -47,5 +47,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             ReadModifyWriteRowResponse response = bigtableServiceApiClient.ReadModifyWriteRow(tableName, rowKey, rules);
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_ReadModifyWriteRow_sync_flattened1_resourceNames]
+    // [END bigtable_v2_generated_Bigtable_ReadModifyWriteRow_sync_flattened1_resourceNames]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadModifyWriteRow1Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadModifyWriteRow1Snippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_ReadModifyWriteRow_sync_flattened1]
+    // [START bigtable_v2_generated_Bigtable_ReadModifyWriteRow_sync_flattened1]
     using Google.Cloud.Bigtable.V2;
     using Google.Protobuf;
     using System.Collections.Generic;
@@ -46,5 +46,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             ReadModifyWriteRowResponse response = bigtableServiceApiClient.ReadModifyWriteRow(tableName, rowKey, rules);
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_ReadModifyWriteRow_sync_flattened1]
+    // [END bigtable_v2_generated_Bigtable_ReadModifyWriteRow_sync_flattened1]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadModifyWriteRow2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadModifyWriteRow2AsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_ReadModifyWriteRow_async_flattened2]
+    // [START bigtable_v2_generated_Bigtable_ReadModifyWriteRow_async_flattened2]
     using Google.Cloud.Bigtable.V2;
     using Google.Protobuf;
     using System.Collections.Generic;
@@ -48,5 +48,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             ReadModifyWriteRowResponse response = await bigtableServiceApiClient.ReadModifyWriteRowAsync(tableName, rowKey, rules, appProfileId);
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_ReadModifyWriteRow_async_flattened2]
+    // [END bigtable_v2_generated_Bigtable_ReadModifyWriteRow_async_flattened2]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadModifyWriteRow2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadModifyWriteRow2ResourceNamesAsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_ReadModifyWriteRow_async_flattened2_resourceNames]
+    // [START bigtable_v2_generated_Bigtable_ReadModifyWriteRow_async_flattened2_resourceNames]
     using Google.Cloud.Bigtable.Common.V2;
     using Google.Cloud.Bigtable.V2;
     using Google.Protobuf;
@@ -49,5 +49,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             ReadModifyWriteRowResponse response = await bigtableServiceApiClient.ReadModifyWriteRowAsync(tableName, rowKey, rules, appProfileId);
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_ReadModifyWriteRow_async_flattened2_resourceNames]
+    // [END bigtable_v2_generated_Bigtable_ReadModifyWriteRow_async_flattened2_resourceNames]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadModifyWriteRow2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadModifyWriteRow2ResourceNamesSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_ReadModifyWriteRow_sync_flattened2_resourceNames]
+    // [START bigtable_v2_generated_Bigtable_ReadModifyWriteRow_sync_flattened2_resourceNames]
     using Google.Cloud.Bigtable.Common.V2;
     using Google.Cloud.Bigtable.V2;
     using Google.Protobuf;
@@ -48,5 +48,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             ReadModifyWriteRowResponse response = bigtableServiceApiClient.ReadModifyWriteRow(tableName, rowKey, rules, appProfileId);
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_ReadModifyWriteRow_sync_flattened2_resourceNames]
+    // [END bigtable_v2_generated_Bigtable_ReadModifyWriteRow_sync_flattened2_resourceNames]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadModifyWriteRow2Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadModifyWriteRow2Snippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_ReadModifyWriteRow_sync_flattened2]
+    // [START bigtable_v2_generated_Bigtable_ReadModifyWriteRow_sync_flattened2]
     using Google.Cloud.Bigtable.V2;
     using Google.Protobuf;
     using System.Collections.Generic;
@@ -47,5 +47,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             ReadModifyWriteRowResponse response = bigtableServiceApiClient.ReadModifyWriteRow(tableName, rowKey, rules, appProfileId);
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_ReadModifyWriteRow_sync_flattened2]
+    // [END bigtable_v2_generated_Bigtable_ReadModifyWriteRow_sync_flattened2]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadModifyWriteRowRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadModifyWriteRowRequestObjectAsyncSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_ReadModifyWriteRow_async]
+    // [START bigtable_v2_generated_Bigtable_ReadModifyWriteRow_async]
     using Google.Cloud.Bigtable.Common.V2;
     using Google.Cloud.Bigtable.V2;
     using Google.Protobuf;
@@ -51,5 +51,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             ReadModifyWriteRowResponse response = await bigtableServiceApiClient.ReadModifyWriteRowAsync(request);
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_ReadModifyWriteRow_async]
+    // [END bigtable_v2_generated_Bigtable_ReadModifyWriteRow_async]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadModifyWriteRowRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadModifyWriteRowRequestObjectSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_ReadModifyWriteRow_sync]
+    // [START bigtable_v2_generated_Bigtable_ReadModifyWriteRow_sync]
     using Google.Cloud.Bigtable.Common.V2;
     using Google.Cloud.Bigtable.V2;
     using Google.Protobuf;
@@ -50,5 +50,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             ReadModifyWriteRowResponse response = bigtableServiceApiClient.ReadModifyWriteRow(request);
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_ReadModifyWriteRow_sync]
+    // [END bigtable_v2_generated_Bigtable_ReadModifyWriteRow_sync]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadRows1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadRows1ResourceNamesSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_ReadRows_sync_flattened1_resourceNames]
+    // [START bigtable_v2_generated_Bigtable_ReadRows_sync_flattened1_resourceNames]
     using Google.Api.Gax.Grpc;
     using Google.Cloud.Bigtable.Common.V2;
     using Google.Cloud.Bigtable.V2;
@@ -52,5 +52,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             // The response stream has completed
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_ReadRows_sync_flattened1_resourceNames]
+    // [END bigtable_v2_generated_Bigtable_ReadRows_sync_flattened1_resourceNames]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadRows1Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadRows1Snippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_ReadRows_sync_flattened1]
+    // [START bigtable_v2_generated_Bigtable_ReadRows_sync_flattened1]
     using Google.Api.Gax.Grpc;
     using Google.Cloud.Bigtable.V2;
     using System.Threading.Tasks;
@@ -51,5 +51,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             // The response stream has completed
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_ReadRows_sync_flattened1]
+    // [END bigtable_v2_generated_Bigtable_ReadRows_sync_flattened1]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadRows2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadRows2ResourceNamesSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_ReadRows_sync_flattened2_resourceNames]
+    // [START bigtable_v2_generated_Bigtable_ReadRows_sync_flattened2_resourceNames]
     using Google.Api.Gax.Grpc;
     using Google.Cloud.Bigtable.Common.V2;
     using Google.Cloud.Bigtable.V2;
@@ -53,5 +53,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             // The response stream has completed
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_ReadRows_sync_flattened2_resourceNames]
+    // [END bigtable_v2_generated_Bigtable_ReadRows_sync_flattened2_resourceNames]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadRows2Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadRows2Snippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_ReadRows_sync_flattened2]
+    // [START bigtable_v2_generated_Bigtable_ReadRows_sync_flattened2]
     using Google.Api.Gax.Grpc;
     using Google.Cloud.Bigtable.V2;
     using System.Threading.Tasks;
@@ -52,5 +52,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             // The response stream has completed
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_ReadRows_sync_flattened2]
+    // [END bigtable_v2_generated_Bigtable_ReadRows_sync_flattened2]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadRowsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadRowsRequestObjectSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_ReadRows_sync]
+    // [START bigtable_v2_generated_Bigtable_ReadRows_sync]
     using Google.Api.Gax.Grpc;
     using Google.Cloud.Bigtable.Common.V2;
     using Google.Cloud.Bigtable.V2;
@@ -60,5 +60,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             // The response stream has completed
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_ReadRows_sync]
+    // [END bigtable_v2_generated_Bigtable_ReadRows_sync]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.SampleRowKeys1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.SampleRowKeys1ResourceNamesSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_SampleRowKeys_sync_flattened1_resourceNames]
+    // [START bigtable_v2_generated_Bigtable_SampleRowKeys_sync_flattened1_resourceNames]
     using Google.Api.Gax.Grpc;
     using Google.Cloud.Bigtable.Common.V2;
     using Google.Cloud.Bigtable.V2;
@@ -52,5 +52,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             // The response stream has completed
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_SampleRowKeys_sync_flattened1_resourceNames]
+    // [END bigtable_v2_generated_Bigtable_SampleRowKeys_sync_flattened1_resourceNames]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.SampleRowKeys1Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.SampleRowKeys1Snippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_SampleRowKeys_sync_flattened1]
+    // [START bigtable_v2_generated_Bigtable_SampleRowKeys_sync_flattened1]
     using Google.Api.Gax.Grpc;
     using Google.Cloud.Bigtable.V2;
     using System.Threading.Tasks;
@@ -51,5 +51,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             // The response stream has completed
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_SampleRowKeys_sync_flattened1]
+    // [END bigtable_v2_generated_Bigtable_SampleRowKeys_sync_flattened1]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.SampleRowKeys2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.SampleRowKeys2ResourceNamesSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_SampleRowKeys_sync_flattened2_resourceNames]
+    // [START bigtable_v2_generated_Bigtable_SampleRowKeys_sync_flattened2_resourceNames]
     using Google.Api.Gax.Grpc;
     using Google.Cloud.Bigtable.Common.V2;
     using Google.Cloud.Bigtable.V2;
@@ -53,5 +53,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             // The response stream has completed
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_SampleRowKeys_sync_flattened2_resourceNames]
+    // [END bigtable_v2_generated_Bigtable_SampleRowKeys_sync_flattened2_resourceNames]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.SampleRowKeys2Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.SampleRowKeys2Snippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_SampleRowKeys_sync_flattened2]
+    // [START bigtable_v2_generated_Bigtable_SampleRowKeys_sync_flattened2]
     using Google.Api.Gax.Grpc;
     using Google.Cloud.Bigtable.V2;
     using System.Threading.Tasks;
@@ -52,5 +52,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             // The response stream has completed
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_SampleRowKeys_sync_flattened2]
+    // [END bigtable_v2_generated_Bigtable_SampleRowKeys_sync_flattened2]
 }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.SampleRowKeysRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.SampleRowKeysRequestObjectSnippet.g.cs
@@ -16,7 +16,7 @@
 
 namespace Google.Cloud.Bigtable.V2.Snippets
 {
-    // [START bigtable_v2_generated_BigtableServiceApi_SampleRowKeys_sync]
+    // [START bigtable_v2_generated_Bigtable_SampleRowKeys_sync]
     using Google.Api.Gax.Grpc;
     using Google.Cloud.Bigtable.Common.V2;
     using Google.Cloud.Bigtable.V2;
@@ -56,5 +56,5 @@ namespace Google.Cloud.Bigtable.V2.Snippets
             // The response stream has completed
         }
     }
-    // [END bigtable_v2_generated_BigtableServiceApi_SampleRowKeys_sync]
+    // [END bigtable_v2_generated_Bigtable_SampleRowKeys_sync]
 }

--- a/apis/Google.Cloud.Bigtable.V2/midmicrogeneration.sh
+++ b/apis/Google.Cloud.Bigtable.V2/midmicrogeneration.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-# Rename the service to BigtableServiceApi
-sed -i 's/service Bigtable/service BigtableServiceApi/g' $GOOGLEAPIS/google/bigtable/v2/bigtable.proto
-sed -i 's/v2.Bigtable/v2.BigtableServiceApi/g' $GOOGLEAPIS/google/bigtable/v2/bigtable_grpc_service_config.json
-sed -i 's/v2.Bigtable/v2.BigtableServiceApi/g' $GOOGLEAPIS/google/bigtable/v2/bigtable_v2.yaml

--- a/apis/Google.Cloud.Bigtable.V2/postgeneration.sh
+++ b/apis/Google.Cloud.Bigtable.V2/postgeneration.sh
@@ -2,24 +2,6 @@
 
 set -e
 
-# Undo the changes in googleapis
-# (Do this first so that if we have any failures in the remaining steps)
-git -C $GOOGLEAPIS checkout google/bigtable/v2/bigtable.proto
-git -C $GOOGLEAPIS checkout google/bigtable/v2/bigtable_grpc_service_config.json
-git -C $GOOGLEAPIS checkout google/bigtable/v2/bigtable_v2.yaml
-
-# Apply changes required due to the service renaming
-sed -i s/BigtableServiceApi.BigtableServiceApiClient/Bigtable.BigtableClient/g Google.Cloud.Bigtable.V2/BigtableServiceApiClient.g.cs
-sed -i s/BigtableServiceApi.Descriptor/Bigtable.Descriptor/g Google.Cloud.Bigtable.V2/BigtableServiceApiClient.g.cs
-
-# Fix up the metadata
-sed -i 's/"BigtableServiceApi": {/"Bigtable": {/g' gapic_metadata.json
-
-# Fix up the snippet metadata (carefully)
-sed -i 's/v2.BigtableServiceApi/v2.Bigtable/g' Google.Cloud.Bigtable.V2.GeneratedSnippets/snippet_metadata_google.bigtable.v2.json
-sed -i 's/generated_BigtableServiceApi/generated_Bigtable/g' Google.Cloud.Bigtable.V2.GeneratedSnippets/snippet_metadata_google.bigtable.v2.json
-sed -i 's/"shortName": "BigtableServiceApi"/"shortName": "Bigtable"/g' Google.Cloud.Bigtable.V2.GeneratedSnippets/snippet_metadata_google.bigtable.v2.json
-
 # Generate BigtableClient
 dotnet run --project Google.Cloud.Bigtable.V2.GenerateClient \
   Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj \


### PR DESCRIPTION
(This is enabled by the new settings in the service config.)