### PR TITLE
Release Google.Cloud.Iot.V1 version 2.2.0

### DIFF
--- a/apis/Google.Cloud.Iot.V1/Google.Cloud.Iot.V1/Google.Cloud.Iot.V1.csproj
+++ b/apis/Google.Cloud.Iot.V1/Google.Cloud.Iot.V1/Google.Cloud.Iot.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud IoT API, which registers and manages IoT devices that connect to the Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Iot.V1/docs/history.md
+++ b/apis/Google.Cloud.Iot.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 2.2.0, released 2023-06-15
+
+No API surface changes; just dependency updates.
+
 ## Version 2.1.0, released 2023-01-19
 
 ### New features

--- a/apis/Google.Cloud.Iot.V1/docs/index.md
+++ b/apis/Google.Cloud.Iot.V1/docs/index.md
@@ -2,14 +2,12 @@
 
 {{description}}
 
-{{version}}
+The Google IoT Core service is officially deprecated, with a
+retirement date of August 16th 2023. Contact your Google Cloud
+account team for more information.
 
-{{installation}}
-
-{{auth}}
-
-## Getting started
-
-{{client-classes}}
-
-{{client-construction}}
+The Google.Cloud.IoT.V1 library is delisted from NuGet, and the
+source code removed from the google-cloud-dotnet repository. Any
+projects that depend on Google.Cloud.Debugger.V2 will still be able
+to restore that dependency, but the package won't be shown in search
+results on nuget.org.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2642,7 +2642,7 @@
     },
     {
       "id": "Google.Cloud.Iot.V1",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "type": "grpc",
       "productName": "Cloud IoT",
       "productUrl": "https://cloud.google.com/iot/docs/reference/cloudiot/rest",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
