### PR TITLE
Release Google.Cloud.Deploy.V1 version 2.7.0

### DIFF
--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.csproj
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Deploy API, which automates delivery of your applications to a series of target environments in a defined sequence.</Description>

--- a/apis/Google.Cloud.Deploy.V1/docs/history.md
+++ b/apis/Google.Cloud.Deploy.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.7.0, released 2023-07-13
+
+### New features
+
+- Added support routeUpdateWaitTime field for Deployment Strategies ([commit 783acf4](https://github.com/googleapis/google-cloud-dotnet/commit/783acf4ab45ca43006ebdd21d510f9121f2610e7))
+
 ## Version 2.6.0, released 2023-06-27
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1676,7 +1676,7 @@
     },
     {
       "id": "Google.Cloud.Deploy.V1",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "type": "grpc",
       "productName": "Google Cloud Deploy",
       "productUrl": "https://cloud.google.com/deploy/",


### PR DESCRIPTION

Changes in this release:

### New features

- Added support routeUpdateWaitTime field for Deployment Strategies ([commit 783acf4](https://github.com/googleapis/google-cloud-dotnet/commit/783acf4ab45ca43006ebdd21d510f9121f2610e7))
