### PR TITLE
Release Google.Cloud.Batch.V1 version 2.4.0

### DIFF
--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.csproj
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Batch API (v1), which allows you to manage the running of batch jobs on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Batch.V1/docs/history.md
+++ b/apis/Google.Cloud.Batch.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 2.4.0, released 2023-08-16
+
+### New features
+
+- Clarify Batch API proto doc about pubsub notifications ([commit 0d8755a](https://github.com/googleapis/google-cloud-dotnet/commit/0d8755a21bdbc85c29f8af5cfdc5ad60b91f67df))
+- Add Batch Managed Container support for v1alpha ([commit 0d8755a](https://github.com/googleapis/google-cloud-dotnet/commit/0d8755a21bdbc85c29f8af5cfdc5ad60b91f67df))
+
 ## Version 2.3.0, released 2023-08-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -550,7 +550,7 @@
     },
     {
       "id": "Google.Cloud.Batch.V1",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "type": "grpc",
       "productName": "Batch",
       "productUrl": "https://cloud.google.com/batch/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Clarify Batch API proto doc about pubsub notifications ([commit 0d8755a](https://github.com/googleapis/google-cloud-dotnet/commit/0d8755a21bdbc85c29f8af5cfdc5ad60b91f67df))
- Add Batch Managed Container support for v1alpha ([commit 0d8755a](https://github.com/googleapis/google-cloud-dotnet/commit/0d8755a21bdbc85c29f8af5cfdc5ad60b91f67df))
