### PR TITLE
Release Google.Cloud.Billing.Budgets.V1 version 2.3.0

### DIFF
--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.csproj
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.2.0</Version>
+    <Version>2.3.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Cloud Billing Budget API v1. This API stores Cloud Billing budgets, which define a budget plan and the rules to execute as spend is tracked against that plan.</Description>

--- a/apis/Google.Cloud.Billing.Budgets.V1/docs/history.md
+++ b/apis/Google.Cloud.Billing.Budgets.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 2.3.0, released 2023-08-23
+
+### New features
+
+- Supported project-level-budgets in Public Budget API V1 ([commit 794fa92](https://github.com/googleapis/google-cloud-dotnet/commit/794fa92ad3ebcd05f389a1eb1f4fca5cc9687b1e))
+- Added `enable_project_level_recipients` for project owner budget emails ([commit 794fa92](https://github.com/googleapis/google-cloud-dotnet/commit/794fa92ad3ebcd05f389a1eb1f4fca5cc9687b1e))
+
 ## Version 2.2.0, released 2023-06-20
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -985,7 +985,7 @@
     },
     {
       "id": "Google.Cloud.Billing.Budgets.V1",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "type": "grpc",
       "productName": "Cloud Billing Budget",
       "productUrl": "https://cloud.google.com/billing/docs/how-to/budget-api-overview",


### PR DESCRIPTION

Changes in this release:

### New features

- Supported project-level-budgets in Public Budget API V1 ([commit 794fa92](https://github.com/googleapis/google-cloud-dotnet/commit/794fa92ad3ebcd05f389a1eb1f4fca5cc9687b1e))
- Added `enable_project_level_recipients` for project owner budget emails ([commit 794fa92](https://github.com/googleapis/google-cloud-dotnet/commit/794fa92ad3ebcd05f389a1eb1f4fca5cc9687b1e))
