### PR TITLE
Release Google.Cloud.PolicyTroubleshooter.V1 version 2.2.0

### DIFF
--- a/apis/Google.Cloud.PolicyTroubleshooter.V1/Google.Cloud.PolicyTroubleshooter.V1/Google.Cloud.PolicyTroubleshooter.V1.csproj
+++ b/apis/Google.Cloud.PolicyTroubleshooter.V1/Google.Cloud.PolicyTroubleshooter.V1/Google.Cloud.PolicyTroubleshooter.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google IAM Policy Troubleshooter API.</Description>

--- a/apis/Google.Cloud.PolicyTroubleshooter.V1/docs/history.md
+++ b/apis/Google.Cloud.PolicyTroubleshooter.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 2.2.0, released 2023-08-04
+
+### New features
+
+- Include errors in troubleshoot response ([commit 5543e86](https://github.com/googleapis/google-cloud-dotnet/commit/5543e8685f83cb45fa0399a34aebaae3927e991f))
+
+### Documentation improvements
+
+- Update documentation for ToubleshootIamPolicy RPC method ([commit 5543e86](https://github.com/googleapis/google-cloud-dotnet/commit/5543e8685f83cb45fa0399a34aebaae3927e991f))
+
 ## Version 2.1.0, released 2023-01-18
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3470,7 +3470,7 @@
     },
     {
       "id": "Google.Cloud.PolicyTroubleshooter.V1",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "type": "grpc",
       "productName": "Policy Troubleshooter",
       "productUrl": "https://cloud.google.com/iam/docs/reference/policytroubleshooter/rest",


### PR DESCRIPTION

Changes in this release:

### New features

- Include errors in troubleshoot response ([commit 5543e86](https://github.com/googleapis/google-cloud-dotnet/commit/5543e8685f83cb45fa0399a34aebaae3927e991f))

### Documentation improvements

- Update documentation for ToubleshootIamPolicy RPC method ([commit 5543e86](https://github.com/googleapis/google-cloud-dotnet/commit/5543e8685f83cb45fa0399a34aebaae3927e991f))
