### PR TITLE
Release Google.Cloud.Metastore.V1Beta version 2.0.0-beta06

### DIFF
--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.csproj
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta05</Version>
+    <Version>2.0.0-beta06</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Dataproc Metastore API (v1beta) which is used to manage the lifecycle and configuration of metastore services.</Description>

--- a/apis/Google.Cloud.Metastore.V1Beta/docs/history.md
+++ b/apis/Google.Cloud.Metastore.V1Beta/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 2.0.0-beta06, released 2023-07-13
+
+### New features
+
+- Added Admin Interface (v1) ([commit 699426c](https://github.com/googleapis/google-cloud-dotnet/commit/699426cc14735db516958999cf02588aa7e2e40c))
+- Added gRPC endpoint protocol (v1) ([commit 699426c](https://github.com/googleapis/google-cloud-dotnet/commit/699426cc14735db516958999cf02588aa7e2e40c))
+- Added BigQuery as a backend metastore (v1) ([commit 699426c](https://github.com/googleapis/google-cloud-dotnet/commit/699426cc14735db516958999cf02588aa7e2e40c))
+
 ## Version 2.0.0-beta05, released 2023-04-19
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2998,7 +2998,7 @@
     },
     {
       "id": "Google.Cloud.Metastore.V1Beta",
-      "version": "2.0.0-beta05",
+      "version": "2.0.0-beta06",
       "type": "grpc",
       "productName": "Dataproc Metastore",
       "productUrl": "https://cloud.google.com/dataproc-metastore/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Added Admin Interface (v1) ([commit 699426c](https://github.com/googleapis/google-cloud-dotnet/commit/699426cc14735db516958999cf02588aa7e2e40c))
- Added gRPC endpoint protocol (v1) ([commit 699426c](https://github.com/googleapis/google-cloud-dotnet/commit/699426cc14735db516958999cf02588aa7e2e40c))
- Added BigQuery as a backend metastore (v1) ([commit 699426c](https://github.com/googleapis/google-cloud-dotnet/commit/699426cc14735db516958999cf02588aa7e2e40c))
