### PR TITLE
Release Google.Cloud.Talent.V4 version 2.3.0

### DIFF
--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.csproj
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.2.0</Version>
+    <Version>2.3.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Talent solution API (v4) which provides the capability to create, read, update, and delete job postings, as well as search jobs based on keywords and filters.</Description>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>

--- a/apis/Google.Cloud.Talent.V4/docs/history.md
+++ b/apis/Google.Cloud.Talent.V4/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.3.0, released 2023-05-03
+
+### Bug fixes
+
+- Change timeout settings for SearchJobsForAlert ([commit 91e9f13](https://github.com/googleapis/google-cloud-dotnet/commit/91e9f1381ab8f9bdf5eab593b8df73c1d1021b94))
+
 ## Version 2.2.0, released 2023-01-20
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4303,7 +4303,7 @@
     },
     {
       "id": "Google.Cloud.Talent.V4",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "type": "grpc",
       "productName": "Google Cloud Talent Solution",
       "productUrl": "https://cloud.google.com/talent-solution/",
@@ -4313,7 +4313,7 @@
         "Jobs"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.3.1",
         "Google.LongRunning": "3.0.0",
         "Grpc.Core": "2.46.5"
       },


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Change timeout settings for SearchJobsForAlert ([commit 91e9f13](https://github.com/googleapis/google-cloud-dotnet/commit/91e9f1381ab8f9bdf5eab593b8df73c1d1021b94))
