### PR TITLE
Release Google.Cloud.ServiceUsage.V1 version 2.2.0

### DIFF
--- a/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1.csproj
+++ b/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Service Usage API, which enables services that service consumers want to use on Google Cloud Platform, lists the available or enabled services, or disables services that service consumers no longer use.</Description>

--- a/apis/Google.Cloud.ServiceUsage.V1/docs/history.md
+++ b/apis/Google.Cloud.ServiceUsage.V1/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 2.2.0, released 2023-09-18
+
+### New features
+
+- Introduce resource class serviceusage.googleapis.com/Service ([commit 6cecdd9](https://github.com/googleapis/google-cloud-dotnet/commit/6cecdd9badf4d838884abdf2faaba829b5225739))
+- Added ConsumerQuotaLimit.supported_locations ([commit 6cecdd9](https://github.com/googleapis/google-cloud-dotnet/commit/6cecdd9badf4d838884abdf2faaba829b5225739))
+- Added ProducerQuotaPolicy message and QuotaBucket.producer_quota_policy field ([commit 6cecdd9](https://github.com/googleapis/google-cloud-dotnet/commit/6cecdd9badf4d838884abdf2faaba829b5225739))
+
 ## Version 2.1.0, released 2023-01-19
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4125,7 +4125,7 @@
     },
     {
       "id": "Google.Cloud.ServiceUsage.V1",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "type": "grpc",
       "productName": "Service Usage",
       "productUrl": "https://cloud.google.com/service-usage/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Introduce resource class serviceusage.googleapis.com/Service ([commit 6cecdd9](https://github.com/googleapis/google-cloud-dotnet/commit/6cecdd9badf4d838884abdf2faaba829b5225739))
- Added ConsumerQuotaLimit.supported_locations ([commit 6cecdd9](https://github.com/googleapis/google-cloud-dotnet/commit/6cecdd9badf4d838884abdf2faaba829b5225739))
- Added ProducerQuotaPolicy message and QuotaBucket.producer_quota_policy field ([commit 6cecdd9](https://github.com/googleapis/google-cloud-dotnet/commit/6cecdd9badf4d838884abdf2faaba829b5225739))
