### PR TITLE
Release Google.Analytics.Admin.V1Alpha version 2.0.0-alpha08

### DIFF
--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha07</Version>
+    <Version>2.0.0-alpha08</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Analytics Admin API (v1alpha)</Description>

--- a/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
+++ b/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 2.0.0-alpha08, released 2023-05-03
+
+### New features
+
+- Add FetchConnectedGa4Property method to the Admin API v1alpha ([commit c8b636f](https://github.com/googleapis/google-cloud-dotnet/commit/c8b636f560e7144b101451be96564d247e0eb879))
+- Add `GetChannelGroup`, `ListChannelGroups`, `CreateChannelGroup`, `UpdateChannelGroup` methods to the Admin API v1alpha ([commit c8b636f](https://github.com/googleapis/google-cloud-dotnet/commit/c8b636f560e7144b101451be96564d247e0eb879))
+- Add `ChannelGroupFilter`, `ChannelGroupFilterExpression`, `ChannelGroupFilterExpressionList`, `GroupingRule`, `ChannelGroup` types to the Admin API v1alpha ([commit c8b636f](https://github.com/googleapis/google-cloud-dotnet/commit/c8b636f560e7144b101451be96564d247e0eb879))
+
 ## Version 2.0.0-alpha07, released 2023-03-27
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2,7 +2,7 @@
   "apis": [
     {
       "id": "Google.Analytics.Admin.V1Alpha",
-      "version": "2.0.0-alpha07",
+      "version": "2.0.0-alpha08",
       "type": "grpc",
       "productName": "Analytics Admin",
       "productUrl": "https://developers.google.com/analytics",


### PR DESCRIPTION

Changes in this release:

### New features

- Add FetchConnectedGa4Property method to the Admin API v1alpha ([commit c8b636f](https://github.com/googleapis/google-cloud-dotnet/commit/c8b636f560e7144b101451be96564d247e0eb879))
- Add `GetChannelGroup`, `ListChannelGroups`, `CreateChannelGroup`, `UpdateChannelGroup` methods to the Admin API v1alpha ([commit c8b636f](https://github.com/googleapis/google-cloud-dotnet/commit/c8b636f560e7144b101451be96564d247e0eb879))
- Add `ChannelGroupFilter`, `ChannelGroupFilterExpression`, `ChannelGroupFilterExpressionList`, `GroupingRule`, `ChannelGroup` types to the Admin API v1alpha ([commit c8b636f](https://github.com/googleapis/google-cloud-dotnet/commit/c8b636f560e7144b101451be96564d247e0eb879))
