### PR TITLE
chore: OwlBot post-processor support for release-please

### DIFF
--- a/owl-bot-post-processor/main.sh
+++ b/owl-bot-post-processor/main.sh
@@ -141,5 +141,9 @@ then
   rm -rf owl-bot-staging
 fi
 
+# Update dependencies if we're releasing anything.
+# (This is for release-please integration.)
+dotnet run --project tools/Google.Cloud.Tools.ReleaseManager -- update-dependencies --owlbot
+
 # Generate .csproj files in all the /apis directories.
 ./generateprojects.sh

--- a/tools/Google.Cloud.Tools.ReleaseManager/CommandBase.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/CommandBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,7 +28,9 @@ namespace Google.Cloud.Tools.ReleaseManager
         // releases, but fundamentally it's "the current source of truth we're basing this release on".
         internal const string PrimaryBranch = "main";
 
-        private readonly int _expectedArgCount;
+        private readonly int _minArgs;
+        private readonly int _maxArgs;
+        private bool _requireExactArguments { get; }
 
         public string Description { get; }
 
@@ -36,20 +38,25 @@ namespace Google.Cloud.Tools.ReleaseManager
 
         public string ExpectedArguments { get; }
 
-
-        protected CommandBase(string command, string description, params string[] argNames)
+        protected CommandBase(string command, string description, int minArgs, int maxArgs, string expectedArguments)
         {
             Command = command;
             Description = description;
-            _expectedArgCount = argNames.Length;
-            ExpectedArguments = string.Join(" ", argNames.Select(arg => $"<{arg}>"));
+            _minArgs = minArgs;
+            _maxArgs = maxArgs;
+            ExpectedArguments = expectedArguments;
+        }
+
+        protected CommandBase(string command, string description, params string[] argNames)
+            : this(command, description, argNames.Length, argNames.Length, string.Join(" ", argNames.Select(arg => $"<{arg}>")))
+        {
         }
 
         public void Execute(string[] args)
         {
-            if (args.Length != _expectedArgCount)
+            if (args.Length < _minArgs || args.Length > _maxArgs)
             {
-                throw new UserErrorException(_expectedArgCount == 0
+                throw new UserErrorException(_maxArgs == 0
                     ? $"{Command} does not accept additional arguments"
                     : $"{Command} expected arguments: {ExpectedArguments}");
             }

--- a/tools/Google.Cloud.Tools.ReleaseManager/UpdateDependencies.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/UpdateDependencies.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2021 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,15 +13,18 @@
 // limitations under the License.
 
 using Google.Cloud.Tools.Common;
+using LibGit2Sharp;
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace Google.Cloud.Tools.ReleaseManager
 {
     public sealed class UpdateDependenciesCommand : CommandBase
     {
         public UpdateDependenciesCommand()
-            : base("update-dependencies", "Updates dependencies for all APIs")
+            : base("update-dependencies", "Updates dependencies for all APIs (or those changed in the previous commit, with --owlbot)", 0, 1, "[--owlbot]")
         {
         }
 
@@ -30,7 +33,23 @@ namespace Google.Cloud.Tools.ReleaseManager
             var catalog = ApiCatalog.Load();
             var apiNames = catalog.CreateIdHashSet();
 
-            foreach (var api in catalog.Apis)
+            var apisToUpdate = catalog.Apis;
+
+            if (args.Length == 1)
+            {
+                if (args[0] != "--owlbot")
+                {
+                    throw new UserErrorException("Only valid argument for update-dependencies is --owlbot.");
+                }
+                apisToUpdate = FindApisToUpdateFromPreviousCommit(catalog);
+                // Don't even bother checking if we don't have any updates.
+                if (apisToUpdate.Count == 0)
+                {
+                    return;
+                }
+            }
+
+            foreach (var api in apisToUpdate)
             {
                 GenerateProjectsCommand.UpdateDependencies(catalog, api);
                 var layout = DirectoryLayout.ForApi(api.Id);
@@ -38,8 +57,43 @@ namespace Google.Cloud.Tools.ReleaseManager
                 GenerateProjectsCommand.GenerateProjects(layout.SourceDirectory, api, apiNames);
             }
             string formatted = catalog.FormatJson();
-            File.WriteAllText(ApiCatalog.CatalogPath, formatted);
-            Console.WriteLine("Updated apis.json");
+            string currentFileContent = File.ReadAllText(ApiCatalog.CatalogPath);
+            if (currentFileContent == formatted)
+            {
+                Console.WriteLine("No dependencies were updated.");
+            }
+            else
+            {
+                File.WriteAllText(ApiCatalog.CatalogPath, formatted);
+                Console.WriteLine("Updated apis.json");
+            }
+        }
+
+        private static List<ApiMetadata> FindApisToUpdateFromPreviousCommit(ApiCatalog catalog)
+        {
+            var root = DirectoryLayout.DetermineRootDirectory();
+            using var repo = new Repository(root);
+            // OwlBot will be post-processing a new commit from either OwlBot itself or
+            // release-please; we want to find out what the API catalog looked like in the commit
+            // *before* that.
+            var previousCommit = repo.Head.Commits.Skip(1).First();
+            var oldCatalogBlob = (Blob) previousCommit.Tree["apis/apis.json"].Target;
+            var text = oldCatalogBlob.GetContentText();
+            var oldCatalog = ApiCatalog.FromJson(text);
+
+            // We only want to check for dependency updates in APIs that have changed *and* aren't patch releases.
+            var apisToUpdate = catalog.Apis
+                .Where(api => oldCatalog.TryGetApi(api.Id, out var oldApi) && api.Version != oldApi.Version && api.StructuredVersion.Patch == 0)
+                .ToList();
+            if (apisToUpdate.Any())
+            {
+                Console.WriteLine("Checking for dependency updates in:");
+                foreach (var api in apisToUpdate)
+                {
+                    Console.WriteLine($"  {api.Id}");
+                }
+            }
+            return apisToUpdate;
         }
     }
 }


### PR DESCRIPTION
When release-please updates apis.json with a new version, we should update the dependencies for that API as well (unless it's a patch release).