### PR TITLE
Release Google.Analytics.Admin.V1Alpha version 2.0.0-alpha10

### DIFF
--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha09</Version>
+    <Version>2.0.0-alpha10</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Analytics Admin API (v1alpha)</Description>

--- a/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
+++ b/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 2.0.0-alpha10, released 2023-06-27
+
+### New features
+
+- Update the `default_uri` field of the `WebStreamData` type to be mutable ([commit e8c8b20](https://github.com/googleapis/google-cloud-dotnet/commit/e8c8b209240faca77da8e750e2feb15b01155982))
+- Add the `ads_web_conversion_data_export_scope` field to the `ReportingAttributionModel` type ([commit e8c8b20](https://github.com/googleapis/google-cloud-dotnet/commit/e8c8b209240faca77da8e750e2feb15b01155982))
+- Add `AdsWebConversionDataExportScope` enum to the Admin API v1alpha ([commit e8c8b20](https://github.com/googleapis/google-cloud-dotnet/commit/e8c8b209240faca77da8e750e2feb15b01155982))
+
+### Documentation improvements
+
+- Announce the deprecation of first-click, linear, time-decay and position-based attribution models ([commit e8c8b20](https://github.com/googleapis/google-cloud-dotnet/commit/e8c8b209240faca77da8e750e2feb15b01155982))
+
 ## Version 2.0.0-alpha09, released 2023-05-16
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2,7 +2,7 @@
   "apis": [
     {
       "id": "Google.Analytics.Admin.V1Alpha",
-      "version": "2.0.0-alpha09",
+      "version": "2.0.0-alpha10",
       "type": "grpc",
       "productName": "Analytics Admin",
       "productUrl": "https://developers.google.com/analytics",


### PR DESCRIPTION

Changes in this release:

### New features

- Update the `default_uri` field of the `WebStreamData` type to be mutable ([commit e8c8b20](https://github.com/googleapis/google-cloud-dotnet/commit/e8c8b209240faca77da8e750e2feb15b01155982))
- Add the `ads_web_conversion_data_export_scope` field to the `ReportingAttributionModel` type ([commit e8c8b20](https://github.com/googleapis/google-cloud-dotnet/commit/e8c8b209240faca77da8e750e2feb15b01155982))
- Add `AdsWebConversionDataExportScope` enum to the Admin API v1alpha ([commit e8c8b20](https://github.com/googleapis/google-cloud-dotnet/commit/e8c8b209240faca77da8e750e2feb15b01155982))

### Documentation improvements

- Announce the deprecation of first-click, linear, time-decay and position-based attribution models ([commit e8c8b20](https://github.com/googleapis/google-cloud-dotnet/commit/e8c8b209240faca77da8e750e2feb15b01155982))
