### PR TITLE
Release Google.Cloud.CloudBuild.V2 version 1.0.0-beta03

### DIFF
--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.csproj
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Build API v2, which creates and manages builds on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.CloudBuild.V2/docs/history.md
+++ b/apis/Google.Cloud.CloudBuild.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta03, released 2023-07-13
+
+### New features
+
+- Add GitLabConfig and fetchGitRefs for Cloud Build Repositories ([commit 4eae185](https://github.com/googleapis/google-cloud-dotnet/commit/4eae185ab6cc4cea1b6b8de555d01d0d6a6e1444))
+
 ## Version 1.0.0-beta02, released 2023-03-27
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1191,7 +1191,7 @@
     },
     {
       "id": "Google.Cloud.CloudBuild.V2",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0-beta03",
       "type": "grpc",
       "productName": "Cloud Build",
       "description": "Recommended Google client library to access the Google Cloud Build API v2, which creates and manages builds on Google Cloud Platform.",


### PR DESCRIPTION

Changes in this release:

### New features

- Add GitLabConfig and fetchGitRefs for Cloud Build Repositories ([commit 4eae185](https://github.com/googleapis/google-cloud-dotnet/commit/4eae185ab6cc4cea1b6b8de555d01d0d6a6e1444))
