### PR TITLE
Release Google.Cloud.AlloyDb.V1Beta version 1.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.csproj
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AlloyDB API (v1beta). AlloyDB for PostgreSQL is an open source-compatible database service that provides a powerful option for migrating, modernizing, or building commercial-grade applications.</Description>

--- a/apis/Google.Cloud.AlloyDb.V1Beta/docs/history.md
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/docs/history.md
@@ -1,5 +1,24 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2023-06-20
+
+### Bug fixes
+
+- Deprecated SSL modes SSL_MODE_ALLOW, SSL_MODE_REQUIRE, SSL_MODE_VERIFY_CA ([commit a839416](https://github.com/googleapis/google-cloud-dotnet/commit/a839416ee1a6572e3c0fb71b57c277d71dcfb424))
+
+### New features
+
+- Added ClusterView supporting more granular view of continuous backups ([commit a839416](https://github.com/googleapis/google-cloud-dotnet/commit/a839416ee1a6572e3c0fb71b57c277d71dcfb424))
+- Added new SSL modes ALLOW_UNENCRYPTED_AND_ENCRYPTED, ENCRYPTED_ONLY ([commit a839416](https://github.com/googleapis/google-cloud-dotnet/commit/a839416ee1a6572e3c0fb71b57c277d71dcfb424))
+- Added users API ([commit a839416](https://github.com/googleapis/google-cloud-dotnet/commit/a839416ee1a6572e3c0fb71b57c277d71dcfb424))
+- Added fault injection API ([commit a839416](https://github.com/googleapis/google-cloud-dotnet/commit/a839416ee1a6572e3c0fb71b57c277d71dcfb424))
+- Added instance update policy ([commit a839416](https://github.com/googleapis/google-cloud-dotnet/commit/a839416ee1a6572e3c0fb71b57c277d71dcfb424))
+- Added cluster network config ([commit a839416](https://github.com/googleapis/google-cloud-dotnet/commit/a839416ee1a6572e3c0fb71b57c277d71dcfb424))
+
+### Documentation improvements
+
+- Minor formatting in description of AvailabilityType ([commit 460b883](https://github.com/googleapis/google-cloud-dotnet/commit/460b88319a026f0a3e9da6a21880b1fb0dbf3731))
+
 ## Version 1.0.0-beta01, released 2023-03-02
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -181,7 +181,7 @@
     },
     {
       "id": "Google.Cloud.AlloyDb.V1Beta",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "AlloyDB",
       "productUrl": "https://cloud.google.com/alloydb/docs",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Deprecated SSL modes SSL_MODE_ALLOW, SSL_MODE_REQUIRE, SSL_MODE_VERIFY_CA ([commit a839416](https://github.com/googleapis/google-cloud-dotnet/commit/a839416ee1a6572e3c0fb71b57c277d71dcfb424))

### New features

- Added ClusterView supporting more granular view of continuous backups ([commit a839416](https://github.com/googleapis/google-cloud-dotnet/commit/a839416ee1a6572e3c0fb71b57c277d71dcfb424))
- Added new SSL modes ALLOW_UNENCRYPTED_AND_ENCRYPTED, ENCRYPTED_ONLY ([commit a839416](https://github.com/googleapis/google-cloud-dotnet/commit/a839416ee1a6572e3c0fb71b57c277d71dcfb424))
- Added users API ([commit a839416](https://github.com/googleapis/google-cloud-dotnet/commit/a839416ee1a6572e3c0fb71b57c277d71dcfb424))
- Added fault injection API ([commit a839416](https://github.com/googleapis/google-cloud-dotnet/commit/a839416ee1a6572e3c0fb71b57c277d71dcfb424))
- Added instance update policy ([commit a839416](https://github.com/googleapis/google-cloud-dotnet/commit/a839416ee1a6572e3c0fb71b57c277d71dcfb424))
- Added cluster network config ([commit a839416](https://github.com/googleapis/google-cloud-dotnet/commit/a839416ee1a6572e3c0fb71b57c277d71dcfb424))

### Documentation improvements

- Minor formatting in description of AvailabilityType ([commit 460b883](https://github.com/googleapis/google-cloud-dotnet/commit/460b88319a026f0a3e9da6a21880b1fb0dbf3731))
