### PR TITLE
Release Google.Cloud.Kms.Inventory.V1 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.Kms.Inventory.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.Kms.Inventory.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.Kms.Inventory.V1",
-  "release_level": "preview",
+  "release_level": "stable",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Kms.Inventory.V1/latest",
   "library_type": "GAPIC_AUTO",
   "api_shortname": "kmsinventory"

--- a/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.csproj
+++ b/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud KMS Inventory API.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Kms.V1" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Kms.V1" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Kms.Inventory.V1/docs/history.md
+++ b/apis/Google.Cloud.Kms.Inventory.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0, released 2023-06-08
+
+No API surface changes; just dependency updates, and promotion to GA.
+
 ## Version 1.0.0-beta01, released 2023-02-27
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2630,7 +2630,7 @@
     },
     {
       "id": "Google.Cloud.Kms.Inventory.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "KMS Inventory",
       "productUrl": "https://cloud.google.com/kms/docs/",
@@ -2641,7 +2641,9 @@
         "cryptography"
       ],
       "dependencies": {
-        "Google.Cloud.Kms.V1": "3.4.0"
+        "Google.Api.Gax.Grpc": "4.4.0",
+        "Google.Cloud.Kms.V1": "3.5.0",
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/kms/inventory/v1",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates, and promotion to GA.
