### PR TITLE
Release Google.Cloud.Container.V1 version 3.11.0

### DIFF
--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.10.0</Version>
+    <Version>3.11.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.</Description>

--- a/apis/Google.Cloud.Container.V1/docs/history.md
+++ b/apis/Google.Cloud.Container.V1/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 3.11.0, released 2023-05-03
+
+### New features
+
+- Cluster resizes will now have their own operation type (RESIZE_CLUSTER) instead of reusing REPAIR_CLUSTER; they will start using this in the near future ([commit 297d5b8](https://github.com/googleapis/google-cloud-dotnet/commit/297d5b8c898aa4d65c1d5272a9f798aae2521d24))
+
+### Documentation improvements
+
+- Minor formatting in docstring ([commit 3439142](https://github.com/googleapis/google-cloud-dotnet/commit/34391423be1d7efaf6f1e03fe1c5788b953131a2))
+- Operation.Type is now documented in detail ([commit 297d5b8](https://github.com/googleapis/google-cloud-dotnet/commit/297d5b8c898aa4d65c1d5272a9f798aae2521d24))
+- Operation.self_link and Operation.target_link given examples ([commit 297d5b8](https://github.com/googleapis/google-cloud-dotnet/commit/297d5b8c898aa4d65c1d5272a9f798aae2521d24))
+
 ## Version 3.10.0, released 2023-04-19
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1332,7 +1332,7 @@
       "protoPath": "google/container/v1",
       "productName": "Google Kubernetes Engine",
       "productUrl": "https://cloud.google.com/kubernetes-engine/docs/reference/rest/",
-      "version": "3.10.0",
+      "version": "3.11.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Cluster resizes will now have their own operation type (RESIZE_CLUSTER) instead of reusing REPAIR_CLUSTER; they will start using this in the near future ([commit 297d5b8](https://github.com/googleapis/google-cloud-dotnet/commit/297d5b8c898aa4d65c1d5272a9f798aae2521d24))

### Documentation improvements

- Minor formatting in docstring ([commit 3439142](https://github.com/googleapis/google-cloud-dotnet/commit/34391423be1d7efaf6f1e03fe1c5788b953131a2))
- Operation.Type is now documented in detail ([commit 297d5b8](https://github.com/googleapis/google-cloud-dotnet/commit/297d5b8c898aa4d65c1d5272a9f798aae2521d24))
- Operation.self_link and Operation.target_link given examples ([commit 297d5b8](https://github.com/googleapis/google-cloud-dotnet/commit/297d5b8c898aa4d65c1d5272a9f798aae2521d24))
