### PR TITLE
refactor: Encapsulate lease timing in a separate nested class

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberClientImpl.LeaseTiming.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberClientImpl.LeaseTiming.cs
@@ -1,0 +1,60 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+using System;
+
+namespace Google.Cloud.PubSub.V1;
+
+public partial class SubscriberClientImpl
+{
+    /// <summary>
+    /// Helper class to keep track of lease timing values. Each <see cref="SingleChannel"/>
+    /// has references to two instances of this: one for exactly-once delivery, and once for
+    /// normal delivery.
+    /// </summary>
+    private sealed class LeaseTiming
+    {
+        /// <summary>
+        /// Delay between message lease auto-extends.
+        /// </summary>
+        internal TimeSpan AutoExtendDelay { get; }
+
+        /// <summary>
+        /// Value to use as new deadline when lease auto-extends.
+        /// </summary>
+        internal int AckDeadlineSeconds { get; }
+
+        /// <summary>
+        /// Throttle pull if items in the extend queue are older than this.
+        /// </summary>
+        internal TimeSpan ExtendQueueThrottleInterval { get; }
+
+        internal LeaseTiming(TimeSpan ackDeadline, TimeSpan ackExtensionWindow)
+        {
+            // Truncate the ack deadline to a whole number of seconds, just for simplicity with later calculations.
+            AckDeadlineSeconds = (int) ackDeadline.TotalSeconds;
+            ackDeadline = TimeSpan.FromSeconds(AckDeadlineSeconds);
+
+            // The delay is calculated as AckDeadline - AckWindow, but with a hard-coded minimum.
+            var delay = ackDeadline - ackExtensionWindow;
+            // Clamp the delay to the MinimumLeaseExtensionDelay value if delay is less than that.
+            AutoExtendDelay = TimeSpan.FromTicks(Math.Max(delay.Ticks, MinimumLeaseExtensionDelay.Ticks));
+
+            // The throttle is normally half the ack extension window, but is expressed in terms of the computed
+            // AutoExtendDelay to take account of any clamping to MinimumLeaseExtensionDelay.
+            // Annoyingly, the TimeSpan division operator isn't available in .NET Framework.
+            ExtendQueueThrottleInterval = TimeSpan.FromTicks((ackDeadline - AutoExtendDelay).Ticks / 2);
+        }
+    }
+}

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberClientImpl.SingleChannel.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberClientImpl.SingleChannel.cs
@@ -149,13 +149,9 @@ public sealed partial class SubscriberClientImpl
         private readonly CancellationTokenSource _pushStopCts;
         private readonly CancellationTokenSource _softStopCts;
         private readonly SubscriptionName _subscriptionName;
-        private readonly int _ackDeadlineSeconds; // Seconds to add to the deadline on lease extension for regular subscriptions.
-        private readonly int _ackDeadlineSecondsForExactlyOnceDelivery; // Seconds to add to the deadline on lease extension for exactly-once delivery subscriptions.
-        private readonly TimeSpan _autoExtendDelay; // Delay between auto-extends for non-exactly once delivery subscriptions.
-        private readonly TimeSpan _autoExtendDelayForExactlyOnceDelivery; // Delay between auto-extends for exactly once delivery subscriptions.
+        private readonly LeaseTiming _normalLeaseTiming;
+        private readonly LeaseTiming _exactlyOnceDeliveryLeaseTiming;
         private readonly TimeSpan _maxExtensionDuration; // Maximum duration for which a message lease will be extended.
-        private readonly TimeSpan _extendQueueThrottleInterval; // Throttle pull if items in the extend queue are older than this.
-        private readonly TimeSpan _extendQueueThrottleIntervalForExactlyOnceDelivery; // Throttle pull if items in the extend queue are older than this for exactly-once delivery subscriptions.
         private readonly int _maxAckExtendQueueSize; // Soft limit on push queue sizes. Used to throttle pulls.
         private readonly int _maxAckExtendSendCount; // Maximum number of ids to include in an ack/nack/extend push RPC.
         private readonly int _maxConcurrentPush; // Mamimum number (slightly soft) of concurrent ack/nack/extend push RPCs.
@@ -195,14 +191,10 @@ public sealed partial class SubscriberClientImpl
             _pushStopCts = CancellationTokenSource.CreateLinkedTokenSource(_hardStopCts.Token);
             _softStopCts = subscriber._globalSoftStopCts;
             _subscriptionName = subscriber.SubscriptionName;
-            _ackDeadlineSeconds = subscriber._ackDeadlineSeconds;
-            _ackDeadlineSecondsForExactlyOnceDelivery = subscriber._ackDeadlineSecondsForExactlyOnceDelivery;
+            _normalLeaseTiming = subscriber._normalLeaseTiming;
+            _exactlyOnceDeliveryLeaseTiming = subscriber._exactlyOnceDeliveryLeaseTiming;
             _maxAckExtendQueueSize = subscriber._maxAckExtendQueue;
-            _autoExtendDelay = subscriber._autoExtendDelay;
-            _autoExtendDelayForExactlyOnceDelivery = subscriber._autoExtendDelayForExactlyOnceDelivery;
             _maxExtensionDuration = subscriber._maxExtensionDuration;
-            _extendQueueThrottleInterval = TimeSpan.FromTicks((long)((TimeSpan.FromSeconds(_ackDeadlineSeconds) - _autoExtendDelay).Ticks * 0.5));
-            _extendQueueThrottleIntervalForExactlyOnceDelivery = TimeSpan.FromTicks((long) ((TimeSpan.FromSeconds(_ackDeadlineSecondsForExactlyOnceDelivery) - _autoExtendDelayForExactlyOnceDelivery).Ticks * 0.5));
             _maxAckExtendSendCount = Math.Max(10, subscriber._maxAckExtendQueue / 4);
             _maxConcurrentPush = 3; // Fairly arbitrary.
             _flow = flow;
@@ -252,6 +244,8 @@ public sealed partial class SubscriberClientImpl
             // Stop waiting for data to push.
             _pushStopCts.Cancel();
         }
+
+        private LeaseTiming EffectiveLeaseTiming => _exactlyOnceDeliveryEnabled ? _exactlyOnceDeliveryLeaseTiming : _normalLeaseTiming;
 
         private bool IsPushComplete()
         {
@@ -322,7 +316,7 @@ public sealed partial class SubscriberClientImpl
             Task initTask = _pull.WriteAsync(new StreamingPullRequest
             {
                 SubscriptionAsSubscriptionName = _subscriptionName,
-                StreamAckDeadlineSeconds = _exactlyOnceDeliveryEnabled ? _ackDeadlineSecondsForExactlyOnceDelivery : _ackDeadlineSeconds,
+                StreamAckDeadlineSeconds = EffectiveLeaseTiming.AckDeadlineSeconds,
                 MaxOutstandingMessages = _useLegacyFlowControl ? 0 : _flow.MaxOutstandingElementCount,
                 MaxOutstandingBytes = _useLegacyFlowControl ? 0 : _flow.MaxOutstandingByteCount
             });
@@ -616,10 +610,10 @@ public sealed partial class SubscriberClientImpl
                     _eventPush.Set();
                     // Some ids still exist, schedule another extension.
                     // The overall `_maxExtensionDuration` is maintained by passing through the existing `cancellation`.
-                    Add(_scheduler.Delay(_exactlyOnceDeliveryEnabled ? _autoExtendDelayForExactlyOnceDelivery : _autoExtendDelay, _softStopCts.Token), Next(false, () => HandleExtendLease(msgIds, cancellation)));
+                    Add(_scheduler.Delay(EffectiveLeaseTiming.AutoExtendDelay, _softStopCts.Token), Next(false, () => HandleExtendLease(msgIds, cancellation)));
                     // Increment _extendThrottles.
                     _extendThrottleHigh += 1;
-                    Add(_scheduler.Delay(_exactlyOnceDeliveryEnabled ? _extendQueueThrottleIntervalForExactlyOnceDelivery : _extendQueueThrottleInterval, _softStopCts.Token), Next(false, () => _extendThrottleLow += 1));
+                    Add(_scheduler.Delay(EffectiveLeaseTiming.ExtendQueueThrottleInterval, _softStopCts.Token), Next(false, () => _extendThrottleLow += 1));
                 }
                 else
                 {
@@ -672,7 +666,7 @@ public sealed partial class SubscriberClientImpl
             {
                 _pushInFlight += extends.Count;
                 _concurrentPushCount += 1;
-                Task extendTask = _client.ModifyAckDeadlineAsync(_subscriptionName, extends.Select(x => x.Id), _exactlyOnceDeliveryEnabled ? _ackDeadlineSecondsForExactlyOnceDelivery : _ackDeadlineSeconds, _hardStopCts.Token);
+                Task extendTask = _client.ModifyAckDeadlineAsync(_subscriptionName, extends.Select(x => x.Id), EffectiveLeaseTiming.AckDeadlineSeconds, _hardStopCts.Token);
                 Add(extendTask, Next(false, () => HandleAckResponse(extendTask, null, null, extends)));
             }
             if (nacks.Count > 0)


### PR DESCRIPTION
Personally I think this makes everything significantly clearer, but YMMV :)

The auto-extend throttle calculation looks a bit odd to me - which is clearer when it's extracted from everything else. Please check that carefully.