### PR TITLE
Release Google.Cloud.Datastore.V1 version 4.6.0

### DIFF
--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.5.0</Version>
+    <Version>4.6.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Datastore API, which accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.</Description>

--- a/apis/Google.Cloud.Datastore.V1/docs/history.md
+++ b/apis/Google.Cloud.Datastore.V1/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 4.6.0, released 2023-08-22
+
+### New features
+
+- Add sum and average aggregates ([commit 4b253b0](https://github.com/googleapis/google-cloud-dotnet/commit/4b253b0d2b2c09a379142e59481f3ce8a3643b1e))
+- Publish proto definitions for SUM/AVG ([commit ab0464e](https://github.com/googleapis/google-cloud-dotnet/commit/ab0464e993fbacc50d91f80c6f6d7b87ff8682da))
+
+### Documentation improvements
+
+- Update property requirement specifications ([commit 11b3f20](https://github.com/googleapis/google-cloud-dotnet/commit/11b3f208b70651234d2bfef07460b98220ed23a7))
+- Minor comment update for Entity message ([commit 1d662d5](https://github.com/googleapis/google-cloud-dotnet/commit/1d662d52c880b995c733f1a2b0d70f8957fb5bf1))
+
 ## Version 4.5.0, released 2023-03-13
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1626,7 +1626,7 @@
       "protoPath": "google/datastore/v1",
       "productName": "Google Cloud Datastore",
       "productUrl": "https://cloud.google.com/datastore/docs/concepts/overview",
-      "version": "4.5.0",
+      "version": "4.6.0",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Datastore API, which accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.",


### PR DESCRIPTION

Changes in this release:

### New features

- Add sum and average aggregates ([commit 4b253b0](https://github.com/googleapis/google-cloud-dotnet/commit/4b253b0d2b2c09a379142e59481f3ce8a3643b1e))
- Publish proto definitions for SUM/AVG ([commit ab0464e](https://github.com/googleapis/google-cloud-dotnet/commit/ab0464e993fbacc50d91f80c6f6d7b87ff8682da))

### Documentation improvements

- Update property requirement specifications ([commit 11b3f20](https://github.com/googleapis/google-cloud-dotnet/commit/11b3f208b70651234d2bfef07460b98220ed23a7))
- Minor comment update for Entity message ([commit 1d662d5](https://github.com/googleapis/google-cloud-dotnet/commit/1d662d52c880b995c733f1a2b0d70f8957fb5bf1))
