### PR TITLE
Release Google.Cloud.Metastore.V1 version 2.4.0

### DIFF
--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.csproj
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Dataproc Metastore API which is used to manage the lifecycle and configuration of metastore services.</Description>

--- a/apis/Google.Cloud.Metastore.V1/docs/history.md
+++ b/apis/Google.Cloud.Metastore.V1/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 2.4.0, released 2023-07-13
+
+### New features
+
+- Added Admin Interface (v1) ([commit bbd1b88](https://github.com/googleapis/google-cloud-dotnet/commit/bbd1b8818823d9cec0994cc232b427f988cf291a))
+- Added gRPC endpoint protocol (v1) ([commit bbd1b88](https://github.com/googleapis/google-cloud-dotnet/commit/bbd1b8818823d9cec0994cc232b427f988cf291a))
+- Added BigQuery as a backend metastore (v1) ([commit bbd1b88](https://github.com/googleapis/google-cloud-dotnet/commit/bbd1b8818823d9cec0994cc232b427f988cf291a))
+
 ## Version 2.3.0, released 2023-04-19
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2950,7 +2950,7 @@
     },
     {
       "id": "Google.Cloud.Metastore.V1",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "type": "grpc",
       "productName": "Dataproc Metastore",
       "productUrl": "https://cloud.google.com/dataproc-metastore/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Added Admin Interface (v1) ([commit bbd1b88](https://github.com/googleapis/google-cloud-dotnet/commit/bbd1b8818823d9cec0994cc232b427f988cf291a))
- Added gRPC endpoint protocol (v1) ([commit bbd1b88](https://github.com/googleapis/google-cloud-dotnet/commit/bbd1b8818823d9cec0994cc232b427f988cf291a))
- Added BigQuery as a backend metastore (v1) ([commit bbd1b88](https://github.com/googleapis/google-cloud-dotnet/commit/bbd1b8818823d9cec0994cc232b427f988cf291a))
