### PR TITLE
Revert "chore(deps): update dependency microsoft.codeanalysis.csharp to v4.6.0"

### DIFF
--- a/tools/Google.Cloud.Tools.SourceManipulation/Google.Cloud.Tools.SourceManipulation.csproj
+++ b/tools/Google.Cloud.Tools.SourceManipulation/Google.Cloud.Tools.SourceManipulation.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Reverts googleapis/google-cloud-dotnet#10732 as the Kokoro jobs are the failing due to dependency issue.
like https://fusion2.corp.google.com/ci;ids=42745856/kokoro/prod:cloud-sharp%2Fgoogle-cloud-dotnet%2Fgcp_windows%2Fbuild-docs/activity/5b57a45b-64ef-4e1b-b23f-7f04bff2b20d/log