### PR TITLE
Release Google.Cloud.Container.V1 version 3.15.0

### DIFF
--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.14.0</Version>
+    <Version>3.15.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.</Description>

--- a/apis/Google.Cloud.Container.V1/docs/history.md
+++ b/apis/Google.Cloud.Container.V1/docs/history.md
@@ -1,5 +1,14 @@
 # Version history
 
+## Version 3.15.0, released 2023-07-13
+
+### New features
+
+- Add advanced_datapath_observability_config to monitoring_config ([commit 00a826c](https://github.com/googleapis/google-cloud-dotnet/commit/00a826c3d23b9312dc5ca83ee8feae666d3958be))
+- Add a Pod IP Utilization API ([commit 00a826c](https://github.com/googleapis/google-cloud-dotnet/commit/00a826c3d23b9312dc5ca83ee8feae666d3958be))
+- Add `KUBE_DNS` option to `DNSConfig.cluster_dns` ([commit 2d109b3](https://github.com/googleapis/google-cloud-dotnet/commit/2d109b3edbdda52bd356775ebabdf9edb9291e93))
+- Add Tier 1 cluster-level API network_performance_config ([commit 2d109b3](https://github.com/googleapis/google-cloud-dotnet/commit/2d109b3edbdda52bd356775ebabdf9edb9291e93))
+
 ## Version 3.14.0, released 2023-06-20
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1366,7 +1366,7 @@
       "protoPath": "google/container/v1",
       "productName": "Google Kubernetes Engine",
       "productUrl": "https://cloud.google.com/kubernetes-engine/docs/reference/rest/",
-      "version": "3.14.0",
+      "version": "3.15.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Add advanced_datapath_observability_config to monitoring_config ([commit 00a826c](https://github.com/googleapis/google-cloud-dotnet/commit/00a826c3d23b9312dc5ca83ee8feae666d3958be))
- Add a Pod IP Utilization API ([commit 00a826c](https://github.com/googleapis/google-cloud-dotnet/commit/00a826c3d23b9312dc5ca83ee8feae666d3958be))
- Add `KUBE_DNS` option to `DNSConfig.cluster_dns` ([commit 2d109b3](https://github.com/googleapis/google-cloud-dotnet/commit/2d109b3edbdda52bd356775ebabdf9edb9291e93))
- Add Tier 1 cluster-level API network_performance_config ([commit 2d109b3](https://github.com/googleapis/google-cloud-dotnet/commit/2d109b3edbdda52bd356775ebabdf9edb9291e93))
