### PR TITLE
chore: Remove direct dependency from Google.Cloud.Asset.V1 to Google.Identity.AccessContextManager.Type

### DIFF
--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.csproj
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.csproj
@@ -13,7 +13,6 @@
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.OrgPolicy.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.OsConfig.V1" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Google.Identity.AccessContextManager.Type" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.Identity.AccessContextManager.V1" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -419,7 +419,6 @@
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.OrgPolicy.V1": "3.0.0",
         "Google.Cloud.OsConfig.V1": "2.1.0",
-        "Google.Identity.AccessContextManager.Type": "2.0.0",
         "Google.Identity.AccessContextManager.V1": "2.2.0",
         "Google.LongRunning": "3.0.0",
         "Grpc.Core": "2.46.5"


### PR DESCRIPTION
There's already an indirect dependency via Google.Identity.AccessContextManager.V1. We don't need the direct one. (This was noticed when building googleapis-gen.)