### PR TITLE
test: Unskip smoke test for Discovery Engine v1

### DIFF
--- a/apis/Google.Cloud.DiscoveryEngine.V1/smoketests.json
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/smoketests.json
@@ -2,7 +2,6 @@
   {
     "method": "ListDocuments",
     "client": "DocumentServiceClient",
-    "skip": "b/284167057",
     "arguments": {
       "parent": "projects/${PROJECT_ID}/locations/global/dataStores/default_data_store/branches/default_branch"
     }

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1856,7 +1856,7 @@
       "shortName": "discoveryengine",
       "serviceConfigFile": "discoveryengine_v1.yaml",
       "restNumericEnums": true,
-      "blockRelease": "Smoke test needs fixing before release"
+      "blockRelease": "API is behind an allow-list"
     },
     {
       "id": "Google.Cloud.DiscoveryEngine.V1Beta",


### PR DESCRIPTION
We're still not ready to release a library, but we can run the test.