### PR TITLE
Release Google.Analytics.Admin.V1Alpha version 2.0.0-alpha12

### DIFF
--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha11</Version>
+    <Version>2.0.0-alpha12</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Analytics Admin API (v1alpha)</Description>

--- a/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
+++ b/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 2.0.0-alpha12, released 2023-08-16
+
+### Bug fixes
+
+- **BREAKING CHANGE** Rename the `enterprise_daily_export_enabled` field to `fresh_daily_export_enabled` in the `BigQueryLink` resource ([commit bb7b89d](https://github.com/googleapis/google-cloud-dotnet/commit/bb7b89df13baa26b976c2829cd4c41349853bd4e))
+
+### New features
+
+- Add `UpdateConversionEvent` method to the Admin API v1 alpha ([commit bb7b89d](https://github.com/googleapis/google-cloud-dotnet/commit/bb7b89df13baa26b976c2829cd4c41349853bd4e))
+- Add the `counting_method` field to the `ConversionEvent` type ([commit bb7b89d](https://github.com/googleapis/google-cloud-dotnet/commit/bb7b89df13baa26b976c2829cd4c41349853bd4e))
+- Add the `ConversionCountingMethod` enum ([commit bb7b89d](https://github.com/googleapis/google-cloud-dotnet/commit/bb7b89df13baa26b976c2829cd4c41349853bd4e))
+
 ## Version 2.0.0-alpha11, released 2023-08-04
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2,7 +2,7 @@
   "apis": [
     {
       "id": "Google.Analytics.Admin.V1Alpha",
-      "version": "2.0.0-alpha11",
+      "version": "2.0.0-alpha12",
       "type": "grpc",
       "productName": "Analytics Admin",
       "productUrl": "https://developers.google.com/analytics",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- **BREAKING CHANGE** Rename the `enterprise_daily_export_enabled` field to `fresh_daily_export_enabled` in the `BigQueryLink` resource ([commit bb7b89d](https://github.com/googleapis/google-cloud-dotnet/commit/bb7b89df13baa26b976c2829cd4c41349853bd4e))

### New features

- Add `UpdateConversionEvent` method to the Admin API v1 alpha ([commit bb7b89d](https://github.com/googleapis/google-cloud-dotnet/commit/bb7b89df13baa26b976c2829cd4c41349853bd4e))
- Add the `counting_method` field to the `ConversionEvent` type ([commit bb7b89d](https://github.com/googleapis/google-cloud-dotnet/commit/bb7b89df13baa26b976c2829cd4c41349853bd4e))
- Add the `ConversionCountingMethod` enum ([commit bb7b89d](https://github.com/googleapis/google-cloud-dotnet/commit/bb7b89df13baa26b976c2829cd4c41349853bd4e))
