### PR TITLE
Release Google.Cloud.AIPlatform.V1 version 2.13.0

### DIFF
--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.12.0</Version>
+    <Version>2.13.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AI Platform API, which allows you to train high-quality custom machine learning models with minimal machine learning expertise and effort.</Description>

--- a/apis/Google.Cloud.AIPlatform.V1/docs/history.md
+++ b/apis/Google.Cloud.AIPlatform.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.13.0, released 2023-04-19
+
+### New features
+
+- Add is_default to Tensorboard in aiplatform v1 tensorboard.proto and v1beta1 tensorboard.proto ([commit 0fe126a](https://github.com/googleapis/google-cloud-dotnet/commit/0fe126af822d5691488387da74cccb9650040d5e))
+
 ## Version 2.12.0, released 2023-04-12
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -222,7 +222,7 @@
     },
     {
       "id": "Google.Cloud.AIPlatform.V1",
-      "version": "2.12.0",
+      "version": "2.13.0",
       "type": "grpc",
       "productName": "Cloud AI Platform",
       "productUrl": "https://cloud.google.com/ai-platform/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add is_default to Tensorboard in aiplatform v1 tensorboard.proto and v1beta1 tensorboard.proto ([commit 0fe126a](https://github.com/googleapis/google-cloud-dotnet/commit/0fe126af822d5691488387da74cccb9650040d5e))
