### PR TITLE
Release Google.Cloud.Monitoring.V3 version 3.3.0

### DIFF
--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.csproj
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.2.0</Version>
+    <Version>3.3.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Monitoring API, which manages your Google Cloud Monitoring data and configurations.</Description>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>

--- a/apis/Google.Cloud.Monitoring.V3/docs/history.md
+++ b/apis/Google.Cloud.Monitoring.V3/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 3.3.0, released 2023-05-11
+
+### New features
+
+- Add ICMP pings ([commit d4e696b](https://github.com/googleapis/google-cloud-dotnet/commit/d4e696b126046a162870fabb092118fa58ed3b86))
+- Add basic http authentication ([commit d4e696b](https://github.com/googleapis/google-cloud-dotnet/commit/d4e696b126046a162870fabb092118fa58ed3b86))
+- Add json path matching capabilities ([commit d4e696b](https://github.com/googleapis/google-cloud-dotnet/commit/d4e696b126046a162870fabb092118fa58ed3b86))
+- Add httpStatusCode ([commit d4e696b](https://github.com/googleapis/google-cloud-dotnet/commit/d4e696b126046a162870fabb092118fa58ed3b86))
+- Add individual USA regions ([commit d4e696b](https://github.com/googleapis/google-cloud-dotnet/commit/d4e696b126046a162870fabb092118fa58ed3b86))
+
 ## Version 3.2.0, released 2023-01-16
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3011,7 +3011,7 @@
       "protoPath": "google/monitoring/v3",
       "productName": "Google Cloud Monitoring",
       "productUrl": "https://cloud.google.com/monitoring/api/v3/",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Monitoring API, which manages your Google Cloud Monitoring data and configurations.",
       "tags": [
@@ -3019,7 +3019,7 @@
         "Stackdriver"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.3.1",
         "Google.LongRunning": "3.0.0",
         "Grpc.Core": "2.46.5"
       },


### PR DESCRIPTION

Changes in this release:

### New features

- Add ICMP pings ([commit d4e696b](https://github.com/googleapis/google-cloud-dotnet/commit/d4e696b126046a162870fabb092118fa58ed3b86))
- Add basic http authentication ([commit d4e696b](https://github.com/googleapis/google-cloud-dotnet/commit/d4e696b126046a162870fabb092118fa58ed3b86))
- Add json path matching capabilities ([commit d4e696b](https://github.com/googleapis/google-cloud-dotnet/commit/d4e696b126046a162870fabb092118fa58ed3b86))
- Add httpStatusCode ([commit d4e696b](https://github.com/googleapis/google-cloud-dotnet/commit/d4e696b126046a162870fabb092118fa58ed3b86))
- Add individual USA regions ([commit d4e696b](https://github.com/googleapis/google-cloud-dotnet/commit/d4e696b126046a162870fabb092118fa58ed3b86))
