### PR TITLE
Release Google.Cloud.AIPlatform.V1 version 2.15.0

### DIFF
--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.14.0</Version>
+    <Version>2.15.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AI Platform API, which allows you to train high-quality custom machine learning models with minimal machine learning expertise and effort.</Description>

--- a/apis/Google.Cloud.AIPlatform.V1/docs/history.md
+++ b/apis/Google.Cloud.AIPlatform.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 2.15.0, released 2023-05-23
+
+### New features
+
+- Add match service in aiplatform v1 ([commit 7fa56aa](https://github.com/googleapis/google-cloud-dotnet/commit/7fa56aa6604cfeb78597c7799e3d9ea10a39e4a7))
+- Add examples to ExplanationParameters in aiplatform v1 explanation.proto ([commit 0ec8cc2](https://github.com/googleapis/google-cloud-dotnet/commit/0ec8cc2caa812e2a879687d0ba2150806b42078a))
+
 ## Version 2.14.0, released 2023-05-03
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -222,7 +222,7 @@
     },
     {
       "id": "Google.Cloud.AIPlatform.V1",
-      "version": "2.14.0",
+      "version": "2.15.0",
       "type": "grpc",
       "productName": "Cloud AI Platform",
       "productUrl": "https://cloud.google.com/ai-platform/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add match service in aiplatform v1 ([commit 7fa56aa](https://github.com/googleapis/google-cloud-dotnet/commit/7fa56aa6604cfeb78597c7799e3d9ea10a39e4a7))
- Add examples to ExplanationParameters in aiplatform v1 explanation.proto ([commit 0ec8cc2](https://github.com/googleapis/google-cloud-dotnet/commit/0ec8cc2caa812e2a879687d0ba2150806b42078a))
