### PR TITLE
Release Google.Cloud.Logging.Log4Net version 4.1.0

### DIFF
--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.csproj
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.0.0</Version>
+    <Version>4.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Log4Net client library for the Google Cloud Logging API.</Description>
@@ -11,7 +11,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.DevTools.Common" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Logging.V2" Version="[4.0.0, 5.0.0)" />
+    <PackageReference Include="Google.Cloud.Logging.V2" Version="[4.1.0, 5.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
     <PackageReference Include="log4net" Version="2.0.14" />
   </ItemGroup>

--- a/apis/Google.Cloud.Logging.Log4Net/docs/history.md
+++ b/apis/Google.Cloud.Logging.Log4Net/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 4.1.0, released 2023-09-25
+
+### Bug fixes
+
+- Make Log4Net type searching more robust ([commit 3a9cf53](https://github.com/googleapis/google-cloud-dotnet/commit/3a9cf538123553707bf7e49b82d8887102254c5c))
+
 ## Version 4.0.0, released 2022-06-09
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2749,7 +2749,7 @@
     },
     {
       "id": "Google.Cloud.Logging.Log4Net",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "type": "other",
       "metadataType": "INTEGRATION",
       "targetFrameworks": "netstandard2.1;net462",
@@ -2763,7 +2763,7 @@
       "dependencies": {
         "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.DevTools.Common": "3.0.0",
-        "Google.Cloud.Logging.V2": "4.0.0",
+        "Google.Cloud.Logging.V2": "4.1.0",
         "Grpc.Core": "2.46.6",
         "log4net": "2.0.14"
       },


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Make Log4Net type searching more robust ([commit 3a9cf53](https://github.com/googleapis/google-cloud-dotnet/commit/3a9cf538123553707bf7e49b82d8887102254c5c))
