### PR TITLE
Release Google.Cloud.GkeBackup.V1 version 2.2.0

### DIFF
--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.csproj
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Backup for GKE API, which is a managed Kubernetes workload backup and restore service for GKE clusters.</Description>

--- a/apis/Google.Cloud.GkeBackup.V1/docs/history.md
+++ b/apis/Google.Cloud.GkeBackup.V1/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 2.2.0, released 2023-06-27
+
+### New features
+
+- Added new restore scope options ([commit b606f4c](https://github.com/googleapis/google-cloud-dotnet/commit/b606f4c5293289554f5a035f3f8e0ce4c71ef3fe))
+- Added transformation rules for restore ([commit b606f4c](https://github.com/googleapis/google-cloud-dotnet/commit/b606f4c5293289554f5a035f3f8e0ce4c71ef3fe))
+- Added BackupPlan and RestorePlan state information ([commit b606f4c](https://github.com/googleapis/google-cloud-dotnet/commit/b606f4c5293289554f5a035f3f8e0ce4c71ef3fe))
+
+### Documentation improvements
+
+- Minor documentation fixes ([commit c78b468](https://github.com/googleapis/google-cloud-dotnet/commit/c78b46845ade4aafe6388159c5d12796fe150c77))
+
 ## Version 2.1.0, released 2023-01-19
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2378,7 +2378,7 @@
     },
     {
       "id": "Google.Cloud.GkeBackup.V1",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "type": "grpc",
       "productName": "Backup for GKE",
       "productUrl": "https://cloud.google.com/kubernetes-engine/docs/add-on/backup-for-gke",


### PR DESCRIPTION

Changes in this release:

### New features

- Added new restore scope options ([commit b606f4c](https://github.com/googleapis/google-cloud-dotnet/commit/b606f4c5293289554f5a035f3f8e0ce4c71ef3fe))
- Added transformation rules for restore ([commit b606f4c](https://github.com/googleapis/google-cloud-dotnet/commit/b606f4c5293289554f5a035f3f8e0ce4c71ef3fe))
- Added BackupPlan and RestorePlan state information ([commit b606f4c](https://github.com/googleapis/google-cloud-dotnet/commit/b606f4c5293289554f5a035f3f8e0ce4c71ef3fe))

### Documentation improvements

- Minor documentation fixes ([commit c78b468](https://github.com/googleapis/google-cloud-dotnet/commit/c78b46845ade4aafe6388159c5d12796fe150c77))
