### PR TITLE
Release Google.Cloud.BigQuery.Connection.V1 version 2.6.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.5.0</Version>
+    <Version>2.6.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery connection API, which allows users to manage BigQuery connections to external data sources.</Description>

--- a/apis/Google.Cloud.BigQuery.Connection.V1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 2.6.0, released 2023-07-13
+
+### New features
+
+- Add support for Salesforce connections, which are usable only by allowlisted partners ([commit 1a2b063](https://github.com/googleapis/google-cloud-dotnet/commit/1a2b06397170cbddadd29fa491656fe92f5b199b))
+- Add cloud spanner connection properties - use_data_boost ([commit 1a2b063](https://github.com/googleapis/google-cloud-dotnet/commit/1a2b06397170cbddadd29fa491656fe92f5b199b))
+- Add cloud spanner connection properties - max_parallelism ([commit 1a2b063](https://github.com/googleapis/google-cloud-dotnet/commit/1a2b06397170cbddadd29fa491656fe92f5b199b))
+
 ## Version 2.5.0, released 2023-03-20
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -732,7 +732,7 @@
     },
     {
       "id": "Google.Cloud.BigQuery.Connection.V1",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "type": "grpc",
       "productName": "BigQuery Connection",
       "productUrl": "https://cloud.google.com/bigquery/docs/reference/bigqueryconnection",


### PR DESCRIPTION

Changes in this release:

### New features

- Add support for Salesforce connections, which are usable only by allowlisted partners ([commit 1a2b063](https://github.com/googleapis/google-cloud-dotnet/commit/1a2b06397170cbddadd29fa491656fe92f5b199b))
- Add cloud spanner connection properties - use_data_boost ([commit 1a2b063](https://github.com/googleapis/google-cloud-dotnet/commit/1a2b06397170cbddadd29fa491656fe92f5b199b))
- Add cloud spanner connection properties - max_parallelism ([commit 1a2b063](https://github.com/googleapis/google-cloud-dotnet/commit/1a2b06397170cbddadd29fa491656fe92f5b199b))
