### PR TITLE
Release Google.Cloud.StorageInsights.V1 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.StorageInsights.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.StorageInsights.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.StorageInsights.V1",
-  "release_level": "preview",
+  "release_level": "stable",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.StorageInsights.V1/latest",
   "library_type": "GAPIC_AUTO",
   "language": "dotnet",

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.csproj
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Storage Insights API, which helps you manage your object storage at scale.</Description>

--- a/apis/Google.Cloud.StorageInsights.V1/docs/history.md
+++ b/apis/Google.Cloud.StorageInsights.V1/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 1.0.0, released 2023-06-12
+
+Primary purpose of release is to update dependencies and promote to 1.0.0.
+
+### Documentation improvements
+
+- Minor formatting in docstring ([commit e38ec2d](https://github.com/googleapis/google-cloud-dotnet/commit/e38ec2db7db5e575744350f6effcd1e4c302ca65))
+
 ## Version 1.0.0-beta01, released 2023-04-19
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4283,7 +4283,7 @@
     },
     {
       "id": "Google.Cloud.StorageInsights.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Google Cloud Storage Insights",
       "productUrl": "https://cloud.google.com/storage/docs/insights/inventory-reports",
@@ -4294,8 +4294,10 @@
         "reporting"
       ],
       "dependencies": {
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Location": "2.0.0",
-        "Google.LongRunning": "3.0.0"
+        "Google.LongRunning": "3.0.0",
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/storageinsights/v1",


### PR DESCRIPTION

Changes in this release:

Primary purpose of the release is promotion to 1.0.0.

- Minor formatting in docstring ([commit e38ec2d](https://github.com/googleapis/google-cloud-dotnet/commit/e38ec2db7db5e575744350f6effcd1e4c302ca65))
