### PR TITLE
chore: Fix Logging.V2 generation by renaming two RPCs

### DIFF
--- a/apis/Google.Cloud.Logging.V2/.OwlBot-ForceRegeneration.txt
+++ b/apis/Google.Cloud.Logging.V2/.OwlBot-ForceRegeneration.txt
@@ -1,0 +1,1 @@
+API requires pre-generation tweaks.

--- a/apis/Google.Cloud.Logging.V2/postgeneration.sh
+++ b/apis/Google.Cloud.Logging.V2/postgeneration.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+# Fix the gRPC generated code (for the grpc::Method instances) so it refers to the right server-side RPC
+sed -i 's/"BeginUpdateBucket"/"UpdateBucketAsync"/g' Google.Cloud.Logging.V2/LoggingConfigGrpc.g.cs
+sed -i 's/"BeginCreateBucket"/"CreateBucketAsync"/g' Google.Cloud.Logging.V2/LoggingConfigGrpc.g.cs
+
+# Undo the changes made in pregeneration.sh
+git -C $GOOGLEAPIS checkout google/logging/v2

--- a/apis/Google.Cloud.Logging.V2/pregeneration.sh
+++ b/apis/Google.Cloud.Logging.V2/pregeneration.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+# LoggingConfig has methods UpdateBucket and UpdateBucketAsync,
+# and CreateBucket and CreateBucketAsync... which causes conflicts
+# in both GAPIC and gRPC-generated code.
+# For now, rename the "XyzAsync" versions to "BeginXyz".
+# We'll revisit this naming before the next release.
+# (AIPs will be updated to prohibit this and suggest a different name.)
+sed -i 's/rpc UpdateBucketAsync/rpc BeginUpdateBucket/g' $GOOGLEAPIS/google/logging/v2/logging_config.proto
+sed -i 's/rpc CreateBucketAsync/rpc BeginCreateBucket/g' $GOOGLEAPIS/google/logging/v2/logging_config.proto


### PR DESCRIPTION
The names chosen are temporary (but not awful).