### PR TITLE
Release Google.Cloud.Redis.V1 version 3.2.0

### DIFF
--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.csproj
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.1.0</Version>
+    <Version>3.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to administer Cloud Memorystore for Redis.</Description>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />

--- a/apis/Google.Cloud.Redis.V1/docs/history.md
+++ b/apis/Google.Cloud.Redis.V1/docs/history.md
@@ -1,5 +1,14 @@
 # Version history
 
+## Version 3.2.0, released 2023-05-11
+
+### New features
+
+- [Cloud Memorystore for Redis] Add CMEK key field ([commit 5856c34](https://github.com/googleapis/google-cloud-dotnet/commit/5856c345a5b226fe041eebdfabeb70e53d2ec9b4))
+- [Cloud Memorystore for Redis] Add suspension_reasons field ([commit 5856c34](https://github.com/googleapis/google-cloud-dotnet/commit/5856c345a5b226fe041eebdfabeb70e53d2ec9b4))
+- [Cloud Memorystore for Redis] Add persistence support ([commit 5856c34](https://github.com/googleapis/google-cloud-dotnet/commit/5856c345a5b226fe041eebdfabeb70e53d2ec9b4))
+- [Cloud Memorystore for Redis] Add self service update maintenance version support ([commit 5856c34](https://github.com/googleapis/google-cloud-dotnet/commit/5856c345a5b226fe041eebdfabeb70e53d2ec9b4))
+
 ## Version 3.1.0, released 2023-01-19
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3575,11 +3575,11 @@
       "protoPath": "google/cloud/redis/v1",
       "productName": "Google Cloud Memorystore for Redis",
       "productUrl": "https://cloud.google.com/memorystore/",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "type": "grpc",
       "description": "Recommended Google client library to administer Cloud Memorystore for Redis.",
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.3.1",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
         "Grpc.Core": "2.46.5"


### PR DESCRIPTION

Changes in this release:

### New features

- [Cloud Memorystore for Redis] Add CMEK key field ([commit 5856c34](https://github.com/googleapis/google-cloud-dotnet/commit/5856c345a5b226fe041eebdfabeb70e53d2ec9b4))
- [Cloud Memorystore for Redis] Add suspension_reasons field ([commit 5856c34](https://github.com/googleapis/google-cloud-dotnet/commit/5856c345a5b226fe041eebdfabeb70e53d2ec9b4))
- [Cloud Memorystore for Redis] Add persistence support ([commit 5856c34](https://github.com/googleapis/google-cloud-dotnet/commit/5856c345a5b226fe041eebdfabeb70e53d2ec9b4))
- [Cloud Memorystore for Redis] Add self service update maintenance version support ([commit 5856c34](https://github.com/googleapis/google-cloud-dotnet/commit/5856c345a5b226fe041eebdfabeb70e53d2ec9b4))
