### PR TITLE
Release Google.Cloud.Metastore.V1Alpha version 2.0.0-alpha06

### DIFF
--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.csproj
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha05</Version>
+    <Version>2.0.0-alpha06</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Dataproc Metastore API (v1alpha) which is used to manage the lifecycle and configuration of metastore services.</Description>

--- a/apis/Google.Cloud.Metastore.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.Metastore.V1Alpha/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 2.0.0-alpha06, released 2023-07-13
+
+### New features
+
+- Added Admin Interface (v1) ([commit a162298](https://github.com/googleapis/google-cloud-dotnet/commit/a162298c75f8de10922c8f881c1783479b32a2cb))
+- Added gRPC endpoint protocol (v1) ([commit a162298](https://github.com/googleapis/google-cloud-dotnet/commit/a162298c75f8de10922c8f881c1783479b32a2cb))
+- Added BigQuery as a backend metastore (v1) ([commit a162298](https://github.com/googleapis/google-cloud-dotnet/commit/a162298c75f8de10922c8f881c1783479b32a2cb))
+
 ## Version 2.0.0-alpha05, released 2023-04-19
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2975,7 +2975,7 @@
     },
     {
       "id": "Google.Cloud.Metastore.V1Alpha",
-      "version": "2.0.0-alpha05",
+      "version": "2.0.0-alpha06",
       "type": "grpc",
       "productName": "Dataproc Metastore",
       "productUrl": "https://cloud.google.com/dataproc-metastore/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Added Admin Interface (v1) ([commit a162298](https://github.com/googleapis/google-cloud-dotnet/commit/a162298c75f8de10922c8f881c1783479b32a2cb))
- Added gRPC endpoint protocol (v1) ([commit a162298](https://github.com/googleapis/google-cloud-dotnet/commit/a162298c75f8de10922c8f881c1783479b32a2cb))
- Added BigQuery as a backend metastore (v1) ([commit a162298](https://github.com/googleapis/google-cloud-dotnet/commit/a162298c75f8de10922c8f881c1783479b32a2cb))
