### PR TITLE
Release Google.Cloud.PubSub.V1 version 3.6.0

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.6.0-beta01</Version>
+    <Version>3.6.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.</Description>

--- a/apis/Google.Cloud.PubSub.V1/docs/history.md
+++ b/apis/Google.Cloud.PubSub.V1/docs/history.md
@@ -1,5 +1,21 @@
 # Version history
 
+## Version 3.6.0, released 2023-06-12
+
+### Bug fixes
+
+- Correct the auto-extend lease interval for exactly-once delivery. ([commit c33999d](https://github.com/googleapis/google-cloud-dotnet/commit/c33999d4bed6d7777bd1d1e4bc019d67448ce844))
+- Dispose the pull stream. ([commit 3518402](https://github.com/googleapis/google-cloud-dotnet/commit/351840238416353db7a87431ac2f8687537c9352))
+
+### New features
+
+- Add push config wrapper fields ([commit 1cdef74](https://github.com/googleapis/google-cloud-dotnet/commit/1cdef749b46a406e6abea44001db68b9276c338d))
+- Add support for Publisher Compression. ([commit e684e05](https://github.com/googleapis/google-cloud-dotnet/commit/e684e05a21cd47042f05b4f4662611e13632bef9))
+
+### Documentation improvements
+
+- Clarify the use of FlowControlSettings in SusbcriberClient. ([commit 7081baf](https://github.com/googleapis/google-cloud-dotnet/commit/7081baf1a5b95aaaa09d513fe380208f8e039c57))
+
 ## Version 3.6.0-beta01, released 2023-05-16
 
 Note that this is a beta release as the deadlock workaround for

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3487,7 +3487,7 @@
       "protoPath": "google/pubsub/v1",
       "productName": "Cloud Pub/Sub",
       "productUrl": "https://cloud.google.com/pubsub/",
-      "version": "3.6.0-beta01",
+      "version": "3.6.0",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Correct the auto-extend lease interval for exactly-once delivery. ([commit c33999d](https://github.com/googleapis/google-cloud-dotnet/commit/c33999d4bed6d7777bd1d1e4bc019d67448ce844))
- Dispose the pull stream. ([commit 3518402](https://github.com/googleapis/google-cloud-dotnet/commit/351840238416353db7a87431ac2f8687537c9352))

### New features

- Add push config wrapper fields ([commit 1cdef74](https://github.com/googleapis/google-cloud-dotnet/commit/1cdef749b46a406e6abea44001db68b9276c338d))
- Add support for Publisher Compression. ([commit e684e05](https://github.com/googleapis/google-cloud-dotnet/commit/e684e05a21cd47042f05b4f4662611e13632bef9))

### Documentation improvements

- Clarify the use of FlowControlSettings in SusbcriberClient. ([commit 7081baf](https://github.com/googleapis/google-cloud-dotnet/commit/7081baf1a5b95aaaa09d513fe380208f8e039c57))
