### PR TITLE
Release Google.Cloud.Config.V1 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1/Google.Cloud.Config.V1.csproj
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1/Google.Cloud.Config.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Infrastructure Manager API, which creates and manages Google Cloud Platform resources and infrastructure.</Description>

--- a/apis/Google.Cloud.Config.V1/docs/history.md
+++ b/apis/Google.Cloud.Config.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2023-09-25
+
+### Bug fixes
+
+- Change the config service's Ruby namespace to avoid a collision with a base class in the Ruby client platform ([commit be2b45d](https://github.com/googleapis/google-cloud-dotnet/commit/be2b45d71ea18d2614a2ff555160ee2d1a507c1d))
+
 ## Version 1.0.0-beta01, released 2023-08-15
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1309,7 +1309,7 @@
     },
     {
       "id": "Google.Cloud.Config.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Infrastructure Manager",
       "productUrl": "https://cloud.google.com/infrastructure-manager/docs/overview",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Change the config service's Ruby namespace to avoid a collision with a base class in the Ruby client platform ([commit be2b45d](https://github.com/googleapis/google-cloud-dotnet/commit/be2b45d71ea18d2614a2ff555160ee2d1a507c1d))
