### PR TITLE
Release Google.Cloud.Iap.V1 version 2.4.0

### DIFF
--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.csproj
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud IAP API, which controls access to cloud applications running on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Iap.V1/docs/history.md
+++ b/apis/Google.Cloud.Iap.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 2.4.0, released 2023-09-18
+
+### New features
+
+- Adding programmatic_clients attribute to UpdateIapSettings API request ([commit 31934fa](https://github.com/googleapis/google-cloud-dotnet/commit/31934fa84d842b659d6dd2c67723e5a477f5b5a6))
+
+### Documentation improvements
+
+- Few minor changes on doc description came out of cl/512701532 ([commit 48f33ea](https://github.com/googleapis/google-cloud-dotnet/commit/48f33ea923ee67bfe04181855670e8698940d6b7))
+
 ## Version 2.3.0, released 2023-03-20
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2570,7 +2570,7 @@
     },
     {
       "id": "Google.Cloud.Iap.V1",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "type": "grpc",
       "productName": "Cloud Identity-Aware Proxy",
       "productUrl": "https://cloud.google.com/iap/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Adding programmatic_clients attribute to UpdateIapSettings API request ([commit 31934fa](https://github.com/googleapis/google-cloud-dotnet/commit/31934fa84d842b659d6dd2c67723e5a477f5b5a6))

### Documentation improvements

- Few minor changes on doc description came out of cl/512701532 ([commit 48f33ea](https://github.com/googleapis/google-cloud-dotnet/commit/48f33ea923ee67bfe04181855670e8698940d6b7))
