### PR TITLE
Release Google.Cloud.Gaming.V1Beta version 2.0.0-beta03

### DIFF
--- a/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta.csproj
+++ b/apis/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta/Google.Cloud.Gaming.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta02</Version>
+    <Version>2.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Gaming API, version v1beta.</Description>

--- a/apis/Google.Cloud.Gaming.V1Beta/docs/history.md
+++ b/apis/Google.Cloud.Gaming.V1Beta/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 2.0.0-beta03, released 2023-08-08
+
+This release is being used to publish a new front-page of
+documentation, to indicate package deprecation.
 ## Version 2.0.0-beta02, released 2023-01-17
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2378,7 +2378,7 @@
       "id": "Google.Cloud.Gaming.V1Beta",
       "generator": "micro",
       "protoPath": "google/cloud/gaming/v1beta",
-      "version": "2.0.0-beta02",
+      "version": "2.0.0-beta03",
       "type": "grpc",
       "productName": "Google Cloud for Games",
       "productUrl": "https://cloud.google.com/solutions/gaming",


### PR DESCRIPTION

Changes in this release:

This release is being used to publish a new front-page of documentation, to indicate package deprecation.
