### PR TITLE
Release Google.Cloud.AlloyDb.V1Alpha version 1.0.0-alpha04

### DIFF
--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.csproj
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha03</Version>
+    <Version>1.0.0-alpha04</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AlloyDB API (v1alpha). AlloyDB for PostgreSQL is an open source-compatible database service that provides a powerful option for migrating, modernizing, or building commercial-grade applications.</Description>

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/docs/history.md
@@ -1,5 +1,14 @@
 # Version history
 
+## Version 1.0.0-alpha04, released 2023-09-25
+
+### New features
+
+- Added enum value for PG15 ([commit 92f51da](https://github.com/googleapis/google-cloud-dotnet/commit/92f51da889998ff8160a5bd778ff07d89d01f636))
+- Deprecate network field in favor of network_config.network ([commit 92f51da](https://github.com/googleapis/google-cloud-dotnet/commit/92f51da889998ff8160a5bd778ff07d89d01f636))
+- Added ClientConnectionConfig ([commit 92f51da](https://github.com/googleapis/google-cloud-dotnet/commit/92f51da889998ff8160a5bd778ff07d89d01f636))
+- Added DatabaseVersion ([commit 92f51da](https://github.com/googleapis/google-cloud-dotnet/commit/92f51da889998ff8160a5bd778ff07d89d01f636))
+
 ## Version 1.0.0-alpha03, released 2023-07-25
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -158,7 +158,7 @@
     },
     {
       "id": "Google.Cloud.AlloyDb.V1Alpha",
-      "version": "1.0.0-alpha03",
+      "version": "1.0.0-alpha04",
       "type": "grpc",
       "productName": "AlloyDB",
       "productUrl": "https://cloud.google.com/alloydb/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Added enum value for PG15 ([commit 92f51da](https://github.com/googleapis/google-cloud-dotnet/commit/92f51da889998ff8160a5bd778ff07d89d01f636))
- Deprecate network field in favor of network_config.network ([commit 92f51da](https://github.com/googleapis/google-cloud-dotnet/commit/92f51da889998ff8160a5bd778ff07d89d01f636))
- Added ClientConnectionConfig ([commit 92f51da](https://github.com/googleapis/google-cloud-dotnet/commit/92f51da889998ff8160a5bd778ff07d89d01f636))
- Added DatabaseVersion ([commit 92f51da](https://github.com/googleapis/google-cloud-dotnet/commit/92f51da889998ff8160a5bd778ff07d89d01f636))
