### PR TITLE
Release Google.Cloud.Audit version 2.2.0

### DIFF
--- a/apis/Google.Cloud.Audit/Google.Cloud.Audit/Google.Cloud.Audit.csproj
+++ b/apis/Google.Cloud.Audit/Google.Cloud.Audit/Google.Cloud.Audit.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Protobuf messages for Google Cloud audit logs.</Description>

--- a/apis/Google.Cloud.Audit/docs/history.md
+++ b/apis/Google.Cloud.Audit/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 2.2.0, released 2023-09-18
+
+### New features
+
+- Add the name of the reservation the job was submitted to as a field ([commit 8509295](https://github.com/googleapis/google-cloud-dotnet/commit/8509295870d00b72bc70b8d3a63a10bcacd8dafd))
+
+### Documentation improvements
+
+- Use deprecated=true for deprecated fields ([commit ac35511](https://github.com/googleapis/google-cloud-dotnet/commit/ac35511716630dc7391dde688e03e9224386e8b1))
+- Mark ReservationResourceUsage field as deprecated ([commit f1929cb](https://github.com/googleapis/google-cloud-dotnet/commit/f1929cbfa7a04ddf841749c9df6adab1696cf1e7))
+
 ## Version 2.1.0, released 2022-10-17
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -484,7 +484,7 @@
     },
     {
       "id": "Google.Cloud.Audit",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "targetFrameworks": "netstandard2.1;net462",
       "productName": "Google Cloud Audit",
       "productUrl": "https://cloud.google.com/logging/docs/audit",


### PR DESCRIPTION

Changes in this release:

### New features

- Add the name of the reservation the job was submitted to as a field ([commit 8509295](https://github.com/googleapis/google-cloud-dotnet/commit/8509295870d00b72bc70b8d3a63a10bcacd8dafd))

### Documentation improvements

- Use deprecated=true for deprecated fields ([commit ac35511](https://github.com/googleapis/google-cloud-dotnet/commit/ac35511716630dc7391dde688e03e9224386e8b1))
- Mark ReservationResourceUsage field as deprecated ([commit f1929cb](https://github.com/googleapis/google-cloud-dotnet/commit/f1929cbfa7a04ddf841749c9df6adab1696cf1e7))
