### PR TITLE
Release Google.Cloud.SecurityCenter.V1 version 3.10.0

### DIFF
--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.csproj
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.9.0</Version>
+    <Version>3.10.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Security Command Center API, which helps security teams gather data, identify threats, and act on them before they result in business damage or loss.</Description>

--- a/apis/Google.Cloud.SecurityCenter.V1/docs/history.md
+++ b/apis/Google.Cloud.SecurityCenter.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 3.10.0, released 2023-05-03
+
+### New features
+
+- Add cloud_dlp_inspection and cloud_dlp_data_profile fields to finding's list of attributes ([commit f4c7a0e](https://github.com/googleapis/google-cloud-dotnet/commit/f4c7a0e6d98452c60f5308448ee703901e7ef670))
+
+### Documentation improvements
+
+- Miscellaneous style improvements ([commit f4c7a0e](https://github.com/googleapis/google-cloud-dotnet/commit/f4c7a0e6d98452c60f5308448ee703901e7ef670))
+
 ## Version 3.9.0, released 2023-04-12
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3851,7 +3851,7 @@
       "protoPath": "google/cloud/securitycenter/v1",
       "productName": "Google Cloud Security Command Center",
       "productUrl": "https://cloud.google.com/security-command-center/",
-      "version": "3.9.0",
+      "version": "3.10.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Security Command Center API, which helps security teams gather data, identify threats, and act on them before they result in business damage or loss.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Add cloud_dlp_inspection and cloud_dlp_data_profile fields to finding's list of attributes ([commit f4c7a0e](https://github.com/googleapis/google-cloud-dotnet/commit/f4c7a0e6d98452c60f5308448ee703901e7ef670))

### Documentation improvements

- Miscellaneous style improvements ([commit f4c7a0e](https://github.com/googleapis/google-cloud-dotnet/commit/f4c7a0e6d98452c60f5308448ee703901e7ef670))
