### PR TITLE
Release Google.Cloud.DocumentAI.V1 version 3.9.0

### DIFF
--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.csproj
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.8.0</Version>
+    <Version>3.9.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Document AI API (v1), which is a service to parse structured information from unstructured or semi-structured documents using state-of-the-art Google AI such as natural language, computer vision, translation, and AutoML.</Description>

--- a/apis/Google.Cloud.DocumentAI.V1/docs/history.md
+++ b/apis/Google.Cloud.DocumentAI.V1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 3.9.0, released 2023-09-25
+
+### Bug fixes
+
+- Deprecated OcrConfig.compute_style_info ([commit ab6b622](https://github.com/googleapis/google-cloud-dotnet/commit/ab6b622e7e2a1a79fe808f860ed21d90ded49a58))
+
+### New features
+
+- Added field Processor.processor_version_aliases ([commit ab6b622](https://github.com/googleapis/google-cloud-dotnet/commit/ab6b622e7e2a1a79fe808f860ed21d90ded49a58))
+- Added field RawDocument.display_name ([commit ab6b622](https://github.com/googleapis/google-cloud-dotnet/commit/ab6b622e7e2a1a79fe808f860ed21d90ded49a58))
+
 ## Version 3.8.0, released 2023-08-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1958,7 +1958,7 @@
     },
     {
       "id": "Google.Cloud.DocumentAI.V1",
-      "version": "3.8.0",
+      "version": "3.9.0",
       "type": "grpc",
       "productName": "Cloud Document AI",
       "productUrl": "https://cloud.google.com/solutions/document-ai",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Deprecated OcrConfig.compute_style_info ([commit ab6b622](https://github.com/googleapis/google-cloud-dotnet/commit/ab6b622e7e2a1a79fe808f860ed21d90ded49a58))

### New features

- Added field Processor.processor_version_aliases ([commit ab6b622](https://github.com/googleapis/google-cloud-dotnet/commit/ab6b622e7e2a1a79fe808f860ed21d90ded49a58))
- Added field RawDocument.display_name ([commit ab6b622](https://github.com/googleapis/google-cloud-dotnet/commit/ab6b622e7e2a1a79fe808f860ed21d90ded49a58))
