### PR TITLE
Release Google.Cloud.AlloyDb.V1Beta version 1.0.0-beta03

### DIFF
--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.csproj
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AlloyDB API (v1beta). AlloyDB for PostgreSQL is an open source-compatible database service that provides a powerful option for migrating, modernizing, or building commercial-grade applications.</Description>

--- a/apis/Google.Cloud.AlloyDb.V1Beta/docs/history.md
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 1.0.0-beta03, released 2023-09-25
+
+### New features
+
+- Added enum value for PG15 ([commit c4cb2c1](https://github.com/googleapis/google-cloud-dotnet/commit/c4cb2c151c4dc63b650dae9f5bf6c88ef910abe0))
+- Changed description for recovery_window_days in ContinuousBackupConfig ([commit c4cb2c1](https://github.com/googleapis/google-cloud-dotnet/commit/c4cb2c151c4dc63b650dae9f5bf6c88ef910abe0))
+- Deprecate network field in favor of network_config.network ([commit c4cb2c1](https://github.com/googleapis/google-cloud-dotnet/commit/c4cb2c151c4dc63b650dae9f5bf6c88ef910abe0))
+- Added ClientConnectionConfig ([commit c4cb2c1](https://github.com/googleapis/google-cloud-dotnet/commit/c4cb2c151c4dc63b650dae9f5bf6c88ef910abe0))
+- Added QuantityBasedExpiry ([commit c4cb2c1](https://github.com/googleapis/google-cloud-dotnet/commit/c4cb2c151c4dc63b650dae9f5bf6c88ef910abe0))
+- Added DatabaseVersion ([commit c4cb2c1](https://github.com/googleapis/google-cloud-dotnet/commit/c4cb2c151c4dc63b650dae9f5bf6c88ef910abe0))
+
 ## Version 1.0.0-beta02, released 2023-06-20
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -181,7 +181,7 @@
     },
     {
       "id": "Google.Cloud.AlloyDb.V1Beta",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0-beta03",
       "type": "grpc",
       "productName": "AlloyDB",
       "productUrl": "https://cloud.google.com/alloydb/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Added enum value for PG15 ([commit c4cb2c1](https://github.com/googleapis/google-cloud-dotnet/commit/c4cb2c151c4dc63b650dae9f5bf6c88ef910abe0))
- Changed description for recovery_window_days in ContinuousBackupConfig ([commit c4cb2c1](https://github.com/googleapis/google-cloud-dotnet/commit/c4cb2c151c4dc63b650dae9f5bf6c88ef910abe0))
- Deprecate network field in favor of network_config.network ([commit c4cb2c1](https://github.com/googleapis/google-cloud-dotnet/commit/c4cb2c151c4dc63b650dae9f5bf6c88ef910abe0))
- Added ClientConnectionConfig ([commit c4cb2c1](https://github.com/googleapis/google-cloud-dotnet/commit/c4cb2c151c4dc63b650dae9f5bf6c88ef910abe0))
- Added QuantityBasedExpiry ([commit c4cb2c1](https://github.com/googleapis/google-cloud-dotnet/commit/c4cb2c151c4dc63b650dae9f5bf6c88ef910abe0))
- Added DatabaseVersion ([commit c4cb2c1](https://github.com/googleapis/google-cloud-dotnet/commit/c4cb2c151c4dc63b650dae9f5bf6c88ef910abe0))
