### PR TITLE
Release Google.Cloud.Workstations.V1 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.csproj
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Allows administrators to create managed developer environments in the cloud.</Description>

--- a/apis/Google.Cloud.Workstations.V1/docs/history.md
+++ b/apis/Google.Cloud.Workstations.V1/docs/history.md
@@ -1,5 +1,18 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2023-09-06
+
+### New features
+
+- Add config service_account_scopes ([commit 0eccfe0](https://github.com/googleapis/google-cloud-dotnet/commit/0eccfe0644ec322852f049d9e070b6785928f3d0))
+- Add enable_nested_virtualization ([commit 0eccfe0](https://github.com/googleapis/google-cloud-dotnet/commit/0eccfe0644ec322852f049d9e070b6785928f3d0))
+- Add replica_zones ([commit 0eccfe0](https://github.com/googleapis/google-cloud-dotnet/commit/0eccfe0644ec322852f049d9e070b6785928f3d0))
+- Add output field start_time ([commit 0eccfe0](https://github.com/googleapis/google-cloud-dotnet/commit/0eccfe0644ec322852f049d9e070b6785928f3d0))
+
+### Documentation improvements
+
+- Adjust documentation wording & annotations ([commit 0eccfe0](https://github.com/googleapis/google-cloud-dotnet/commit/0eccfe0644ec322852f049d9e070b6785928f3d0))
+
 ## Version 1.0.0-beta01, released 2023-06-12
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5060,7 +5060,7 @@
     },
     {
       "id": "Google.Cloud.Workstations.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Cloud Workstations",
       "productUrl": "https://cloud.google.com/workstations/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Add config service_account_scopes ([commit 0eccfe0](https://github.com/googleapis/google-cloud-dotnet/commit/0eccfe0644ec322852f049d9e070b6785928f3d0))
- Add enable_nested_virtualization ([commit 0eccfe0](https://github.com/googleapis/google-cloud-dotnet/commit/0eccfe0644ec322852f049d9e070b6785928f3d0))
- Add replica_zones ([commit 0eccfe0](https://github.com/googleapis/google-cloud-dotnet/commit/0eccfe0644ec322852f049d9e070b6785928f3d0))
- Add output field start_time ([commit 0eccfe0](https://github.com/googleapis/google-cloud-dotnet/commit/0eccfe0644ec322852f049d9e070b6785928f3d0))

### Documentation improvements

- Adjust documentation wording & annotations ([commit 0eccfe0](https://github.com/googleapis/google-cloud-dotnet/commit/0eccfe0644ec322852f049d9e070b6785928f3d0))
