### PR TITLE
Release Google.Cloud.PubSub.V1 version 3.5.0

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.4.0</Version>
+    <Version>3.5.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.</Description>

--- a/apis/Google.Cloud.PubSub.V1/docs/history.md
+++ b/apis/Google.Cloud.PubSub.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.5.0, released 2023-04-19
+
+### New features
+
+- Reliability improvements in exactly-once delivery. ([commit 27b2430](https://github.com/googleapis/google-cloud-dotnet/commit/27b2430894ddd1f857ad49a5945282670760fa56))
+
 ## Version 3.4.0, released 2023-03-08
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3465,7 +3465,7 @@
       "protoPath": "google/pubsub/v1",
       "productName": "Cloud Pub/Sub",
       "productUrl": "https://cloud.google.com/pubsub/",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.",


### PR DESCRIPTION

Changes in this release:

### New features

- Reliability improvements in exactly-once delivery. ([commit 27b2430](https://github.com/googleapis/google-cloud-dotnet/commit/27b2430894ddd1f857ad49a5945282670760fa56))
