### PR TITLE
Release Google.Cloud.BinaryAuthorization.V1Beta1 version 2.0.0-beta04

### DIFF
--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.csproj
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta03</Version>
+    <Version>2.0.0-beta04</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Binary Authorization API v1beta1, providing policy control for images deployed to Kubernetes Engine clusters.</Description>

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 2.0.0-beta04, released 2023-08-16
+
+### Bug fixes
+
+- **BREAKING CHANGE** Remove unused unsupported_policy_event event_type from ContinuousValidationPodEvent ([commit 84043b5](https://github.com/googleapis/google-cloud-dotnet/commit/84043b5f6a260678e2c3fdb6dde2ac56ba64b81b))
+
+### New features
+
+- Adds support for check-based platform policy evaluation to Binary Authorization Continuous Validation logs ([commit 84043b5](https://github.com/googleapis/google-cloud-dotnet/commit/84043b5f6a260678e2c3fdb6dde2ac56ba64b81b))
+- Adds support for communicating configuration issues that prevent Continuous Validation from monitoring pods ([commit 84043b5](https://github.com/googleapis/google-cloud-dotnet/commit/84043b5f6a260678e2c3fdb6dde2ac56ba64b81b))
+
 ## Version 2.0.0-beta03, released 2023-01-19
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1075,7 +1075,7 @@
     },
     {
       "id": "Google.Cloud.BinaryAuthorization.V1Beta1",
-      "version": "2.0.0-beta03",
+      "version": "2.0.0-beta04",
       "type": "grpc",
       "productName": "Binary Authorization",
       "productUrl": "https://cloud.google.com/binary-authorization/docs/reference/rpc",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- **BREAKING CHANGE** Remove unused unsupported_policy_event event_type from ContinuousValidationPodEvent ([commit 84043b5](https://github.com/googleapis/google-cloud-dotnet/commit/84043b5f6a260678e2c3fdb6dde2ac56ba64b81b))

### New features

- Adds support for check-based platform policy evaluation to Binary Authorization Continuous Validation logs ([commit 84043b5](https://github.com/googleapis/google-cloud-dotnet/commit/84043b5f6a260678e2c3fdb6dde2ac56ba64b81b))
- Adds support for communicating configuration issues that prevent Continuous Validation from monitoring pods ([commit 84043b5](https://github.com/googleapis/google-cloud-dotnet/commit/84043b5f6a260678e2c3fdb6dde2ac56ba64b81b))
