### PR TITLE
Release Google.Cloud.Bigtable.Admin.V2 version 3.4.0

### DIFF
--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.csproj
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.3.0</Version>
+    <Version>3.4.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Bigtable Instance and Table Admin APIs.</Description>

--- a/apis/Google.Cloud.Bigtable.Admin.V2/docs/history.md
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 3.4.0, released 2023-05-26
+
+### New features
+
+- Add ChangeStreamConfig to CreateTable and UpdateTable ([commit d00cf93](https://github.com/googleapis/google-cloud-dotnet/commit/d00cf93767c057936cdc6883dca6b62bbdb0a765))
+
+### Documentation improvements
+
+- Remove unnecessary comment ([commit 62c70cb](https://github.com/googleapis/google-cloud-dotnet/commit/62c70cb90901b26652f4961a84dc809386a1c657))
+
 ## Version 3.3.0, released 2022-09-15
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -939,7 +939,7 @@
       "protoPath": "google/bigtable/admin/v2",
       "productName": "Google Cloud Bigtable Administration",
       "productUrl": "https://cloud.google.com/bigtable/",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "commonResourcesConfig": "apis/Google.Cloud.Bigtable.Common.V2/CommonResourcesConfig.json",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Bigtable Instance and Table Admin APIs.",


### PR DESCRIPTION

Changes in this release:

### New features

- Add ChangeStreamConfig to CreateTable and UpdateTable ([commit d00cf93](https://github.com/googleapis/google-cloud-dotnet/commit/d00cf93767c057936cdc6883dca6b62bbdb0a765))

### Documentation improvements

- Remove unnecessary comment ([commit 62c70cb](https://github.com/googleapis/google-cloud-dotnet/commit/62c70cb90901b26652f4961a84dc809386a1c657))
