### PR TITLE
Release Google.Cloud.Channel.V1 version 2.7.0

### DIFF
--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.csproj
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Channel API, which enables Google Cloud resellers and distributors to manage their customers, channel partners, entitlements and reports.</Description>

--- a/apis/Google.Cloud.Channel.V1/docs/history.md
+++ b/apis/Google.Cloud.Channel.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 2.7.0, released 2023-05-26
+
+### New features
+
+- Added partition_keys field to filter results from FetchReportResults ([commit fde5897](https://github.com/googleapis/google-cloud-dotnet/commit/fde58971e156bacda1b547f770c210c0c14eca9c))
+
+### Documentation improvements
+
+- Change references from GCP to Google Cloud ([commit fde5897](https://github.com/googleapis/google-cloud-dotnet/commit/fde58971e156bacda1b547f770c210c0c14eca9c))
+
 ## Version 2.6.0, released 2023-05-11
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1140,7 +1140,7 @@
     },
     {
       "id": "Google.Cloud.Channel.V1",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "type": "grpc",
       "productName": "Cloud Channel",
       "productUrl": "https://cloud.google.com/channel/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Added partition_keys field to filter results from FetchReportResults ([commit fde5897](https://github.com/googleapis/google-cloud-dotnet/commit/fde58971e156bacda1b547f770c210c0c14eca9c))

### Documentation improvements

- Change references from GCP to Google Cloud ([commit fde5897](https://github.com/googleapis/google-cloud-dotnet/commit/fde58971e156bacda1b547f770c210c0c14eca9c))
