### PR TITLE
chore: Stop using message strings to determine if an error message "session expired"

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/V1/Internal/ExecuteHelperTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/V1/Internal/ExecuteHelperTests.cs
@@ -1,0 +1,66 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+using Google.Cloud.Spanner.Data;
+using Google.Cloud.Spanner.Data.IntegrationTests;
+using Grpc.Core;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Cloud.Spanner.V1.Internal.IntegrationTests;
+
+[Collection(nameof(SpannerDatabaseFixture))]
+[CommonTestDiagnostics]
+public class ExecuteHelperTests
+{
+    private readonly SpannerDatabaseFixture _fixture;
+
+    public ExecuteHelperTests(SpannerDatabaseFixture fixture) =>
+        _fixture = fixture;
+
+    [Fact]
+    public Task SessionNotFound() => WithSessionPool(async pool =>
+    {
+        var session = await pool.Client.CreateSessionAsync(_fixture.DatabaseName);
+        await pool.Client.DeleteSessionAsync(session.SessionName);
+
+        // The session doesn't become invalid immediately after deletion.
+        // Wait for a minute to ensure the session is really expired.
+        await Task.Delay(TimeSpan.FromMinutes(1));
+
+        var request = new ExecuteSqlRequest
+        {
+            Sql = $"SELECT 1",
+            Session = session.Name
+        };
+        var exception = await Assert.ThrowsAsync<RpcException>(() => pool.Client.ExecuteSqlAsync(request));
+        Assert.True(ExecuteHelper.IsSessionExpiredError(exception));
+    });
+
+    // This code is separated out in case we need more tests. It's really just fluff.
+    private async Task WithSessionPool(Func<SessionPool, Task> action)
+    {
+        var builder = new SpannerConnectionStringBuilder(_fixture.ConnectionString);
+        var pool = await builder.AcquireSessionPoolAsync();
+        try
+        {
+            await action(pool);
+        }
+        finally
+        {
+            builder.SessionPoolManager.Release(pool);
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/Internal/ExecuteHelperTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/Internal/ExecuteHelperTests.cs
@@ -1,0 +1,55 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+using Google.Protobuf;
+using Google.Rpc;
+using Grpc.Core;
+using Xunit;
+
+namespace Google.Cloud.Spanner.V1.Internal.Tests;
+
+public class ExecuteHelperTests
+{
+    private static readonly ResourceInfo s_sessionResourceInfo = new ResourceInfo { ResourceType = ExecuteHelper.SessionResourceType };
+
+    [Fact]
+    public void IsSessionExpiredError_WrongStatusCode() =>
+        Assert.False(CreateException(StatusCode.Aborted, s_sessionResourceInfo.ToByteArray()).IsSessionExpiredError());
+
+    [Fact]
+    public void IsSessionExpiredError_NoResourceInfo() =>
+        Assert.False(CreateException(StatusCode.NotFound, null).IsSessionExpiredError());
+
+    [Fact]
+    public void IsSessionExpiredError_WrongResourceInfo() =>
+        Assert.False(CreateException(StatusCode.NotFound, new ResourceInfo { ResourceType = "not-a-session" }.ToByteArray()).IsSessionExpiredError());
+
+    [Fact]
+    public void IsSessionExpiredError_InvalidResourceInfo() =>
+        Assert.False(CreateException(StatusCode.NotFound, new byte[1]).IsSessionExpiredError());
+
+    [Fact]
+    public void IsSessionExpiredError_Valid() =>
+        Assert.True(CreateException(StatusCode.NotFound, s_sessionResourceInfo.ToByteArray()).IsSessionExpiredError());
+
+    private static RpcException CreateException(StatusCode code, byte[] resourceInfoData)
+    {
+        var trailers = new Metadata();
+        if (resourceInfoData is not null)
+        {
+            trailers.Add(ExecuteHelper.ResourceInfoMetadataKey, resourceInfoData);
+        }
+        return new RpcException(new Grpc.Core.Status(code, "Bang"), trailers);
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/PooledSessionTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/PooledSessionTests.cs
@@ -15,6 +15,7 @@
 using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
 using Google.Api.Gax.Testing;
+using Google.Cloud.Spanner.V1.Internal;
 using Google.Cloud.Spanner.V1.Internal.Logging;
 using Google.Protobuf;
 using Grpc.Core;
@@ -24,6 +25,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 using static Google.Cloud.Spanner.V1.TransactionOptions.ModeOneofCase;
+using ResourceInfo = Google.Rpc.ResourceInfo;
 
 namespace Google.Cloud.Spanner.V1.Tests
 {
@@ -116,7 +118,7 @@ namespace Google.Cloud.Spanner.V1.Tests
             // Make a request which fails due to the session not being found (because it has expired).
             var request = new BeginTransactionRequest();
             pool.Mock.Setup(client => client.BeginTransactionAsync(request, It.IsAny<CallSettings>()))
-                .ThrowsAsync(new RpcException(new Status(StatusCode.NotFound, "Session not found")))
+                .ThrowsAsync(CreateSessionExpiredException())
                 .Verifiable();
             await Assert.ThrowsAsync<RpcException>(() => pooledSession.BeginTransactionAsync(request, null));
             Assert.True(pooledSession.ServerExpired);
@@ -297,7 +299,7 @@ namespace Google.Cloud.Spanner.V1.Tests
             // Make a request which fails due to the session not being found (because it has expired).
             var request = new BeginTransactionRequest();
             pool.Mock.Setup(client => client.BeginTransactionAsync(request, It.IsAny<CallSettings>()))
-                .ThrowsAsync(new RpcException(new Status(StatusCode.NotFound, "Session not found")))
+                .ThrowsAsync(CreateSessionExpiredException())
                 .Verifiable();
             await Assert.ThrowsAsync<RpcException>(() => pooledSession.BeginTransactionAsync(request, null));
 
@@ -391,6 +393,10 @@ namespace Google.Cloud.Spanner.V1.Tests
             pooledSession.ReleaseToPool(false);
             Assert.Equal(pool.RolledBackTransaction, pooledSession.TransactionId);
         }
+
+        private static RpcException CreateSessionExpiredException() =>
+            new RpcException(new Status(StatusCode.NotFound, "Session not found"),
+                new Metadata { { ExecuteHelper.ResourceInfoMetadataKey, new ResourceInfo { ResourceType = ExecuteHelper.SessionResourceType }.ToByteArray() } });
 
         private PooledSession CreateWithTransaction(SessionPool.ISessionPool pool, TransactionOptions.ModeOneofCase mode)
         {


### PR DESCRIPTION
Fixes #10620.