### PR TITLE
Release Google.Cloud.ArtifactRegistry.V1 version 2.3.0

### DIFF
--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.csproj
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.2.0</Version>
+    <Version>2.3.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Artifact Registry API v1, which stores and manages build artifacts in a scalable and integrated service built on Google infrastructure.</Description>

--- a/apis/Google.Cloud.ArtifactRegistry.V1/docs/history.md
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.3.0, released 2023-09-26
+
+### Bug fixes
+
+- Make repository and repository_id in CreateRepository required ([commit b0752af](https://github.com/googleapis/google-cloud-dotnet/commit/b0752afb3c5a83bffb901743d9a8cd44d526d574))
+
 ## Version 2.2.0, released 2023-02-08
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -362,7 +362,7 @@
     },
     {
       "id": "Google.Cloud.ArtifactRegistry.V1",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "type": "grpc",
       "productName": "Artifact Registry",
       "productUrl": "https://cloud.google.com/artifact-registry",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Make repository and repository_id in CreateRepository required ([commit b0752af](https://github.com/googleapis/google-cloud-dotnet/commit/b0752afb3c5a83bffb901743d9a8cd44d526d574))
