### PR TITLE
Release Google.Cloud.Iam.V2 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.Iam.V2/.repo-metadata.json
+++ b/apis/Google.Cloud.Iam.V2/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.Iam.V2",
-  "release_level": "preview",
+  "release_level": "stable",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Iam.V2/latest",
   "library_type": "GAPIC_AUTO",
   "language": "dotnet",

--- a/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.csproj
+++ b/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud IAM API (v2) which manages identity and access control for Google Cloud Platform resources, including the creation of service accounts, which you can use to authenticate to Google and make API calls.</Description>

--- a/apis/Google.Cloud.Iam.V2/docs/history.md
+++ b/apis/Google.Cloud.Iam.V2/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0, released 2023-06-12
+
+No API surface changes; just dependency updates and promotion to 1.0.0.
+
 ## Version 1.0.0-beta02, released 2023-01-16
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2536,7 +2536,7 @@
     },
     {
       "id": "Google.Cloud.Iam.V2",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Google Cloud Identity and Access Management (IAM)",
       "productUrl": "https://cloud.google.com/iam/",
@@ -2547,7 +2547,9 @@
         "Access"
       ],
       "dependencies": {
-        "Google.LongRunning": "3.0.0"
+        "Google.Api.Gax.Grpc": "4.4.0",
+        "Google.LongRunning": "3.0.0",
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/iam/v2",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates and promotion to 1.0.0.
