### PR TITLE
Release Google.Cloud.Batch.V1Alpha version 1.0.0-alpha16

### DIFF
--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.csproj
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha15</Version>
+    <Version>1.0.0-alpha16</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Batch API (v1alpha), which allows you to manage the running of batch jobs on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Batch.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.Batch.V1Alpha/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 1.0.0-alpha16, released 2023-08-22
+
+### New features
+
+- Add more compute resource API descriptions to match with VM's machine type field ([commit 2a9340b](https://github.com/googleapis/google-cloud-dotnet/commit/2a9340bb14ba9ad0a0e0706363fac4f26730f750))
+- Clarify Batch API proto doc about pubsub notifications ([commit 2a9340b](https://github.com/googleapis/google-cloud-dotnet/commit/2a9340bb14ba9ad0a0e0706363fac4f26730f750))
+- Add Batch Managed Container support for v1alpha ([commit 2a9340b](https://github.com/googleapis/google-cloud-dotnet/commit/2a9340bb14ba9ad0a0e0706363fac4f26730f750))
+
 ## Version 1.0.0-alpha15, released 2023-08-16
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -574,7 +574,7 @@
     },
     {
       "id": "Google.Cloud.Batch.V1Alpha",
-      "version": "1.0.0-alpha15",
+      "version": "1.0.0-alpha16",
       "type": "grpc",
       "productName": "Batch",
       "productUrl": "https://cloud.google.com/batch/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add more compute resource API descriptions to match with VM's machine type field ([commit 2a9340b](https://github.com/googleapis/google-cloud-dotnet/commit/2a9340bb14ba9ad0a0e0706363fac4f26730f750))
- Clarify Batch API proto doc about pubsub notifications ([commit 2a9340b](https://github.com/googleapis/google-cloud-dotnet/commit/2a9340bb14ba9ad0a0e0706363fac4f26730f750))
- Add Batch Managed Container support for v1alpha ([commit 2a9340b](https://github.com/googleapis/google-cloud-dotnet/commit/2a9340bb14ba9ad0a0e0706363fac4f26730f750))
