### PR TITLE
Release Google.Cloud.Run.V2 version 2.2.0

### DIFF
--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/Google.Cloud.Run.V2.csproj
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/Google.Cloud.Run.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Run Admin API (v2)</Description>

--- a/apis/Google.Cloud.Run.V2/docs/history.md
+++ b/apis/Google.Cloud.Run.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.2.0, released 2023-07-13
+
+### New features
+
+- Adds support for custom audiences ([commit 5233add](https://github.com/googleapis/google-cloud-dotnet/commit/5233add1e8fb5a8ab6bb5324ac830e4926373357))
+
 ## Version 2.1.0, released 2023-05-03
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3739,7 +3739,7 @@
     },
     {
       "id": "Google.Cloud.Run.V2",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "type": "grpc",
       "productName": "Cloud Run Admin",
       "productUrl": "https://cloud.google.com/run/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Adds support for custom audiences ([commit 5233add](https://github.com/googleapis/google-cloud-dotnet/commit/5233add1e8fb5a8ab6bb5324ac830e4926373357))
