### PR TITLE
Release Google.Cloud.DataCatalog.V1 version 2.4.0

### DIFF
--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.csproj
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Data Catalog API. Data Catalog is a fully managed and highly scalable data discovery and metadata management service.</Description>

--- a/apis/Google.Cloud.DataCatalog.V1/docs/history.md
+++ b/apis/Google.Cloud.DataCatalog.V1/docs/history.md
@@ -1,5 +1,14 @@
 # Version history
 
+## Version 2.4.0, released 2023-06-05
+
+### New features
+
+- Add support for entries associated with Spanner and ClougBigTable ([commit 065b49c](https://github.com/googleapis/google-cloud-dotnet/commit/065b49c46d85cf2a0bbb517f32274669d7eac4d0))
+- Expand SearchCatalogResponse with totalSize ([commit 065b49c](https://github.com/googleapis/google-cloud-dotnet/commit/065b49c46d85cf2a0bbb517f32274669d7eac4d0))
+- Modify documentation for FQN support ([commit 065b49c](https://github.com/googleapis/google-cloud-dotnet/commit/065b49c46d85cf2a0bbb517f32274669d7eac4d0))
+- Extend ImportApiRequest with jobId parameter ([commit 065b49c](https://github.com/googleapis/google-cloud-dotnet/commit/065b49c46d85cf2a0bbb517f32274669d7eac4d0))
+
 ## Version 2.3.0, released 2023-03-20
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1380,7 +1380,7 @@
       "protoPath": "google/cloud/datacatalog/v1",
       "productName": "Data Catalog",
       "productUrl": "https://cloud.google.com/data-catalog/docs",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Data Catalog API. Data Catalog is a fully managed and highly scalable data discovery and metadata management service.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- Add support for entries associated with Spanner and ClougBigTable ([commit 065b49c](https://github.com/googleapis/google-cloud-dotnet/commit/065b49c46d85cf2a0bbb517f32274669d7eac4d0))
- Expand SearchCatalogResponse with totalSize ([commit 065b49c](https://github.com/googleapis/google-cloud-dotnet/commit/065b49c46d85cf2a0bbb517f32274669d7eac4d0))
- Modify documentation for FQN support ([commit 065b49c](https://github.com/googleapis/google-cloud-dotnet/commit/065b49c46d85cf2a0bbb517f32274669d7eac4d0))
- Extend ImportApiRequest with jobId parameter ([commit 065b49c](https://github.com/googleapis/google-cloud-dotnet/commit/065b49c46d85cf2a0bbb517f32274669d7eac4d0))
