### PR TITLE
fix: return session to the pool after commit/rollback

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/SpannerConnectionSnippets.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/SpannerConnectionSnippets.cs
@@ -1,11 +1,11 @@
 // Copyright 2017 Google Inc. All Rights Reserved.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -287,6 +287,7 @@ namespace Google.Cloud.Spanner.Data.Snippets
                     // Insert a second row
                     cmd.Parameters["Id"].Value = 11L;
                     cmd.Parameters["Name"].Value = "Demo 2";
+                    cmd.Transaction = transaction;
                     rowsAffected += await cmd.ExecuteNonQueryAsync();
                 });
 

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerTransaction.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerTransaction.cs
@@ -415,7 +415,7 @@ namespace Google.Cloud.Spanner.Data
             // timestamp, and there's no need for us to repeat the RPC here when we already know the
             // result. This also allows us to more aggressively return the session to the pool after
             // committing/rolling back a transaction.
-            if (_hasCommittedOrRolledBack && _commitResponse != null)
+            if (_commitResponse != null)
             {
                 return Task.FromResult(_commitResponse.CommitTimestamp.ToDateTime());
             }
@@ -446,14 +446,11 @@ namespace Google.Cloud.Spanner.Data
                     }
                     finally
                     {
-                        // Dispose the transaction unless it is a retriable transaction.
-                        // Disposing the transaction will return the session to the pool.
-                        // Retriable transactions reuse the same session for a new transaction if the transaction is aborted
-                        // by Cloud Spanner, and will make sure the session is returned to the pool when done.
-                        if (!_isRetriable)
-                        {
-                            Dispose();
-                        }
+                        // Dispose the transaction. Disposing the transaction will return the session to the pool,
+                        // unless it is a retriable transaction. Retriable transactions reuse the same session for a new
+                        // transaction if the transaction is aborted by Cloud Spanner, and will make sure the session is
+                        // returned to the pool when done.
+                        Dispose();
                     }
                 }, "SpannerTransaction.Commit", SpannerConnection.Logger);
         }
@@ -485,14 +482,11 @@ namespace Google.Cloud.Spanner.Data
             }
             finally
             {
-                // Dispose the transaction unless it is a retriable transaction.
-                // Disposing the transaction will return the session to the pool.
-                // Retriable transactions reuse the same session for a new transaction if the transaction is aborted
-                // by Cloud Spanner, and will make sure the session is returned to the pool when done.
-                if (!_isRetriable)
-                {
-                    Dispose();
-                }
+                // Dispose the transaction. Disposing the transaction will return the session to the pool,
+                // unless it is a retriable transaction. Retriable transactions reuse the same session for a new
+                // transaction if the transaction is aborted by Cloud Spanner, and will make sure the session is
+                // returned to the pool when done.
+                Dispose();
             }
         }
 

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/PooledSession.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/PooledSession.cs
@@ -202,7 +202,7 @@ namespace Google.Cloud.Spanner.V1
         private bool MarkAsDisposed() => Interlocked.Exchange(ref _disposed, 1) != 1;
 
         /// <summary>
-        /// Remembers that the transaction in this session has been successfully commmitted or rolled back.
+        /// Remembers that the transaction in this session has been successfully committed or rolled back.
         /// If a session is disposed but still has a read/write transaction that hasn't been committed or rolled back,
         /// the transaction will be rolled back before the session is reused.
         /// </summary>


### PR DESCRIPTION
Transactions would hold on to the session it was using after having been committed or rolled back, and would wait before returning it to the pool until the transaction was disposed. This could cause a higher than expected use of sessions, and could in theory also cause the session pool to be exhausted if someone would execute a large number of transactions in a loop without disposing those transactions in that loop.