### PR TITLE
Release Google.Cloud.NetworkManagement.V1 version 2.4.0

### DIFF
--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.csproj
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Network Management API, which provides a collection of network performance monitoring and diagnostic capabilities.</Description>

--- a/apis/Google.Cloud.NetworkManagement.V1/docs/history.md
+++ b/apis/Google.Cloud.NetworkManagement.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 2.4.0, released 2023-06-27
+
+### New features
+
+- Add forwarding_rule field to Connectivity Test Endpoint proto ([commit 73e23cb](https://github.com/googleapis/google-cloud-dotnet/commit/73e23cbd9816fb4b1f1d4ede8d011f9393974225))
+
+### Documentation improvements
+
+- Update comments in Connectivity Test protos ([commit 874831c](https://github.com/googleapis/google-cloud-dotnet/commit/874831c081fd3f713e108d9ec3835f9f5dfa7cf9))
+
 ## Version 2.3.0, released 2023-01-18
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3108,7 +3108,7 @@
     },
     {
       "id": "Google.Cloud.NetworkManagement.V1",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "type": "grpc",
       "productName": "Network Management",
       "productUrl": "https://cloud.google.com/network-intelligence-center/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add forwarding_rule field to Connectivity Test Endpoint proto ([commit 73e23cb](https://github.com/googleapis/google-cloud-dotnet/commit/73e23cbd9816fb4b1f1d4ede8d011f9393974225))

### Documentation improvements

- Update comments in Connectivity Test protos ([commit 874831c](https://github.com/googleapis/google-cloud-dotnet/commit/874831c081fd3f713e108d9ec3835f9f5dfa7cf9))
