### PR TITLE
chore: update autorelease.sh to use the new publish reporter tool

### DIFF
--- a/.kokoro/autorelease.sh
+++ b/.kokoro/autorelease.sh
@@ -15,12 +15,7 @@ populate_all_secrets
 python -m pip install --require-hashes -r pip-requirements.txt
 python -m pip install --require-hashes -r requirements.txt
 
-# The publish reporter script uses "python3" which doesn't exist on Windows.
-# Work out what we should use instead, and fix up the script.
-python -m releasetool publish-reporter-script > /tmp/publisher-script
-PYTHON3=$(source ../toolversions.sh && echo $PYTHON3)
-sed -i "s/python3/$PYTHON3/g" /tmp/publisher-script
-source /tmp/publisher-script
+source ../tools/Google.Cloud.Tools.ReleaseProgressReporter/publish_reporter.sh
 
 # Secrets are already populated, let's not do that again
 ./release.sh --skippopulatesecrets


### PR DESCRIPTION
This updates the autorelease.sh script to use trigger in house(.Net) release publish reporter tool.