### PR TITLE
Release Google.Cloud.Batch.V1Alpha version 1.0.0-alpha12

### DIFF
--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.csproj
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha11</Version>
+    <Version>1.0.0-alpha12</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Batch API (v1alpha), which allows you to manage the running of batch jobs on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Batch.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.Batch.V1Alpha/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 1.0.0-alpha12, released 2023-06-20
+
+### New features
+
+- Implement minCpuPlatform ([commit 6fcb3d6](https://github.com/googleapis/google-cloud-dotnet/commit/6fcb3d6168fd713196ffaf82a16af61684111e2e))
+- Enable scheduling_policy in v1 ([commit 6fcb3d6](https://github.com/googleapis/google-cloud-dotnet/commit/6fcb3d6168fd713196ffaf82a16af61684111e2e))
+- Update TaskGroup doc ([commit 6fcb3d6](https://github.com/googleapis/google-cloud-dotnet/commit/6fcb3d6168fd713196ffaf82a16af61684111e2e))
+
 ## Version 1.0.0-alpha11, released 2023-05-26
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -574,7 +574,7 @@
     },
     {
       "id": "Google.Cloud.Batch.V1Alpha",
-      "version": "1.0.0-alpha11",
+      "version": "1.0.0-alpha12",
       "type": "grpc",
       "productName": "Batch",
       "productUrl": "https://cloud.google.com/batch/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Implement minCpuPlatform ([commit 6fcb3d6](https://github.com/googleapis/google-cloud-dotnet/commit/6fcb3d6168fd713196ffaf82a16af61684111e2e))
- Enable scheduling_policy in v1 ([commit 6fcb3d6](https://github.com/googleapis/google-cloud-dotnet/commit/6fcb3d6168fd713196ffaf82a16af61684111e2e))
- Update TaskGroup doc ([commit 6fcb3d6](https://github.com/googleapis/google-cloud-dotnet/commit/6fcb3d6168fd713196ffaf82a16af61684111e2e))
