### PR TITLE
Release Google.Cloud.Bigtable.V2 version 3.5.0

### DIFF
--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.4.0</Version>
+    <Version>3.5.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Bigtable API.</Description>

--- a/apis/Google.Cloud.Bigtable.V2/docs/history.md
+++ b/apis/Google.Cloud.Bigtable.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.5.0, released 2023-05-03
+
+### New features
+
+- Publish RateLimitInfo and FeatureFlag protos ([commit b1efbfe](https://github.com/googleapis/google-cloud-dotnet/commit/b1efbfeabdbe21c90b7a5028828d935b75fa1b15))
+
 ## Version 3.4.0, released 2023-03-01
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -978,7 +978,7 @@
       "protoPath": "google/bigtable/v2",
       "productName": "Google Bigtable",
       "productUrl": "https://cloud.google.com/bigtable/",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "commonResourcesConfig": "apis/Google.Cloud.Bigtable.Common.V2/CommonResourcesConfig.json",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",


### PR DESCRIPTION

Changes in this release:

### New features

- Publish RateLimitInfo and FeatureFlag protos ([commit b1efbfe](https://github.com/googleapis/google-cloud-dotnet/commit/b1efbfeabdbe21c90b7a5028828d935b75fa1b15))
