### PR TITLE
chore: Run devsite post-processing on devsite utilities

### DIFF
--- a/docs/generate-devsite-utilities.sh
+++ b/docs/generate-devsite-utilities.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 source ../toolversions.sh
 
 install_docfx
@@ -128,18 +130,19 @@ dotnet docfx metadata --logLevel Error -o output --property TargetFramework=$TAR
 
 # This will have created an output/output directory. 
 # (For some reason docfx takes "output" and doubles it to output/output.)
-# We rename this to output/devsite/api so we can use output/devsite as the
+# We rename this to output/utility/devsite/api so we can use output/utility/devsite as the
 # "root" directory for docuploader.
 # (This will make it easier to add snippets in the future if we want to.)
+# Having the pseudo-package-name of "utility" makes this more consistent with other tooling, too.
 cd output
-mkdir devsite
+mkdir -p utility/devsite
 
 # It's unclear why we need to do this, but without it we regularly
 # get errors when trying the directory move.
 mv_attempts=10
 until [[ $mv_attempts == 0 ]]
 do
-  mv output/ devsite/api/ && break
+  mv output/ utility/devsite/api/ && break
   mv_attempts=$((mv_attempts-1))
   if [[ mv_attempts == 0 ]]
   then
@@ -152,9 +155,12 @@ do
 done
 
 echo 'Regenerating TOC'
-dotnet run --project ../../tools/Google.Cloud.Tools.RegenerateToc -- devsite/api
+dotnet run --project ../../tools/Google.Cloud.Tools.RegenerateToc -- utility/devsite/api
 
-cd devsite
+echo "Post-processing YAML metadata files"
+dotnet run --project ../../tools/Google.Cloud.Tools.PostProcessDevSite -- utility
+
+cd utility/devsite
 
 echo 'Creating metadata file'
 

--- a/tools/Google.Cloud.Tools.PostProcessDevSite/Program.cs
+++ b/tools/Google.Cloud.Tools.PostProcessDevSite/Program.cs
@@ -40,9 +40,15 @@ namespace Google.Cloud.Tools.PostProcessDevSite
     /// - docs/output/{package}/devsite/api (including guides and tweaked TOC)
     /// - docs/output/{package}/devsite/examples
     /// - docs/output/{package}/devsite/docs-metadata.json (includes xrefs and xrefservices)
+    ///
+    /// If the package ID of "utility" is specified, most processing is bypassed.
+    /// We expect docs/output/devsite/api to already exist, and only metadata
+    /// processing is performed.
     /// </summary>
     internal class Program
     {
+        private const string UtilityApi = "utility";
+
         /// <summary>
         /// The package/API ID
         /// </summary>
@@ -84,6 +90,13 @@ namespace Google.Cloud.Tools.PostProcessDevSite
 
         private void Execute()
         {
+            // The utility pseudo-package only needs a few tweaks.
+            if (_apiId == UtilityApi)
+            {
+                FixExternalReferencesAndNamespaceSpecs();
+                return;
+            }
+
             if (Directory.Exists(_devSiteRoot))
             {
                 Directory.Delete(_devSiteRoot, recursive: true);


### PR DESCRIPTION
We only need the actions on metadata YAML files, as we don't have snippets etc. To simplify the code, the script generating the metadata now writes to docs/output/utility/devsite instead of just docs/output/devsite - this is consistent with other docs, e.g. docs/output/Google.Cloud.Speech.V1/devsite.