### PR TITLE
Release Google.Cloud.ConfidentialComputing.V1 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.csproj
+++ b/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Confidential Computing API (v1)</Description>

--- a/apis/Google.Cloud.ConfidentialComputing.V1/docs/history.md
+++ b/apis/Google.Cloud.ConfidentialComputing.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2023-08-04
+
+### New features
+
+- Added support for signed container image and custom audience and nonce requests ([commit 8a1370f](https://github.com/googleapis/google-cloud-dotnet/commit/8a1370f5f2731fc5b80a9a4b9b81f831da158886))
+
 ## Version 1.0.0-beta01, released 2023-04-19
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1288,7 +1288,7 @@
     },
     {
       "id": "Google.Cloud.ConfidentialComputing.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Confidential Computing",
       "productUrl": "https://cloud.google.com/confidential-computing",


### PR DESCRIPTION

Changes in this release:

### New features

- Added support for signed container image and custom audience and nonce requests ([commit 8a1370f](https://github.com/googleapis/google-cloud-dotnet/commit/8a1370f5f2731fc5b80a9a4b9b81f831da158886))
