### PR TITLE
Release Google.Cloud.Batch.V1Alpha version 1.0.0-alpha10

### DIFF
--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.csproj
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha09</Version>
+    <Version>1.0.0-alpha10</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Batch API (v1alpha), which allows you to manage the running of batch jobs on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Batch.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.Batch.V1Alpha/docs/history.md
@@ -1,5 +1,21 @@
 # Version history
 
+## Version 1.0.0-alpha10, released 2023-04-19
+
+### New features
+
+- Add TaskStatus's new terminated state UNEXECUTED ([commit c721955](https://github.com/googleapis/google-cloud-dotnet/commit/c72195511d02ef07dbc8452d94c85dd4c5153e23))
+- Add scheduling_policy IN_ORDER enum to support sequential task executions ([commit c721955](https://github.com/googleapis/google-cloud-dotnet/commit/c72195511d02ef07dbc8452d94c85dd4c5153e23))
+- Add support for placement policies ([commit c721955](https://github.com/googleapis/google-cloud-dotnet/commit/c72195511d02ef07dbc8452d94c85dd4c5153e23))
+
+### Documentation improvements
+
+- Update comments on boot disk fields for clearer usage scope ([commit c721955](https://github.com/googleapis/google-cloud-dotnet/commit/c72195511d02ef07dbc8452d94c85dd4c5153e23))
+- Update block_external_network field comment to reduce confusion ([commit c721955](https://github.com/googleapis/google-cloud-dotnet/commit/c72195511d02ef07dbc8452d94c85dd4c5153e23))
+- Update disk and network field comment for better readability ([commit c721955](https://github.com/googleapis/google-cloud-dotnet/commit/c72195511d02ef07dbc8452d94c85dd4c5153e23))
+- Fix `book disk` typo ([commit c721955](https://github.com/googleapis/google-cloud-dotnet/commit/c72195511d02ef07dbc8452d94c85dd4c5153e23))
+- Update reservation field API doc ([commit c721955](https://github.com/googleapis/google-cloud-dotnet/commit/c72195511d02ef07dbc8452d94c85dd4c5153e23))
+
 ## Version 1.0.0-alpha09, released 2023-03-09
 
 ### BREAKING CHANGE

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -569,7 +569,7 @@
     },
     {
       "id": "Google.Cloud.Batch.V1Alpha",
-      "version": "1.0.0-alpha09",
+      "version": "1.0.0-alpha10",
       "type": "grpc",
       "productName": "Batch",
       "productUrl": "https://cloud.google.com/batch/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add TaskStatus's new terminated state UNEXECUTED ([commit c721955](https://github.com/googleapis/google-cloud-dotnet/commit/c72195511d02ef07dbc8452d94c85dd4c5153e23))
- Add scheduling_policy IN_ORDER enum to support sequential task executions ([commit c721955](https://github.com/googleapis/google-cloud-dotnet/commit/c72195511d02ef07dbc8452d94c85dd4c5153e23))
- Add support for placement policies ([commit c721955](https://github.com/googleapis/google-cloud-dotnet/commit/c72195511d02ef07dbc8452d94c85dd4c5153e23))

### Documentation improvements

- Update comments on boot disk fields for clearer usage scope ([commit c721955](https://github.com/googleapis/google-cloud-dotnet/commit/c72195511d02ef07dbc8452d94c85dd4c5153e23))
- Update block_external_network field comment to reduce confusion ([commit c721955](https://github.com/googleapis/google-cloud-dotnet/commit/c72195511d02ef07dbc8452d94c85dd4c5153e23))
- Update disk and network field comment for better readability ([commit c721955](https://github.com/googleapis/google-cloud-dotnet/commit/c72195511d02ef07dbc8452d94c85dd4c5153e23))
- Fix `book disk` typo ([commit c721955](https://github.com/googleapis/google-cloud-dotnet/commit/c72195511d02ef07dbc8452d94c85dd4c5153e23))
- Update reservation field API doc ([commit c721955](https://github.com/googleapis/google-cloud-dotnet/commit/c72195511d02ef07dbc8452d94c85dd4c5153e23))
