### PR TITLE
Release Google.Cloud.AlloyDb.V1Alpha version 1.0.0-alpha02

### DIFF
--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.csproj
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha01</Version>
+    <Version>1.0.0-alpha02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AlloyDB API (v1alpha). AlloyDB for PostgreSQL is an open source-compatible database service that provides a powerful option for migrating, modernizing, or building commercial-grade applications.</Description>

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/docs/history.md
@@ -1,5 +1,24 @@
 # Version history
 
+## Version 1.0.0-alpha02, released 2023-06-20
+
+### Bug fixes
+
+- Deprecated SSL modes SSL_MODE_ALLOW, SSL_MODE_REQUIRE, SSL_MODE_VERIFY_CA ([commit 027919d](https://github.com/googleapis/google-cloud-dotnet/commit/027919d2b913857478708237864a70ac3ba92195))
+
+### New features
+
+- Added ClusterView supporting more granular view of continuous backups ([commit 027919d](https://github.com/googleapis/google-cloud-dotnet/commit/027919d2b913857478708237864a70ac3ba92195))
+- Added new SSL modes ALLOW_UNENCRYPTED_AND_ENCRYPTED, ENCRYPTED_ONLY ([commit 027919d](https://github.com/googleapis/google-cloud-dotnet/commit/027919d2b913857478708237864a70ac3ba92195))
+- Added users API ([commit 027919d](https://github.com/googleapis/google-cloud-dotnet/commit/027919d2b913857478708237864a70ac3ba92195))
+- Added fault injection API ([commit 027919d](https://github.com/googleapis/google-cloud-dotnet/commit/027919d2b913857478708237864a70ac3ba92195))
+- Added instance update policy ([commit 027919d](https://github.com/googleapis/google-cloud-dotnet/commit/027919d2b913857478708237864a70ac3ba92195))
+- Added cluster network config ([commit 027919d](https://github.com/googleapis/google-cloud-dotnet/commit/027919d2b913857478708237864a70ac3ba92195))
+
+### Documentation improvements
+
+- Minor formatting in description of AvailabilityType ([commit 324516f](https://github.com/googleapis/google-cloud-dotnet/commit/324516f3b1e3284afeb1f18f265a89c592aea2ff))
+
 ## Version 1.0.0-alpha01, released 2023-03-01
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -158,7 +158,7 @@
     },
     {
       "id": "Google.Cloud.AlloyDb.V1Alpha",
-      "version": "1.0.0-alpha01",
+      "version": "1.0.0-alpha02",
       "type": "grpc",
       "productName": "AlloyDB",
       "productUrl": "https://cloud.google.com/alloydb/docs",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Deprecated SSL modes SSL_MODE_ALLOW, SSL_MODE_REQUIRE, SSL_MODE_VERIFY_CA ([commit 027919d](https://github.com/googleapis/google-cloud-dotnet/commit/027919d2b913857478708237864a70ac3ba92195))

### New features

- Added ClusterView supporting more granular view of continuous backups ([commit 027919d](https://github.com/googleapis/google-cloud-dotnet/commit/027919d2b913857478708237864a70ac3ba92195))
- Added new SSL modes ALLOW_UNENCRYPTED_AND_ENCRYPTED, ENCRYPTED_ONLY ([commit 027919d](https://github.com/googleapis/google-cloud-dotnet/commit/027919d2b913857478708237864a70ac3ba92195))
- Added users API ([commit 027919d](https://github.com/googleapis/google-cloud-dotnet/commit/027919d2b913857478708237864a70ac3ba92195))
- Added fault injection API ([commit 027919d](https://github.com/googleapis/google-cloud-dotnet/commit/027919d2b913857478708237864a70ac3ba92195))
- Added instance update policy ([commit 027919d](https://github.com/googleapis/google-cloud-dotnet/commit/027919d2b913857478708237864a70ac3ba92195))
- Added cluster network config ([commit 027919d](https://github.com/googleapis/google-cloud-dotnet/commit/027919d2b913857478708237864a70ac3ba92195))

### Documentation improvements

- Minor formatting in description of AvailabilityType ([commit 324516f](https://github.com/googleapis/google-cloud-dotnet/commit/324516f3b1e3284afeb1f18f265a89c592aea2ff))
