### PR TITLE
Release Google.Cloud.MigrationCenter.V1 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.csproj
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Migration Center API, which is a unified platform that helps you accelerate your end-to-end cloud journey from your current on-premises or cloud environments to Google Cloud.</Description>

--- a/apis/Google.Cloud.MigrationCenter.V1/docs/history.md
+++ b/apis/Google.Cloud.MigrationCenter.V1/docs/history.md
@@ -1,5 +1,21 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2023-09-18
+
+### Bug fixes
+
+- Deprecated the bios_name, total_rows_count and overlapping_asset_count fields ([commit 98654b5](https://github.com/googleapis/google-cloud-dotnet/commit/98654b5494a647dec12967d83094fa6ae21d293f))
+
+### New features
+
+- Added GenericInsight which exposes generic insights on assets ([commit 98654b5](https://github.com/googleapis/google-cloud-dotnet/commit/98654b5494a647dec12967d83094fa6ae21d293f))
+- Added ComputeStorageDescriptor for Compute Engine migration insights ([commit 98654b5](https://github.com/googleapis/google-cloud-dotnet/commit/98654b5494a647dec12967d83094fa6ae21d293f))
+- Added new target-related options to VirtualMachinePreferences ([commit 98654b5](https://github.com/googleapis/google-cloud-dotnet/commit/98654b5494a647dec12967d83094fa6ae21d293f))
+
+### Documentation improvements
+
+- Updated performance_samples docs ([commit 98654b5](https://github.com/googleapis/google-cloud-dotnet/commit/98654b5494a647dec12967d83094fa6ae21d293f))
+
 ## Version 1.0.0-beta01, released 2023-06-12
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3016,7 +3016,7 @@
     },
     {
       "id": "Google.Cloud.MigrationCenter.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Migration Center",
       "productUrl": "https://cloud.google.com/migration-center/docs/migration-center-overview",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Deprecated the bios_name, total_rows_count and overlapping_asset_count fields ([commit 98654b5](https://github.com/googleapis/google-cloud-dotnet/commit/98654b5494a647dec12967d83094fa6ae21d293f))

### New features

- Added GenericInsight which exposes generic insights on assets ([commit 98654b5](https://github.com/googleapis/google-cloud-dotnet/commit/98654b5494a647dec12967d83094fa6ae21d293f))
- Added ComputeStorageDescriptor for Compute Engine migration insights ([commit 98654b5](https://github.com/googleapis/google-cloud-dotnet/commit/98654b5494a647dec12967d83094fa6ae21d293f))
- Added new target-related options to VirtualMachinePreferences ([commit 98654b5](https://github.com/googleapis/google-cloud-dotnet/commit/98654b5494a647dec12967d83094fa6ae21d293f))

### Documentation improvements

- Updated performance_samples docs ([commit 98654b5](https://github.com/googleapis/google-cloud-dotnet/commit/98654b5494a647dec12967d83094fa6ae21d293f))
