### PR TITLE
Release Google.Cloud.Batch.V1Alpha version 1.0.0-alpha13

### DIFF
--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.csproj
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha12</Version>
+    <Version>1.0.0-alpha13</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Batch API (v1alpha), which allows you to manage the running of batch jobs on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Batch.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.Batch.V1Alpha/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 1.0.0-alpha13, released 2023-07-13
+
+### New features
+
+- Add gpu driver version field ([commit 2836b1b](https://github.com/googleapis/google-cloud-dotnet/commit/2836b1b93c7aa7ed870d80aab7ff1e1070dab771))
+
+### Documentation improvements
+
+- Add image shortcut example for Batch HPC CentOS Image ([commit 2836b1b](https://github.com/googleapis/google-cloud-dotnet/commit/2836b1b93c7aa7ed870d80aab7ff1e1070dab771))
+
 ## Version 1.0.0-alpha12, released 2023-06-20
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -574,7 +574,7 @@
     },
     {
       "id": "Google.Cloud.Batch.V1Alpha",
-      "version": "1.0.0-alpha12",
+      "version": "1.0.0-alpha13",
       "type": "grpc",
       "productName": "Batch",
       "productUrl": "https://cloud.google.com/batch/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add gpu driver version field ([commit 2836b1b](https://github.com/googleapis/google-cloud-dotnet/commit/2836b1b93c7aa7ed870d80aab7ff1e1070dab771))

### Documentation improvements

- Add image shortcut example for Batch HPC CentOS Image ([commit 2836b1b](https://github.com/googleapis/google-cloud-dotnet/commit/2836b1b93c7aa7ed870d80aab7ff1e1070dab771))
