### PR TITLE
Release Google.Cloud.AdvisoryNotifications.V1 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.AdvisoryNotifications.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.AdvisoryNotifications.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.AdvisoryNotifications.V1",
-  "release_level": "preview",
+  "release_level": "stable",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.AdvisoryNotifications.V1/latest",
   "library_type": "GAPIC_AUTO",
   "language": "dotnet",

--- a/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.csproj
+++ b/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>An API for accessing Advisory Notifications in Google Cloud</Description>

--- a/apis/Google.Cloud.AdvisoryNotifications.V1/docs/history.md
+++ b/apis/Google.Cloud.AdvisoryNotifications.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0, released 2023-06-12
+
+No API surface changes; just dependency updates and promotion to 1.0.0.
+
 ## Version 1.0.0-beta02, released 2023-04-11
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -110,7 +110,7 @@
     },
     {
       "id": "Google.Cloud.AdvisoryNotifications.V1",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Advisory Notifications",
       "productUrl": "https://cloud.google.com/advisory-notifications/docs/overview",
@@ -121,7 +121,10 @@
         "security",
         "privacy"
       ],
-      "dependencies": {},
+      "dependencies": {
+        "Google.Api.Gax.Grpc": "4.4.0",
+        "Grpc.Core": "2.46.6"
+      },
       "generator": "micro",
       "protoPath": "google/cloud/advisorynotifications/v1",
       "shortName": "advisorynotifications",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates and promotion to 1.0.0.
