### PR TITLE
chore: Update dependencies for all APIs

### DIFF
--- a/apis/Google.Apps.Script.Type/Google.Apps.Script.Type/Google.Apps.Script.Type.csproj
+++ b/apis/Google.Apps.Script.Type/Google.Apps.Script.Type/Google.Apps.Script.Type.csproj
@@ -9,6 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.CommonProtos" Version="[2.7.0, 3.0.0)" />
+    <PackageReference Include="Google.Api.CommonProtos" Version="[2.10.0, 3.0.0)" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.csproj
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.csproj
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.csproj
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1.csproj
+++ b/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.csproj
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.csproj
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.csproj
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.csproj
@@ -9,12 +9,12 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.OrgPolicy.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.OsConfig.V1" Version="[2.1.0, 3.0.0)" />
     <PackageReference Include="Google.Identity.AccessContextManager.V1" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.csproj
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.csproj
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.csproj
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.csproj
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.csproj
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.csproj
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.csproj
+++ b/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BeyondCorp.ClientConnectorServices.V1/Google.Cloud.BeyondCorp.ClientConnectorServices.V1/Google.Cloud.BeyondCorp.ClientConnectorServices.V1.csproj
+++ b/apis/Google.Cloud.BeyondCorp.ClientConnectorServices.V1/Google.Cloud.BeyondCorp.ClientConnectorServices.V1/Google.Cloud.BeyondCorp.ClientConnectorServices.V1.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.csproj
+++ b/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.csproj
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Rest" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Rest" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Apis.Bigquery.v2" Version="[1.60.0.2949, 2.0.0.0)" />
   </ItemGroup>
   <ItemGroup>

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\Google.Cloud.Bigtable.Admin.V2\Google.Cloud.Bigtable.Admin.V2.csproj" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.Snippets/Google.Cloud.Bigtable.Admin.V2.Snippets.csproj
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.Snippets/Google.Cloud.Bigtable.Admin.V2.Snippets.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\Google.Cloud.Bigtable.Admin.V2\Google.Cloud.Bigtable.Admin.V2.csproj" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.Tests/Google.Cloud.Bigtable.Admin.V2.Tests.csproj
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.Tests/Google.Cloud.Bigtable.Admin.V2.Tests.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\Google.Cloud.Bigtable.Admin.V2\Google.Cloud.Bigtable.Admin.V2.csproj" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.csproj
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Bigtable.Common.V2" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Bigtable.Common.V2/Google.Cloud.Bigtable.Common.V2/Google.Cloud.Bigtable.Common.V2.csproj
+++ b/apis/Google.Cloud.Bigtable.Common.V2/Google.Cloud.Bigtable.Common.V2/Google.Cloud.Bigtable.Common.V2.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax" Version="[4.2.0, 5.0.0)" />
-    <PackageReference Include="Google.Protobuf" Version="[3.21.0, 4.0.0)" />
+    <PackageReference Include="Google.Api.Gax" Version="[4.4.0, 5.0.0)" />
+    <PackageReference Include="Google.Protobuf" Version="[3.23.0, 4.0.0)" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/Google.Cloud.Bigtable.V2.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/Google.Cloud.Bigtable.V2.GeneratedSnippets.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.Bigtable.Admin.V2\Google.Cloud.Bigtable.Admin.V2\Google.Cloud.Bigtable.Admin.V2.csproj" />
     <ProjectReference Include="..\Google.Cloud.Bigtable.V2\Google.Cloud.Bigtable.V2.csproj" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.IntegrationTests/Google.Cloud.Bigtable.V2.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.IntegrationTests/Google.Cloud.Bigtable.V2.IntegrationTests.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.Bigtable.Admin.V2\Google.Cloud.Bigtable.Admin.V2\Google.Cloud.Bigtable.Admin.V2.csproj" />
     <ProjectReference Include="..\Google.Cloud.Bigtable.V2\Google.Cloud.Bigtable.V2.csproj" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Snippets/Google.Cloud.Bigtable.V2.Snippets.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Snippets/Google.Cloud.Bigtable.V2.Snippets.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.Bigtable.Admin.V2\Google.Cloud.Bigtable.Admin.V2\Google.Cloud.Bigtable.Admin.V2.csproj" />
     <ProjectReference Include="..\Google.Cloud.Bigtable.V2\Google.Cloud.Bigtable.V2.csproj" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/Google.Cloud.Bigtable.V2.Tests.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/Google.Cloud.Bigtable.V2.Tests.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.Bigtable.Admin.V2\Google.Cloud.Bigtable.Admin.V2\Google.Cloud.Bigtable.Admin.V2.csproj" />
     <ProjectReference Include="..\Google.Cloud.Bigtable.V2\Google.Cloud.Bigtable.V2.csproj" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Bigtable.Common.V2" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.csproj
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.csproj
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.csproj
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
-    <PackageReference Include="Grafeas.V1" Version="3.0.0" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
+    <PackageReference Include="Grafeas.V1" Version="3.4.0" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.csproj
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.csproj
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.csproj
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.csproj
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Common/Google.Cloud.Common/Google.Cloud.Common.csproj
+++ b/apis/Google.Cloud.Common/Google.Cloud.Common/Google.Cloud.Common.csproj
@@ -9,6 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.CommonProtos" Version="[2.6.0, 3.0.0)" />
+    <PackageReference Include="Google.Api.CommonProtos" Version="[2.10.0, 3.0.0)" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.csproj
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.csproj
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.csproj
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.csproj
+++ b/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.csproj
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.csproj
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.csproj
+++ b/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/Google.Cloud.Datastore.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/Google.Cloud.Datastore.V1.GeneratedSnippets.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Datastore.V1\Google.Cloud.Datastore.V1.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/Google.Cloud.Datastore.V1.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/Google.Cloud.Datastore.V1.IntegrationTests.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Datastore.V1\Google.Cloud.Datastore.V1.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/Google.Cloud.Datastore.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/Google.Cloud.Datastore.V1.Snippets.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Datastore.V1\Google.Cloud.Datastore.V1.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Tests/Google.Cloud.Datastore.V1.Tests.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Tests/Google.Cloud.Datastore.V1.Tests.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Datastore.V1\Google.Cloud.Datastore.V1.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.csproj
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2.csproj
+++ b/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.DevTools.Common" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.csproj
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.csproj
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <ProjectReference Include="..\..\Grafeas.V1\Grafeas.V1\Grafeas.V1.csproj" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <ProjectReference Include="..\..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.csproj" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Google.Cloud.Diagnostics.Common.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Google.Cloud.Diagnostics.Common.IntegrationTests.csproj
@@ -13,7 +13,7 @@
     <DebugType Condition="'$(TargetFramework)' == 'net6.0'">portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.csproj" />
     <PackageReference Include="Google.Cloud.ErrorReporting.V1Beta1" Version="[3.0.0-beta02, 4.0.0)" />

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Snippets/Google.Cloud.Diagnostics.Common.Snippets.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Snippets/Google.Cloud.Diagnostics.Common.Snippets.csproj
@@ -13,7 +13,7 @@
     <DebugType Condition="'$(TargetFramework)' == 'net6.0'">portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.csproj" />
     <PackageReference Include="Google.Cloud.ErrorReporting.V1Beta1" Version="[3.0.0-beta02, 4.0.0)" />

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Google.Cloud.Diagnostics.Common.Tests.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Google.Cloud.Diagnostics.Common.Tests.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.csproj" />
     <PackageReference Include="Google.Cloud.ErrorReporting.V1Beta1" Version="[3.0.0-beta02, 4.0.0)" />

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Logging.V2" Version="[4.0.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Trace.V1" Version="[3.1.0, 4.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.csproj
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.csproj
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.csproj
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.csproj
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.csproj
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.csproj
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.csproj
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.csproj
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Common" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.csproj
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.csproj
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/Google.Cloud.Firestore.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/Google.Cloud.Firestore.IntegrationTests.csproj
@@ -7,11 +7,11 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.3.1, 5.0.0)" />
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.4.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Firestore\Google.Cloud.Firestore.csproj" />
-    <PackageReference Include="Grpc.Core.Testing" Version="[2.46.5, 3.0.0)" />
+    <PackageReference Include="Grpc.Core.Testing" Version="[2.46.6, 3.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/Google.Cloud.Firestore.Snippets.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/Google.Cloud.Firestore.Snippets.csproj
@@ -7,11 +7,11 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.3.1, 5.0.0)" />
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.4.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Firestore\Google.Cloud.Firestore.csproj" />
-    <PackageReference Include="Grpc.Core.Testing" Version="[2.46.5, 3.0.0)" />
+    <PackageReference Include="Grpc.Core.Testing" Version="[2.46.6, 3.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Google.Cloud.Firestore.Tests.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Google.Cloud.Firestore.Tests.csproj
@@ -7,11 +7,11 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.3.1, 5.0.0)" />
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.4.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Firestore\Google.Cloud.Firestore.csproj" />
-    <PackageReference Include="Grpc.Core.Testing" Version="[2.46.5, 3.0.0)" />
+    <PackageReference Include="Grpc.Core.Testing" Version="[2.46.6, 3.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Google.Cloud.Firestore.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Google.Cloud.Firestore.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <ProjectReference Include="..\..\Google.Cloud.Firestore.V1\Google.Cloud.Firestore.V1\Google.Cloud.Firestore.V1.csproj" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.csproj
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.csproj
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.csproj
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Apps.Script.Type" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Gaming.V1/Google.Cloud.Gaming.V1/Google.Cloud.Gaming.V1.csproj
+++ b/apis/Google.Cloud.Gaming.V1/Google.Cloud.Gaming.V1/Google.Cloud.Gaming.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.csproj
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.csproj
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.csproj
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.csproj
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.csproj
+++ b/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.csproj
+++ b/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.2.0, 5.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.csproj
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.csproj
+++ b/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Iot.V1/Google.Cloud.Iot.V1/Google.Cloud.Iot.V1.csproj
+++ b/apis/Google.Cloud.Iot.V1/Google.Cloud.Iot.V1/Google.Cloud.Iot.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.csproj
+++ b/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Kms.V1" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Kms.V1" Version="[3.4.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.csproj
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/Google.Cloud.Language.V1.csproj
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/Google.Cloud.Language.V1.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Location/Google.Cloud.Location/Google.Cloud.Location.csproj
+++ b/apis/Google.Cloud.Location/Google.Cloud.Location/Google.Cloud.Location.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.2.0, 5.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.IntegrationTests/Google.Cloud.Logging.Log4Net.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.IntegrationTests/Google.Cloud.Logging.Log4Net.IntegrationTests.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Logging.Log4Net\Google.Cloud.Logging.Log4Net.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />

--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Snippets/Google.Cloud.Logging.Log4Net.Snippets.csproj
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Snippets/Google.Cloud.Logging.Log4Net.Snippets.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Logging.Log4Net\Google.Cloud.Logging.Log4Net.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />

--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Tests/Google.Cloud.Logging.Log4Net.Tests.csproj
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Tests/Google.Cloud.Logging.Log4Net.Tests.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Logging.Log4Net\Google.Cloud.Logging.Log4Net.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />

--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.csproj
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.DevTools.Common" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Logging.V2" Version="[4.0.0, 5.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
     <PackageReference Include="log4net" Version="2.0.14" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">

--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.IntegrationTests/Google.Cloud.Logging.NLog.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.IntegrationTests/Google.Cloud.Logging.NLog.IntegrationTests.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Logging.NLog\Google.Cloud.Logging.NLog.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />

--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.Snippets/Google.Cloud.Logging.NLog.Snippets.csproj
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.Snippets/Google.Cloud.Logging.NLog.Snippets.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Logging.NLog\Google.Cloud.Logging.NLog.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />

--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.Tests/Google.Cloud.Logging.NLog.Tests.csproj
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.Tests/Google.Cloud.Logging.NLog.Tests.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Logging.NLog\Google.Cloud.Logging.NLog.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />

--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.csproj
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.DevTools.Common" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Logging.V2" Version="[4.0.0, 5.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
     <PackageReference Include="NLog" Version="4.7.15" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Logging.Type/Google.Cloud.Logging.Type/Google.Cloud.Logging.Type.csproj
+++ b/apis/Google.Cloud.Logging.Type/Google.Cloud.Logging.Type/Google.Cloud.Logging.Type.csproj
@@ -9,6 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.CommonProtos" Version="[2.6.0, 3.0.0)" />
+    <PackageReference Include="Google.Api.CommonProtos" Version="[2.10.0, 3.0.0)" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.csproj
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Logging.Type" Version="[4.0.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.csproj
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.csproj
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.csproj
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.csproj
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.csproj
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.csproj
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.csproj
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.csproj
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Optimization.V1/Google.Cloud.Optimization.V1/Google.Cloud.Optimization.V1.csproj
+++ b/apis/Google.Cloud.Optimization.V1/Google.Cloud.Optimization.V1/Google.Cloud.Optimization.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.csproj
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.OrgPolicy.V1/Google.Cloud.OrgPolicy.V1/Google.Cloud.OrgPolicy.V1.csproj
+++ b/apis/Google.Cloud.OrgPolicy.V1/Google.Cloud.OrgPolicy.V1/Google.Cloud.OrgPolicy.V1.csproj
@@ -9,6 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.CommonProtos" Version="[2.6.0, 3.0.0)" />
+    <PackageReference Include="Google.Api.CommonProtos" Version="[2.10.0, 3.0.0)" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.csproj
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.csproj
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.OsLogin.Common/Google.Cloud.OsLogin.Common/Google.Cloud.OsLogin.Common.csproj
+++ b/apis/Google.Cloud.OsLogin.Common/Google.Cloud.OsLogin.Common/Google.Cloud.OsLogin.Common.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.CommonProtos" Version="[2.7.0, 3.0.0)" />
-    <PackageReference Include="Google.Api.Gax" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.CommonProtos" Version="[2.10.0, 3.0.0)" />
+    <PackageReference Include="Google.Api.Gax" Version="[4.4.0, 5.0.0)" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.csproj
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.OsLogin.Common\Google.Cloud.OsLogin.Common\Google.Cloud.OsLogin.Common.csproj" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.csproj
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.OsLogin.Common\Google.Cloud.OsLogin.Common\Google.Cloud.OsLogin.Common.csproj" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.PolicyTroubleshooter.V1/Google.Cloud.PolicyTroubleshooter.V1/Google.Cloud.PolicyTroubleshooter.V1.csproj
+++ b/apis/Google.Cloud.PolicyTroubleshooter.V1/Google.Cloud.PolicyTroubleshooter.V1/Google.Cloud.PolicyTroubleshooter.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.csproj
+++ b/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/Google.Cloud.PubSub.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/Google.Cloud.PubSub.V1.GeneratedSnippets.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Apis.CloudResourceManager.v1" Version="[1.60.0.2950, 2.0.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1.csproj" />

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.IntegrationTests/Google.Cloud.PubSub.V1.IntegrationTests.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.IntegrationTests/Google.Cloud.PubSub.V1.IntegrationTests.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Apis.CloudResourceManager.v1" Version="[1.60.0.2950, 2.0.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1.csproj" />

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/Google.Cloud.PubSub.V1.Snippets.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/Google.Cloud.PubSub.V1.Snippets.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Apis.CloudResourceManager.v1" Version="[1.60.0.2950, 2.0.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1.csproj" />

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Tests/Google.Cloud.PubSub.V1.Tests.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Tests/Google.Cloud.PubSub.V1.Tests.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Apis.CloudResourceManager.v1" Version="[1.60.0.2950, 2.0.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1.csproj" />

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="PublisherClient.*.cs">

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.csproj
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.csproj
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.csproj
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.csproj
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ResourceSettings.V1/Google.Cloud.ResourceSettings.V1/Google.Cloud.ResourceSettings.V1.csproj
+++ b/apis/Google.Cloud.ResourceSettings.V1/Google.Cloud.ResourceSettings.V1/Google.Cloud.ResourceSettings.V1.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.csproj
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/Google.Cloud.Run.V2.csproj
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/Google.Cloud.Run.V2.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.csproj
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.csproj
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.csproj
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.csproj
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.csproj
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.csproj
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1.csproj
+++ b/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Logging.Type" Version="[4.0.0, 5.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.csproj
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.csproj
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1.csproj
+++ b/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.csproj
+++ b/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.csproj
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1.csproj" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.csproj
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1.csproj" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1.csproj
+++ b/apis/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1.csproj
@@ -9,6 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax" Version="[4.4.0, 5.0.0)" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/Google.Cloud.Spanner.Data.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/Google.Cloud.Spanner.Data.IntegrationTests.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CoreCompat.EnterpriseLibrary.TransientFaultHandling" Version="6.0.1304-r3" />
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.3.1, 5.0.0)" />
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.4.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Spanner.Data\Google.Cloud.Spanner.Data.csproj" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/Google.Cloud.Spanner.Data.Snippets.csproj
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/Google.Cloud.Spanner.Data.Snippets.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CoreCompat.EnterpriseLibrary.TransientFaultHandling" Version="6.0.1304-r3" />
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.3.1, 5.0.0)" />
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.4.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Spanner.Data\Google.Cloud.Spanner.Data.csproj" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/Google.Cloud.Spanner.Data.Tests.csproj
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/Google.Cloud.Spanner.Data.Tests.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CoreCompat.EnterpriseLibrary.TransientFaultHandling" Version="6.0.1304-r3" />
-    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.3.1, 5.0.0)" />
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.4.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Spanner.Data\Google.Cloud.Spanner.Data.csproj" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.csproj
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.csproj
@@ -9,11 +9,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.Spanner.Admin.Database.V1\Google.Cloud.Spanner.Admin.Database.V1\Google.Cloud.Spanner.Admin.Database.V1.csproj" />
     <ProjectReference Include="..\..\Google.Cloud.Spanner.Admin.Instance.V1\Google.Cloud.Spanner.Admin.Instance.V1\Google.Cloud.Spanner.Admin.Instance.V1.csproj" />
     <ProjectReference Include="..\..\Google.Cloud.Spanner.V1\Google.Cloud.Spanner.V1\Google.Cloud.Spanner.V1.csproj" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.csproj
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1\Google.Cloud.Spanner.Common.V1.csproj" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="SessionPool.*.cs">

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.csproj
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/Google.Cloud.Storage.V1.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/Google.Cloud.Storage.V1.IntegrationTests.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Apis.Iam.v1" Version="[1.60.0.2961, 2.0.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\..\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1.csproj" />

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Snippets/Google.Cloud.Storage.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Snippets/Google.Cloud.Storage.V1.Snippets.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Apis.Iam.v1" Version="[1.60.0.2961, 2.0.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\..\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1.csproj" />

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/Google.Cloud.Storage.V1.Tests.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/Google.Cloud.Storage.V1.Tests.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Apis.Iam.v1" Version="[1.60.0.2961, 2.0.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\..\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1\Google.Cloud.PubSub.V1.csproj" />

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Rest" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Rest" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Apis.Storage.v1" Version="[1.60.0.2742, 2.0.0.0)" />
   </ItemGroup>
   <ItemGroup>

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.csproj
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.csproj
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.csproj
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.csproj
+++ b/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.csproj
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.csproj
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.csproj
+++ b/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.csproj
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.csproj
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Rest" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Rest" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Apis.Translate.v2" Version="[1.60.0.875, 2.0.0.0)" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.csproj
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.csproj
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.csproj
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.csproj
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1.csproj
+++ b/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.csproj
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.csproj
+++ b/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.csproj
+++ b/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.csproj
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Workflows.Common.V1/Google.Cloud.Workflows.Common.V1/Google.Cloud.Workflows.Common.V1.csproj
+++ b/apis/Google.Cloud.Workflows.Common.V1/Google.Cloud.Workflows.Common.V1/Google.Cloud.Workflows.Common.V1.csproj
@@ -9,6 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax" Version="[4.4.0, 5.0.0)" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Workflows.Common.V1Beta/Google.Cloud.Workflows.Common.V1Beta/Google.Cloud.Workflows.Common.V1Beta.csproj
+++ b/apis/Google.Cloud.Workflows.Common.V1Beta/Google.Cloud.Workflows.Common.V1Beta/Google.Cloud.Workflows.Common.V1Beta.csproj
@@ -9,6 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax" Version="[4.4.0, 5.0.0)" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.csproj
+++ b/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.Workflows.Common.V1\Google.Cloud.Workflows.Common.V1\Google.Cloud.Workflows.Common.V1.csproj" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.csproj
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\Google.Cloud.Workflows.Common.V1\Google.Cloud.Workflows.Common.V1\Google.Cloud.Workflows.Common.V1.csproj" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Geo.Type/Google.Geo.Type/Google.Geo.Type.csproj
+++ b/apis/Google.Geo.Type/Google.Geo.Type/Google.Geo.Type.csproj
@@ -9,6 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.CommonProtos" Version="[2.6.0, 3.0.0)" />
+    <PackageReference Include="Google.Api.CommonProtos" Version="[2.10.0, 3.0.0)" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Identity.AccessContextManager.Type/Google.Identity.AccessContextManager.Type/Google.Identity.AccessContextManager.Type.csproj
+++ b/apis/Google.Identity.AccessContextManager.Type/Google.Identity.AccessContextManager.Type/Google.Identity.AccessContextManager.Type.csproj
@@ -9,6 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.CommonProtos" Version="[2.6.0, 3.0.0)" />
+    <PackageReference Include="Google.Api.CommonProtos" Version="[2.10.0, 3.0.0)" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.csproj
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Identity.AccessContextManager.Type" Version="[2.0.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.LongRunning/Google.LongRunning.GeneratedSnippets/Google.LongRunning.GeneratedSnippets.csproj
+++ b/apis/Google.LongRunning/Google.LongRunning.GeneratedSnippets/Google.LongRunning.GeneratedSnippets.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.LongRunning\Google.LongRunning.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />

--- a/apis/Google.LongRunning/Google.LongRunning.Snippets/Google.LongRunning.Snippets.csproj
+++ b/apis/Google.LongRunning/Google.LongRunning.Snippets/Google.LongRunning.Snippets.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.LongRunning\Google.LongRunning.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />

--- a/apis/Google.LongRunning/Google.LongRunning.Tests/Google.LongRunning.Tests.csproj
+++ b/apis/Google.LongRunning/Google.LongRunning.Tests/Google.LongRunning.Tests.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.LongRunning\Google.LongRunning.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />

--- a/apis/Google.LongRunning/Google.LongRunning/Google.LongRunning.csproj
+++ b/apis/Google.LongRunning/Google.LongRunning/Google.LongRunning.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.2.0, 5.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Grafeas.V1/Grafeas.V1/Grafeas.V1.csproj
+++ b/apis/Grafeas.V1/Grafeas.V1/Grafeas.V1.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.3.1, 5.0.0)" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -64,7 +64,7 @@
         "gsuite"
       ],
       "dependencies": {
-        "Google.Api.CommonProtos": "2.7.0"
+        "Google.Api.CommonProtos": "2.10.0"
       },
       "generator": "proto",
       "protoPath": "google/apps/script/type"
@@ -98,8 +98,8 @@
         "approval"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
-        "Grpc.Core": "2.46.5"
+        "Google.Api.Gax.Grpc": "4.4.0",
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/accessapproval/v1",
@@ -209,9 +209,9 @@
         "gateway"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/apigateway/v1",
@@ -232,11 +232,11 @@
         "ml"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/aiplatform/v1",
@@ -255,9 +255,9 @@
         "authorization"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/api/apikeys/v2",
@@ -279,8 +279,8 @@
         "hybrid"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
-        "Grpc.Core": "2.46.5"
+        "Google.Api.Gax.Grpc": "4.4.0",
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/apigeeconnect/v1",
@@ -344,9 +344,9 @@
         "appengine"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/appengine/v1",
@@ -368,11 +368,11 @@
         "containers"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/devtools/artifactregistry/v1",
@@ -415,13 +415,13 @@
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Asset Inventory API (v1).",
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.OrgPolicy.V1": "3.0.0",
         "Google.Cloud.OsConfig.V1": "2.1.0",
         "Google.Identity.AccessContextManager.V1": "2.2.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "tags": [
         "asset",
@@ -445,9 +445,9 @@
         "compilance"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/assuredworkloads/v1",
@@ -504,9 +504,9 @@
       "type": "grpc",
       "description": "Recommended Google client library to access the AutoML API, which allows you to train high-quality custom machine learning models with minimal effort and machine learning expertise.",
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "tags": [
         "automl",
@@ -529,11 +529,11 @@
         "hardware"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/baremetalsolution/v2",
@@ -553,11 +553,11 @@
         "batch"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/batch/v1",
@@ -599,11 +599,11 @@
         "beyondcorp"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.2.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.3"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/beyondcorp/appconnections/v1",
@@ -622,11 +622,11 @@
         "beyondcorp"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.2.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.3"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/beyondcorp/appconnectors/v1",
@@ -645,11 +645,11 @@
         "beyondcorp"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.2.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.3"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/beyondcorp/appgateways/v1",
@@ -668,11 +668,11 @@
         "beyondcorp"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.2.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.3"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/beyondcorp/clientconnectorservices/v1",
@@ -691,11 +691,11 @@
         "beyondcorp"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.2.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.3"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/beyondcorp/clientgateways/v1",
@@ -715,9 +715,9 @@
         "analytics"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.2.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
-        "Grpc.Core": "2.46.3"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/bigquery/analyticshub/v1",
@@ -736,9 +736,9 @@
         "connection"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/bigquery/connection/v1",
@@ -779,9 +779,9 @@
         "policies"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/bigquery/datapolicies/v1",
@@ -819,9 +819,9 @@
       "type": "grpc",
       "description": "Recommended Google client library to access the BigQuery Data Transfer API, which transfers data from partner SaaS applications to Google BigQuery on a scheduled, managed basis.",
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Location": "2.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "tags": [
         "BigQuery",
@@ -862,8 +862,8 @@
         "migration"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
-        "Grpc.Core": "2.46.5"
+        "Google.Api.Gax.Grpc": "4.4.0",
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/bigquery/migration/v2",
@@ -882,8 +882,8 @@
         "Reservation"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
-        "Grpc.Core": "2.46.5"
+        "Google.Api.Gax.Grpc": "4.4.0",
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/bigquery/reservation/v1",
@@ -900,7 +900,7 @@
       "type": "rest",
       "description": "Recommended Google client library to access the BigQuery API. It wraps the Google.Apis.Bigquery.v2 client library, making common operations simpler in client code. BigQuery is a data platform for customers to create, manage, share and query data.",
       "dependencies": {
-        "Google.Api.Gax.Rest": "4.3.1",
+        "Google.Api.Gax.Rest": "4.4.0",
         "Google.Apis.Bigquery.v2": "1.60.0.2949"
       },
       "testDependencies": {
@@ -922,8 +922,8 @@
       "type": "grpc",
       "description": "Recommended Google client library to access the BigQuery Storage API.",
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
-        "Grpc.Core": "2.46.5"
+        "Google.Api.Gax.Grpc": "4.4.0",
+        "Grpc.Core": "2.46.6"
       },
       "tags": [
         "BigQuery"
@@ -945,14 +945,14 @@
         "Bigtable"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.2.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Bigtable.Common.V2": "3.0.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.3"
+        "Grpc.Core": "2.46.6"
       },
       "testDependencies": {
-        "Google.Api.Gax.Grpc.Testing": "4.2.0"
+        "Google.Api.Gax.Grpc.Testing": "4.4.0"
       },
       "shortName": "bigtableadmin",
       "serviceConfigFile": "bigtableadmin_v2.yaml",
@@ -968,8 +968,8 @@
         "Bigtable"
       ],
       "dependencies": {
-        "Google.Api.Gax": "4.2.0",
-        "Google.Protobuf": "3.21.0"
+        "Google.Api.Gax": "4.4.0",
+        "Google.Protobuf": "3.23.0"
       }
     },
     {
@@ -987,12 +987,12 @@
         "Bigtable"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Bigtable.Common.V2": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "testDependencies": {
-        "Google.Api.Gax.Grpc.Testing": "4.3.1",
+        "Google.Api.Gax.Grpc.Testing": "4.4.0",
         "Google.Cloud.Bigtable.Admin.V2": "project"
       },
       "shortName": "bigtable",
@@ -1012,8 +1012,8 @@
         "budget"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
-        "Grpc.Core": "2.46.5"
+        "Google.Api.Gax.Grpc": "4.4.0",
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/billing/budgets/v1",
@@ -1051,9 +1051,9 @@
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Billing API, which allows you to define a budget plan and the rules to execute as spend is tracked against that plan.",
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "tags": [
         "Billing"
@@ -1078,9 +1078,9 @@
         "kubernetes"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
-        "Grafeas.V1": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Google.Api.Gax.Grpc": "4.4.0",
+        "Grafeas.V1": "3.4.0",
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/binaryauthorization/v1",
@@ -1124,10 +1124,10 @@
         "certificates"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/certificatemanager/v1",
@@ -1148,9 +1148,9 @@
         "reseller"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/channel/v1",
@@ -1171,9 +1171,9 @@
         "cloudbuild"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/devtools/cloudbuild/v1",
@@ -1215,11 +1215,11 @@
         "migration"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.2.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.3"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/clouddms/v1",
@@ -1235,7 +1235,7 @@
       "description": "Common protos for Cloud APIs.",
       "tags": [],
       "dependencies": {
-        "Google.Api.CommonProtos": "2.6.0"
+        "Google.Api.CommonProtos": "2.10.0"
       },
       "generator": "proto",
       "protoPath": "google/cloud/common"
@@ -1251,7 +1251,7 @@
         "compute"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.LongRunning": "3.0.0"
       },
       "generator": "micro",
@@ -1317,9 +1317,9 @@
         "feedback"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/contactcenterinsights/v1",
@@ -1338,8 +1338,8 @@
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.",
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
-        "Grpc.Core": "2.46.5"
+        "Google.Api.Gax.Grpc": "4.4.0",
+        "Grpc.Core": "2.46.6"
       },
       "tags": [
         "Kubernetes"
@@ -1361,9 +1361,9 @@
         "data"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/datacatalog/lineage/v1",
@@ -1386,10 +1386,10 @@
         "metadata"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "shortName": "datacatalog",
       "serviceConfigFile": "datacatalog_v1.yaml",
@@ -1408,9 +1408,9 @@
         "data"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/datafusion/v1",
@@ -1510,11 +1510,11 @@
         "dataplex"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/dataplex/v1",
@@ -1537,10 +1537,10 @@
         "Hadoop"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "shortName": "dataproc",
       "serviceConfigFile": "dataproc_v1.yaml",
@@ -1558,9 +1558,9 @@
         "admin"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/datastore/admin/v1",
@@ -1583,13 +1583,13 @@
         "Datastore"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5",
+        "Grpc.Core": "2.46.6",
         "System.Linq.Async": "6.0.1"
       },
       "testDependencies": {
-        "Google.Api.Gax.Grpc.Testing": "4.3.1"
+        "Google.Api.Gax.Grpc.Testing": "4.4.0"
       },
       "shortName": "datastore",
       "serviceConfigFile": "datastore_v1.yaml",
@@ -1608,11 +1608,11 @@
         "synchronization"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/datastream/v1",
@@ -1658,9 +1658,9 @@
         "Stackdriver"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.DevTools.Common": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "shortName": "clouddebugger",
       "serviceConfigFile": "clouddebugger_v2.yaml",
@@ -1683,11 +1683,11 @@
         "kubernetes"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/deploy/v1",
@@ -1707,7 +1707,7 @@
         "Tools"
       ],
       "dependencies": {
-        "Google.Api.CommonProtos": "2.6.0"
+        "Google.Api.CommonProtos": "2.10.0"
       }
     },
     {
@@ -1726,10 +1726,10 @@
         "grafeas"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Grafeas.V1": "project",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "shortName": "containeranalysis",
       "serviceConfigFile": "containeranalysis_v1.yaml",
@@ -1754,7 +1754,7 @@
       ],
       "dependencies": {
         "Google.Cloud.Diagnostics.Common": "project",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "testDependencies": {
         "Google.Cloud.Diagnostics.Common.IntegrationTests": "project",
@@ -1777,14 +1777,14 @@
         "Diagnostics"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Logging.V2": "4.0.0",
         "Google.Cloud.Trace.V1": "3.1.0",
         "Microsoft.Extensions.Http": "6.0.0",
         "System.Diagnostics.StackTrace": "4.3.0"
       },
       "testDependencies": {
-        "Google.Api.Gax.Testing": "4.3.1",
+        "Google.Api.Gax.Testing": "4.4.0",
         "Google.Cloud.ErrorReporting.V1Beta1": "3.0.0-beta02",
         "Microsoft.Extensions.Hosting": "6.0.0"
       }
@@ -1802,10 +1802,10 @@
         "agents"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/dialogflow/cx/v3",
@@ -1828,10 +1828,10 @@
         "iot"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "testDependencies": {
         "Microsoft.AspNetCore.Mvc.Core": "2.1.16"
@@ -1891,9 +1891,9 @@
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Data Loss Prevention API, which provides methods for detection of privacy-sensitive fragments in text, images, and Google Cloud Platform storage repositories.",
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Location": "2.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "tags": [
         "DLP",
@@ -1922,10 +1922,10 @@
         "automl"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/documentai/v1",
@@ -1971,9 +1971,9 @@
         "domains"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/domains/v1",
@@ -2052,8 +2052,8 @@
         "contacts"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
-        "Grpc.Core": "2.46.5"
+        "Google.Api.Gax.Grpc": "4.4.0",
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/essentialcontacts/v1",
@@ -2093,11 +2093,11 @@
         "cloudevents"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/eventarc/v1",
@@ -2114,10 +2114,10 @@
       "description": "The Cloud Filestore API is used for creating and managing cloud file servers.",
       "tags": [],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Common": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/filestore/v1",
@@ -2144,10 +2144,10 @@
         "admin"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "shortName": "firestore",
       "serviceConfigFile": "firestore_v1.yaml",
@@ -2171,14 +2171,14 @@
       ],
       "dependencies": {
         "Google.Cloud.Firestore.V1": "project",
-        "Grpc.Core": "2.46.5",
+        "Grpc.Core": "2.46.6",
         "System.Collections.Immutable": "6.0.0",
         "System.Linq.Async": "6.0.1"
       },
       "testDependencies": {
-        "Google.Api.Gax.Grpc.Testing": "4.3.1",
-        "Google.Api.Gax.Testing": "4.3.1",
-        "Grpc.Core.Testing": "2.46.5",
+        "Google.Api.Gax.Grpc.Testing": "4.4.0",
+        "Google.Api.Gax.Testing": "4.4.0",
+        "Grpc.Core.Testing": "2.46.6",
         "System.ValueTuple": "4.5.0",
         "Xunit.Combinatorial": "1.4.1"
       },
@@ -2201,10 +2201,10 @@
         "firebase"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "shortName": "firestore",
       "serviceConfigFile": "firestore_v1.yaml",
@@ -2221,11 +2221,11 @@
         "functions"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/functions/v1",
@@ -2245,11 +2245,11 @@
         "functions"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/functions/v2",
@@ -2293,9 +2293,9 @@
         "add-ons"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Apps.Script.Type": "2.1.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/gsuiteaddons/v1",
@@ -2316,9 +2316,9 @@
         "games"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/gaming/v1",
@@ -2361,9 +2361,9 @@
         "backup"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/gkebackup/v1",
@@ -2430,9 +2430,9 @@
         "anthos"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/gkehub/v1",
@@ -2456,9 +2456,9 @@
         "azure"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/gkemulticloud/v1",
@@ -2480,9 +2480,9 @@
         "admin"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.2.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
-        "Grpc.Core": "2.46.3"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/iam/admin/v1",
@@ -2504,8 +2504,8 @@
         "account"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
-        "Grpc.Core": "2.46.5"
+        "Google.Api.Gax.Grpc": "4.4.0",
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/iam/credentials/v1",
@@ -2530,8 +2530,8 @@
         "Access"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.2.0",
-        "Grpc.Core": "2.46.3"
+        "Google.Api.Gax.Grpc": "4.4.0",
+        "Grpc.Core": "2.46.6"
       },
       "forceOwlBotRegeneration": "AuditData proto is generated in the wrong place.",
       "serviceConfigFile": "iam_meta_api.yaml"
@@ -2571,9 +2571,9 @@
         "access"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/iap/v1",
@@ -2597,9 +2597,9 @@
         "threats"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/ids/v1",
@@ -2619,9 +2619,9 @@
         "iot"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/iot/v1",
@@ -2643,7 +2643,7 @@
         "cryptography"
       ],
       "dependencies": {
-        "Google.Cloud.Kms.V1": "3.3.0"
+        "Google.Cloud.Kms.V1": "3.4.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/kms/inventory/v1",
@@ -2667,10 +2667,10 @@
         "encryption"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "shortName": "cloudkms",
       "serviceConfigFile": "cloudkms_v1.yaml",
@@ -2687,8 +2687,8 @@
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Natural Language API, which provides natural language understanding technologies to developers. Examples include sentiment analysis, entity recognition, and text annotations.",
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
-        "Grpc.Core": "2.46.5"
+        "Google.Api.Gax.Grpc": "4.4.0",
+        "Grpc.Core": "2.46.6"
       },
       "tags": [
         "Language"
@@ -2732,8 +2732,8 @@
         "zones"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.2.0",
-        "Grpc.Core": "2.46.3"
+        "Google.Api.Gax.Grpc": "4.4.0",
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/location",
@@ -2754,14 +2754,14 @@
         "Stackdriver"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.2.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.DevTools.Common": "3.0.0",
         "Google.Cloud.Logging.V2": "4.0.0",
-        "Grpc.Core": "2.46.3",
+        "Grpc.Core": "2.46.6",
         "log4net": "2.0.14"
       },
       "testDependencies": {
-        "Google.Api.Gax.Testing": "4.2.0"
+        "Google.Api.Gax.Testing": "4.4.0"
       }
     },
     {
@@ -2796,14 +2796,14 @@
         "Stackdriver"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.2.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.DevTools.Common": "3.0.0",
         "Google.Cloud.Logging.V2": "4.0.0",
-        "Grpc.Core": "2.46.3",
+        "Grpc.Core": "2.46.6",
         "NLog": "4.7.15"
       },
       "testDependencies": {
-        "Google.Api.Gax.Testing": "4.2.0"
+        "Google.Api.Gax.Testing": "4.4.0"
       }
     },
     {
@@ -2819,7 +2819,7 @@
         "Stackdriver"
       ],
       "dependencies": {
-        "Google.Api.CommonProtos": "2.6.0"
+        "Google.Api.CommonProtos": "2.10.0"
       }
     },
     {
@@ -2836,10 +2836,10 @@
         "Stackdriver"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.2.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Logging.Type": "4.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.3"
+        "Grpc.Core": "2.46.6"
       },
       "shortName": "logging",
       "serviceConfigFile": "logging_v2.yaml",
@@ -2861,9 +2861,9 @@
         "Active Directory"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.2.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.3"
+        "Grpc.Core": "2.46.6"
       },
       "shortName": "managedidentities",
       "serviceConfigFile": "managedidentities_v1.yaml",
@@ -2901,10 +2901,10 @@
         "Memorystore"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/memcache/v1",
@@ -2923,10 +2923,10 @@
       "type": "grpc",
       "description": "Recommended Google client library to administer Cloud Memorystore for Memcache (v1beta2).",
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "tags": [
         "Redis",
@@ -2949,11 +2949,11 @@
         "metastore"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/metastore/v1",
@@ -3022,9 +3022,9 @@
         "Stackdriver"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "shortName": "monitoring",
       "serviceConfigFile": "monitoring.yaml",
@@ -3043,11 +3043,11 @@
         "vpc"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/networkconnectivity/v1",
@@ -3091,9 +3091,9 @@
         "diagnostics"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/networkmanagement/v1",
@@ -3143,11 +3143,11 @@
         "notebooks"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/notebooks/v1",
@@ -3188,9 +3188,9 @@
         "optimization"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/optimization/v1",
@@ -3212,9 +3212,9 @@
         "orchestration"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/orchestration/airflow/service/v1",
@@ -3233,7 +3233,7 @@
       "description": "OrgPolicy API messages.",
       "tags": [],
       "dependencies": {
-        "Google.Api.CommonProtos": "2.6.0"
+        "Google.Api.CommonProtos": "2.10.0"
       }
     },
     {
@@ -3249,8 +3249,8 @@
         "governance"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
-        "Grpc.Core": "2.46.5"
+        "Google.Api.Gax.Grpc": "4.4.0",
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/orgpolicy/v2",
@@ -3276,9 +3276,9 @@
         "Configuration"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "shortName": "osconfig",
       "serviceConfigFile": "osconfig_v1.yaml",
@@ -3322,8 +3322,8 @@
         "Login"
       ],
       "dependencies": {
-        "Google.Api.CommonProtos": "2.7.0",
-        "Google.Api.Gax": "4.3.1"
+        "Google.Api.CommonProtos": "2.10.0",
+        "Google.Api.Gax": "4.4.0"
       },
       "noVersionHistory": true,
       "forceOwlBotRegeneration": "OsLogin Common proto is generated in the wrong place.",
@@ -3343,9 +3343,9 @@
         "Login"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.OsLogin.Common": "project",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "forceOwlBotRegeneration": "OsLogin Common proto is generated and copied when it shouldn't be.",
       "shortName": "oslogin",
@@ -3368,9 +3368,9 @@
         "Login"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.OsLogin.Common": "project",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "forceOwlBotRegeneration": "OsLogin Common proto is generated and copied when it shouldn't be.",
       "shortName": "oslogin",
@@ -3408,9 +3408,9 @@
         "diagnostics"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/policytroubleshooter/v1",
@@ -3452,8 +3452,8 @@
         "profiler"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
-        "Grpc.Core": "2.46.5"
+        "Google.Api.Gax.Grpc": "4.4.0",
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/devtools/cloudprofiler/v2",
@@ -3473,12 +3473,12 @@
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.",
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "testDependencies": {
-        "Google.Api.Gax.Testing": "4.3.1",
+        "Google.Api.Gax.Testing": "4.4.0",
         "Google.Apis.CloudResourceManager.v1": "1.60.0.2950",
         "Microsoft.Extensions.DependencyInjection": "6.0.0",
         "Microsoft.Extensions.Hosting": "6.0.0",
@@ -3506,8 +3506,8 @@
         "reCAPTCHA"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
-        "Grpc.Core": "2.46.5"
+        "Google.Api.Gax.Grpc": "4.4.0",
+        "Grpc.Core": "2.46.6"
       },
       "shortName": "recaptchaenterprise",
       "serviceConfigFile": "recaptchaenterprise_v1.yaml",
@@ -3561,8 +3561,8 @@
       "type": "grpc",
       "description": "Recommended Google client library for the Recommender API, which provides usage recommendations for Cloud products and services.",
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
-        "Grpc.Core": "2.46.5"
+        "Google.Api.Gax.Grpc": "4.4.0",
+        "Grpc.Core": "2.46.6"
       },
       "tags": [
         "Recommender"
@@ -3582,10 +3582,10 @@
       "type": "grpc",
       "description": "Recommended Google client library to administer Cloud Memorystore for Redis.",
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "tags": [
         "Redis",
@@ -3629,10 +3629,10 @@
         "resources"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/resourcemanager/v3",
@@ -3653,8 +3653,8 @@
         "settings"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
-        "Grpc.Core": "2.46.5"
+        "Google.Api.Gax.Grpc": "4.4.0",
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/resourcesettings/v1",
@@ -3674,10 +3674,10 @@
         "retail"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/retail/v2",
@@ -3698,11 +3698,11 @@
         "admin"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/run/v2",
@@ -3725,9 +3725,9 @@
         "cron"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Location": "2.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "shortName": "cloudscheduler",
       "serviceConfigFile": "cloudscheduler_v1.yaml",
@@ -3744,9 +3744,9 @@
       "type": "grpc",
       "description": "Recommended Google client library to access the Secret Manager API.",
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "tags": [
         "secret",
@@ -3794,11 +3794,11 @@
         "private-ca"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/security/privateca/v1",
@@ -3837,10 +3837,10 @@
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Security Command Center Settings API.",
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.2.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.3"
+        "Grpc.Core": "2.46.6"
       },
       "tags": [
         "security",
@@ -3860,10 +3860,10 @@
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Security Command Center API, which helps security teams gather data, identify threats, and act on them before they result in business damage or loss.",
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "tags": [
         "security",
@@ -3884,10 +3884,10 @@
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Security Command Center API version v1p1beta1, which helps security teams gather data, identify threats, and act on them before they result in business damage or loss.",
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "tags": [
         "security",
@@ -3910,9 +3910,9 @@
         "services"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Logging.Type": "4.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/api/servicecontrol/v1",
@@ -3932,9 +3932,9 @@
         "services"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/servicedirectory/v1",
@@ -3976,9 +3976,9 @@
         "management"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/api/servicemanagement/v1",
@@ -3999,9 +3999,9 @@
         "apis"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/api/serviceusage/v1",
@@ -4021,9 +4021,9 @@
         "shell"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/shell/v1",
@@ -4046,11 +4046,11 @@
         "Spanner"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Spanner.Common.V1": "project",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "noVersionHistory": true,
       "shortName": "spanner",
@@ -4072,11 +4072,11 @@
         "Spanner"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Spanner.Common.V1": "project",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "noVersionHistory": true,
       "shortName": "spanner",
@@ -4097,17 +4097,17 @@
         "ADO"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Spanner.Admin.Database.V1": "project",
         "Google.Cloud.Spanner.Admin.Instance.V1": "project",
         "Google.Cloud.Spanner.V1": "project",
-        "Grpc.Core": "2.46.5",
+        "Grpc.Core": "2.46.6",
         "Microsoft.Extensions.Configuration.Abstractions": "6.0.0"
       },
       "testDependencies": {
         "CoreCompat.EnterpriseLibrary.TransientFaultHandling": "6.0.1304-r3",
-        "Google.Api.Gax.Grpc.Testing": "4.3.1",
-        "Google.Api.Gax.Testing": "4.3.1",
+        "Google.Api.Gax.Grpc.Testing": "4.4.0",
+        "Google.Api.Gax.Testing": "4.4.0",
         "Microsoft.Extensions.Configuration": "6.0.0",
         "Microsoft.Extensions.DependencyInjection": "6.0.0",
         "Xunit.Combinatorial": "1.4.1"
@@ -4123,7 +4123,7 @@
         "Spanner"
       ],
       "dependencies": {
-        "Google.Api.Gax": "4.3.1"
+        "Google.Api.Gax": "4.4.0"
       },
       "noVersionHistory": true
     },
@@ -4142,9 +4142,9 @@
         "Spanner"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Spanner.Common.V1": "project",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "testDependencies": {
         "Xunit.Combinatorial": "1.4.1"
@@ -4168,9 +4168,9 @@
         "Speech"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "shortName": "speech",
       "serviceConfigFile": "speech_v1.yaml",
@@ -4228,11 +4228,11 @@
       "type": "rest",
       "description": "Recommended Google client library to access the Google Cloud Storage API. It wraps the Google.Apis.Storage.v1 client library, making common operations simpler in client code. Google Cloud Storage stores and retrieves potentially large, immutable data objects.",
       "dependencies": {
-        "Google.Api.Gax.Rest": "4.3.1",
+        "Google.Api.Gax.Rest": "4.4.0",
         "Google.Apis.Storage.v1": "1.60.0.2742"
       },
       "testDependencies": {
-        "Google.Api.Gax.Testing": "4.3.1",
+        "Google.Api.Gax.Testing": "4.4.0",
         "Google.Apis.Iam.v1": "1.60.0.2961",
         "Google.Cloud.PubSub.V1": "project"
       },
@@ -4278,9 +4278,9 @@
         "gcs"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/storagetransfer/v1",
@@ -4318,9 +4318,9 @@
         "Jobs"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/talent/v4",
@@ -4364,9 +4364,9 @@
         "Tasks"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "shortName": "cloudtasks",
       "serviceConfigFile": "cloudtasks_v2.yaml",
@@ -4404,9 +4404,9 @@
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Text-to-Speech API v1, synthesizes natural-sounding speech by applying powerful neural network models.",
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "tags": [
         "Speech",
@@ -4449,10 +4449,10 @@
         "tpu"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.2.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.3"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/tpu/v1",
@@ -4470,8 +4470,8 @@
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Trace API, which sends and retrieves trace data from Google Cloud Trace. Data is generated and available by default for all App Engine applications. Data from other applications can be written to Cloud Trace for display, reporting, and analysis.",
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
-        "Grpc.Core": "2.46.5"
+        "Google.Api.Gax.Grpc": "4.4.0",
+        "Grpc.Core": "2.46.6"
       },
       "tags": [
         "Tracing",
@@ -4492,8 +4492,8 @@
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Trace V2 API, which sends and retrieves trace data from Google Cloud Trace. Data is generated and available by default for all App Engine applications. Data from other applications can be written to Cloud Trace for display, reporting, and analysis.",
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
-        "Grpc.Core": "2.46.5"
+        "Google.Api.Gax.Grpc": "4.4.0",
+        "Grpc.Core": "2.46.6"
       },
       "tags": [
         "Tracing",
@@ -4514,9 +4514,9 @@
       "type": "grpc",
       "description": "Recommended Google client library to access the Translate v3 API. The Translate API translates text from one language to another.",
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "tags": [
         "Translate",
@@ -4535,7 +4535,7 @@
       "type": "rest",
       "description": "Recommended Google client library to access the Translate v2 API. It wraps the Google.Apis.Translate.v2 client library, making common operations simpler in client code. The Translate API translates text from one language to another.",
       "dependencies": {
-        "Google.Api.Gax.Rest": "4.3.1",
+        "Google.Api.Gax.Rest": "4.4.0",
         "Google.Apis.Translate.v2": "1.60.0.875"
       },
       "tags": [
@@ -4557,11 +4557,11 @@
         "virtual-machine"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/vmmigration/v1",
@@ -4583,10 +4583,10 @@
         "transcoding"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/video/livestream/v1",
@@ -4608,9 +4608,9 @@
         "content"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/video/stitcher/v1",
@@ -4631,8 +4631,8 @@
         "transcoding"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
-        "Grpc.Core": "2.46.5"
+        "Google.Api.Gax.Grpc": "4.4.0",
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/video/transcoder/v1",
@@ -4655,9 +4655,9 @@
         "VideoIntelligence"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "shortName": "videointelligence",
       "serviceConfigFile": "videointelligence_v1.yaml",
@@ -4678,9 +4678,9 @@
         "Vision"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "shortName": "vision",
       "serviceConfigFile": "vision_v1.yaml",
@@ -4720,10 +4720,10 @@
         "vpc"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/vpcaccess/v1",
@@ -4750,9 +4750,9 @@
         "url"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "shortName": "webrisk",
       "serviceConfigFile": "webrisk_v1.yaml",
@@ -4794,8 +4794,8 @@
         "scanner"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
-        "Grpc.Core": "2.46.5"
+        "Google.Api.Gax.Grpc": "4.4.0",
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/websecurityscanner/v1",
@@ -4814,7 +4814,7 @@
         "Spanner"
       ],
       "dependencies": {
-        "Google.Api.Gax": "4.3.1"
+        "Google.Api.Gax": "4.4.0"
       },
       "noVersionHistory": true
     },
@@ -4828,7 +4828,7 @@
         "Spanner"
       ],
       "dependencies": {
-        "Google.Api.Gax": "4.3.1"
+        "Google.Api.Gax": "4.4.0"
       },
       "noVersionHistory": true
     },
@@ -4844,9 +4844,9 @@
         "workflows"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Workflows.Common.V1": "project",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/workflows/executions/v1",
@@ -4884,10 +4884,10 @@
         "workflows"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Workflows.Common.V1": "project",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/workflows/v1",
@@ -4928,7 +4928,7 @@
         "geo"
       ],
       "dependencies": {
-        "Google.Api.CommonProtos": "2.6.0"
+        "Google.Api.CommonProtos": "2.10.0"
       },
       "generator": "proto",
       "protoPath": "google/geo/type"
@@ -4946,7 +4946,7 @@
         "identity"
       ],
       "dependencies": {
-        "Google.Api.CommonProtos": "2.6.0"
+        "Google.Api.CommonProtos": "2.10.0"
       }
     },
     {
@@ -4963,11 +4963,11 @@
         "identity"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.0",
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Identity.AccessContextManager.Type": "2.0.0",
         "Google.LongRunning": "3.0.0",
-        "Grpc.Core": "2.46.5"
+        "Grpc.Core": "2.46.6"
       },
       "shortName": "accesscontextmanager",
       "serviceConfigFile": "accesscontextmanager_v1.yaml",
@@ -4988,11 +4988,11 @@
         "LongRunning"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.2.0",
-        "Grpc.Core": "2.46.3"
+        "Google.Api.Gax.Grpc": "4.4.0",
+        "Grpc.Core": "2.46.6"
       },
       "testDependencies": {
-        "Google.Api.Gax.Testing": "4.2.0"
+        "Google.Api.Gax.Testing": "4.4.0"
       },
       "forceOwlBotRegeneration": "Post-processor requires googleapis repo.",
       "serviceConfigFile": "longrunning.yaml"
@@ -5097,8 +5097,8 @@
         "grafeas"
       ],
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.3.1",
-        "Grpc.Core": "2.46.5"
+        "Google.Api.Gax.Grpc": "4.4.0",
+        "Grpc.Core": "2.46.6"
       },
       "shortName": "containeranalysis",
       "serviceConfigFile": "grafeas_v1.yaml",


### PR DESCRIPTION
This will allow us to update the generator to use protoc 3.23.x. It does mean that we can't release *patch* versions of libraries without either undoing these changes or creating a branch - but that's unlikely to cause an issue.