### PR TITLE
Release Google.Cloud.AIPlatform.V1 version 2.18.0

### DIFF
--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.17.0</Version>
+    <Version>2.18.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AI Platform API, which allows you to train high-quality custom machine learning models with minimal machine learning expertise and effort.</Description>

--- a/apis/Google.Cloud.AIPlatform.V1/docs/history.md
+++ b/apis/Google.Cloud.AIPlatform.V1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 2.18.0, released 2023-08-16
+
+### New features
+
+- Update field_behavior for `name` to be IMMUTABLE instead of OUTPUT_ONLY in Context, ModelMonitor, Schedule, DeploymentResourcePool ([commit 67e1930](https://github.com/googleapis/google-cloud-dotnet/commit/67e1930923029f84aab0fe7d0d60bf744a94f099))
+- Expose CreateDatasetVersionOperationMetadata and RestoreDatasetVersionOperationMetadata to DatasetService ([commit 67e1930](https://github.com/googleapis/google-cloud-dotnet/commit/67e1930923029f84aab0fe7d0d60bf744a94f099))
+- Add disk_type and disk_size_gb to PersistentDiskSpec ([commit 67e1930](https://github.com/googleapis/google-cloud-dotnet/commit/67e1930923029f84aab0fe7d0d60bf744a94f099))
+- Add schedule_name to PipelineJob ([commit 67e1930](https://github.com/googleapis/google-cloud-dotnet/commit/67e1930923029f84aab0fe7d0d60bf744a94f099))
+- Add open_evaluation_pipeline to PublisherModel ([commit 67e1930](https://github.com/googleapis/google-cloud-dotnet/commit/67e1930923029f84aab0fe7d0d60bf744a94f099))
+- Add ReadTensorboardSize to TensorboardService ([commit 67e1930](https://github.com/googleapis/google-cloud-dotnet/commit/67e1930923029f84aab0fe7d0d60bf744a94f099))
+
 ## Version 2.17.0, released 2023-08-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -227,7 +227,7 @@
     },
     {
       "id": "Google.Cloud.AIPlatform.V1",
-      "version": "2.17.0",
+      "version": "2.18.0",
       "type": "grpc",
       "productName": "Cloud AI Platform",
       "productUrl": "https://cloud.google.com/ai-platform/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Update field_behavior for `name` to be IMMUTABLE instead of OUTPUT_ONLY in Context, ModelMonitor, Schedule, DeploymentResourcePool ([commit 67e1930](https://github.com/googleapis/google-cloud-dotnet/commit/67e1930923029f84aab0fe7d0d60bf744a94f099))
- Expose CreateDatasetVersionOperationMetadata and RestoreDatasetVersionOperationMetadata to DatasetService ([commit 67e1930](https://github.com/googleapis/google-cloud-dotnet/commit/67e1930923029f84aab0fe7d0d60bf744a94f099))
- Add disk_type and disk_size_gb to PersistentDiskSpec ([commit 67e1930](https://github.com/googleapis/google-cloud-dotnet/commit/67e1930923029f84aab0fe7d0d60bf744a94f099))
- Add schedule_name to PipelineJob ([commit 67e1930](https://github.com/googleapis/google-cloud-dotnet/commit/67e1930923029f84aab0fe7d0d60bf744a94f099))
- Add open_evaluation_pipeline to PublisherModel ([commit 67e1930](https://github.com/googleapis/google-cloud-dotnet/commit/67e1930923029f84aab0fe7d0d60bf744a94f099))
- Add ReadTensorboardSize to TensorboardService ([commit 67e1930](https://github.com/googleapis/google-cloud-dotnet/commit/67e1930923029f84aab0fe7d0d60bf744a94f099))
