### PR TITLE
Release Google.Cloud.Batch.V1Alpha version 1.0.0-alpha14

### DIFF
--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.csproj
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha13</Version>
+    <Version>1.0.0-alpha14</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Batch API (v1alpha), which allows you to manage the running of batch jobs on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Batch.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.Batch.V1Alpha/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 1.0.0-alpha14, released 2023-08-04
+
+### New features
+
+- Enable gpu driver version field on v1 ([commit 08fd6c5](https://github.com/googleapis/google-cloud-dotnet/commit/08fd6c54e8590932815a9afac40513afd68133aa))
+
+### Documentation improvements
+
+- Mark `order_by` field in `ListTasksRequest` as not implemented. ([commit 08fd6c5](https://github.com/googleapis/google-cloud-dotnet/commit/08fd6c54e8590932815a9afac40513afd68133aa))
+- Improve url examples in comments ([commit 08fd6c5](https://github.com/googleapis/google-cloud-dotnet/commit/08fd6c54e8590932815a9afac40513afd68133aa))
+
 ## Version 1.0.0-alpha13, released 2023-07-13
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -574,7 +574,7 @@
     },
     {
       "id": "Google.Cloud.Batch.V1Alpha",
-      "version": "1.0.0-alpha13",
+      "version": "1.0.0-alpha14",
       "type": "grpc",
       "productName": "Batch",
       "productUrl": "https://cloud.google.com/batch/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Enable gpu driver version field on v1 ([commit 08fd6c5](https://github.com/googleapis/google-cloud-dotnet/commit/08fd6c54e8590932815a9afac40513afd68133aa))

### Documentation improvements

- Mark `order_by` field in `ListTasksRequest` as not implemented. ([commit 08fd6c5](https://github.com/googleapis/google-cloud-dotnet/commit/08fd6c54e8590932815a9afac40513afd68133aa))
- Improve url examples in comments ([commit 08fd6c5](https://github.com/googleapis/google-cloud-dotnet/commit/08fd6c54e8590932815a9afac40513afd68133aa))
