### PR TITLE
Release Google.Cloud.Compute.V1 version 2.11.0

### DIFF
--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.10.0</Version>
+    <Version>2.11.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Compute Engine API.</Description>

--- a/apis/Google.Cloud.Compute.V1/docs/history.md
+++ b/apis/Google.Cloud.Compute.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.11.0, released 2023-08-04
+
+### New features
+
+- Update Compute Engine API to revision 20230711 ([issue 836](https://github.com/googleapis/google-cloud-dotnet/issues/836)) ([commit 95216dc](https://github.com/googleapis/google-cloud-dotnet/commit/95216dcc3d77c9aefcbc4225c389932dde0f578c))
+
 ## Version 2.10.0, released 2023-07-13
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1268,7 +1268,7 @@
     },
     {
       "id": "Google.Cloud.Compute.V1",
-      "version": "2.10.0",
+      "version": "2.11.0",
       "type": "regapic",
       "productName": "Compute Engine",
       "productUrl": "https://cloud.google.com/compute",


### PR DESCRIPTION

Changes in this release:

### New features

- Update Compute Engine API to revision 20230711 ([issue 836](https://github.com/googleapis/google-cloud-dotnet/issues/836)) ([commit 95216dc](https://github.com/googleapis/google-cloud-dotnet/commit/95216dcc3d77c9aefcbc4225c389932dde0f578c))
