### PR TITLE
Release Google.Cloud.BigQuery.Storage.V1 version 3.10.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.9.0</Version>
+    <Version>3.10.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery Storage API.</Description>

--- a/apis/Google.Cloud.BigQuery.Storage.V1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.10.0, released 2023-08-16
+
+### New features
+
+- Add default_missing_value_interpretation field; indicate KMS_SERVICE_ERROR is retryable ([commit 6d11153](https://github.com/googleapis/google-cloud-dotnet/commit/6d1115399c4ea9a0478ec15b1b725c5cc8e91f12))
+
 ## Version 3.9.0, released 2023-07-13
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -902,7 +902,7 @@
       "protoPath": "google/cloud/bigquery/storage/v1",
       "productName": "Google BigQuery Storage",
       "productUrl": "https://cloud.google.com/bigquery/docs/reference/storage/",
-      "version": "3.9.0",
+      "version": "3.10.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the BigQuery Storage API.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Add default_missing_value_interpretation field; indicate KMS_SERVICE_ERROR is retryable ([commit 6d11153](https://github.com/googleapis/google-cloud-dotnet/commit/6d1115399c4ea9a0478ec15b1b725c5cc8e91f12))
