### PR TITLE
Release Google.Analytics.Admin.V1Beta version 1.0.0-beta04

### DIFF
--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.csproj
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta03</Version>
+    <Version>1.0.0-beta04</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Analytics Admin API (v1beta)</Description>

--- a/apis/Google.Analytics.Admin.V1Beta/docs/history.md
+++ b/apis/Google.Analytics.Admin.V1Beta/docs/history.md
@@ -1,5 +1,19 @@
 # Version history
 
+## Version 1.0.0-beta04, released 2023-09-01
+
+### Bug fixes
+
+- **BREAKING CHANGE** Add the missing `REQUIRED` annotation to the `update_mask` field of `UpdateMeasurementProtocolSecretRequest` ([commit c54eaea](https://github.com/googleapis/google-cloud-dotnet/commit/c54eaea9c6fb63c36eb3ec72c53da88c64e82dae))
+
+### New features
+
+- Add `UpdateConversionEvent` method to the Admin API v1 beta ([commit c54eaea](https://github.com/googleapis/google-cloud-dotnet/commit/c54eaea9c6fb63c36eb3ec72c53da88c64e82dae))
+- Add the `counting_method` field to the `ConversionEvent` type ([commit c54eaea](https://github.com/googleapis/google-cloud-dotnet/commit/c54eaea9c6fb63c36eb3ec72c53da88c64e82dae))
+- Add the `ConversionCountingMethod` enum ([commit c54eaea](https://github.com/googleapis/google-cloud-dotnet/commit/c54eaea9c6fb63c36eb3ec72c53da88c64e82dae))
+- Add the `ITEM` option to the `DimensionScope` enum ([commit c54eaea](https://github.com/googleapis/google-cloud-dotnet/commit/c54eaea9c6fb63c36eb3ec72c53da88c64e82dae))
+- Make the field `default_uri` of `WebStreamData` mutable ([commit c54eaea](https://github.com/googleapis/google-cloud-dotnet/commit/c54eaea9c6fb63c36eb3ec72c53da88c64e82dae))
+
 ## Version 1.0.0-beta03, released 2023-03-27
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -20,7 +20,7 @@
     },
     {
       "id": "Google.Analytics.Admin.V1Beta",
-      "version": "1.0.0-beta03",
+      "version": "1.0.0-beta04",
       "type": "grpc",
       "productName": "Google Analytics Admin",
       "productUrl": "https://developers.google.com/analytics",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- **BREAKING CHANGE** Add the missing `REQUIRED` annotation to the `update_mask` field of `UpdateMeasurementProtocolSecretRequest` ([commit c54eaea](https://github.com/googleapis/google-cloud-dotnet/commit/c54eaea9c6fb63c36eb3ec72c53da88c64e82dae))

### New features

- Add `UpdateConversionEvent` method to the Admin API v1 beta ([commit c54eaea](https://github.com/googleapis/google-cloud-dotnet/commit/c54eaea9c6fb63c36eb3ec72c53da88c64e82dae))
- Add the `counting_method` field to the `ConversionEvent` type ([commit c54eaea](https://github.com/googleapis/google-cloud-dotnet/commit/c54eaea9c6fb63c36eb3ec72c53da88c64e82dae))
- Add the `ConversionCountingMethod` enum ([commit c54eaea](https://github.com/googleapis/google-cloud-dotnet/commit/c54eaea9c6fb63c36eb3ec72c53da88c64e82dae))
- Add the `ITEM` option to the `DimensionScope` enum ([commit c54eaea](https://github.com/googleapis/google-cloud-dotnet/commit/c54eaea9c6fb63c36eb3ec72c53da88c64e82dae))
- Make the field `default_uri` of `WebStreamData` mutable ([commit c54eaea](https://github.com/googleapis/google-cloud-dotnet/commit/c54eaea9c6fb63c36eb3ec72c53da88c64e82dae))
