### PR TITLE
Release Google.Cloud.Channel.V1 version 2.9.0

### DIFF
--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.csproj
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.8.0</Version>
+    <Version>2.9.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Channel API, which enables Google Cloud resellers and distributors to manage their customers, channel partners, entitlements and reports.</Description>

--- a/apis/Google.Cloud.Channel.V1/docs/history.md
+++ b/apis/Google.Cloud.Channel.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 2.9.0, released 2023-09-11
+
+### New features
+
+- Mark ChannelPartnerGranularity as deprecated and offer alternatives ([commit 40d1d8f](https://github.com/googleapis/google-cloud-dotnet/commit/40d1d8f082c4240c541be12911e06bb1e9f0eb39))
+- Launch QueryEligibleBillingAccounts API ([commit 5496ac6](https://github.com/googleapis/google-cloud-dotnet/commit/5496ac69a5806e5453e7dee405d219cf85b8b91b))
+
 ## Version 2.8.0, released 2023-06-20
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1122,7 +1122,7 @@
     },
     {
       "id": "Google.Cloud.Channel.V1",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "type": "grpc",
       "productName": "Cloud Channel",
       "productUrl": "https://cloud.google.com/channel/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Mark ChannelPartnerGranularity as deprecated and offer alternatives ([commit 40d1d8f](https://github.com/googleapis/google-cloud-dotnet/commit/40d1d8f082c4240c541be12911e06bb1e9f0eb39))
- Launch QueryEligibleBillingAccounts API ([commit 5496ac6](https://github.com/googleapis/google-cloud-dotnet/commit/5496ac69a5806e5453e7dee405d219cf85b8b91b))
