### PR TITLE
Release Google.Geo.Type version 1.0.0

### DIFF
--- a/apis/Google.Geo.Type/.repo-metadata.json
+++ b/apis/Google.Geo.Type/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Geo.Type",
-  "release_level": "preview",
+  "release_level": "stable",
   "client_documentation": "https://googleapis.dev/dotnet/Google.Geo.Type/latest",
   "library_type": "OTHER",
   "language": "dotnet"

--- a/apis/Google.Geo.Type/Google.Geo.Type/Google.Geo.Type.csproj
+++ b/apis/Google.Geo.Type/Google.Geo.Type/Google.Geo.Type.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Version-agnostic types for Geo APIs.</Description>

--- a/apis/Google.Geo.Type/docs/history.md
+++ b/apis/Google.Geo.Type/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0, released 2023-06-12
+
+No API surface changes; just dependency updates and promotion to 1.0.0.
+
 ## Version 1.0.0-beta01, released 2022-08-03
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4960,7 +4960,7 @@
     },
     {
       "id": "Google.Geo.Type",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0",
       "targetFrameworks": "netstandard2.1;net462",
       "type": "other",
       "description": "Version-agnostic types for Geo APIs.",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates and promotion to 1.0.0.
