### PR TITLE
Release Google.Cloud.Orchestration.Airflow.Service.V1 version 2.4.0

### DIFF
--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.csproj
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Cloud Composer API, which manages Apache Airflow environments on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/docs/history.md
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.4.0, released 2023-06-20
+
+### New features
+
+- Added RPCs StopAirflowCommand, ExecuteAirflowCommand, PollAirflowCommand, DatabaseFailover, FetchDatabaseProperties ([commit 2e644b4](https://github.com/googleapis/google-cloud-dotnet/commit/2e644b42c98e20244cf95921f1ef074a4f469b42))
+
 ## Version 2.3.0, released 2023-05-03
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3232,7 +3232,7 @@
     },
     {
       "id": "Google.Cloud.Orchestration.Airflow.Service.V1",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "type": "grpc",
       "productName": "Cloud Composer",
       "productUrl": "https://cloud.google.com/composer/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Added RPCs StopAirflowCommand, ExecuteAirflowCommand, PollAirflowCommand, DatabaseFailover, FetchDatabaseProperties ([commit 2e644b4](https://github.com/googleapis/google-cloud-dotnet/commit/2e644b42c98e20244cf95921f1ef074a4f469b42))
