### PR TITLE
Release Google.Cloud.Dialogflow.Cx.V3 version 2.7.0

### DIFF
--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.csproj
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Builds conversational interfaces (for example, chatbots, and voice-powered apps and devices).</Description>

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/docs/history.md
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/docs/history.md
@@ -1,5 +1,18 @@
 # Version history
 
+## Version 2.7.0, released 2023-05-11
+
+### New features
+
+- Extended CreateAgent timeout to 180 seconds ([commit f12f32b](https://github.com/googleapis/google-cloud-dotnet/commit/f12f32b063816b420d3e7d38b2cf0f77a83f4942))
+- Added debug info to StreamingDetectIntent ([commit f12f32b](https://github.com/googleapis/google-cloud-dotnet/commit/f12f32b063816b420d3e7d38b2cf0f77a83f4942))
+- Added dtmf digits to WebhookRequest ([commit f12f32b](https://github.com/googleapis/google-cloud-dotnet/commit/f12f32b063816b420d3e7d38b2cf0f77a83f4942))
+- Added FLOW as a new DiffType in TestRunDifference ([commit f12f32b](https://github.com/googleapis/google-cloud-dotnet/commit/f12f32b063816b420d3e7d38b2cf0f77a83f4942))
+
+### Documentation improvements
+
+- Clarified wording around quota usage ([commit 9439fbb](https://github.com/googleapis/google-cloud-dotnet/commit/9439fbb6268ef09a480e37d4e521512629546332))
+
 ## Version 2.6.0, released 2023-03-06
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1789,7 +1789,7 @@
     },
     {
       "id": "Google.Cloud.Dialogflow.Cx.V3",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "type": "grpc",
       "productName": "Dialogflow",
       "productUrl": "https://cloud.google.com/dialogflow/cx/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Extended CreateAgent timeout to 180 seconds ([commit f12f32b](https://github.com/googleapis/google-cloud-dotnet/commit/f12f32b063816b420d3e7d38b2cf0f77a83f4942))
- Added debug info to StreamingDetectIntent ([commit f12f32b](https://github.com/googleapis/google-cloud-dotnet/commit/f12f32b063816b420d3e7d38b2cf0f77a83f4942))
- Added dtmf digits to WebhookRequest ([commit f12f32b](https://github.com/googleapis/google-cloud-dotnet/commit/f12f32b063816b420d3e7d38b2cf0f77a83f4942))
- Added FLOW as a new DiffType in TestRunDifference ([commit f12f32b](https://github.com/googleapis/google-cloud-dotnet/commit/f12f32b063816b420d3e7d38b2cf0f77a83f4942))

### Documentation improvements

- Clarified wording around quota usage ([commit 9439fbb](https://github.com/googleapis/google-cloud-dotnet/commit/9439fbb6268ef09a480e37d4e521512629546332))
