### PR TITLE
Release Google.Cloud.DocumentAI.V1 version 3.10.0

### DIFF
--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.csproj
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.9.0</Version>
+    <Version>3.10.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Document AI API (v1), which is a service to parse structured information from unstructured or semi-structured documents using state-of-the-art Google AI such as natural language, computer vision, translation, and AutoML.</Description>

--- a/apis/Google.Cloud.DocumentAI.V1/docs/history.md
+++ b/apis/Google.Cloud.DocumentAI.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 3.10.0, released 2023-09-26
+
+### Bug fixes
+
+- `OcrConfig.compute_style_info` is deprecated. Use `PremiumFeatures.compute_style_info` instead. ([commit 8f008d6](https://github.com/googleapis/google-cloud-dotnet/commit/8f008d65ca5544d9410bb45552dfaae735158419))
+
+### New features
+
+- [Google.Cloud.DocumentAI.V1] make `page_range` field public ([issue 11086](https://github.com/googleapis/google-cloud-dotnet/issues/11086)) ([commit 8f008d6](https://github.com/googleapis/google-cloud-dotnet/commit/8f008d65ca5544d9410bb45552dfaae735158419))
+
 ## Version 3.9.0, released 2023-09-25
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1959,7 +1959,7 @@
     },
     {
       "id": "Google.Cloud.DocumentAI.V1",
-      "version": "3.9.0",
+      "version": "3.10.0",
       "type": "grpc",
       "productName": "Cloud Document AI",
       "productUrl": "https://cloud.google.com/solutions/document-ai",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- `OcrConfig.compute_style_info` is deprecated. Use `PremiumFeatures.compute_style_info` instead. ([commit 8f008d6](https://github.com/googleapis/google-cloud-dotnet/commit/8f008d65ca5544d9410bb45552dfaae735158419))

### New features

- [Google.Cloud.DocumentAI.V1] make `page_range` field public ([issue 11086](https://github.com/googleapis/google-cloud-dotnet/issues/11086)) ([commit 8f008d6](https://github.com/googleapis/google-cloud-dotnet/commit/8f008d65ca5544d9410bb45552dfaae735158419))
