### PR TITLE
Release Google.Cloud.Batch.V1 version 2.2.0

### DIFF
--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.csproj
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Batch API (v1), which allows you to manage the running of batch jobs on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Batch.V1/docs/history.md
+++ b/apis/Google.Cloud.Batch.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 2.2.0, released 2023-06-20
+
+### New features
+
+- Add support for scheduling_policy ([commit 051cc0d](https://github.com/googleapis/google-cloud-dotnet/commit/051cc0dacb387fe65863e9c94ec4afaf27733539))
+
+### Documentation improvements
+
+- Minor clarifications for TaskGroup and min_cpu_platform ([commit 051cc0d](https://github.com/googleapis/google-cloud-dotnet/commit/051cc0dacb387fe65863e9c94ec4afaf27733539))
+
 ## Version 2.1.0, released 2023-05-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -550,7 +550,7 @@
     },
     {
       "id": "Google.Cloud.Batch.V1",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "type": "grpc",
       "productName": "Batch",
       "productUrl": "https://cloud.google.com/batch/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add support for scheduling_policy ([commit 051cc0d](https://github.com/googleapis/google-cloud-dotnet/commit/051cc0dacb387fe65863e9c94ec4afaf27733539))

### Documentation improvements

- Minor clarifications for TaskGroup and min_cpu_platform ([commit 051cc0d](https://github.com/googleapis/google-cloud-dotnet/commit/051cc0dacb387fe65863e9c94ec4afaf27733539))
