### PR TITLE
Release Google.Cloud.Commerce.Consumer.Procurement.V1 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.csproj
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Commerce Consumer Procurement API, which enables consumers to procure products served by Cloud Marketplace platform.</Description>

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/docs/history.md
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2023-08-04
+
+### Bug fixes
+
+- Correct csharp, php, and ruby package namespaces for order.proto ([commit 2b8ef98](https://github.com/googleapis/google-cloud-dotnet/commit/2b8ef984884b9297156420832d44e45c6252f238))
+
+### New features
+
+- Consumer Procurement API v1 ([commit 2b8ef98](https://github.com/googleapis/google-cloud-dotnet/commit/2b8ef984884b9297156420832d44e45c6252f238))
+
 ## Version 1.0.0-beta01, released 2023-07-24
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1236,7 +1236,7 @@
     },
     {
       "id": "Google.Cloud.Commerce.Consumer.Procurement.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Cloud Commerce Consumer Procurement",
       "productUrl": "https://cloud.google.com/marketplace/docs/",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Correct csharp, php, and ruby package namespaces for order.proto ([commit 2b8ef98](https://github.com/googleapis/google-cloud-dotnet/commit/2b8ef984884b9297156420832d44e45c6252f238))

### New features

- Consumer Procurement API v1 ([commit 2b8ef98](https://github.com/googleapis/google-cloud-dotnet/commit/2b8ef984884b9297156420832d44e45c6252f238))
