### PR TITLE
Release Google.Cloud.Deploy.V1 version 2.6.0

### DIFF
--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.csproj
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.5.0</Version>
+    <Version>2.6.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Deploy API, which automates delivery of your applications to a series of target environments in a defined sequence.</Description>

--- a/apis/Google.Cloud.Deploy.V1/docs/history.md
+++ b/apis/Google.Cloud.Deploy.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.6.0, released 2023-06-27
+
+### New features
+
+- Add deploy parameters for cloud deploy ([commit 09b648f](https://github.com/googleapis/google-cloud-dotnet/commit/09b648f9964573de91bb23b2da17d788174b3242))
+
 ## Version 2.5.0, released 2023-06-20
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1676,7 +1676,7 @@
     },
     {
       "id": "Google.Cloud.Deploy.V1",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "type": "grpc",
       "productName": "Google Cloud Deploy",
       "productUrl": "https://cloud.google.com/deploy/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add deploy parameters for cloud deploy ([commit 09b648f](https://github.com/googleapis/google-cloud-dotnet/commit/09b648f9964573de91bb23b2da17d788174b3242))
