### PR TITLE
Release Google.Cloud.Debugger.V2 version 3.2.0

### DIFF
--- a/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2.csproj
+++ b/apis/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2/Google.Cloud.Debugger.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.1.0</Version>
+    <Version>3.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Debugger API.</Description>

--- a/apis/Google.Cloud.Debugger.V2/docs/history.md
+++ b/apis/Google.Cloud.Debugger.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.2.0, released 2023-05-22
+
+### Documentation changes
+
+- Update Debugger documentation to reflect deprecation
+
 ## Version 3.1.0, released 2023-01-19
 
 ### New features

--- a/apis/Google.Cloud.Debugger.V2/docs/index.md
+++ b/apis/Google.Cloud.Debugger.V2/docs/index.md
@@ -2,20 +2,13 @@
 
 {{description}}
 
-{{version}}
+The Google Cloud Debugger service is officially deprecated. See
+the [deprecation page](https://cloud.google.com/debugger/docs/deprecations) and
+[release notes](https://cloud.google.com/debugger/docs/release-notes)
+for details.
 
-{{installation}}
-
-{{auth}}
-
-## Getting started
-
-{{client-classes}}
-
-{{client-construction}}
-
-## Sample code
-
-## Register Debuggee
-
-{{sample:Controller2Client.RegisterDebuggee}}
+The Google.Cloud.Debugger.V2 library is delisted from NuGet,
+and the source code removed from the google-cloud-dotnet repository.
+Any projects that depend on Google.Cloud.Debugger.V2 will still be
+able to restore that dependency, but the package won't be shown in
+search results on [nuget.org](https://www.nuget.org/).

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1648,7 +1648,7 @@
       "protoPath": "google/devtools/clouddebugger/v2",
       "productName": "Google Cloud Debugger",
       "productUrl": "https://cloud.google.com/debugger/",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Debugger API.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### Documentation changes

- Update Debugger documentation to reflect deprecation
