### PR TITLE
Release Google.Cloud.Video.Stitcher.V1 version 3.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.csproj
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0-beta01</Version>
+    <Version>3.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Video Stitcher API, which helps you generate dynamic content for delivery to client devices. </Description>

--- a/apis/Google.Cloud.Video.Stitcher.V1/docs/history.md
+++ b/apis/Google.Cloud.Video.Stitcher.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.0.0-beta02, released 2023-08-22
+
+### Bug fixes
+
+- **BREAKING CHANGE** Use correct child_type annotation ([commit 324d882](https://github.com/googleapis/google-cloud-dotnet/commit/324d882b5e6fbf7a193d5c953ba169b6e05afbcc))
+
 ## Version 3.0.0-beta01, released 2023-04-25
 
 New major version to accommodate breaking changes. This is initially

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4734,7 +4734,7 @@
     },
     {
       "id": "Google.Cloud.Video.Stitcher.V1",
-      "version": "3.0.0-beta01",
+      "version": "3.0.0-beta02",
       "type": "grpc",
       "productName": "Video Stitcher",
       "productUrl": "https://cloud.google.com/video-stitcher/docs",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- **BREAKING CHANGE** Use correct child_type annotation ([commit 324d882](https://github.com/googleapis/google-cloud-dotnet/commit/324d882b5e6fbf7a193d5c953ba169b6e05afbcc))
