### PR TITLE
Release Google.Cloud.Functions.V2 version 1.3.0

### DIFF
--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.csproj
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Functions API (v2), which manages lightweight user-provided functions executed in response to events.</Description>

--- a/apis/Google.Cloud.Functions.V2/docs/history.md
+++ b/apis/Google.Cloud.Functions.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.3.0, released 2023-05-26
+
+### New features
+
+- ListFunctions now include metadata which indicates whether a function is a `GEN_1` or `GEN_2` function ([commit a678905](https://github.com/googleapis/google-cloud-dotnet/commit/a678905cbacd1970ed1b3e2d46e14d82635c5dcd))
+
 ## Version 1.2.0, released 2023-03-20
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2234,7 +2234,7 @@
     },
     {
       "id": "Google.Cloud.Functions.V2",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "type": "grpc",
       "productName": "Cloud Functions",
       "productUrl": "https://cloud.google.com/functions",


### PR DESCRIPTION

Changes in this release:

### New features

- ListFunctions now include metadata which indicates whether a function is a `GEN_1` or `GEN_2` function ([commit a678905](https://github.com/googleapis/google-cloud-dotnet/commit/a678905cbacd1970ed1b3e2d46e14d82635c5dcd))
