### PR TITLE
Release Google.Cloud.AlloyDb.V1 version 1.2.0

### DIFF
--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.csproj
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AlloyDB API (v1). AlloyDB for PostgreSQL is an open source-compatible database service that provides a powerful option for migrating, modernizing, or building commercial-grade applications.</Description>

--- a/apis/Google.Cloud.AlloyDb.V1/docs/history.md
+++ b/apis/Google.Cloud.AlloyDb.V1/docs/history.md
@@ -1,5 +1,14 @@
 # Version history
 
+## Version 1.2.0, released 2023-09-25
+
+### New features
+
+- Changed description for recovery_window_days in ContinuousBackupConfig ([commit 4de4022](https://github.com/googleapis/google-cloud-dotnet/commit/4de402263662134af0f348db4d8d16dcbfc7799e))
+- Added NetworkConfig, deprecated network ([commit 4de4022](https://github.com/googleapis/google-cloud-dotnet/commit/4de402263662134af0f348db4d8d16dcbfc7799e))
+- Added ClientConnectionConfig ([commit 4de4022](https://github.com/googleapis/google-cloud-dotnet/commit/4de402263662134af0f348db4d8d16dcbfc7799e))
+- Added DatabaseVersion ([commit 4de4022](https://github.com/googleapis/google-cloud-dotnet/commit/4de402263662134af0f348db4d8d16dcbfc7799e))
+- Added QuantityBasedExpiry ([commit 4de4022](https://github.com/googleapis/google-cloud-dotnet/commit/4de402263662134af0f348db4d8d16dcbfc7799e))
 ## Version 1.1.0, released 2023-06-20
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -133,7 +133,7 @@
     },
     {
       "id": "Google.Cloud.AlloyDb.V1",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "type": "grpc",
       "productName": "AlloyDB",
       "productUrl": "https://cloud.google.com/alloydb/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Changed description for recovery_window_days in ContinuousBackupConfig ([commit 4de4022](https://github.com/googleapis/google-cloud-dotnet/commit/4de402263662134af0f348db4d8d16dcbfc7799e))
- Added NetworkConfig, deprecated network ([commit 4de4022](https://github.com/googleapis/google-cloud-dotnet/commit/4de402263662134af0f348db4d8d16dcbfc7799e))
- Added ClientConnectionConfig ([commit 4de4022](https://github.com/googleapis/google-cloud-dotnet/commit/4de402263662134af0f348db4d8d16dcbfc7799e))
- Added DatabaseVersion ([commit 4de4022](https://github.com/googleapis/google-cloud-dotnet/commit/4de402263662134af0f348db4d8d16dcbfc7799e))
- Added QuantityBasedExpiry ([commit 4de4022](https://github.com/googleapis/google-cloud-dotnet/commit/4de402263662134af0f348db4d8d16dcbfc7799e))
