### PR TITLE
Release Google.Cloud.Bigtable.Admin.V2 version 3.5.0

### DIFF
--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.csproj
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.4.0</Version>
+    <Version>3.5.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Bigtable Instance and Table Admin APIs.</Description>

--- a/apis/Google.Cloud.Bigtable.Admin.V2/docs/history.md
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.5.0, released 2023-07-13
+
+### New features
+
+- Increase the maximum retention period for a Cloud Bigtable backup from 30 days to 90 days ([commit 0567fa8](https://github.com/googleapis/google-cloud-dotnet/commit/0567fa84747a4ca2e215710692f9abc7f238d017))
+
 ## Version 3.4.0, released 2023-05-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -944,7 +944,7 @@
       "protoPath": "google/bigtable/admin/v2",
       "productName": "Google Cloud Bigtable Administration",
       "productUrl": "https://cloud.google.com/bigtable/",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "commonResourcesConfig": "apis/Google.Cloud.Bigtable.Common.V2/CommonResourcesConfig.json",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Bigtable Instance and Table Admin APIs.",


### PR DESCRIPTION

Changes in this release:

### New features

- Increase the maximum retention period for a Cloud Bigtable backup from 30 days to 90 days ([commit 0567fa8](https://github.com/googleapis/google-cloud-dotnet/commit/0567fa84747a4ca2e215710692f9abc7f238d017))
