### PR TITLE
Release Google.Cloud.Metastore.V1Beta version 2.0.0-beta05

### DIFF
--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.csproj
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta04</Version>
+    <Version>2.0.0-beta05</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Dataproc Metastore API (v1beta) which is used to manage the lifecycle and configuration of metastore services.</Description>

--- a/apis/Google.Cloud.Metastore.V1Beta/docs/history.md
+++ b/apis/Google.Cloud.Metastore.V1Beta/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 2.0.0-beta05, released 2023-04-19
+
+### New features
+
+- Added ScalingConfig (v1) ([commit ca0d304](https://github.com/googleapis/google-cloud-dotnet/commit/ca0d3042ca823b64105b27b3cbd72b4f095825e0))
+- Added Auxiliary Versions Config (v1) ([commit ca0d304](https://github.com/googleapis/google-cloud-dotnet/commit/ca0d3042ca823b64105b27b3cbd72b4f095825e0))
+- Added Dataplex and BQ metastore types for federation (v1alpa, v1beta) ([commit ca0d304](https://github.com/googleapis/google-cloud-dotnet/commit/ca0d3042ca823b64105b27b3cbd72b4f095825e0))
+
 ## Version 2.0.0-beta04, released 2023-01-19
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2984,7 +2984,7 @@
     },
     {
       "id": "Google.Cloud.Metastore.V1Beta",
-      "version": "2.0.0-beta04",
+      "version": "2.0.0-beta05",
       "type": "grpc",
       "productName": "Dataproc Metastore",
       "productUrl": "https://cloud.google.com/dataproc-metastore/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Added ScalingConfig (v1) ([commit ca0d304](https://github.com/googleapis/google-cloud-dotnet/commit/ca0d3042ca823b64105b27b3cbd72b4f095825e0))
- Added Auxiliary Versions Config (v1) ([commit ca0d304](https://github.com/googleapis/google-cloud-dotnet/commit/ca0d3042ca823b64105b27b3cbd72b4f095825e0))
- Added Dataplex and BQ metastore types for federation (v1alpa, v1beta) ([commit ca0d304](https://github.com/googleapis/google-cloud-dotnet/commit/ca0d3042ca823b64105b27b3cbd72b4f095825e0))
