### PR TITLE
Release Google.Cloud.ServiceDirectory.V1Beta1 version 2.0.0-beta03

### DIFF
--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.csproj
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta02</Version>
+    <Version>2.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Service Directory API version v1beta1.</Description>

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/docs/history.md
@@ -1,5 +1,19 @@
 # Version history
 
+## Version 2.0.0-beta03, released 2023-08-04
+
+### New features
+
+- Added network and uid fields in Endpoint message ([commit 832f388](https://github.com/googleapis/google-cloud-dotnet/commit/832f388e29a18c4d7e0e39d74d1dc45536ada722))
+- Added uid field to Namespace message ([commit 832f388](https://github.com/googleapis/google-cloud-dotnet/commit/832f388e29a18c4d7e0e39d74d1dc45536ada722))
+- Added uid field to Service message ([commit 832f388](https://github.com/googleapis/google-cloud-dotnet/commit/832f388e29a18c4d7e0e39d74d1dc45536ada722))
+- Enable Location methods ([commit 832f388](https://github.com/googleapis/google-cloud-dotnet/commit/832f388e29a18c4d7e0e39d74d1dc45536ada722))
+
+### Documentation improvements
+
+- Updated docs for ResolveServiceRequest message ([commit 832f388](https://github.com/googleapis/google-cloud-dotnet/commit/832f388e29a18c4d7e0e39d74d1dc45536ada722))
+- Updated docs for ListServicesRequest and ListEndpointsRequest message ([commit 832f388](https://github.com/googleapis/google-cloud-dotnet/commit/832f388e29a18c4d7e0e39d74d1dc45536ada722))
+
 ## Version 2.0.0-beta02, released 2023-01-19
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4042,7 +4042,7 @@
       "protoPath": "google/cloud/servicedirectory/v1beta1",
       "productName": "Service Directory",
       "productUrl": "https://cloud.google.com/service-directory/",
-      "version": "2.0.0-beta02",
+      "version": "2.0.0-beta03",
       "type": "grpc",
       "description": "Recommended Google client library to access the Service Directory API version v1beta1.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Added network and uid fields in Endpoint message ([commit 832f388](https://github.com/googleapis/google-cloud-dotnet/commit/832f388e29a18c4d7e0e39d74d1dc45536ada722))
- Added uid field to Namespace message ([commit 832f388](https://github.com/googleapis/google-cloud-dotnet/commit/832f388e29a18c4d7e0e39d74d1dc45536ada722))
- Added uid field to Service message ([commit 832f388](https://github.com/googleapis/google-cloud-dotnet/commit/832f388e29a18c4d7e0e39d74d1dc45536ada722))
- Enable Location methods ([commit 832f388](https://github.com/googleapis/google-cloud-dotnet/commit/832f388e29a18c4d7e0e39d74d1dc45536ada722))

### Documentation improvements

- Updated docs for ResolveServiceRequest message ([commit 832f388](https://github.com/googleapis/google-cloud-dotnet/commit/832f388e29a18c4d7e0e39d74d1dc45536ada722))
- Updated docs for ListServicesRequest and ListEndpointsRequest message ([commit 832f388](https://github.com/googleapis/google-cloud-dotnet/commit/832f388e29a18c4d7e0e39d74d1dc45536ada722))
