### PR TITLE
chore: Unskip Functions v2 smoke test

### DIFF
--- a/apis/Google.Cloud.Functions.V2/smoketests.json
+++ b/apis/Google.Cloud.Functions.V2/smoketests.json
@@ -15,7 +15,6 @@
   },
   {
     "method": "ListLocations",
-    "skip": "b/283396160",
     "client": "FunctionServiceClient",
     "clientNavigationProperty": "LocationsClient",
     "arguments": {


### PR DESCRIPTION
This has been fixed by the location metadata being included.