### PR TITLE
Release Google.Cloud.Functions.V2Beta version 1.0.0-beta03

### DIFF
--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.csproj
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Functions API (v2beta), which manages lightweight user-provided functions executed in response to events.</Description>

--- a/apis/Google.Cloud.Functions.V2Beta/docs/history.md
+++ b/apis/Google.Cloud.Functions.V2Beta/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 1.0.0-beta03, released 2023-05-26
+
+### New features
+
+- ListFunctions now include metadata which indicates whether a function is a `GEN_1` or `GEN_2` function ([commit 6634dea](https://github.com/googleapis/google-cloud-dotnet/commit/6634dead8993023333024d350fd8016fecc636b2))
+- KMS crypto keys can now be specified when uploading function source code, enabling source code to be encrypted at rest with a user-managed encryption key ([commit 6634dea](https://github.com/googleapis/google-cloud-dotnet/commit/6634dead8993023333024d350fd8016fecc636b2))
+- You can now specify concurrency and cpu of a gen 2 function through the Function API, without needing to modify the underlying Cloud Run service ([commit 6634dea](https://github.com/googleapis/google-cloud-dotnet/commit/6634dead8993023333024d350fd8016fecc636b2))
+
 ## Version 1.0.0-beta02, released 2023-01-19
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2258,7 +2258,7 @@
     },
     {
       "id": "Google.Cloud.Functions.V2Beta",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0-beta03",
       "type": "grpc",
       "productName": "Cloud Functions",
       "productUrl": "https://cloud.google.com/functions",


### PR DESCRIPTION

Changes in this release:

### New features

- ListFunctions now include metadata which indicates whether a function is a `GEN_1` or `GEN_2` function ([commit 6634dea](https://github.com/googleapis/google-cloud-dotnet/commit/6634dead8993023333024d350fd8016fecc636b2))
- KMS crypto keys can now be specified when uploading function source code, enabling source code to be encrypted at rest with a user-managed encryption key ([commit 6634dea](https://github.com/googleapis/google-cloud-dotnet/commit/6634dead8993023333024d350fd8016fecc636b2))
- You can now specify concurrency and cpu of a gen 2 function through the Function API, without needing to modify the underlying Cloud Run service ([commit 6634dea](https://github.com/googleapis/google-cloud-dotnet/commit/6634dead8993023333024d350fd8016fecc636b2))
