### PR TITLE
Release Google.Cloud.Container.V1 version 3.18.0

### DIFF
--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.17.0</Version>
+    <Version>3.18.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.</Description>

--- a/apis/Google.Cloud.Container.V1/docs/history.md
+++ b/apis/Google.Cloud.Container.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 3.18.0, released 2023-09-04
+
+### New features
+
+- Add support for NodeConfig Update ([commit d5f12a7](https://github.com/googleapis/google-cloud-dotnet/commit/d5f12a7b8d70a2d7cbcef3a349c44e77751b58e6))
+- Publicize tpu topology in v1 API ([commit d5f12a7](https://github.com/googleapis/google-cloud-dotnet/commit/d5f12a7b8d70a2d7cbcef3a349c44e77751b58e6))
+
 ## Version 3.17.0, released 2023-08-16
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1385,7 +1385,7 @@
       "protoPath": "google/container/v1",
       "productName": "Google Kubernetes Engine",
       "productUrl": "https://cloud.google.com/kubernetes-engine/docs/reference/rest/",
-      "version": "3.17.0",
+      "version": "3.18.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Add support for NodeConfig Update ([commit d5f12a7](https://github.com/googleapis/google-cloud-dotnet/commit/d5f12a7b8d70a2d7cbcef3a349c44e77751b58e6))
- Publicize tpu topology in v1 API ([commit d5f12a7](https://github.com/googleapis/google-cloud-dotnet/commit/d5f12a7b8d70a2d7cbcef3a349c44e77751b58e6))
