### PR TITLE
docs: Add a page describing gRPC streaming

### DIFF
--- a/docs/Google.Cloud.DocTools.sln
+++ b/docs/Google.Cloud.DocTools.sln
@@ -35,6 +35,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Tools.FetchDep
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Language.V1", "..\apis\Google.Cloud.Language.V1\Google.Cloud.Language.V1\Google.Cloud.Language.V1.csproj", "{33357DA1-7028-42CA-8798-28EC86EC32C1}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.BigQuery.Storage.V1", "..\apis\Google.Cloud.BigQuery.Storage.V1\Google.Cloud.BigQuery.Storage.V1\Google.Cloud.BigQuery.Storage.V1.csproj", "{0E29A05C-77A0-48DE-8966-58E484813B07}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.BigQuery.V2", "..\apis\Google.Cloud.BigQuery.V2\Google.Cloud.BigQuery.V2\Google.Cloud.BigQuery.V2.csproj", "{6FE49B67-0CED-4FB8-91D7-4EC01DF2B806}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -237,6 +241,30 @@ Global
 		{33357DA1-7028-42CA-8798-28EC86EC32C1}.Release|x64.Build.0 = Release|Any CPU
 		{33357DA1-7028-42CA-8798-28EC86EC32C1}.Release|x86.ActiveCfg = Release|Any CPU
 		{33357DA1-7028-42CA-8798-28EC86EC32C1}.Release|x86.Build.0 = Release|Any CPU
+		{0E29A05C-77A0-48DE-8966-58E484813B07}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0E29A05C-77A0-48DE-8966-58E484813B07}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0E29A05C-77A0-48DE-8966-58E484813B07}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0E29A05C-77A0-48DE-8966-58E484813B07}.Debug|x64.Build.0 = Debug|Any CPU
+		{0E29A05C-77A0-48DE-8966-58E484813B07}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0E29A05C-77A0-48DE-8966-58E484813B07}.Debug|x86.Build.0 = Debug|Any CPU
+		{0E29A05C-77A0-48DE-8966-58E484813B07}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0E29A05C-77A0-48DE-8966-58E484813B07}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0E29A05C-77A0-48DE-8966-58E484813B07}.Release|x64.ActiveCfg = Release|Any CPU
+		{0E29A05C-77A0-48DE-8966-58E484813B07}.Release|x64.Build.0 = Release|Any CPU
+		{0E29A05C-77A0-48DE-8966-58E484813B07}.Release|x86.ActiveCfg = Release|Any CPU
+		{0E29A05C-77A0-48DE-8966-58E484813B07}.Release|x86.Build.0 = Release|Any CPU
+		{6FE49B67-0CED-4FB8-91D7-4EC01DF2B806}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6FE49B67-0CED-4FB8-91D7-4EC01DF2B806}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6FE49B67-0CED-4FB8-91D7-4EC01DF2B806}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6FE49B67-0CED-4FB8-91D7-4EC01DF2B806}.Debug|x64.Build.0 = Debug|Any CPU
+		{6FE49B67-0CED-4FB8-91D7-4EC01DF2B806}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6FE49B67-0CED-4FB8-91D7-4EC01DF2B806}.Debug|x86.Build.0 = Debug|Any CPU
+		{6FE49B67-0CED-4FB8-91D7-4EC01DF2B806}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6FE49B67-0CED-4FB8-91D7-4EC01DF2B806}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6FE49B67-0CED-4FB8-91D7-4EC01DF2B806}.Release|x64.ActiveCfg = Release|Any CPU
+		{6FE49B67-0CED-4FB8-91D7-4EC01DF2B806}.Release|x64.Build.0 = Release|Any CPU
+		{6FE49B67-0CED-4FB8-91D7-4EC01DF2B806}.Release|x86.ActiveCfg = Release|Any CPU
+		{6FE49B67-0CED-4FB8-91D7-4EC01DF2B806}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/docs/devsite-help/cleanup.md
+++ b/docs/devsite-help/cleanup.md
@@ -37,6 +37,11 @@ it has handled all requests appropriately before exiting.
 
 For more information, see the [client lifecycle documentation](client-lifecycle.md)
 
+### Streaming calls
+
+Streaming RPCs should be disposed, and ideally all responses read before
+disposal. See the [streaming RPCs documentation](grpc-streaming.md) for more details.
+
 ## REST-based APIs
 
 Summary: Use a single client if you can. Clients are threads-safe,

--- a/docs/devsite-help/grpc-streaming.md
+++ b/docs/devsite-help/grpc-streaming.md
@@ -1,0 +1,132 @@
+# Streaming RPCs
+
+[gRPC](https://grpc.io) supports *streaming RPCs* as well as the more common
+*unary* RPCs. The four different kinds of RPC are:
+
+- *Unary*: one request, one response
+- *Server-streaming*: one request, a stream of responses
+- *Client-streaming*: a stream of requests, one response at the end
+- *Bidirectional-streaming* (also known as *bidi-streaming* for short):
+  a stream of requests and a stream of responses
+
+More details of the underlying concepts can be found in the
+[gRPC core concepts](https://grpc.io/docs/what-is-grpc/core-concepts/)
+documentation. This page is focused on how streaming RPCs are used
+within Google Cloud Libraries for .NET, and specifically the libraries
+where we expect customers to use those RPCs directly. (The libraries
+for Firestore, Spanner, Pub/Sub and Bigtable have code wrapping the streaming
+RPCs to expose higher-level abstractions.)
+
+Note that this page does not cover client-streaming, as we do not currently
+publish any libraries with client-streaming RPCs. A new section will be added
+if and when we publish such a library.
+
+# Server-streaming RPCs
+
+A server-streaming RPC starts with a single request, and then the server
+sends responses over time, which are read asynchronously. The server indicates
+when it has finished sending responses, and the stream completes.
+
+In the Google Cloud Libraries for .NET, an ongoing server-streaming call
+is represented by the base class `ServerStreamingBase<TResponse>`, with a
+separate derived class for each RPC. For example, in the client library for the
+[BigQuery Storage API](https://cloud.google.com/bigquery/docs/reference/storage),
+the [BigQueryReadClient.ReadRows](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.BigQuery.Storage.V1/latest/Google.Cloud.BigQuery.Storage.V1.BigQueryReadClient#Google_Cloud_BigQuery_Storage_V1_BigQueryReadClient_ReadRows_Google_Cloud_BigQuery_Storage_V1_ReadRowsRequest_Google_Api_Gax_Grpc_CallSettings_) method returns a [BigQueryReadClient.ReadRowsStream](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.BigQuery.Storage.V1/latest/Google.Cloud.BigQuery.Storage.V1.BigQueryReadClient.ReadRowsStream).
+
+`ServerStreamingBase<TResponse>` has three important aspects:
+
+- It provides a `GetResponseStream()` method to return a conveniently-wrapped
+  `IAsyncEnumerable<TResponse>` in the form of `AsyncResponseStream<TResponse>`.
+- It exposes the underlying gRPC call via the `GrpcCall` property (in case you
+  need access to any of the underlying details).
+- It implements `IDisposable`, and will dispose of the underlying gRPC call
+  when it's disposed.
+
+The typical usage pattern for a server-streaming call is to keep the call itself
+in a variable with a `using` statement to dispose of it automatically, call
+`GetResponseStream()` to access the stream of responses, and iterate over them
+using an `await foreach` loop.
+
+The sample below demonstrates this for `BigQueryReadClient.ReadRows`; it deliberately
+doesn't go into the detail of how the query is set up or how the responses are processed,
+as those are API-specific and unrelated to stream usage.
+
+[!code-cs[](../examples/help.Streaming.txt#ServerStreaming)]
+
+# Bidirectional-streaming RPCs
+
+A bidirectional-streaming RPC is started without a client-side request, as clients
+can send requests as and when they wish to. Similarly, the server provides a stream
+of responses. The request and response streams often involve some sort of "conversation"
+where one client request triggers one or more server responses, but they're treated
+as separate streams - it would be entirely possible for an API to be designed so that
+the client makes all its requests, then the server makes a series of responses, for example.
+
+APIs using bidirectional-streaming calls vary significantly, and you should consult the
+API documentation for details. One common pattern is for the *first* client request to
+contain some initialization data (for example, the name of a data store to write to) and
+subsequent requests are slightly different. Again, consult the API-specific documentation
+for details.
+
+In the Google Cloud Libraries for .NET, an ongoing bidirectional-streaming call
+is represented by the base class `BidirectionalStreamingBase<TRequest, TResponse>`, with a
+separate derived class for each RPC. For example, in the client library for the
+[BigQuery Storage API](https://cloud.google.com/bigquery/docs/reference/storage),
+the [BigQueryWriteClient.AppendRows](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.BigQuery.Storage.V1/latest/Google.Cloud.BigQuery.Storage.V1.BigQueryWriteClient#Google_Cloud_BigQuery_Storage_V1_BigQueryWriteClient_AppendRows_Google_Api_Gax_Grpc_CallSettings_Google_Api_Gax_Grpc_BidirectionalStreamingSettings_) method returns a [BigQueryWriteClient.AppendRowsStream](https://cloud.google.com/dotnet/docs/reference/Google.Cloud.BigQuery.Storage.V1/latest/Google.Cloud.BigQuery.Storage.V1.BigQueryWriteClient.AppendRowsStream).
+
+`BidirectionalStreamingBase<TRequest, TResponse>` has all the aspects of `ServerStreamingBase<TResponse>` described above, but with additional methods related to the client's request stream:
+
+- `WriteAsync` and `TryWriteAsync` send a request.
+- `CompleteAsync` and `TryCompleteAsync` are called by the client to indicate that it has
+  finished sending requests.
+
+The requests are stored in a buffer until they can be sent; the buffer capacity can
+be specified in the `BidirectionalStreamingSettings` passed into the initial call.
+
+The difference between the methods with a `Try` prefix and those without is about error
+handling:
+
+- A call to `WriteAsync` will throw an exception if the client stream has already been
+  completed, or if the buffer is full. A call to `TryWriteAsync` in the same failure
+  scenarios will return a null `Task` to indicate failure instead.
+- A call to `CompleteAsync` will throw an exception if the client stream has already been
+  completed. A call to `TryCompleteAsync` will return a null `Task` to indicate failure
+  instead.
+
+In most cases, it's more appropriate to use `WriteAsync` and `CompleteAsync`; the `Try` variants
+are provided for situations where you may have multiple threads sending requests and potentially
+completing the stream.
+
+Unlike the "raw" gRPC stub, users do not need to ensure that only a single request is in-flight
+at a time: the buffer takes care of handling multiple requests, so long as the buffer capacity
+is not exceeded. The tasks returned by the `TryWrite`/`Write` methods complete when the request has been
+written to the underlying stream. The tasks returned by the `TryComplete`/`Complete` methods
+complete when the stream has actually been marked as completed. (This only occurs when all the
+buffered requests have been written to the stream.)
+
+It's important to complete the request stream, in order to complete the call cleanly.
+
+The sample below demonstrates the use of bidirectional streaming for
+`BigQueryWriteClient.AppendRows`; it deliberately doesn't go into the detail of how the requests are
+created or how the responses are handled, as those are API-specific and unrelated to stream usage.
+Even the aspect of "the requests can all be created independently from the responses" is
+API-specific, but the sample provides a reasonably common pattern.
+
+[!code-cs[](../examples/help.Streaming.txt#BidirectionalStreaming)]
+
+## Disposal
+
+While unary RPCs require no special handling, streaming RPC calls *must* be disposed to
+avoid resource leaks. The types representing the calls returned by the initial method call
+(e.g. `ReadRowsStream` and `AppendRowsStream`) implement `IDisposable`, and should be handled
+with a `using` statement where possible. (In more complex scenarios where the call needs to be
+preserved across multiple methods, it should be disposed directly at the end.)
+
+Additionally, users should *attempt* to read all the responses from both server-streaming
+and bidirectional-streaming calls, unless they have particular reasons not to do so. Disposing
+of the call before all the responses have been read effectively aborts the call, which may have
+performance implications depending on the exact timing involved. On the other hand, there
+can be a performance impact of continuing to read responses (e.g. for a long-running query)
+after you've received all the data you're actually interested in. It's all API-specific, but as
+a general rule it's better to read the responses where you can do so. See the
+[Microsoft gRPC documentation](https://learn.microsoft.com/en-us/aspnet/core/grpc/client?view=aspnetcore-7.0#bi-directional-streaming-call) for more details on this.

--- a/docs/devsite-help/toc.yml
+++ b/docs/devsite-help/toc.yml
@@ -32,6 +32,8 @@
     href: api-layers.md
   - name: Call settings
     href: call-settings.md
+  - name: Streaming RPCs
+    href: grpc-streaming.md
   - name: Resource clean-up
     href: cleanup.md
   - name: Versioning

--- a/tools/Google.Cloud.Docs.Snippets/Google.Cloud.Docs.Snippets.csproj
+++ b/tools/Google.Cloud.Docs.Snippets/Google.Cloud.Docs.Snippets.csproj
@@ -11,6 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\apis\Google.Cloud.BigQuery.Storage.V1\Google.Cloud.BigQuery.Storage.V1\Google.Cloud.BigQuery.Storage.V1.csproj" />
+    <ProjectReference Include="..\..\apis\Google.Cloud.BigQuery.V2\Google.Cloud.BigQuery.V2\Google.Cloud.BigQuery.V2.csproj" />
     <ProjectReference Include="..\..\apis\Google.Cloud.Language.V1\Google.Cloud.Language.V1\Google.Cloud.Language.V1.csproj" />
     <ProjectReference Include="..\..\apis\Google.Cloud.Scheduler.V1\Google.Cloud.Scheduler.V1\Google.Cloud.Scheduler.V1.csproj" />
     <ProjectReference Include="..\..\apis\Google.Cloud.Vision.V1\Google.Cloud.Vision.V1\Google.Cloud.Vision.V1.csproj" />
@@ -20,6 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Apache.Avro" Version="1.11.1" />
+    <!-- Temporary update until Google.Cloud.BigQuery.Storage.V1 depends on GAX 4.4.0 or later -->
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="4.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/tools/Google.Cloud.Docs.Snippets/StreamingSnippets.cs
+++ b/tools/Google.Cloud.Docs.Snippets/StreamingSnippets.cs
@@ -1,0 +1,217 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+using Avro;
+using Avro.Generic;
+using Avro.IO;
+using Google.Api.Gax.ResourceNames;
+using Google.Cloud.BigQuery.Storage.V1;
+using Google.Cloud.BigQuery.V2;
+using Google.Cloud.ClientTesting;
+using Google.Cloud.Tools.Snippets;
+using Google.Protobuf;
+using Google.Type;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using static Google.Cloud.BigQuery.Storage.V1.AppendRowsRequest.Types;
+
+namespace Google.Cloud.Docs.Snippets;
+
+[SnippetOutputCollector]
+[Collection(nameof(SnippetFixture))]
+public class StreamingSnippets
+{
+    private readonly SnippetFixture _fixture;
+
+    public StreamingSnippets(SnippetFixture fixture) =>
+        _fixture = fixture;
+
+    [Fact]
+    public async Task ServerStreaming()
+    {
+        // Used in the local method; declared here to avoid them being shown in the sample.
+        DefaultReader reader = null;
+        int totalRows = 0;
+        string projectId = _fixture.ProjectId;
+
+        // Sample: ServerStreaming
+        BigQueryReadClient client = BigQueryReadClient.Create();
+
+        // Create a read session and return the name of a stream from it.
+        // (The details are unimportant for this sample.)
+        ReadStreamName streamName = await PrepareQuery(client);
+
+        // Make the streaming RPC, which will return responses asynchronously.
+        // The using statement ensures that we dispose of the call at the end.
+        using BigQueryReadClient.ReadRowsStream readRowsStream = client.ReadRows(streamName, offset: 0);
+
+        // Asynchronously iterate over all the responses in the stream, processing each one in a
+        // separate method (not shown in this sample).
+        await foreach (ReadRowsResponse response in readRowsStream.GetResponseStream())
+        {
+            ProcessResponse(response);
+        }
+        // End sample
+
+        // At the time of writing, this is 249. It's plausible that it may change,
+        // so let's test in a fairly loose way.
+        Assert.InRange(totalRows, 240, 270);
+
+        void ProcessResponse(ReadRowsResponse response)
+        {
+            Console.WriteLine($"Start of response");
+            var bytes = response.AvroRows.SerializedBinaryRows;
+            if (reader is null && response.AvroSchema is not null)
+            {
+                var schema = Schema.Parse(response.AvroSchema.Schema);
+                Console.WriteLine($"Read schema: {schema.Name}");
+                reader = new DefaultReader(schema, schema);
+            }
+
+            if (reader is not null)
+            {
+                var decoder = new BinaryDecoder(new MemoryStream(bytes.ToArray()));
+                for (int i = 0; i < response.RowCount; i++)
+                {
+                    var record = reader.Read<GenericRecord>(reuse: null, decoder);
+                    Console.WriteLine($"Row {i}:");
+                    foreach (var field in record.Schema.Fields)
+                    {
+                        Console.WriteLine($"{field.Name}: {record[field.Name]}");
+                    }
+                    totalRows++;
+                }
+            }
+            Console.WriteLine($"End of response");
+        }
+
+        async Task<ReadStreamName> PrepareQuery(BigQueryReadClient client)
+        {
+            CreateReadSessionRequest createSessionRequest = new CreateReadSessionRequest
+            {
+                MaxStreamCount = 1,
+                ParentAsProjectName = new ProjectName(projectId),
+                ReadSession = new ReadSession
+                {
+                    DataFormat = DataFormat.Avro,
+                    TableAsTableName = new TableName("bigquery-public-data", "country_codes", "country_codes")
+                }
+            };
+            ReadSession session = await client.CreateReadSessionAsync(createSessionRequest);
+            return session.Streams[0].ReadStreamName;
+        }
+    }
+
+    [Fact]
+    public async Task BidirectionalStreaming()
+    {
+        // Populated in the ProcessResponsesAsync
+        int totalResponses = 0;
+        int errorResponses = 0;
+
+        string projectId = _fixture.ProjectId;
+        string datasetId = IdGenerator.FromDateTime(prefix: "test_");
+        string tableId = "write_test";
+
+        // The storage write API forces us to write proto messages.
+        // LocalizedText is a handy message with two string fields - nice
+        // and easy to describe in a schema and populate with test data.
+        var bqClient = BigQueryClient.Create(projectId);
+        var dataset = bqClient.CreateDataset(datasetId);
+        var schema = new TableSchemaBuilder
+        {
+            { "language_code", BigQueryDbType.String, BigQueryFieldMode.Required },
+            { "text", BigQueryDbType.String, BigQueryFieldMode.Required },
+        }.Build();
+        dataset.CreateTable(tableId, schema);
+        // Use the default write stream for the table.
+        WriteStreamName streamName = new WriteStreamName(projectId, datasetId, tableId, "_default");
+
+        // Sample: BidirectionalStreaming
+        BigQueryWriteClient client = BigQueryWriteClient.Create();
+        // The using statement ensures that we dispose of the call at the end.
+        using BigQueryWriteClient.AppendRowsStream stream = client.AppendRows();
+
+        // Start processing responses from the stream asynchronously, in a separate
+        // asynchronous method which uses
+        // await foreach (AppendRowsResponse response in stream.GetResponseStream()).
+        // In this example, the requests and responses are effectively independent;
+        // in more complex scenarios you may wish to send requests to react to
+        // responses, etc.
+        var responseTask = ProcessResponsesAsync(stream);
+
+        // Write each request to the stream.
+        foreach (AppendRowsRequest request in CreateRequests())
+        {
+            await stream.WriteAsync(request);
+        }
+        // Indicate that we've finished writing requests.
+        await stream.WriteCompleteAsync();
+
+        // Wait for all the responses to be processed before automatically
+        // disposing of the stream (due to the using statement).
+        await responseTask;
+        // End sample
+
+        // We should have seen at least one response, but no errors.
+        Assert.NotEqual(0, totalResponses);
+        Assert.Equal(0, errorResponses);
+
+        async Task ProcessResponsesAsync(BigQueryWriteClient.AppendRowsStream stream)
+        {
+            await foreach (AppendRowsResponse response in stream.GetResponseStream())
+            {
+                Console.WriteLine($"Received {response}");
+                totalResponses++;
+                if (response.Error is not null)
+                {
+                    errorResponses++;
+                }
+            }
+        }
+
+        IEnumerable<AppendRowsRequest> CreateRequests()
+        {
+            var data = new[]
+            {
+                new LocalizedText { LanguageCode = "en", Text = "It is raining" },
+                new LocalizedText { LanguageCode = "fr", Text = "Il pleut" },
+                new LocalizedText { LanguageCode = "de", Text = "Es regnet" }
+            };
+
+            bool firstRequest = true;
+            foreach (var item in data)
+            {
+                var request = new AppendRowsRequest
+                {
+                    ProtoRows = new ProtoData
+                    {
+                        Rows = new ProtoRows { SerializedRows = { item.ToByteString() } }
+                    }
+                };
+                if (firstRequest)
+                {
+                    request.ProtoRows.WriterSchema = new ProtoSchema { ProtoDescriptor = LocalizedText.Descriptor.ToProto() };
+                    request.WriteStreamAsWriteStreamName = streamName;
+                    firstRequest = false;
+                }
+                yield return request;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is primarily to make sure users are informed about the need to dispose of streaming calls - but additional information and samples is useful as well.

Fixes #10134.