### PR TITLE
Release Google.Cloud.AlloyDb.V1 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.AlloyDb.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.AlloyDb.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.AlloyDb.V1",
-  "release_level": "preview",
+  "release_level": "stable",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.AlloyDb.V1/latest",
   "library_type": "GAPIC_AUTO",
   "language": "dotnet",

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.csproj
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AlloyDB API (v1). AlloyDB for PostgreSQL is an open source-compatible database service that provides a powerful option for migrating, modernizing, or building commercial-grade applications.</Description>

--- a/apis/Google.Cloud.AlloyDb.V1/docs/history.md
+++ b/apis/Google.Cloud.AlloyDb.V1/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 1.0.0, released 2023-06-12
+
+Primary purpose of release is to update dependencies and promote to 1.0.0.
+
+### Documentation improvements
+
+- Minor formatting in description of AvailabilityType ([commit fa13762](https://github.com/googleapis/google-cloud-dotnet/commit/fa13762d844bda825fd8caa4473c55c405e0c5b1))
+
 ## Version 1.0.0-beta01, released 2023-03-02
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -130,7 +130,7 @@
     },
     {
       "id": "Google.Cloud.AlloyDb.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "AlloyDB",
       "productUrl": "https://cloud.google.com/alloydb/docs",
@@ -141,9 +141,11 @@
         "database"
       ],
       "dependencies": {
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
-        "Google.LongRunning": "3.0.0"
+        "Google.LongRunning": "3.0.0",
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/alloydb/v1",


### PR DESCRIPTION

Changes in this release:

Primary purpose of release is to update dependencies and promote to 1.0.0.

### Documentation improvements

- Minor formatting in description of AvailabilityType ([commit fa13762](https://github.com/googleapis/google-cloud-dotnet/commit/fa13762d844bda825fd8caa4473c55c405e0c5b1))
