### PR TITLE
Release Google.Cloud.Dialogflow.Cx.V3 version 2.10.0

### DIFF
--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.csproj
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.9.0</Version>
+    <Version>2.10.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Builds conversational interfaces (for example, chatbots, and voice-powered apps and devices).</Description>

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/docs/history.md
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 2.10.0, released 2023-08-16
+
+### New features
+
+- Added agent level route group ([commit a1d57da](https://github.com/googleapis/google-cloud-dotnet/commit/a1d57da865d33facbeddbf03d0e72de6caa48e4a))
+- Added flow import strategy ([commit a1d57da](https://github.com/googleapis/google-cloud-dotnet/commit/a1d57da865d33facbeddbf03d0e72de6caa48e4a))
+
 ## Version 2.9.0, released 2023-07-13
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1817,7 +1817,7 @@
     },
     {
       "id": "Google.Cloud.Dialogflow.Cx.V3",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "type": "grpc",
       "productName": "Dialogflow",
       "productUrl": "https://cloud.google.com/dialogflow/cx/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Added agent level route group ([commit a1d57da](https://github.com/googleapis/google-cloud-dotnet/commit/a1d57da865d33facbeddbf03d0e72de6caa48e4a))
- Added flow import strategy ([commit a1d57da](https://github.com/googleapis/google-cloud-dotnet/commit/a1d57da865d33facbeddbf03d0e72de6caa48e4a))
