### PR TITLE
feat: Support `dataBoostEnabled` field in partitioned Read/ExecuteSql

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/PartitionOptionsTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/PartitionOptionsTests.cs
@@ -1,0 +1,47 @@
+// Copyright 2023 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using Google.Cloud.Spanner.V1;
+using System;
+using System.Threading;
+using Xunit;
+
+namespace Google.Cloud.Spanner.Data.Tests;
+
+public class PartitionOptionsTests
+{
+    [Fact]
+    public void CheckDefaultValues()
+    {
+        var defaultOptions = PartitionOptions.Default;
+
+        Assert.Null(defaultOptions.MaxPartitions);
+        Assert.Null(defaultOptions.PartitionSizeBytes);
+        Assert.False(defaultOptions.DataBoostEnabled);
+    }
+
+    [Fact]
+    public void WithMethods()
+    {
+        var options = PartitionOptions.Default.WithPartitionSizeBytes(10).WithMaxPartitions(20).WithDataBoostEnabled(false);
+        var newOptions = options.WithPartitionSizeBytes(100).WithMaxPartitions(200).WithDataBoostEnabled(true);
+
+        Assert.Equal(10, options.PartitionSizeBytes);
+        Assert.Equal(20, options.MaxPartitions);
+        Assert.Equal(false, options.DataBoostEnabled);
+
+        Assert.Equal(100, newOptions.PartitionSizeBytes);
+        Assert.Equal(200, newOptions.MaxPartitions);
+        Assert.Equal(true, newOptions.DataBoostEnabled);
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/DisposeBehavior.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/DisposeBehavior.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Threading;
+
 namespace Google.Cloud.Spanner.Data
 {
     /// <summary>
@@ -21,7 +23,7 @@ namespace Google.Cloud.Spanner.Data
     {
         /// <summary>
         /// Releases transactional resources back to the global pool when <see cref="SpannerTransaction.Dispose"/> is called.
-        /// This option is not valid for shared transactions (see <see cref="SpannerCommand.GetReaderPartitionsAsync"/>).
+        /// This option is not valid for shared transactions (see <see cref="SpannerCommand.GetReaderPartitionsAsync(PartitionOptions, CancellationToken)"/>).
         /// </summary>
         ReleaseToPool = 0,
         /// <summary>

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/PartitionOptions.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/PartitionOptions.cs
@@ -1,0 +1,86 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+using System.Threading;
+
+namespace Google.Cloud.Spanner.Data;
+
+/// <summary>
+/// An immutable class representing partition options.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The specified values of `PartitionSizeBytes` and `MaxPartitions`
+/// are utilized in the RPC call while generating the partition tokens.
+/// </para>
+/// <para>
+/// The specified flag for `DataBoostEnabled` will be stored in the request property
+/// of the <see cref="CommandPartition"/> object and is used when creating a request
+/// to read from the partition. If `DataBoostEnabled` is set to true, the request will be
+/// executed using Spanner-independent compute resources.
+/// </para>
+/// </remarks>
+public sealed class PartitionOptions
+{
+    /// <summary>
+    /// Returns a default instance of <see cref="PartitionOptions"/>.
+    /// </summary>
+    public static PartitionOptions Default { get; } = new PartitionOptions(null, null, false);
+
+    /// <summary>
+    /// Returns a new instance with the same options as this one, but with the specified new value for <see cref="DataBoostEnabled" />.
+    /// </summary>
+    /// <returns>A new instance of <see cref="PartitionOptions"/>.</returns>
+    public PartitionOptions WithDataBoostEnabled(bool? dataBoostEnabled) => new(PartitionSizeBytes, MaxPartitions, dataBoostEnabled);
+
+    /// <summary>
+    /// Returns a new instance with the same options as this one, but with the specified new value for <see cref="PartitionSizeBytes"/>.
+    /// </summary>
+    /// <returns>A new instance of <see cref="PartitionOptions"/>.</returns>
+    public PartitionOptions WithPartitionSizeBytes(long? partitionSizeBytes) => new(partitionSizeBytes, MaxPartitions, DataBoostEnabled);
+
+    /// <summary>
+    /// Returns a new instance with the same options as this one, but with the specified new value for <see cref="MaxPartitions"/>.
+    /// </summary>
+    /// <returns>A new instance of <see cref="PartitionOptions"/>.</returns>
+    public PartitionOptions WithMaxPartitions(long? maxPartitions) => new(PartitionSizeBytes, maxPartitions, DataBoostEnabled);
+
+    /// <summary>
+    /// The desired data size for each partition generated.
+    /// The default value for this is null, in which case the server will decide the data size for each partition generated.
+    /// </summary>
+    public long? PartitionSizeBytes { get; }
+
+    /// <summary>
+    /// The desired maximum number of partitions to return.
+    /// The default value for this is null, in which case the server will decide how many partitions to return.
+    /// </summary>
+    public long? MaxPartitions { get; }
+
+    /// <summary>
+    /// If set to true, the request will be executed using Spanner independent compute resources.
+    /// The default value for this option is false.
+    /// </summary>
+    public bool DataBoostEnabled { get; }
+
+    /// <summary>
+    /// Creates a new instance of <see cref="PartitionOptions"/> class.
+    /// </summary>
+    private PartitionOptions(long? partitionSizeBytes, long? maxPartitions, bool? dataBoostEnabled)
+    {
+        PartitionSizeBytes = partitionSizeBytes;
+        MaxPartitions = maxPartitions;
+        DataBoostEnabled = dataBoostEnabled ?? false;
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.ExecutableCommand.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.ExecutableCommand.cs
@@ -164,7 +164,7 @@ namespace Google.Cloud.Spanner.Data
                 return effectiveTransaction.ExecuteReadOrQueryAsync(request, cancellationToken, CommandTimeout);
             }
 
-            internal async Task<IReadOnlyList<CommandPartition>> GetReaderPartitionsAsync(long? partitionSizeBytes, long? maxPartitions, CancellationToken cancellationToken)
+            internal async Task<IReadOnlyList<CommandPartition>> GetReaderPartitionsAsync(PartitionOptions options, CancellationToken cancellationToken)
             {
                 ValidateConnectionAndCommandTextBuilder();
 
@@ -173,8 +173,9 @@ namespace Google.Cloud.Spanner.Data
 
                 await Connection.EnsureIsOpenAsync(cancellationToken).ConfigureAwait(false);
                 var readOrQueryRequest = GetReadOrQueryRequest();
+                readOrQueryRequest.DataBoostEnabled = options.DataBoostEnabled;
                 var tokens = await Transaction.GetPartitionTokensAsync(
-                        readOrQueryRequest, partitionSizeBytes, maxPartitions, cancellationToken, CommandTimeout)
+                        readOrQueryRequest, options.PartitionSizeBytes, options.MaxPartitions, cancellationToken, CommandTimeout)
                     .ConfigureAwait(false);
                 return tokens.Select(
                     x =>

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// Copyright 2017 Google Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -377,30 +377,51 @@ namespace Google.Cloud.Spanner.Data
 
         /// <summary>
         /// Creates a set of <see cref="CommandPartition"/> objects that are used to execute a query or read
-        /// operation in parallel.  Each of the returned command partitions are used
+        /// operation in parallel. Each of the returned command partitions are used
         /// by <see cref="SpannerConnection.CreateCommandWithPartition"/> to create a new <see cref="SpannerCommand"/>
         /// that returns a subset of data.
         /// </summary>
         /// <param name="maxPartitions">
-        /// The desired maximum number of partitions to return.  For example, this may
-        /// be set to the number of workers available.  The default for this option
-        /// is currently 10,000. The maximum value is currently 200,000.  This is only
-        /// a hint.  The actual number of partitions returned may be smaller or larger than
+        /// The desired maximum number of partitions to return. For example, this may
+        /// be set to the number of workers available. The default for this option
+        /// is currently 10,000. The maximum value is currently 200,000. This is only
+        /// a hint. The actual number of partitions returned may be smaller or larger than
         /// this maximum count request.
         /// </param>
         /// <param name="partitionSizeBytes">
-        /// The desired data size for each partition generated.  The default for this
-        /// option is currently 1 GiB.  This is only a hint. The actual size of each
+        /// The desired data size for each partition generated. The default for this
+        /// option is currently 1 GiB. This is only a hint. The actual size of each
         /// partition may be smaller or larger than this size request.
         /// </param>
         /// <param name="cancellationToken">An optional token for canceling the call.</param>
         /// <returns>The list of partitions that can be used to create <see cref="SpannerCommand"/>
         /// objects.</returns>
+        [Obsolete("This method is deprecated, please use GetReaderPartitionsAsync(PartitionOptions, CancellationToken) instead.")]
         public Task<IReadOnlyList<CommandPartition>> GetReaderPartitionsAsync(
             long? partitionSizeBytes = null,
             long? maxPartitions = null,
             CancellationToken cancellationToken = default) =>
-            CreateExecutableCommand().GetReaderPartitionsAsync(partitionSizeBytes, maxPartitions, cancellationToken);
+            GetReaderPartitionsAsync(
+                PartitionOptions.Default.
+                WithPartitionSizeBytes(partitionSizeBytes).
+                WithMaxPartitions(maxPartitions),
+                cancellationToken);
+
+        /// <summary>
+        /// Creates a set of <see cref="CommandPartition"/> objects that are used to execute a query or read
+        /// operation in parallel. Each of the returned command partitions are used
+        /// by <see cref="SpannerConnection.CreateCommandWithPartition"/> to create a new <see cref="SpannerCommand"/>
+        /// that returns a subset of data.
+        /// </summary>
+        /// <param name="options">An instance of <see cref="PartitionOptions"/> class in
+        /// which we can set the maxPartitions, partitionSizeBytes, dataBoostEnabled and
+        /// cancellationToken options for generating and executing partitions.
+        /// </param>
+        /// <param name="cancellationToken">An optional token for canceling the call.</param>
+        /// <returns>The list of partitions that can be used to create <see cref="SpannerCommand"/>
+        /// objects.</returns>
+        public Task<IReadOnlyList<CommandPartition>> GetReaderPartitionsAsync(PartitionOptions options, CancellationToken cancellationToken = default) =>
+            CreateExecutableCommand().GetReaderPartitionsAsync(options, cancellationToken);
 
         /// <summary>
         /// Sends the command to Cloud Spanner and builds a <see cref="SpannerDataReader"/>.

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerTransaction.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerTransaction.cs
@@ -204,7 +204,7 @@ namespace Google.Cloud.Spanner.Data
 
         /// <summary>
         /// Returns true if this transaction is being used by multiple <see cref="SpannerConnection"/> objects.
-        /// <see cref="SpannerCommand.GetReaderPartitionsAsync"/> will automatically mark the transaction as shared
+        /// <see cref="SpannerCommand.GetReaderPartitionsAsync(PartitionOptions, CancellationToken)"/> will automatically mark the transaction as shared
         /// because it is expected that you will be distributing the read among several tasks or processes.
         /// </summary>
         public bool Shared { get; internal set; }

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/ReadOrQueryRequest.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/ReadOrQueryRequest.cs
@@ -56,6 +56,11 @@ namespace Google.Cloud.Spanner.V1
         ByteString ResumeToken { set; }
 
         /// <summary>
+        /// See <see cref="ReadRequest.DataBoostEnabled"/> and <see cref="ExecuteSqlRequest.DataBoostEnabled"/>
+        /// </summary>
+        bool DataBoostEnabled { get; set; }
+
+        /// <summary>
         /// See <see cref="ReadRequest.PartitionToken"/> and <see cref="ExecuteSqlRequest.PartitionToken"/>
         /// </summary>
         ByteString PartitionToken { get; set; }
@@ -238,6 +243,15 @@ namespace Google.Cloud.Spanner.V1
         public ByteString ResumeToken
         {
             set => Request.ResumeToken = value;
+        }
+
+        /// <summary>
+        /// See <see cref="V1.ReadRequest.DataBoostEnabled"/> and <see cref="V1.ExecuteSqlRequest.DataBoostEnabled"/>
+        /// </summary>
+        public bool DataBoostEnabled
+        {
+            get => Request.DataBoostEnabled;
+            set => Request.DataBoostEnabled = value;
         }
 
         /// <summary>


### PR DESCRIPTION
- Adds a new overload of public method SpannerCommand.GetReaderPartitionsAsync
- Adds a new class `PartitionOptions` to be taken as a mandatory parameter in the new overloaded method.
- Updates existing and adds new unit tests.
- Updates existing and adds new integration tests.