### PR TITLE
chore: Update to xunit 2.5.1

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/Google.Cloud.Storage.V1.Tests.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/Google.Cloud.Storage.V1.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit" Version="2.5.1-pre.12" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/UrlSignerTest.RequestTemplateTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/UrlSignerTest.RequestTemplateTest.cs
@@ -1,4 +1,4 @@
-// Copyright 2020 Google Inc. All Rights Reserved.
+﻿// Copyright 2020 Google Inc. All Rights Reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -96,7 +96,7 @@ namespace Google.Cloud.Storage.V1.Tests
 
                 var expectedHeaders = ToExpectedEntries(headers);
                 Assert.NotSame(requestTemplate, newRequestTemplate);
-                AssertDictionariesEqual(expectedHeaders, newRequestTemplate.RequestHeaders);
+                Assert.Equal(expectedHeaders, newRequestTemplate.RequestHeaders);
             }
 
             [Fact]
@@ -113,7 +113,7 @@ namespace Google.Cloud.Storage.V1.Tests
 
                 var expectedHeaders = ToExpectedEntries(headers);
                 Assert.NotSame(requestTemplate, newRequestTemplate);
-                AssertDictionariesEqual(expectedHeaders, newRequestTemplate.ContentHeaders);
+                Assert.Equal(expectedHeaders, newRequestTemplate.ContentHeaders);
             }
 
             [Fact]
@@ -130,22 +130,7 @@ namespace Google.Cloud.Storage.V1.Tests
 
                 var expectedParameters = ToExpectedEntries(queryParameters);
                 Assert.NotSame(requestTemplate, newRequestTemplate);
-                AssertDictionariesEqual(expectedParameters, newRequestTemplate.QueryParameters);
-            }
-
-            private void AssertDictionariesEqual(
-                IReadOnlyDictionary<string, IReadOnlyCollection<string>> expected,
-                IReadOnlyDictionary<string, IReadOnlyCollection<string>> actual)
-            {
-                // xUnit 2.5.0 changed the behavior of Assert.Equal; previously we could just use
-                // Assert.Equal(expected, actual) for this.
-                Assert.Equal(
-                    expected.Keys.OrderBy(key => key, StringComparer.Ordinal),
-                    actual.Keys.OrderBy(key => key, StringComparer.Ordinal));
-                foreach (var key in expected.Keys)
-                {
-                    Assert.Equal(expected[key], actual[key]);
-                }
+                Assert.Equal(expectedParameters, newRequestTemplate.QueryParameters);
             }
 
             private IReadOnlyDictionary<string, IReadOnlyCollection<string>> ToExpectedEntries(


### PR DESCRIPTION
This allows us to revert some of the changes we made when updating to 2.5.0.

I've verified this works with 2.5.1-pre.12 - we just need to wait for 2.5.1 to be released.