### PR TITLE
Release Google.Cloud.Tools.DocUploader version 0.2.1

### DIFF
--- a/tools/Google.Cloud.Tools.DocUploader/Google.Cloud.Tools.DocUploader.csproj
+++ b/tools/Google.Cloud.Tools.DocUploader/Google.Cloud.Tools.DocUploader.csproj
@@ -8,7 +8,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
-    <Version>0.2.0</Version>
+    <Version>0.2.1</Version>
     <Description>Tool used by Google .NET release processes for documentation. While there is nothing "secret" in this package, it is unlikely to be useful to other developers. It is only published as a matter of convenience for other Google .NET repositories.</Description>
     <ToolCommandName>docuploader</ToolCommandName>
   </PropertyGroup>


### PR DESCRIPTION
(No code changes; just a release build fix.)