### PR TITLE
Release Google.Cloud.Storage.V1 version 4.5.0

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.4.0</Version>
+    <Version>4.5.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Storage API. It wraps the Google.Apis.Storage.v1 client library, making common operations simpler in client code. Google Cloud Storage stores and retrieves potentially large, immutable data objects.</Description>

--- a/apis/Google.Cloud.Storage.V1/docs/history.md
+++ b/apis/Google.Cloud.Storage.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 4.5.0, released 2023-04-20
+
+### New features
+
+- Support custom retry options on all API calls (other than upload/download object) ([commit cc384b5](https://github.com/googleapis/google-cloud-dotnet/commit/cc384b5e2db95b718d68300141152078f2d736d1)) and ([commit 385ee89](https://github.com/googleapis/google-cloud-dotnet/commit/385ee890cf10cbbebab000b96da04d6fc9f62bcc))
+
 ## Version 4.4.0, released 2023-02-21
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4220,7 +4220,7 @@
       "id": "Google.Cloud.Storage.V1",
       "productName": "Google Cloud Storage",
       "productUrl": "https://cloud.google.com/storage/",
-      "version": "4.4.0",
+      "version": "4.5.0",
       "type": "rest",
       "description": "Recommended Google client library to access the Google Cloud Storage API. It wraps the Google.Apis.Storage.v1 client library, making common operations simpler in client code. Google Cloud Storage stores and retrieves potentially large, immutable data objects.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Support custom retry options on all API calls (other than upload/download object) ([commit cc384b5](https://github.com/googleapis/google-cloud-dotnet/commit/cc384b5e2db95b718d68300141152078f2d736d1)) and ([commit 385ee89](https://github.com/googleapis/google-cloud-dotnet/commit/385ee890cf10cbbebab000b96da04d6fc9f62bcc))
