### PR TITLE
Release Google.Cloud.ConfidentialComputing.V1 version 1.0.0-beta04

### DIFF
--- a/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.csproj
+++ b/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta03</Version>
+    <Version>1.0.0-beta04</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Confidential Computing API (v1)</Description>

--- a/apis/Google.Cloud.ConfidentialComputing.V1/docs/history.md
+++ b/apis/Google.Cloud.ConfidentialComputing.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta04, released 2023-08-16
+
+### New features
+
+- Add a new field `partial_errors` to `VerifyAttestationResponse` proto ([commit ce8f831](https://github.com/googleapis/google-cloud-dotnet/commit/ce8f831ef4bb474edba185294920dbe3fed2b14a))
+
 ## Version 1.0.0-beta03, released 2023-08-07
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1265,7 +1265,7 @@
     },
     {
       "id": "Google.Cloud.ConfidentialComputing.V1",
-      "version": "1.0.0-beta03",
+      "version": "1.0.0-beta04",
       "type": "grpc",
       "productName": "Confidential Computing",
       "productUrl": "https://cloud.google.com/confidential-computing",


### PR DESCRIPTION

Changes in this release:

### New features

- Add a new field `partial_errors` to `VerifyAttestationResponse` proto ([commit ce8f831](https://github.com/googleapis/google-cloud-dotnet/commit/ce8f831ef4bb474edba185294920dbe3fed2b14a))
