### PR TITLE
Release Google.Cloud.Dialogflow.Cx.V3 version 2.8.0

### DIFF
--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.csproj
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.7.0</Version>
+    <Version>2.8.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Builds conversational interfaces (for example, chatbots, and voice-powered apps and devices).</Description>

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/docs/history.md
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 2.8.0, released 2023-06-20
+
+### New features
+
+- Added include_bigquery_export_settings to ExportAgentRequest ([commit d127ca2](https://github.com/googleapis/google-cloud-dotnet/commit/d127ca2ad19c6b3ececae30e974220d308925d17))
+- Added session_ttl to SessionProto ([commit d127ca2](https://github.com/googleapis/google-cloud-dotnet/commit/d127ca2ad19c6b3ececae30e974220d308925d17))
+- Add support for flexible webhook ([commit 79c2a12](https://github.com/googleapis/google-cloud-dotnet/commit/79c2a127df990fdf14ae8657fc7e16dd2321acbf))
+
+### Documentation improvements
+
+- Update synthesize speech configs's documentation ([commit 79c2a12](https://github.com/googleapis/google-cloud-dotnet/commit/79c2a127df990fdf14ae8657fc7e16dd2321acbf))
+
 ## Version 2.7.0, released 2023-05-11
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1798,7 +1798,7 @@
     },
     {
       "id": "Google.Cloud.Dialogflow.Cx.V3",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "type": "grpc",
       "productName": "Dialogflow",
       "productUrl": "https://cloud.google.com/dialogflow/cx/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Added include_bigquery_export_settings to ExportAgentRequest ([commit d127ca2](https://github.com/googleapis/google-cloud-dotnet/commit/d127ca2ad19c6b3ececae30e974220d308925d17))
- Added session_ttl to SessionProto ([commit d127ca2](https://github.com/googleapis/google-cloud-dotnet/commit/d127ca2ad19c6b3ececae30e974220d308925d17))
- Add support for flexible webhook ([commit 79c2a12](https://github.com/googleapis/google-cloud-dotnet/commit/79c2a127df990fdf14ae8657fc7e16dd2321acbf))

### Documentation improvements

- Update synthesize speech configs's documentation ([commit 79c2a12](https://github.com/googleapis/google-cloud-dotnet/commit/79c2a127df990fdf14ae8657fc7e16dd2321acbf))
