### PR TITLE
Release Google.Cloud.Tasks.V2Beta3 version 3.0.0-beta03

### DIFF
--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.csproj
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0-beta02</Version>
+    <Version>3.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Tasks API (v2beta3), which manages the execution of large numbers of distributed requests.</Description>

--- a/apis/Google.Cloud.Tasks.V2Beta3/docs/history.md
+++ b/apis/Google.Cloud.Tasks.V2Beta3/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 3.0.0-beta03, released 2023-08-04
+
+### New features
+
+- Add BufferTask RPC method for CloudTasks service for v2beta3 ([commit 36504a4](https://github.com/googleapis/google-cloud-dotnet/commit/36504a43d32649cb13b347bd18263c341eaf2c26))
+- Add YAML config for GetLocation and ListLocations for v2beta3 ([commit 36504a4](https://github.com/googleapis/google-cloud-dotnet/commit/36504a43d32649cb13b347bd18263c341eaf2c26))
+
+### Documentation improvements
+
+- Minor formatting ([commit 7c49dff](https://github.com/googleapis/google-cloud-dotnet/commit/7c49dffc44bf828460d367673ec802778832cd1d))
+
 ## Version 3.0.0-beta02, released 2023-01-19
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4477,7 +4477,7 @@
       "protoPath": "google/cloud/tasks/v2beta3",
       "productName": "Google Cloud Tasks",
       "productUrl": "https://cloud.google.com/tasks/",
-      "version": "3.0.0-beta02",
+      "version": "3.0.0-beta03",
       "releaseLevelOverride": "preview",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Tasks API (v2beta3), which manages the execution of large numbers of distributed requests.",


### PR DESCRIPTION

Changes in this release:

### New features

- Add BufferTask RPC method for CloudTasks service for v2beta3 ([commit 36504a4](https://github.com/googleapis/google-cloud-dotnet/commit/36504a43d32649cb13b347bd18263c341eaf2c26))
- Add YAML config for GetLocation and ListLocations for v2beta3 ([commit 36504a4](https://github.com/googleapis/google-cloud-dotnet/commit/36504a43d32649cb13b347bd18263c341eaf2c26))

### Documentation improvements

- Minor formatting ([commit 7c49dff](https://github.com/googleapis/google-cloud-dotnet/commit/7c49dffc44bf828460d367673ec802778832cd1d))
