### PR TITLE
Release Google.Cloud.Datastream.V1 version 2.4.0

### DIFF
--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.csproj
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Datastream API (v1), which allows you to synchronize data across heterogeneous databases and applications reliably, and with minimal latency and downtime.</Description>

--- a/apis/Google.Cloud.Datastream.V1/docs/history.md
+++ b/apis/Google.Cloud.Datastream.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.4.0, released 2023-08-04
+
+### New features
+
+- Add precision and scale to MysqlColumn ([commit 0612a03](https://github.com/googleapis/google-cloud-dotnet/commit/0612a03dc591591ff48726846d054fd334f79d97))
+
 ## Version 2.3.0, released 2023-05-11
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1649,7 +1649,7 @@
     },
     {
       "id": "Google.Cloud.Datastream.V1",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "type": "grpc",
       "productName": "DataStream",
       "productUrl": "https://cloud.google.com/datastream/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Add precision and scale to MysqlColumn ([commit 0612a03](https://github.com/googleapis/google-cloud-dotnet/commit/0612a03dc591591ff48726846d054fd334f79d97))
