### PR TITLE
Release Google.Analytics.Admin.V1Alpha version 2.0.0-alpha09

### DIFF
--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha08</Version>
+    <Version>2.0.0-alpha09</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Analytics Admin API (v1alpha)</Description>

--- a/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
+++ b/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 2.0.0-alpha09, released 2023-05-16
+
+### New features
+
+- Add `GetAdSenseLink`, `CreateAdSenseLink`, `DeleteAdSenseLink`, `ListAdSenseLinks` methods to the Admin API v1alpha ([commit 9e6f80c](https://github.com/googleapis/google-cloud-dotnet/commit/9e6f80cee15d2582dad4f230ada810a24d808374))
+- Add `FetchConnectedGa4Property` method to the Admin API v1alpha ([commit 9e6f80c](https://github.com/googleapis/google-cloud-dotnet/commit/9e6f80cee15d2582dad4f230ada810a24d808374))
+- Add `CreateEventCreateRule`, `UpdateEventCreateRule`,`DeleteEventCreateRule`, `ListEventCreateRules` methods to the Admin API v1alpha ([commit 9e6f80c](https://github.com/googleapis/google-cloud-dotnet/commit/9e6f80cee15d2582dad4f230ada810a24d808374))
+- Add `EventCreateRule`, `MatchingCondition` types to the Admin API v1alpha ([commit 9e6f80c](https://github.com/googleapis/google-cloud-dotnet/commit/9e6f80cee15d2582dad4f230ada810a24d808374))
+- Add `AdSenseLink` type to the Admin API v1alpha ([commit 9e6f80c](https://github.com/googleapis/google-cloud-dotnet/commit/9e6f80cee15d2582dad4f230ada810a24d808374))
+- Add `AUDIENCE`, `EVENT_CREATE_RULE` options to the `ChangeHistoryResourceType` enum ([commit 9e6f80c](https://github.com/googleapis/google-cloud-dotnet/commit/9e6f80cee15d2582dad4f230ada810a24d808374))
+- Add `audience`, `event_create_rule` fields to the `ChangeHistoryResource.resource` oneof field ([commit 9e6f80c](https://github.com/googleapis/google-cloud-dotnet/commit/9e6f80cee15d2582dad4f230ada810a24d808374))
+
 ## Version 2.0.0-alpha08, released 2023-05-03
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2,7 +2,7 @@
   "apis": [
     {
       "id": "Google.Analytics.Admin.V1Alpha",
-      "version": "2.0.0-alpha08",
+      "version": "2.0.0-alpha09",
       "type": "grpc",
       "productName": "Analytics Admin",
       "productUrl": "https://developers.google.com/analytics",


### PR DESCRIPTION

Changes in this release:

### New features

- Add `GetAdSenseLink`, `CreateAdSenseLink`, `DeleteAdSenseLink`, `ListAdSenseLinks` methods to the Admin API v1alpha ([commit 9e6f80c](https://github.com/googleapis/google-cloud-dotnet/commit/9e6f80cee15d2582dad4f230ada810a24d808374))
- Add `FetchConnectedGa4Property` method to the Admin API v1alpha ([commit 9e6f80c](https://github.com/googleapis/google-cloud-dotnet/commit/9e6f80cee15d2582dad4f230ada810a24d808374))
- Add `CreateEventCreateRule`, `UpdateEventCreateRule`,`DeleteEventCreateRule`, `ListEventCreateRules` methods to the Admin API v1alpha ([commit 9e6f80c](https://github.com/googleapis/google-cloud-dotnet/commit/9e6f80cee15d2582dad4f230ada810a24d808374))
- Add `EventCreateRule`, `MatchingCondition` types to the Admin API v1alpha ([commit 9e6f80c](https://github.com/googleapis/google-cloud-dotnet/commit/9e6f80cee15d2582dad4f230ada810a24d808374))
- Add `AdSenseLink` type to the Admin API v1alpha ([commit 9e6f80c](https://github.com/googleapis/google-cloud-dotnet/commit/9e6f80cee15d2582dad4f230ada810a24d808374))
- Add `AUDIENCE`, `EVENT_CREATE_RULE` options to the `ChangeHistoryResourceType` enum ([commit 9e6f80c](https://github.com/googleapis/google-cloud-dotnet/commit/9e6f80cee15d2582dad4f230ada810a24d808374))
- Add `audience`, `event_create_rule` fields to the `ChangeHistoryResource.resource` oneof field ([commit 9e6f80c](https://github.com/googleapis/google-cloud-dotnet/commit/9e6f80cee15d2582dad4f230ada810a24d808374))
