### PR TITLE
Release Google.Cloud.Dialogflow.Cx.V3 version 2.12.0

### DIFF
--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.csproj
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.11.0</Version>
+    <Version>2.12.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Builds conversational interfaces (for example, chatbots, and voice-powered apps and devices).</Description>

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/docs/history.md
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.12.0, released 2023-09-18
+
+### Bug fixes
+
+- Fix Ruby namespaces for generative AI classes ([commit 14f47b3](https://github.com/googleapis/google-cloud-dotnet/commit/14f47b39303a84751ea8e43945abdda45af4f6f1))
+
 ## Version 2.11.0, released 2023-09-06
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1817,7 +1817,7 @@
     },
     {
       "id": "Google.Cloud.Dialogflow.Cx.V3",
-      "version": "2.11.0",
+      "version": "2.12.0",
       "type": "grpc",
       "productName": "Dialogflow",
       "productUrl": "https://cloud.google.com/dialogflow/cx/docs",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Fix Ruby namespaces for generative AI classes ([commit 14f47b3](https://github.com/googleapis/google-cloud-dotnet/commit/14f47b39303a84751ea8e43945abdda45af4f6f1))
