### PR TITLE
Release Google.Cloud.BeyondCorp.ClientConnectorServices.V1 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.BeyondCorp.ClientConnectorServices.V1/Google.Cloud.BeyondCorp.ClientConnectorServices.V1/Google.Cloud.BeyondCorp.ClientConnectorServices.V1.csproj
+++ b/apis/Google.Cloud.BeyondCorp.ClientConnectorServices.V1/Google.Cloud.BeyondCorp.ClientConnectorServices.V1/Google.Cloud.BeyondCorp.ClientConnectorServices.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BeyondCorp Enterprise Client Connector Services API.</Description>

--- a/apis/Google.Cloud.BeyondCorp.ClientConnectorServices.V1/docs/history.md
+++ b/apis/Google.Cloud.BeyondCorp.ClientConnectorServices.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.1.0, released 2023-08-08
+
+This release is being used to publish a new front-page of
+documentation, to indicate package deprecation.
 ## Version 1.0.0, released 2022-09-15
 
 No API surface changes; just dependency updates and promotion to GA.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -665,7 +665,7 @@
     },
     {
       "id": "Google.Cloud.BeyondCorp.ClientConnectorServices.V1",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "grpc",
       "productName": "BeyondCorp Client Connector Services",
       "productUrl": "https://cloud.google.com/beyondcorp-enterprise",


### PR DESCRIPTION

Changes in this release:

This release is being used to publish a new front-page of documentation, to indicate package deprecation.
