### PR TITLE
Release Google.Cloud.CloudBuild.V1 version 2.4.0

### DIFF
--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.csproj
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Build API v1, which creates and manages builds on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.CloudBuild.V1/docs/history.md
+++ b/apis/Google.Cloud.CloudBuild.V1/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 2.4.0, released 2023-04-19
+
+### New features
+
+- Add PeeredNetworkIpRange to NetworkConfigs message ([commit dcab5a1](https://github.com/googleapis/google-cloud-dotnet/commit/dcab5a1f3b313f883978d151f09bcf9a3fc0dbca))
+- Add NpmPackages to Artifact and Results messages and new SHA512 hash type ([commit dcab5a1](https://github.com/googleapis/google-cloud-dotnet/commit/dcab5a1f3b313f883978d151f09bcf9a3fc0dbca))
+- Update third party clodubuild.proto library to include git_source ([commit 6c369f5](https://github.com/googleapis/google-cloud-dotnet/commit/6c369f5baaab5af66addcde14d7cf4483a8d4709))
+
+### Documentation improvements
+
+- Various doc updates ([commit dcab5a1](https://github.com/googleapis/google-cloud-dotnet/commit/dcab5a1f3b313f883978d151f09bcf9a3fc0dbca))
+
 ## Version 2.3.0, released 2023-03-20
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1162,7 +1162,7 @@
     },
     {
       "id": "Google.Cloud.CloudBuild.V1",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "type": "grpc",
       "productName": "Cloud Build",
       "productUrl": "https://cloud.google.com/cloud-build",


### PR DESCRIPTION

Changes in this release:

### New features

- Add PeeredNetworkIpRange to NetworkConfigs message ([commit dcab5a1](https://github.com/googleapis/google-cloud-dotnet/commit/dcab5a1f3b313f883978d151f09bcf9a3fc0dbca))
- Add NpmPackages to Artifact and Results messages and new SHA512 hash type ([commit dcab5a1](https://github.com/googleapis/google-cloud-dotnet/commit/dcab5a1f3b313f883978d151f09bcf9a3fc0dbca))
- Update third party clodubuild.proto library to include git_source ([commit 6c369f5](https://github.com/googleapis/google-cloud-dotnet/commit/6c369f5baaab5af66addcde14d7cf4483a8d4709))

### Documentation improvements

- Various doc updates ([commit dcab5a1](https://github.com/googleapis/google-cloud-dotnet/commit/dcab5a1f3b313f883978d151f09bcf9a3fc0dbca))
