### PR TITLE
Release Google.Cloud.BigQuery.Storage.V1 version 3.9.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.8.0</Version>
+    <Version>3.9.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery Storage API.</Description>

--- a/apis/Google.Cloud.BigQuery.Storage.V1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 3.9.0, released 2023-07-13
+
+### New features
+
+- Add ResourceExhausted to retryable error for Write API unary calls ([commit a1262a2](https://github.com/googleapis/google-cloud-dotnet/commit/a1262a25eb219cd79c04f9c36914a9cabeb910a4))
+
+### Documentation improvements
+
+- Add multiplexing documentation ([commit a1262a2](https://github.com/googleapis/google-cloud-dotnet/commit/a1262a25eb219cd79c04f9c36914a9cabeb910a4))
+
 ## Version 3.8.0, released 2023-06-27
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -925,7 +925,7 @@
       "protoPath": "google/cloud/bigquery/storage/v1",
       "productName": "Google BigQuery Storage",
       "productUrl": "https://cloud.google.com/bigquery/docs/reference/storage/",
-      "version": "3.8.0",
+      "version": "3.9.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the BigQuery Storage API.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Add ResourceExhausted to retryable error for Write API unary calls ([commit a1262a2](https://github.com/googleapis/google-cloud-dotnet/commit/a1262a25eb219cd79c04f9c36914a9cabeb910a4))

### Documentation improvements

- Add multiplexing documentation ([commit a1262a2](https://github.com/googleapis/google-cloud-dotnet/commit/a1262a25eb219cd79c04f9c36914a9cabeb910a4))
