### PR TITLE
Release Google.Cloud.DataCatalog.V1 version 2.5.0

### DIFF
--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.csproj
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.4.0</Version>
+    <Version>2.5.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Data Catalog API. Data Catalog is a fully managed and highly scalable data discovery and metadata management service.</Description>

--- a/apis/Google.Cloud.DataCatalog.V1/docs/history.md
+++ b/apis/Google.Cloud.DataCatalog.V1/docs/history.md
@@ -1,5 +1,18 @@
 # Version history
 
+## Version 2.5.0, released 2023-07-13
+
+### New features
+
+- Added rpc RenameTagTemplateFieldEnumValue ([commit 3840102](https://github.com/googleapis/google-cloud-dotnet/commit/3840102cdac33930dee4c73ab098b5c5d09839bc))
+- Returning approximate total size for SearchCatalog ([commit 3840102](https://github.com/googleapis/google-cloud-dotnet/commit/3840102cdac33930dee4c73ab098b5c5d09839bc))
+- Returning unreachable locations for SearchCatalog ([commit 3840102](https://github.com/googleapis/google-cloud-dotnet/commit/3840102cdac33930dee4c73ab098b5c5d09839bc))
+- Added Entry.usage_signal ([commit 3840102](https://github.com/googleapis/google-cloud-dotnet/commit/3840102cdac33930dee4c73ab098b5c5d09839bc))
+
+### Documentation improvements
+
+- Update docs of SearchCatalogRequest message ([commit 3840102](https://github.com/googleapis/google-cloud-dotnet/commit/3840102cdac33930dee4c73ab098b5c5d09839bc))
+
 ## Version 2.4.0, released 2023-06-05
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1410,7 +1410,7 @@
       "protoPath": "google/cloud/datacatalog/v1",
       "productName": "Data Catalog",
       "productUrl": "https://cloud.google.com/data-catalog/docs",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Data Catalog API. Data Catalog is a fully managed and highly scalable data discovery and metadata management service.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- Added rpc RenameTagTemplateFieldEnumValue ([commit 3840102](https://github.com/googleapis/google-cloud-dotnet/commit/3840102cdac33930dee4c73ab098b5c5d09839bc))
- Returning approximate total size for SearchCatalog ([commit 3840102](https://github.com/googleapis/google-cloud-dotnet/commit/3840102cdac33930dee4c73ab098b5c5d09839bc))
- Returning unreachable locations for SearchCatalog ([commit 3840102](https://github.com/googleapis/google-cloud-dotnet/commit/3840102cdac33930dee4c73ab098b5c5d09839bc))
- Added Entry.usage_signal ([commit 3840102](https://github.com/googleapis/google-cloud-dotnet/commit/3840102cdac33930dee4c73ab098b5c5d09839bc))

### Documentation improvements

- Update docs of SearchCatalogRequest message ([commit 3840102](https://github.com/googleapis/google-cloud-dotnet/commit/3840102cdac33930dee4c73ab098b5c5d09839bc))
