### PR TITLE
Release Google.Cloud.Video.Stitcher.V1 version 3.0.0-beta01

### DIFF
--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.csproj
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>3.0.0-beta01</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Video Stitcher API, which helps you generate dynamic content for delivery to client devices. </Description>

--- a/apis/Google.Cloud.Video.Stitcher.V1/docs/history.md
+++ b/apis/Google.Cloud.Video.Stitcher.V1/docs/history.md
@@ -1,5 +1,21 @@
 # Version history
 
+## Version 3.0.0-beta01, released 2023-04-25
+
+New major version to accommodate breaking changes. This is initially
+released as a beta just in case any further breaking changes surface in
+the near future, but a stable release is expected shortly.
+
+### Bug fixes
+
+- **BREAKING CHANGE** Roll back the changes that update of LRO metadata type to google.cloud.common.OperationMetadata ([commit 7d86a96](https://github.com/googleapis/google-cloud-dotnet/commit/7d86a961bff38233446be69ceba2f8966634e721))
+
+### New features
+
+- **BREAKING CHANGE** Introduce GAM settings for GAM related configs and support ListOperations ([commit 8f8a3e6](https://github.com/googleapis/google-cloud-dotnet/commit/8f8a3e6c07531ca3d947a1a47d0e1598b2e8226b))
+- **BREAKING CHANGE** Remove default_ad_break_duration from LiveConfig ([commit 04da5ae](https://github.com/googleapis/google-cloud-dotnet/commit/04da5aee708a10f38ca26781bf92f66fdece8145))
+- **BREAKING CHANGE** Update LRO metadata type to google.cloud.common.OperationMetadata ([commit f0fd7fc](https://github.com/googleapis/google-cloud-dotnet/commit/f0fd7fc2ed620ed39d14488062f851003da912b1))
+
 ## Version 2.0.0, released 2023-03-27
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4576,7 +4576,7 @@
     },
     {
       "id": "Google.Cloud.Video.Stitcher.V1",
-      "version": "2.0.0",
+      "version": "3.0.0-beta01",
       "type": "grpc",
       "productName": "Video Stitcher",
       "productUrl": "https://cloud.google.com/video-stitcher/docs",


### PR DESCRIPTION

Changes in this release:

New major version to accommodate breaking changes. This is initially released as a beta just in case any further breaking changes surface in the near future, but a stable release is expected shortly.

### Bug fixes

- **BREAKING CHANGE** Roll back the changes that update of LRO metadata type to google.cloud.common.OperationMetadata ([commit 7d86a96](https://github.com/googleapis/google-cloud-dotnet/commit/7d86a961bff38233446be69ceba2f8966634e721))

### New features

- **BREAKING CHANGE** Introduce GAM settings for GAM related configs and support ListOperations ([commit 8f8a3e6](https://github.com/googleapis/google-cloud-dotnet/commit/8f8a3e6c07531ca3d947a1a47d0e1598b2e8226b))
- **BREAKING CHANGE** Remove default_ad_break_duration from LiveConfig ([commit 04da5ae](https://github.com/googleapis/google-cloud-dotnet/commit/04da5aee708a10f38ca26781bf92f66fdece8145))
- **BREAKING CHANGE** Update LRO metadata type to google.cloud.common.OperationMetadata ([commit f0fd7fc](https://github.com/googleapis/google-cloud-dotnet/commit/f0fd7fc2ed620ed39d14488062f851003da912b1))
