### PR TITLE
Release Google.Cloud.Metastore.V1 version 2.3.0

### DIFF
--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.csproj
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.2.0</Version>
+    <Version>2.3.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Dataproc Metastore API which is used to manage the lifecycle and configuration of metastore services.</Description>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />

--- a/apis/Google.Cloud.Metastore.V1/docs/history.md
+++ b/apis/Google.Cloud.Metastore.V1/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 2.3.0, released 2023-04-19
+
+### New features
+
+- Added ScalingConfig (v1) ([commit d2e0f6c](https://github.com/googleapis/google-cloud-dotnet/commit/d2e0f6c8f53092c18b2d25bd9fc0e78fa29824d5))
+- Added Auxiliary Versions Config (v1) ([commit d2e0f6c](https://github.com/googleapis/google-cloud-dotnet/commit/d2e0f6c8f53092c18b2d25bd9fc0e78fa29824d5))
+- Added Dataplex and BQ metastore types for federation (v1alpa, v1beta) ([commit d2e0f6c](https://github.com/googleapis/google-cloud-dotnet/commit/d2e0f6c8f53092c18b2d25bd9fc0e78fa29824d5))
+
 ## Version 2.2.0, released 2023-01-16
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2936,7 +2936,7 @@
     },
     {
       "id": "Google.Cloud.Metastore.V1",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "type": "grpc",
       "productName": "Dataproc Metastore",
       "productUrl": "https://cloud.google.com/dataproc-metastore/docs",
@@ -2946,7 +2946,7 @@
         "metastore"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.3.1",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",


### PR DESCRIPTION

Changes in this release:

### New features

- Added ScalingConfig (v1) ([commit d2e0f6c](https://github.com/googleapis/google-cloud-dotnet/commit/d2e0f6c8f53092c18b2d25bd9fc0e78fa29824d5))
- Added Auxiliary Versions Config (v1) ([commit d2e0f6c](https://github.com/googleapis/google-cloud-dotnet/commit/d2e0f6c8f53092c18b2d25bd9fc0e78fa29824d5))
- Added Dataplex and BQ metastore types for federation (v1alpa, v1beta) ([commit d2e0f6c](https://github.com/googleapis/google-cloud-dotnet/commit/d2e0f6c8f53092c18b2d25bd9fc0e78fa29824d5))
