### PR TITLE
Release Google.Cloud.PubSub.V1 version 3.6.0-beta01

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.5.1</Version>
+    <Version>3.6.0-beta01</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.</Description>

--- a/apis/Google.Cloud.PubSub.V1/docs/history.md
+++ b/apis/Google.Cloud.PubSub.V1/docs/history.md
@@ -1,5 +1,20 @@
 # Version history
 
+## Version 3.6.0-beta01, released 2023-05-16
+
+Note that this is a beta release as the deadlock workaround for
+[issue](https://github.com/googleapis/google-cloud-dotnet/issues/10318) is far
+from ideal. We'll create a new GA release when Grpc.Net.Client has been fixed.
+
+### Bug fixes
+
+- Add missing field when creating a SubscriberClient.Settings from another. ([commit 204866c](https://github.com/googleapis/google-cloud-dotnet/commit/204866c229146f888644b30b08b3de150428e9e7))
+- Temporary patch for PubSub Subscriber deadlock issue. ([commit d965b93](https://github.com/googleapis/google-cloud-dotnet/commit/d965b9333d819ba3b764b5f62b2ea790504f6e4e))
+
+### New features
+
+- Add cloud storage subscription fields ([commit b3b6104](https://github.com/googleapis/google-cloud-dotnet/commit/b3b6104c8aa408c2df1e1dfe0ecbb06bd4761705))
+
 ## Version 3.5.1, released 2023-05-05
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3466,7 +3466,7 @@
       "protoPath": "google/pubsub/v1",
       "productName": "Cloud Pub/Sub",
       "productUrl": "https://cloud.google.com/pubsub/",
-      "version": "3.5.1",
+      "version": "3.6.0-beta01",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.",


### PR DESCRIPTION
Changes in this release:

Note that this is a beta release as the deadlock workaround for [issue 10318](https://github.com/googleapis/google-cloud-dotnet/issues/10318) is far from ideal. We'll create a new GA release when Grpc.Net.Client has been fixed.

### Bug fixes

- Add missing field when creating a SubscriberClient.Settings from another. ([commit 204866c](https://github.com/googleapis/google-cloud-dotnet/commit/204866c229146f888644b30b08b3de150428e9e7))
- Temporary patch for PubSub Subscriber deadlock issue. ([commit d965b93](https://github.com/googleapis/google-cloud-dotnet/commit/d965b9333d819ba3b764b5f62b2ea790504f6e4e))

### New features

- Add cloud storage subscription fields ([commit b3b6104](https://github.com/googleapis/google-cloud-dotnet/commit/b3b6104c8aa408c2df1e1dfe0ecbb06bd4761705))
