### PR TITLE
Release Google.Cloud.Speech.V2 version 1.0.0-beta06

### DIFF
--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.csproj
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta05</Version>
+    <Version>1.0.0-beta06</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Speech-to-Text API (v2) which converts audio to text by applying powerful neural network models.</Description>

--- a/apis/Google.Cloud.Speech.V2/docs/history.md
+++ b/apis/Google.Cloud.Speech.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta06, released 2023-07-13
+
+### New features
+
+- Add `model` and `language_codes` fields in `RecognitionConfig` message + enable default `_` recognizer ([commit d2ecbdf](https://github.com/googleapis/google-cloud-dotnet/commit/d2ecbdff4500db196e8ebe2c75a98ba8fe5554d6))
+
 ## Version 1.0.0-beta05, released 2023-05-11
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4253,7 +4253,7 @@
     },
     {
       "id": "Google.Cloud.Speech.V2",
-      "version": "1.0.0-beta05",
+      "version": "1.0.0-beta06",
       "type": "grpc",
       "productName": "Cloud Speech-to-Text",
       "productUrl": "https://cloud.google.com/speech",


### PR DESCRIPTION

Changes in this release:

### New features

- Add `model` and `language_codes` fields in `RecognitionConfig` message + enable default `_` recognizer ([commit d2ecbdf](https://github.com/googleapis/google-cloud-dotnet/commit/d2ecbdff4500db196e8ebe2c75a98ba8fe5554d6))
