### PR TITLE
Release Google.Cloud.Batch.V1Alpha version 1.0.0-alpha17

### DIFF
--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.csproj
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha16</Version>
+    <Version>1.0.0-alpha17</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Batch API (v1alpha), which allows you to manage the running of batch jobs on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Batch.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.Batch.V1Alpha/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 1.0.0-alpha17, released 2023-08-23
+
+### New features
+
+- Add stderr_snippet to indicate the real stderr output by runnables to the execution field of status event ([commit db9f8f2](https://github.com/googleapis/google-cloud-dotnet/commit/db9f8f286a17594bc1a326495d73d213eaebebb7))
+
+### Documentation improvements
+
+- Update comments ([commit db9f8f2](https://github.com/googleapis/google-cloud-dotnet/commit/db9f8f286a17594bc1a326495d73d213eaebebb7))
+
 ## Version 1.0.0-alpha16, released 2023-08-22
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -574,7 +574,7 @@
     },
     {
       "id": "Google.Cloud.Batch.V1Alpha",
-      "version": "1.0.0-alpha16",
+      "version": "1.0.0-alpha17",
       "type": "grpc",
       "productName": "Batch",
       "productUrl": "https://cloud.google.com/batch/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add stderr_snippet to indicate the real stderr output by runnables to the execution field of status event ([commit db9f8f2](https://github.com/googleapis/google-cloud-dotnet/commit/db9f8f286a17594bc1a326495d73d213eaebebb7))

### Documentation improvements

- Update comments ([commit db9f8f2](https://github.com/googleapis/google-cloud-dotnet/commit/db9f8f286a17594bc1a326495d73d213eaebebb7))
