### PR TITLE
fix: Make Log4Net type searching more robust

### DIFF
--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/GoogleStackdriverAppender.cs
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/GoogleStackdriverAppender.cs
@@ -407,9 +407,24 @@ namespace Google.Cloud.Logging.Log4Net
                 {
                     try
                     {
-                        return AppDomain.CurrentDomain.GetAssemblies()
-                            .SelectMany(a => a.GetTypes())
-                            .FirstOrDefault(t => t.FullName == fullTypeName);
+                        var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+                        foreach (var assembly in assemblies)
+                        {
+                            try
+                            {
+                                var type = assembly.GetTypes().FirstOrDefault(t => t.FullName == fullTypeName);
+                                if (type is not null)
+                                {
+                                    return type;
+                                }
+                            }
+                            catch
+                            {
+                                // Ignore exceptions for this assembly, but continue to further assemblies.
+                            }
+                        }
+                        // Type not found, for whatever reason; cache the failure.
+                        return null;
                     }
                     catch
                     {


### PR DESCRIPTION
After recent updates (possibly .NET SDK 6.0.414; possibly dependencies) tests have been failing on net462, due to a loader error in this code. It turns out that while `GetAssemblies()` returns, calling `GetTypes()` on some of those assemblies would fail. This change isolates each `Assembly.GetTypes()` call, so that the search can progress to other assemblies.