### PR TITLE
fix: Makes transactions marked as DisposedBehaviour.Detach actually detach from the session pool.

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/TransactionTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/TransactionTests.cs
@@ -87,6 +87,19 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
         }
 
         [Fact]
+        public async Task DetachOnDisposeTransactionIsDetached()
+        {
+            using var connection = new SpannerConnection(_fixture.ConnectionString);
+            await connection.OpenAsync();
+
+            using var transaction = await connection.BeginTransactionAsync();
+            transaction.DisposeBehavior = DisposeBehavior.Detach;
+
+            // We are testing (through the CommonTestsDiagnostics attribute) that there
+            // are no active sessions or connections after we have disposed of both.
+        }
+
+        [Fact]
         public async Task DisposedTransactionDoesntLeak()
         {
             // This test ensures that a transaction that had neither commit nor rollback called does

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerBatchCommandTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerBatchCommandTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2018 Google LLC
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ namespace Google.Cloud.Spanner.Data.Tests
             var pool = new FakeSessionPool();
             var session = PooledSession.FromSessionName(pool, new SessionName("project", "instance", "database", "session"));
 
-            var transaction = new SpannerTransaction(connection, TransactionMode.ReadWrite, session: session, timestampBound: null);
+            var transaction = new SpannerTransaction(connection, TransactionMode.ReadWrite, session: session, timestampBound: null, isRetriable: false);
             var command = new SpannerBatchCommand(transaction);
 
             Assert.Empty(command.Commands);
@@ -254,6 +254,7 @@ namespace Google.Cloud.Spanner.Data.Tests
             public IClock Clock => SystemClock.Instance;
             public SessionPoolOptions Options { get; } = new SessionPoolOptions();
             public void Release(PooledSession session, ByteString transactionId, bool deleteSession) =>  throw new NotImplementedException();
+            public void Detach(PooledSession session) => throw new NotImplementedException();
 
             public Task<PooledSession> WithFreshTransactionOrNewAsync(PooledSession session, TransactionOptions transactionOptions, CancellationToken cancellationToken) =>
                 throw new NotImplementedException();

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/PooledSessionTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/PooledSessionTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2018 Google LLC
+// Copyright 2018 Google LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -425,6 +425,8 @@ namespace Google.Cloud.Spanner.V1.Tests
                 RolledBackTransaction = transactionToRollback;
                 ReleasedSessionDeleted = deleteSession;
             }
+
+            public void Detach(PooledSession session) => throw new NotImplementedException();
 
             public Task<PooledSession> WithFreshTransactionOrNewAsync(PooledSession session, TransactionOptions transactionOptions, CancellationToken cancellationToken) =>
                 throw new NotImplementedException();

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnection.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnection.cs
@@ -280,7 +280,7 @@ namespace Google.Cloud.Spanner.Data
             ByteString transactionIdBytes = ByteString.FromBase64(transactionId.Id);
             var session = _sessionPool.CreateDetachedSession(sessionName, transactionIdBytes, TransactionOptions.ModeOneofCase.ReadOnly);
             // This transaction is coming from another process potentially, so we don't auto close it.
-            return new SpannerTransaction(this, TransactionMode.ReadOnly, session, transactionId.TimestampBound)
+            return new SpannerTransaction(this, TransactionMode.ReadOnly, session, transactionId.TimestampBound, false)
             {
                 Shared = true,
                 DisposeBehavior = DisposeBehavior.Detach
@@ -863,7 +863,7 @@ namespace Google.Cloud.Spanner.Data
                 {
                     await OpenAsync(cancellationToken).ConfigureAwait(false);
                     var session = await AcquireSessionAsync(transactionOptions, cancellationToken).ConfigureAwait(false);
-                    return new SpannerTransaction(this, transactionMode, session, targetReadTimestamp);
+                    return new SpannerTransaction(this, transactionMode, session, targetReadTimestamp, false);
                 }, "SpannerConnection.BeginTransaction", Logger);
         }
 

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPool.DetachedSessionPool.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPool.DetachedSessionPool.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2018 Google LLC
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -41,6 +41,11 @@ namespace Google.Cloud.Spanner.V1
                 {
                     Parent.DeleteSessionFireAndForget(session);
                 }
+            }
+
+            public override void Detach(PooledSession session)
+            {
+                // No-op: We are already in the detached session pool which doesn't keep track of sessions.
             }
 
             public override Task<PooledSession> WithFreshTransactionOrNewAsync(PooledSession session, TransactionOptions transactionOptions, CancellationToken cancellationToken) =>

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPool.ISessionPool.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPool.ISessionPool.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2018 Google LLC
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,6 +30,14 @@ namespace Google.Cloud.Spanner.V1
             IClock Clock { get; }
             Task<PooledSession> WithFreshTransactionOrNewAsync(PooledSession session, TransactionOptions transactionOptions, CancellationToken cancellationToken);
             void Release(PooledSession session, ByteString transactionToRollback, bool deleteSession);
+            /// <summary>
+            /// Detaches the given session from the pool, meaning the pool stops tracking this session as active,
+            /// but does nothing else, in particular it doesn't return the session to the pool or attempts to delete it.
+            /// </summary>
+            /// <param name="session">The pooled session to be detached. Currently unusued by all <see cref="ISessionPool"/>
+            /// implementations, but that's just an implementation detail: the <see cref="TargetedSessionPool"/> does not
+            /// keep track of active <see cref="PooledSession"/> instances themselves, but only through counters.</param>
+            void Detach(PooledSession session);
             SessionPoolOptions Options { get; }
         }
     }

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPool.SessionPoolBase.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPool.SessionPoolBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2018 Google LLC
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,6 +33,8 @@ namespace Google.Cloud.Spanner.V1
             protected SessionPool Parent { get; }
             public abstract Task<PooledSession> WithFreshTransactionOrNewAsync(PooledSession session, TransactionOptions transactionOptions, CancellationToken cancellationToken);
             public abstract void Release(PooledSession session, ByteString transactionToRollback, bool deleteSession);
+            public abstract void Detach(PooledSession session);
+
             protected SessionPoolBase(SessionPool parent) => Parent = parent;
         }
     }

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPool.TargetedSessionPool.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPool.TargetedSessionPool.cs
@@ -521,6 +521,12 @@ namespace Google.Cloud.Spanner.V1
                 }
             }
 
+            public override void Detach(PooledSession session)
+            {
+                Interlocked.Decrement(ref _activeSessionCount);
+                Interlocked.Decrement(ref _liveOrRequestedSessionCount);
+            }
+
             internal void MaintainPool()
             {
                 if (Shutdown)


### PR DESCRIPTION
The test I added was red before the fix (because of an unexpected active session) and it's now green.

I'm running the rest of the tests locally now.