### PR TITLE
Release Google.Cloud.Bigtable.V2 version 3.7.0

### DIFF
--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.6.0</Version>
+    <Version>3.7.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Bigtable API.</Description>

--- a/apis/Google.Cloud.Bigtable.V2/docs/history.md
+++ b/apis/Google.Cloud.Bigtable.V2/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 3.7.0, released 2023-08-04
+
+### New features
+
+- Add last_scanned_row_key feature ([commit 8ed082d](https://github.com/googleapis/google-cloud-dotnet/commit/8ed082d39a3cf87df915b5f294fc0099a7941129))
+- Add experimental reverse scan for public preview ([commit 132fa75](https://github.com/googleapis/google-cloud-dotnet/commit/132fa75640c28dc851d2da10f6ff0b696bd249b1))
+
+### Documentation improvements
+
+- Fix formatting for reversed order field example ([commit 5b10786](https://github.com/googleapis/google-cloud-dotnet/commit/5b107861e31136cb169dc84b070227d15cbbdc4b))
+
 ## Version 3.6.0, released 2023-05-26
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -985,7 +985,7 @@
       "protoPath": "google/bigtable/v2",
       "productName": "Google Bigtable",
       "productUrl": "https://cloud.google.com/bigtable/",
-      "version": "3.6.0",
+      "version": "3.7.0",
       "commonResourcesConfig": "apis/Google.Cloud.Bigtable.Common.V2/CommonResourcesConfig.json",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",


### PR DESCRIPTION

Changes in this release:

### New features

- Add last_scanned_row_key feature ([commit 8ed082d](https://github.com/googleapis/google-cloud-dotnet/commit/8ed082d39a3cf87df915b5f294fc0099a7941129))
- Add experimental reverse scan for public preview ([commit 132fa75](https://github.com/googleapis/google-cloud-dotnet/commit/132fa75640c28dc851d2da10f6ff0b696bd249b1))

### Documentation improvements

- Fix formatting for reversed order field example ([commit 5b10786](https://github.com/googleapis/google-cloud-dotnet/commit/5b107861e31136cb169dc84b070227d15cbbdc4b))
