### PR TITLE
Release Google.Cloud.Metastore.V1Alpha version 2.0.0-alpha05

### DIFF
--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.csproj
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha04</Version>
+    <Version>2.0.0-alpha05</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Dataproc Metastore API (v1alpha) which is used to manage the lifecycle and configuration of metastore services.</Description>

--- a/apis/Google.Cloud.Metastore.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.Metastore.V1Alpha/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 2.0.0-alpha05, released 2023-04-19
+
+### New features
+
+- Added ScalingConfig (v1) ([commit c10f31b](https://github.com/googleapis/google-cloud-dotnet/commit/c10f31b98522c71db743117dab653063f7396132))
+- Added Auxiliary Versions Config (v1) ([commit c10f31b](https://github.com/googleapis/google-cloud-dotnet/commit/c10f31b98522c71db743117dab653063f7396132))
+- Added Dataplex and BQ metastore types for federation (v1alpa, v1beta) ([commit c10f31b](https://github.com/googleapis/google-cloud-dotnet/commit/c10f31b98522c71db743117dab653063f7396132))
+
 ## Version 2.0.0-alpha04, released 2023-01-19
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2961,7 +2961,7 @@
     },
     {
       "id": "Google.Cloud.Metastore.V1Alpha",
-      "version": "2.0.0-alpha04",
+      "version": "2.0.0-alpha05",
       "type": "grpc",
       "productName": "Dataproc Metastore",
       "productUrl": "https://cloud.google.com/dataproc-metastore/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Added ScalingConfig (v1) ([commit c10f31b](https://github.com/googleapis/google-cloud-dotnet/commit/c10f31b98522c71db743117dab653063f7396132))
- Added Auxiliary Versions Config (v1) ([commit c10f31b](https://github.com/googleapis/google-cloud-dotnet/commit/c10f31b98522c71db743117dab653063f7396132))
- Added Dataplex and BQ metastore types for federation (v1alpa, v1beta) ([commit c10f31b](https://github.com/googleapis/google-cloud-dotnet/commit/c10f31b98522c71db743117dab653063f7396132))
