### PR TITLE
Release Google.Cloud.BigQuery.V2 version 3.3.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.2.0</Version>
+    <Version>3.3.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery API. It wraps the Google.Apis.Bigquery.v2 client library, making common operations simpler in client code. BigQuery is a data platform for customers to create, manage, share and query data.</Description>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Rest" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Rest" Version="[4.3.1, 5.0.0)" />
     <PackageReference Include="Google.Apis.Bigquery.v2" Version="[1.60.0.2949, 2.0.0.0)" />
   </ItemGroup>
   <ItemGroup>

--- a/apis/Google.Cloud.BigQuery.V2/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.3.0, released 2023-04-19
+
+### New features
+
+- Add support for snapshot clones ([commit 09aadf7](https://github.com/googleapis/google-cloud-dotnet/commit/09aadf792d8d20346f0c2e1e4bb45abda2775897))
+
 ## Version 3.2.0, released 2022-11-16
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -897,11 +897,11 @@
       "id": "Google.Cloud.BigQuery.V2",
       "productName": "Google BigQuery",
       "productUrl": "https://cloud.google.com/bigquery/",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "type": "rest",
       "description": "Recommended Google client library to access the BigQuery API. It wraps the Google.Apis.Bigquery.v2 client library, making common operations simpler in client code. BigQuery is a data platform for customers to create, manage, share and query data.",
       "dependencies": {
-        "Google.Api.Gax.Rest": "4.2.0",
+        "Google.Api.Gax.Rest": "4.3.1",
         "Google.Apis.Bigquery.v2": "1.60.0.2949"
       },
       "testDependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Add support for snapshot clones ([commit 09aadf7](https://github.com/googleapis/google-cloud-dotnet/commit/09aadf792d8d20346f0c2e1e4bb45abda2775897))
