### PR TITLE
Release Google.Cloud.DocumentAI.V1Beta3 version 2.0.0-beta12

### DIFF
--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.csproj
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta11</Version>
+    <Version>2.0.0-beta12</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Document AI API (v1beta3), which is a service to parse structured information from unstructured or semi-structured documents using state-of-the-art Google AI such as natural language, computer vision, translation, and AutoML.</Description>

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/docs/history.md
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/docs/history.md
@@ -1,5 +1,14 @@
 # Version history
 
+## Version 2.0.0-beta12, released 2023-08-04
+
+### New features
+
+- Exposed Import PV external_processor_version_source to v1beta3 public ([commit 5962731](https://github.com/googleapis/google-cloud-dotnet/commit/5962731b3c78e602fe5d2ebca4caa16f9b7958dc))
+- **BREAKING CHANGE** Removed id field from Document message ([commit 359acc0](https://github.com/googleapis/google-cloud-dotnet/commit/359acc0963e3df766561d2193150e06fc1aaf150))
+- Added http configuration and document publishing for v1beta2 ([commit 359acc0](https://github.com/googleapis/google-cloud-dotnet/commit/359acc0963e3df766561d2193150e06fc1aaf150))
+- Added ImportDocuments, GetDocument and BatchDeleteDocuments RPCs for v1beta3 ([commit 359acc0](https://github.com/googleapis/google-cloud-dotnet/commit/359acc0963e3df766561d2193150e06fc1aaf150))
+
 ## Version 2.0.0-beta11, released 2023-06-20
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1983,7 +1983,7 @@
     },
     {
       "id": "Google.Cloud.DocumentAI.V1Beta3",
-      "version": "2.0.0-beta11",
+      "version": "2.0.0-beta12",
       "type": "grpc",
       "productName": "Cloud Document AI",
       "productUrl": "https://cloud.google.com/solutions/document-ai",


### PR DESCRIPTION

Changes in this release:

### New features

- Exposed Import PV external_processor_version_source to v1beta3 public ([commit 5962731](https://github.com/googleapis/google-cloud-dotnet/commit/5962731b3c78e602fe5d2ebca4caa16f9b7958dc))
- **BREAKING CHANGE** Removed id field from Document message ([commit 359acc0](https://github.com/googleapis/google-cloud-dotnet/commit/359acc0963e3df766561d2193150e06fc1aaf150))
- Added http configuration and document publishing for v1beta2 ([commit 359acc0](https://github.com/googleapis/google-cloud-dotnet/commit/359acc0963e3df766561d2193150e06fc1aaf150))
- Added ImportDocuments, GetDocument and BatchDeleteDocuments RPCs for v1beta3 ([commit 359acc0](https://github.com/googleapis/google-cloud-dotnet/commit/359acc0963e3df766561d2193150e06fc1aaf150))
