### PR TITLE
Release Google.Cloud.VmwareEngine.V1 version 1.0.0-beta03

### DIFF
--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.csproj
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google VMware Engine API, which lets you programmatically manage VMware environments.</Description>

--- a/apis/Google.Cloud.VmwareEngine.V1/docs/history.md
+++ b/apis/Google.Cloud.VmwareEngine.V1/docs/history.md
@@ -1,5 +1,14 @@
 # Version history
 
+## Version 1.0.0-beta03, released 2023-06-20
+
+### New features
+
+- Adding private connection CRUD, updating management subnets and time-limited PC features ([commit 9a97ef1](https://github.com/googleapis/google-cloud-dotnet/commit/9a97ef14b85a0d530641bf033f55139af723a5c3))
+
+### Documentation improvements
+
+- **BREAKING CHANGE** Resource proto messages moved to new file ([commit 5b94a10](https://github.com/googleapis/google-cloud-dotnet/commit/5b94a10aea6bf2d7f9e874e16ad02637bc586bb3))
 ## Version 1.0.0-beta02, released 2023-01-19
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4743,7 +4743,7 @@
     },
     {
       "id": "Google.Cloud.VmwareEngine.V1",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0-beta03",
       "type": "grpc",
       "productName": "VMware Engine",
       "productUrl": "https://cloud.google.com/vmware-engine/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Adding private connection CRUD, updating management subnets and time-limited PC features ([commit 9a97ef1](https://github.com/googleapis/google-cloud-dotnet/commit/9a97ef14b85a0d530641bf033f55139af723a5c3))

### Documentation improvements

- **BREAKING CHANGE** Resource proto messages moved to new file ([commit 5b94a10](https://github.com/googleapis/google-cloud-dotnet/commit/5b94a10aea6bf2d7f9e874e16ad02637bc586bb3))
