### PR TITLE
chore: Temporarily stop using release trigger

### DIFF
--- a/.github/release-trigger.yml
+++ b/.github/release-trigger.yml
@@ -1,1 +1,1 @@
-enabled: true
+enabled: false


### PR DESCRIPTION
This will prevent duplicate builds while we're sorting out release-please.