### PR TITLE
Release Google.Cloud.BigQuery.AnalyticsHub.V1 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery Analytics Hub, which allows users to exchange data and analytics assets securely and efficiently.</Description>

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 1.1.0, released 2023-09-26
+
+### New features
+
+- Add Subscription resource and RPCs ([commit 1353440](https://github.com/googleapis/google-cloud-dotnet/commit/13534404625d0dcf9e0edafe75c2aa6ddc379a20))
+- Add support for sharing_environment_config using which you can create data clean rooms. ([commit 1353440](https://github.com/googleapis/google-cloud-dotnet/commit/13534404625d0dcf9e0edafe75c2aa6ddc379a20))
+- Support restricted egress on Listings. ([commit 1353440](https://github.com/googleapis/google-cloud-dotnet/commit/13534404625d0dcf9e0edafe75c2aa6ddc379a20))
+
 ## Version 1.0.0, released 2022-11-02
 
 No API surface changes; just dependency updates and promotion to general availability.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -688,7 +688,7 @@
     },
     {
       "id": "Google.Cloud.BigQuery.AnalyticsHub.V1",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "grpc",
       "productName": "Analytics Hub",
       "productUrl": "https://cloud.google.com/analytics-hub",


### PR DESCRIPTION

Changes in this release:

### New features

- Add Subscription resource and RPCs ([commit 1353440](https://github.com/googleapis/google-cloud-dotnet/commit/13534404625d0dcf9e0edafe75c2aa6ddc379a20))
- Add support for sharing_environment_config using which you can create data clean rooms. ([commit 1353440](https://github.com/googleapis/google-cloud-dotnet/commit/13534404625d0dcf9e0edafe75c2aa6ddc379a20))
- Support restricted egress on Listings. ([commit 1353440](https://github.com/googleapis/google-cloud-dotnet/commit/13534404625d0dcf9e0edafe75c2aa6ddc379a20))
