### PR TITLE
Release Google.Cloud.Container.V1 version 3.13.0

### DIFF
--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.12.0</Version>
+    <Version>3.13.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.</Description>

--- a/apis/Google.Cloud.Container.V1/docs/history.md
+++ b/apis/Google.Cloud.Container.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 3.13.0, released 2023-06-05
+
+### New features
+
+- Add SoleTenantConfig API ([commit bdcd865](https://github.com/googleapis/google-cloud-dotnet/commit/bdcd8652db405d069f3541d15ae0c07f451ead90))
+
+### Documentation improvements
+
+- Clarified release channel defaulting behavior for create cluster requests when release channel is unspecified ([commit 8f6305d](https://github.com/googleapis/google-cloud-dotnet/commit/8f6305d0207d7b6119b1eaa28473b68f43ef34a9))
+
 ## Version 3.12.0, released 2023-05-11
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1336,7 +1336,7 @@
       "protoPath": "google/container/v1",
       "productName": "Google Kubernetes Engine",
       "productUrl": "https://cloud.google.com/kubernetes-engine/docs/reference/rest/",
-      "version": "3.12.0",
+      "version": "3.13.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Add SoleTenantConfig API ([commit bdcd865](https://github.com/googleapis/google-cloud-dotnet/commit/bdcd8652db405d069f3541d15ae0c07f451ead90))

### Documentation improvements

- Clarified release channel defaulting behavior for create cluster requests when release channel is unspecified ([commit 8f6305d](https://github.com/googleapis/google-cloud-dotnet/commit/8f6305d0207d7b6119b1eaa28473b68f43ef34a9))
