### PR TITLE
chore: Update release tooling to published versions

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,13 +9,13 @@
       ]
     },
     "Google.Cloud.Tools.DocUploader": {
-      "version": "0.1.0",
+      "version": "0.2.1",
       "commands": [
         "docuploader"
       ]
     },
     "Google.Cloud.Tools.ReleaseProgressReporter": {
-      "version": "0.1.0",
+      "version": "0.2.1",
       "commands": [
         "release-progress-reporter"
       ]


### PR DESCRIPTION
At this point, we should be able to release a normal client library using the same process as before, but with an implementation based entirely on dotnet tools.