### PR TITLE
fix: Fix generating dependencies for release-please commits

### DIFF
--- a/owl-bot-post-processor/main.sh
+++ b/owl-bot-post-processor/main.sh
@@ -143,10 +143,7 @@ fi
 
 # Update dependencies if we're releasing anything.
 # (This is for release-please integration.)
-# Temporarily commented out for now, as it looks like
-# we only have the head commit.
-# Once OwlBot is working again, we can find a proper fix.
-# dotnet run --project tools/Google.Cloud.Tools.ReleaseManager -- update-dependencies --owlbot
+dotnet run --project tools/Google.Cloud.Tools.ReleaseManager -- update-dependencies --owlbot
 
 # Generate .csproj files in all the /apis directories.
 ./generateprojects.sh


### PR DESCRIPTION
The previous code tried to walk to the previous commit; the new code uses the parent of the HEAD commit instead.