### PR TITLE
Release Google.Cloud.StorageTransfer.V1 version 2.3.0

### DIFF
--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.csproj
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.2.0</Version>
+    <Version>2.3.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Transfers data from external data sources to a Google Cloud Storage bucket or between Google Cloud Storage buckets.</Description>

--- a/apis/Google.Cloud.StorageTransfer.V1/docs/history.md
+++ b/apis/Google.Cloud.StorageTransfer.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.3.0, released 2023-06-27
+
+### New features
+
+- Add event driven transfer configuration ([commit 218b433](https://github.com/googleapis/google-cloud-dotnet/commit/218b4337b70dd78b804137fea48998890382686b))
+
 ## Version 2.2.0, released 2023-01-16
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4320,7 +4320,7 @@
     },
     {
       "id": "Google.Cloud.StorageTransfer.V1",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "type": "grpc",
       "productName": "Storage Transfer",
       "productUrl": "https://cloud.google.com/storage-transfer-service",


### PR DESCRIPTION

Changes in this release:

### New features

- Add event driven transfer configuration ([commit 218b433](https://github.com/googleapis/google-cloud-dotnet/commit/218b4337b70dd78b804137fea48998890382686b))
