### PR TITLE
Release Google.Cloud.Run.V2 version 2.1.0

### DIFF
--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/Google.Cloud.Run.V2.csproj
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/Google.Cloud.Run.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Run Admin API (v2)</Description>

--- a/apis/Google.Cloud.Run.V2/docs/history.md
+++ b/apis/Google.Cloud.Run.V2/docs/history.md
@@ -1,5 +1,18 @@
 # Version history
 
+## Version 2.1.0, released 2023-05-03
+
+### New features
+
+- Adds support for Startup CPU Boost (GA) ([commit 32b5017](https://github.com/googleapis/google-cloud-dotnet/commit/32b5017e4f86393961797f15d84b0d5206e58daf))
+- Adds support for Session affinity in Service (GA) ([commit 32b5017](https://github.com/googleapis/google-cloud-dotnet/commit/32b5017e4f86393961797f15d84b0d5206e58daf))
+- New 'port' field for HttpGetAction probe type ([commit 32b5017](https://github.com/googleapis/google-cloud-dotnet/commit/32b5017e4f86393961797f15d84b0d5206e58daf))
+- New fields/enum values ([commit 32b5017](https://github.com/googleapis/google-cloud-dotnet/commit/32b5017e4f86393961797f15d84b0d5206e58daf))
+
+### Documentation improvements
+
+- General documentation fixes. ([commit 32b5017](https://github.com/googleapis/google-cloud-dotnet/commit/32b5017e4f86393961797f15d84b0d5206e58daf))
+
 ## Version 2.0.0, released 2023-03-27
 
 No API surface changes; just dependency updates and initial GA release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3683,7 +3683,7 @@
     },
     {
       "id": "Google.Cloud.Run.V2",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "type": "grpc",
       "productName": "Cloud Run Admin",
       "productUrl": "https://cloud.google.com/run/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Adds support for Startup CPU Boost (GA) ([commit 32b5017](https://github.com/googleapis/google-cloud-dotnet/commit/32b5017e4f86393961797f15d84b0d5206e58daf))
- Adds support for Session affinity in Service (GA) ([commit 32b5017](https://github.com/googleapis/google-cloud-dotnet/commit/32b5017e4f86393961797f15d84b0d5206e58daf))
- New 'port' field for HttpGetAction probe type ([commit 32b5017](https://github.com/googleapis/google-cloud-dotnet/commit/32b5017e4f86393961797f15d84b0d5206e58daf))
- New fields/enum values ([commit 32b5017](https://github.com/googleapis/google-cloud-dotnet/commit/32b5017e4f86393961797f15d84b0d5206e58daf))

### Documentation improvements

- General documentation fixes. ([commit 32b5017](https://github.com/googleapis/google-cloud-dotnet/commit/32b5017e4f86393961797f15d84b0d5206e58daf))
