### PR TITLE
Release Google.Cloud.Video.LiveStream.V1 version 1.3.0

### DIFF
--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.csproj
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Live Stream API, which transcodes mezzanine live signals into direct-to-consumer streaming formats.</Description>

--- a/apis/Google.Cloud.Video.LiveStream.V1/docs/history.md
+++ b/apis/Google.Cloud.Video.LiveStream.V1/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 1.3.0, released 2023-08-04
+
+### New features
+
+- Added support for slate events which allow users to create and insert a slate into a live stream to replace the main live stream content ([commit 9efd50b](https://github.com/googleapis/google-cloud-dotnet/commit/9efd50b73fa6c514ce2b6a8d7567bc07584ed7ae))
+- Added a new asset resource which can be used as the content of slate events ([commit 9efd50b](https://github.com/googleapis/google-cloud-dotnet/commit/9efd50b73fa6c514ce2b6a8d7567bc07584ed7ae))
+- Added a new pool resource for protecting input endpoints within a VPC Service Controls perimeter ([commit 9efd50b](https://github.com/googleapis/google-cloud-dotnet/commit/9efd50b73fa6c514ce2b6a8d7567bc07584ed7ae))
+
 ## Version 1.2.0, released 2023-03-27
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4671,7 +4671,7 @@
     },
     {
       "id": "Google.Cloud.Video.LiveStream.V1",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "type": "grpc",
       "productName": "Live Stream",
       "productUrl": "https://cloud.google.com/livestream/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Added support for slate events which allow users to create and insert a slate into a live stream to replace the main live stream content ([commit 9efd50b](https://github.com/googleapis/google-cloud-dotnet/commit/9efd50b73fa6c514ce2b6a8d7567bc07584ed7ae))
- Added a new asset resource which can be used as the content of slate events ([commit 9efd50b](https://github.com/googleapis/google-cloud-dotnet/commit/9efd50b73fa6c514ce2b6a8d7567bc07584ed7ae))
- Added a new pool resource for protecting input endpoints within a VPC Service Controls perimeter ([commit 9efd50b](https://github.com/googleapis/google-cloud-dotnet/commit/9efd50b73fa6c514ce2b6a8d7567bc07584ed7ae))
