### PR TITLE
chore: Reset Google.Cloud.Batch.V1 to 2.0.0

### DIFF
--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.csproj
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.0.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Batch API (v1), which allows you to manage the running of batch jobs on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Batch.V1/docs/history.md
+++ b/apis/Google.Cloud.Batch.V1/docs/history.md
@@ -1,13 +1,5 @@
 # Version history
 
-## Version 2.1.0, released 2023-05-11
-
-### New features
-
-- Support order_by in ListJobs and ListTasks requests ([commit dd462ce](https://github.com/googleapis/google-cloud-dotnet/commit/dd462ceb1d2016e5ad339a675050ab00bd7fb1bf))
-- Add support for placement policies ([commit dd462ce](https://github.com/googleapis/google-cloud-dotnet/commit/dd462ceb1d2016e5ad339a675050ab00bd7fb1bf))
-- Per-Runnable labels ([commit dd462ce](https://github.com/googleapis/google-cloud-dotnet/commit/dd462ceb1d2016e5ad339a675050ab00bd7fb1bf))
-
 ## Version 2.0.0, released 2023-03-09
 
 ### BREAKING CHANGE

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -544,7 +544,7 @@
     },
     {
       "id": "Google.Cloud.Batch.V1",
-      "version": "2.1.0",
+      "version": "2.0.0",
       "type": "grpc",
       "productName": "Batch",
       "productUrl": "https://cloud.google.com/batch/docs/",


### PR DESCRIPTION
The change in 2.1.0 was reverted, and the release (coincidentally) failed at the same time. We'll just go back to "this didn't happen".