### PR TITLE
Release Google.Cloud.CloudBuild.V1 version 2.5.0

### DIFF
--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.csproj
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.4.0</Version>
+    <Version>2.5.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Build API v1, which creates and manages builds on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.CloudBuild.V1/docs/history.md
+++ b/apis/Google.Cloud.CloudBuild.V1/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 2.5.0, released 2023-07-13
+
+### New features
+
+- Add routing information in Cloud Build GRPC clients ([commit 89156c3](https://github.com/googleapis/google-cloud-dotnet/commit/89156c3719f4dcf1d371fe6a974cf8d62cd9384a))
+- Added e2-medium machine type ([commit dc5d51f](https://github.com/googleapis/google-cloud-dotnet/commit/dc5d51ff8eda2db70bb23bb4034cc65c404c7731))
+- Add repositoryevent to buildtrigger ([commit e207559](https://github.com/googleapis/google-cloud-dotnet/commit/e207559237a093beef962df0b10d973518eac4b4))
+
 ## Version 2.4.0, released 2023-04-19
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1168,7 +1168,7 @@
     },
     {
       "id": "Google.Cloud.CloudBuild.V1",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "type": "grpc",
       "productName": "Cloud Build",
       "productUrl": "https://cloud.google.com/cloud-build",


### PR DESCRIPTION

Changes in this release:

### New features

- Add routing information in Cloud Build GRPC clients ([commit 89156c3](https://github.com/googleapis/google-cloud-dotnet/commit/89156c3719f4dcf1d371fe6a974cf8d62cd9384a))
- Added e2-medium machine type ([commit dc5d51f](https://github.com/googleapis/google-cloud-dotnet/commit/dc5d51ff8eda2db70bb23bb4034cc65c404c7731))
- Add repositoryevent to buildtrigger ([commit e207559](https://github.com/googleapis/google-cloud-dotnet/commit/e207559237a093beef962df0b10d973518eac4b4))
