### PR TITLE
Release Google.Cloud.OsLogin.V1Beta version 3.0.0-beta03

### DIFF
--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.Snippets/coverage.xml
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.Snippets/coverage.xml
@@ -7,9 +7,6 @@
       <FilterEntry>
         <ModuleMask>Google.Cloud.OsLogin.V1</ModuleMask>
       </FilterEntry>
-      <FilterEntry>
-        <ModuleMask>Google.Cloud.OsLogin.Common</ModuleMask>
-      </FilterEntry>
     </IncludeFilters>
   </Filters>
   <AttributeFilters>

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.csproj
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
-    <ProjectReference Include="..\..\Google.Cloud.OsLogin.Common\Google.Cloud.OsLogin.Common\Google.Cloud.OsLogin.Common.csproj" />
+    <PackageReference Include="Google.Cloud.OsLogin.Common" Version="[3.1.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.Snippets/coverage.xml
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.Snippets/coverage.xml
@@ -7,9 +7,6 @@
       <FilterEntry>
         <ModuleMask>Google.Cloud.OsLogin.V1Beta</ModuleMask>
       </FilterEntry>
-      <FilterEntry>
-        <ModuleMask>Google.Cloud.OsLogin.Common</ModuleMask>
-      </FilterEntry>
     </IncludeFilters>
   </Filters>
   <AttributeFilters>

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.csproj
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0-beta02</Version>
+    <Version>3.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to manages OS login configuration for Google account users.</Description>

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.csproj
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
-    <ProjectReference Include="..\..\Google.Cloud.OsLogin.Common\Google.Cloud.OsLogin.Common\Google.Cloud.OsLogin.Common.csproj" />
+    <PackageReference Include="Google.Cloud.OsLogin.Common" Version="[3.1.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.OsLogin.V1Beta/docs/history.md
+++ b/apis/Google.Cloud.OsLogin.V1Beta/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.0.0-beta03, released 2023-08-16
+
+### New features
+
+- Launch signSshPublicKey in beta ([commit 19c34de](https://github.com/googleapis/google-cloud-dotnet/commit/19c34de1802c255a1e87a7f3a136ce07aaab2ec0))
+
 ## Version 3.0.0-beta02, released 2023-02-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3404,7 +3404,7 @@
       "protoPath": "google/cloud/oslogin/v1beta",
       "productName": "Google Cloud OS Login",
       "productUrl": "https://cloud.google.com/compute/docs/instances/managing-instance-access",
-      "version": "3.0.0-beta02",
+      "version": "3.0.0-beta03",
       "releaseLevelOverride": "preview",
       "type": "grpc",
       "description": "Recommended Google client library to manages OS login configuration for Google account users.",

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3389,7 +3389,7 @@
       ],
       "dependencies": {
         "Google.Api.Gax.Grpc": "4.4.0",
-        "Google.Cloud.OsLogin.Common": "project",
+        "Google.Cloud.OsLogin.Common": "3.1.0",
         "Grpc.Core": "2.46.6"
       },
       "forceOwlBotRegeneration": "OsLogin Common proto is generated and copied when it shouldn't be.",
@@ -3414,7 +3414,7 @@
       ],
       "dependencies": {
         "Google.Api.Gax.Grpc": "4.4.0",
-        "Google.Cloud.OsLogin.Common": "project",
+        "Google.Cloud.OsLogin.Common": "3.1.0",
         "Grpc.Core": "2.46.6"
       },
       "forceOwlBotRegeneration": "OsLogin Common proto is generated and copied when it shouldn't be.",
@@ -5287,15 +5287,6 @@
       "packageIds": [
         "Google.Cloud.Firestore",
         "Google.Cloud.Firestore.V1"
-      ]
-    },
-    {
-      "id": "Google.Cloud.OsLogin",
-      "displayName": "OS Login",
-      "packageIds": [
-        "Google.Cloud.OsLogin.Common",
-        "Google.Cloud.OsLogin.V1",
-        "Google.Cloud.OsLogin.V1Beta"
       ]
     },
     {


### PR DESCRIPTION

Changes in this release:

### New features

- Launch signSshPublicKey in beta ([commit 19c34de](https://github.com/googleapis/google-cloud-dotnet/commit/19c34de1802c255a1e87a7f3a136ce07aaab2ec0))
