### PR TITLE
Release Google.Cloud.AlloyDb.V1 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.csproj
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AlloyDB API (v1). AlloyDB for PostgreSQL is an open source-compatible database service that provides a powerful option for migrating, modernizing, or building commercial-grade applications.</Description>

--- a/apis/Google.Cloud.AlloyDb.V1/docs/history.md
+++ b/apis/Google.Cloud.AlloyDb.V1/docs/history.md
@@ -1,5 +1,19 @@
 # Version history
 
+## Version 1.1.0, released 2023-06-20
+
+### Bug fixes
+
+- Deprecated SSL modes SSL_MODE_ALLOW, SSL_MODE_REQUIRE, SSL_MODE_VERIFY_CA ([commit debc17d](https://github.com/googleapis/google-cloud-dotnet/commit/debc17db6a30676abaee3175bde76105bf4c6eb2))
+
+### New features
+
+- Added new SSL modes ALLOW_UNENCRYPTED_AND_ENCRYPTED, ENCRYPTED_ONLY ([commit debc17d](https://github.com/googleapis/google-cloud-dotnet/commit/debc17db6a30676abaee3175bde76105bf4c6eb2))
+- Added support for continuous backups ([commit debc17d](https://github.com/googleapis/google-cloud-dotnet/commit/debc17db6a30676abaee3175bde76105bf4c6eb2))
+- Added support for cross-region replication (secondary clusters/instances and promotion) ([commit debc17d](https://github.com/googleapis/google-cloud-dotnet/commit/debc17db6a30676abaee3175bde76105bf4c6eb2))
+- Added users API ([commit debc17d](https://github.com/googleapis/google-cloud-dotnet/commit/debc17db6a30676abaee3175bde76105bf4c6eb2))
+- Added fault injection API ([commit debc17d](https://github.com/googleapis/google-cloud-dotnet/commit/debc17db6a30676abaee3175bde76105bf4c6eb2))
+
 ## Version 1.0.0, released 2023-06-12
 
 Primary purpose of release is to update dependencies and promote to 1.0.0.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -133,7 +133,7 @@
     },
     {
       "id": "Google.Cloud.AlloyDb.V1",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "grpc",
       "productName": "AlloyDB",
       "productUrl": "https://cloud.google.com/alloydb/docs",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Deprecated SSL modes SSL_MODE_ALLOW, SSL_MODE_REQUIRE, SSL_MODE_VERIFY_CA ([commit debc17d](https://github.com/googleapis/google-cloud-dotnet/commit/debc17db6a30676abaee3175bde76105bf4c6eb2))

### New features

- Added new SSL modes ALLOW_UNENCRYPTED_AND_ENCRYPTED, ENCRYPTED_ONLY ([commit debc17d](https://github.com/googleapis/google-cloud-dotnet/commit/debc17db6a30676abaee3175bde76105bf4c6eb2))
- Added support for continuous backups ([commit debc17d](https://github.com/googleapis/google-cloud-dotnet/commit/debc17db6a30676abaee3175bde76105bf4c6eb2))
- Added support for cross-region replication (secondary clusters/instances and promotion) ([commit debc17d](https://github.com/googleapis/google-cloud-dotnet/commit/debc17db6a30676abaee3175bde76105bf4c6eb2))
- Added users API ([commit debc17d](https://github.com/googleapis/google-cloud-dotnet/commit/debc17db6a30676abaee3175bde76105bf4c6eb2))
- Added fault injection API ([commit debc17d](https://github.com/googleapis/google-cloud-dotnet/commit/debc17db6a30676abaee3175bde76105bf4c6eb2))
