### PR TITLE
Release Google.Cloud.Batch.V1Alpha version 1.0.0-alpha11

### DIFF
--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.csproj
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha10</Version>
+    <Version>1.0.0-alpha11</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Batch API (v1alpha), which allows you to manage the running of batch jobs on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Batch.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.Batch.V1Alpha/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 1.0.0-alpha11, released 2023-05-26
+
+### Bug fixes
+
+- Override HTTP URLs for LRO cancel/delete operations ([commit 82d9df4](https://github.com/googleapis/google-cloud-dotnet/commit/82d9df47ef8c379a593be70dd07749aa46775d41))
+
+### New features
+
+- Support order_by in ListJobs and ListTasks requests ([issue 21](https://github.com/googleapis/google-cloud-dotnet/issues/21)) ([commit 2890c2a](https://github.com/googleapis/google-cloud-dotnet/commit/2890c2a8b3e963bf5172dca1ee6dbf17b5f02ded))
+
 ## Version 1.0.0-alpha10, released 2023-04-19
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -569,7 +569,7 @@
     },
     {
       "id": "Google.Cloud.Batch.V1Alpha",
-      "version": "1.0.0-alpha10",
+      "version": "1.0.0-alpha11",
       "type": "grpc",
       "productName": "Batch",
       "productUrl": "https://cloud.google.com/batch/docs/",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Override HTTP URLs for LRO cancel/delete operations ([commit 82d9df4](https://github.com/googleapis/google-cloud-dotnet/commit/82d9df47ef8c379a593be70dd07749aa46775d41))

### New features

- Support order_by in ListJobs and ListTasks requests ([issue 21](https://github.com/googleapis/google-cloud-dotnet/issues/21)) ([commit 2890c2a](https://github.com/googleapis/google-cloud-dotnet/commit/2890c2a8b3e963bf5172dca1ee6dbf17b5f02ded))
