### PR TITLE
chore: Post the diff results on both success and failure

### DIFF
--- a/.github/workflows/diff-pr.yml
+++ b/.github/workflows/diff-pr.yml
@@ -47,8 +47,11 @@ jobs:
         ./detect-pr-changes.sh $SCRIPT_OPTION 2>&1 | tee -a diff.txt        
         set +o pipefail
 
+    # The purpose of (success() || failure()) in the condition is to
+    # make sure we post a comment on both success and failure, but *not*
+    # if the job is cancelled.
     - name: Post diff as a comment for branches on target fork
-      if: github.event.pull_request.head.repo.full_name == github.repository
+      if: (success() || failure()) && github.event.pull_request.head.repo.full_name == github.repository
       run: |
         ./prepare-release.sh add-pr-comment diff.txt \
            ${{github.event.pull_request.number }} \


### PR DESCRIPTION
(By default, the next step will only run on success, so diff failures - including "it looks like OwlBot hasn't finished" - don't end up creating a comment.)