### PR TITLE
Release Google.Cloud.AlloyDb.V1Alpha version 1.0.0-alpha03

### DIFF
--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.csproj
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha02</Version>
+    <Version>1.0.0-alpha03</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AlloyDB API (v1alpha). AlloyDB for PostgreSQL is an open source-compatible database service that provides a powerful option for migrating, modernizing, or building commercial-grade applications.</Description>

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 1.0.0-alpha03, released 2023-07-25
+
+### New features
+
+- Add metadata exchange support for AlloyDB connectors ([commit 5bd7231](https://github.com/googleapis/google-cloud-dotnet/commit/5bd723164f63b63d9bd260ffd7a77b5ab29a1ac8))
+- Adds metadata field describing an AlloyDB backup's quantity based retention ([commit 5bd7231](https://github.com/googleapis/google-cloud-dotnet/commit/5bd723164f63b63d9bd260ffd7a77b5ab29a1ac8))
+
 ## Version 1.0.0-alpha02, released 2023-06-20
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -158,7 +158,7 @@
     },
     {
       "id": "Google.Cloud.AlloyDb.V1Alpha",
-      "version": "1.0.0-alpha02",
+      "version": "1.0.0-alpha03",
       "type": "grpc",
       "productName": "AlloyDB",
       "productUrl": "https://cloud.google.com/alloydb/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Add metadata exchange support for AlloyDB connectors ([commit 5bd7231](https://github.com/googleapis/google-cloud-dotnet/commit/5bd723164f63b63d9bd260ffd7a77b5ab29a1ac8))
- Adds metadata field describing an AlloyDB backup's quantity based retention ([commit 5bd7231](https://github.com/googleapis/google-cloud-dotnet/commit/5bd723164f63b63d9bd260ffd7a77b5ab29a1ac8))
