### PR TITLE
Release Google.Cloud.Dialogflow.V2Beta1 version 1.0.0-beta07

### DIFF
--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.csproj
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta06</Version>
+    <Version>1.0.0-beta07</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Dialogflow API (v2beta1).</Description>

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/docs/history.md
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/docs/history.md
@@ -1,5 +1,14 @@
 # Version history
 
+## Version 1.0.0-beta07, released 2023-05-11
+
+### New features
+
+- Add baseline model configuration for conversation summarization ([commit e2bfd58](https://github.com/googleapis/google-cloud-dotnet/commit/e2bfd583a2afbd2873ceadeb7fb4abf8ff87fb1a))
+- Extended StreamingListCallCompanionEvents timeout to 600 seconds ([commit 395fbd9](https://github.com/googleapis/google-cloud-dotnet/commit/395fbd912b89199e247ea905047f17aaf904bdae))
+- Added debug info for StreamingDetectIntent ([commit 395fbd9](https://github.com/googleapis/google-cloud-dotnet/commit/395fbd912b89199e247ea905047f17aaf904bdae))
+- Added GenerateStatelessSummary method ([commit 395fbd9](https://github.com/googleapis/google-cloud-dotnet/commit/395fbd912b89199e247ea905047f17aaf904bdae))
+
 ## Version 1.0.0-beta06, released 2023-03-06
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1841,7 +1841,7 @@
     },
     {
       "id": "Google.Cloud.Dialogflow.V2Beta1",
-      "version": "1.0.0-beta06",
+      "version": "1.0.0-beta07",
       "type": "grpc",
       "productName": "Google Cloud Dialogflow",
       "productUrl": "https://cloud.google.com/dialogflow-enterprise/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add baseline model configuration for conversation summarization ([commit e2bfd58](https://github.com/googleapis/google-cloud-dotnet/commit/e2bfd583a2afbd2873ceadeb7fb4abf8ff87fb1a))
- Extended StreamingListCallCompanionEvents timeout to 600 seconds ([commit 395fbd9](https://github.com/googleapis/google-cloud-dotnet/commit/395fbd912b89199e247ea905047f17aaf904bdae))
- Added debug info for StreamingDetectIntent ([commit 395fbd9](https://github.com/googleapis/google-cloud-dotnet/commit/395fbd912b89199e247ea905047f17aaf904bdae))
- Added GenerateStatelessSummary method ([commit 395fbd9](https://github.com/googleapis/google-cloud-dotnet/commit/395fbd912b89199e247ea905047f17aaf904bdae))
