### PR TITLE
Release Google.Cloud.NetworkConnectivity.V1 version 2.4.0

### DIFF
--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.csproj
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Network Connectivity API, which provides access to Network Connectivity Center.</Description>

--- a/apis/Google.Cloud.NetworkConnectivity.V1/docs/history.md
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.4.0, released 2023-09-18
+
+### New features
+
+- Add PolicyBasedRouting APIs ([commit 7d8d2b0](https://github.com/googleapis/google-cloud-dotnet/commit/7d8d2b0f58d91865588fd067a14e558e4db57b32))
+
 ## Version 2.3.0, released 2023-02-08
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3080,7 +3080,7 @@
     },
     {
       "id": "Google.Cloud.NetworkConnectivity.V1",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "type": "grpc",
       "productName": "Network Connectivity",
       "productUrl": "https://cloud.google.com/network-connectivity/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add PolicyBasedRouting APIs ([commit 7d8d2b0](https://github.com/googleapis/google-cloud-dotnet/commit/7d8d2b0f58d91865588fd067a14e558e4db57b32))
