### PR TITLE
Release Google.Cloud.Dataproc.V1 version 5.6.0

### DIFF
--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.csproj
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>5.5.0</Version>
+    <Version>5.6.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Dataproc API, which manages Hadoop-based clusters and jobs on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Dataproc.V1/docs/history.md
+++ b/apis/Google.Cloud.Dataproc.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 5.6.0, released 2023-08-23
+
+### New features
+
+- Support min_num_instances for primary worker and InstanceFlexibilityPolicy for secondary worker ([commit 1783572](https://github.com/googleapis/google-cloud-dotnet/commit/1783572f62de9ed84cb7b0bc44993d39f7cb30ce))
+
+### Documentation improvements
+
+- Minor formatting ([commit 5a4054c](https://github.com/googleapis/google-cloud-dotnet/commit/5a4054c983789e87cee928cf31fdc61483cecd29))
+
 ## Version 5.5.0, released 2023-03-20
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1580,7 +1580,7 @@
       "protoPath": "google/cloud/dataproc/v1",
       "productName": "Google Cloud Dataproc",
       "productUrl": "https://cloud.google.com/dataproc/docs/concepts/overview",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Dataproc API, which manages Hadoop-based clusters and jobs on Google Cloud Platform.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- Support min_num_instances for primary worker and InstanceFlexibilityPolicy for secondary worker ([commit 1783572](https://github.com/googleapis/google-cloud-dotnet/commit/1783572f62de9ed84cb7b0bc44993d39f7cb30ce))

### Documentation improvements

- Minor formatting ([commit 5a4054c](https://github.com/googleapis/google-cloud-dotnet/commit/5a4054c983789e87cee928cf31fdc61483cecd29))
