### PR TITLE
Release Google.Cloud.BigQuery.DataPolicies.V1 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery DataPolicies API (v1), which allows users to manage BigQuery data policies.</Description>

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.1.0, released 2023-08-16
+
+### Bug fixes
+
+- Sync the new PredefinedEpxression types to the client library ([commit d5be2d4](https://github.com/googleapis/google-cloud-dotnet/commit/d5be2d41f5d8c05bda251fbe7322a5b8e479bb8e))
+
 ## Version 1.0.0, released 2023-03-27
 
 No API surface changes; just dependency updates and initial GA release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -752,7 +752,7 @@
     },
     {
       "id": "Google.Cloud.BigQuery.DataPolicies.V1",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "grpc",
       "productName": "BigQuery Data Policy",
       "productUrl": "https://cloud.google.com/bigquery/docs/data-governance",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Sync the new PredefinedEpxression types to the client library ([commit d5be2d4](https://github.com/googleapis/google-cloud-dotnet/commit/d5be2d41f5d8c05bda251fbe7322a5b8e479bb8e))
