### PR TITLE
Release Google.Cloud.DiscoveryEngine.V1Beta version 1.0.0-beta06

### DIFF
--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.csproj
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta05</Version>
+    <Version>1.0.0-beta06</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Discovery Engine API (v1beta). Discovery Engine powers high-quality content recommendations on your digital properties for Discovery for Media.</Description>

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/docs/history.md
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 1.0.0-beta06, released 2023-06-20
+
+### New features
+
+- Support extractive content in search ([commit 46a0119](https://github.com/googleapis/google-cloud-dotnet/commit/46a011957e2fa931c9cec6c04371c9dbf95443f0))
+- Add redirected uri in search response ([commit 46a0119](https://github.com/googleapis/google-cloud-dotnet/commit/46a011957e2fa931c9cec6c04371c9dbf95443f0))
+- Support docx/pptx/txt/csv in allowed data format ([commit 46a0119](https://github.com/googleapis/google-cloud-dotnet/commit/46a011957e2fa931c9cec6c04371c9dbf95443f0))
+
+### Documentation improvements
+
+- Keep the API doc up-to-date with recent changes ([commit 46a0119](https://github.com/googleapis/google-cloud-dotnet/commit/46a011957e2fa931c9cec6c04371c9dbf95443f0))
+
 ## Version 1.0.0-beta05, released 2023-05-26
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1890,7 +1890,7 @@
     },
     {
       "id": "Google.Cloud.DiscoveryEngine.V1Beta",
-      "version": "1.0.0-beta05",
+      "version": "1.0.0-beta06",
       "type": "grpc",
       "productName": "Discovery Engine",
       "productUrl": "https://cloud.google.com/discovery-engine/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Support extractive content in search ([commit 46a0119](https://github.com/googleapis/google-cloud-dotnet/commit/46a011957e2fa931c9cec6c04371c9dbf95443f0))
- Add redirected uri in search response ([commit 46a0119](https://github.com/googleapis/google-cloud-dotnet/commit/46a011957e2fa931c9cec6c04371c9dbf95443f0))
- Support docx/pptx/txt/csv in allowed data format ([commit 46a0119](https://github.com/googleapis/google-cloud-dotnet/commit/46a011957e2fa931c9cec6c04371c9dbf95443f0))

### Documentation improvements

- Keep the API doc up-to-date with recent changes ([commit 46a0119](https://github.com/googleapis/google-cloud-dotnet/commit/46a011957e2fa931c9cec6c04371c9dbf95443f0))
