### PR TITLE
Release Google.Cloud.PubSub.V1 version 3.5.1

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.5.0</Version>
+    <Version>3.5.1</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.</Description>

--- a/apis/Google.Cloud.PubSub.V1/docs/history.md
+++ b/apis/Google.Cloud.PubSub.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.5.1, released 2023-05-05
+
+### Bug fixes
+
+- Dispose channel on PublisherClient/SubscriberClient shutdown. Fixes [#10304](https://github.com/googleapis/google-cloud-dotnet/issues/10304) ([commit d38ab04](https://github.com/googleapis/google-cloud-dotnet/commit/d38ab04a077662748b5d7725d80ab132899c2996))
+
 ## Version 3.5.0, released 2023-04-19
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3464,7 +3464,7 @@
       "protoPath": "google/pubsub/v1",
       "productName": "Cloud Pub/Sub",
       "productUrl": "https://cloud.google.com/pubsub/",
-      "version": "3.5.0",
+      "version": "3.5.1",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Dispose channel on PublisherClient/SubscriberClient shutdown. Fixes [#10304](https://github.com/googleapis/google-cloud-dotnet/issues/10304) ([commit d38ab04](https://github.com/googleapis/google-cloud-dotnet/commit/d38ab04a077662748b5d7725d80ab132899c2996))
