### PR TITLE
feat: Add support for glob pattern storage

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/ListObjectsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/ListObjectsTest.cs
@@ -72,6 +72,17 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
             await AssertObjects(prefix, options, expectedNames.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries));
         }
 
+        [Theory]
+        [InlineData("la*", "large.txt")]
+        [InlineData("a/*.txt", "a/o1.txt", "a/o2.txt")]
+        [InlineData("a/x/*.txt", "a/x/o3.txt", "a/x/o4.txt")]
+        public void MatchGlob(string globPattern, params string[] expectedNames)
+        {
+            var options = new ListObjectsOptions { MatchGlob = globPattern };
+            IEnumerable<Object> actual = _fixture.Client.ListObjects(_fixture.ReadBucket, prefix: null, options);
+            AssertObjectNames(actual, expectedNames);
+        }
+
         [Fact]
         public async Task CancellationTokenRespected()
         {

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/ListObjectsOptionsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/ListObjectsOptionsTest.cs
@@ -35,6 +35,7 @@ namespace Google.Cloud.Storage.V1.Tests
             Assert.Null(request.PageToken);
             Assert.Null(request.StartOffset);
             Assert.Null(request.EndOffset);
+            Assert.Null(request.MatchGlob);
         }
 
         [Fact]
@@ -52,7 +53,8 @@ namespace Google.Cloud.Storage.V1.Tests
                 PageToken = "nextpage",
                 Fields = "items(name),nextPageToken",
                 StartOffset = "start",
-                EndOffset = "end"
+                EndOffset = "end",
+                MatchGlob = "a/*.txt"
             };
             options.ModifyRequest(request);
             Assert.Equal(10, request.MaxResults);
@@ -65,6 +67,7 @@ namespace Google.Cloud.Storage.V1.Tests
             Assert.Equal("items(name),nextPageToken", request.Fields);
             Assert.Equal("start", request.StartOffset);
             Assert.Equal("end", request.EndOffset);
+            Assert.Equal("a/*.txt", request.MatchGlob);
         }
     }
 }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Rest" Version="[4.4.0, 5.0.0)" />
-    <PackageReference Include="Google.Apis.Storage.v1" Version="[1.60.0.2742, 2.0.0.0)" />
+    <PackageReference Include="Google.Apis.Storage.v1" Version="[1.60.0.2981, 2.0.0.0)" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="StorageClient.*.cs">

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/ListObjectsOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/ListObjectsOptions.cs
@@ -57,6 +57,12 @@ namespace Google.Cloud.Storage.V1
         public Projection? Projection { get; set; }
 
         /// <summary>
+        /// A glob pattern used to filter results. See https://cloud.google.com/storage/docs/json_api/v1/objects/list#list-object-glob
+        /// for more details.
+        /// </summary>
+        public string MatchGlob { get; set; }
+
+        /// <summary>
         /// If set, this is the ID of the project which will be billed for the request.
         /// The caller must have suitable permissions for the project being billed.
         /// </summary>
@@ -142,6 +148,10 @@ namespace Google.Cloud.Storage.V1
             if (EndOffset != null)
             {
                 request.EndOffset = EndOffset;
+            }
+            if (MatchGlob != null)
+            {
+                request.MatchGlob = MatchGlob;
             }
         }
     }

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4247,7 +4247,7 @@
       "description": "Recommended Google client library to access the Google Cloud Storage API. It wraps the Google.Apis.Storage.v1 client library, making common operations simpler in client code. Google Cloud Storage stores and retrieves potentially large, immutable data objects.",
       "dependencies": {
         "Google.Api.Gax.Rest": "4.4.0",
-        "Google.Apis.Storage.v1": "1.60.0.2742"
+        "Google.Apis.Storage.v1": "1.60.0.2981"
       },
       "testDependencies": {
         "Google.Api.Gax.Testing": "4.4.0",


### PR DESCRIPTION
Adds support for glob storage in storage ListObjects api. This will resolve https://github.com/googleapis/google-cloud-dotnet/issues/10460.