### PR TITLE
Release Google.Cloud.DocumentAI.V1 version 3.8.0

### DIFF
--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.csproj
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.7.0</Version>
+    <Version>3.8.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Document AI API (v1), which is a service to parse structured information from unstructured or semi-structured documents using state-of-the-art Google AI such as natural language, computer vision, translation, and AutoML.</Description>

--- a/apis/Google.Cloud.DocumentAI.V1/docs/history.md
+++ b/apis/Google.Cloud.DocumentAI.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 3.8.0, released 2023-08-04
+
+### New features
+
+- Added http configuration and document publishing for v1beta2 ([commit 0090f90](https://github.com/googleapis/google-cloud-dotnet/commit/0090f900aca37d59a2948fe0000644383f752778))
+- Added ImportDocuments, GetDocument and BatchDeleteDocuments RPCs for v1beta3 ([commit 0090f90](https://github.com/googleapis/google-cloud-dotnet/commit/0090f900aca37d59a2948fe0000644383f752778))
+
 ## Version 3.7.0, released 2023-06-20
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1955,7 +1955,7 @@
     },
     {
       "id": "Google.Cloud.DocumentAI.V1",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "type": "grpc",
       "productName": "Cloud Document AI",
       "productUrl": "https://cloud.google.com/solutions/document-ai",


### PR DESCRIPTION

Changes in this release:

### New features

- Added http configuration and document publishing for v1beta2 ([commit 0090f90](https://github.com/googleapis/google-cloud-dotnet/commit/0090f900aca37d59a2948fe0000644383f752778))
- Added ImportDocuments, GetDocument and BatchDeleteDocuments RPCs for v1beta3 ([commit 0090f90](https://github.com/googleapis/google-cloud-dotnet/commit/0090f900aca37d59a2948fe0000644383f752778))
