### PR TITLE
Release Google.Cloud.Channel.V1 version 2.8.0

### DIFF
--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.csproj
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.7.0</Version>
+    <Version>2.8.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Channel API, which enables Google Cloud resellers and distributors to manage their customers, channel partners, entitlements and reports.</Description>

--- a/apis/Google.Cloud.Channel.V1/docs/history.md
+++ b/apis/Google.Cloud.Channel.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.8.0, released 2023-06-20
+
+### New features
+
+- Add support for ListSkuGroups and ListSkuGroupBillableSkus APIs in Cloud Channel APIs ([commit 4c49e69](https://github.com/googleapis/google-cloud-dotnet/commit/4c49e69eb380cb8346a6db5291bc71c1913b551d))
+
 ## Version 2.7.0, released 2023-05-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1145,7 +1145,7 @@
     },
     {
       "id": "Google.Cloud.Channel.V1",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "type": "grpc",
       "productName": "Cloud Channel",
       "productUrl": "https://cloud.google.com/channel/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add support for ListSkuGroups and ListSkuGroupBillableSkus APIs in Cloud Channel APIs ([commit 4c49e69](https://github.com/googleapis/google-cloud-dotnet/commit/4c49e69eb380cb8346a6db5291bc71c1913b551d))
