### PR TITLE
Release Google.Cloud.Run.V2 version 2.4.0

### DIFF
--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/Google.Cloud.Run.V2.csproj
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/Google.Cloud.Run.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Run Admin API (v2)</Description>

--- a/apis/Google.Cloud.Run.V2/docs/history.md
+++ b/apis/Google.Cloud.Run.V2/docs/history.md
@@ -1,5 +1,22 @@
 # Version history
 
+## Version 2.4.0, released 2023-09-28
+
+BREAKING CHANGE: The removal of the TrafficTagsCleanupThreshold
+(introduced in 2.3.0 accidentally) is clearly a breaking change, but
+we hope we've released this update quickly enough to avoid any
+customers actually being affected. We believe that using a minor
+version is less disruptive to customers than using a major version
+bump in this particular case. We apologize for any inconvenience.
+
+### Bug fixes
+
+- Removes accidentally exposed field service.traffic_tags_cleanup_threshold in Cloud Run Service ([commit 6b18d1f](https://github.com/googleapis/google-cloud-dotnet/commit/6b18d1fdef57b8e2087a8a5e013e3a59bd4a7c94))
+
+### Documentation improvements
+
+- Minor comment fixes ([commit 6b18d1f](https://github.com/googleapis/google-cloud-dotnet/commit/6b18d1fdef57b8e2087a8a5e013e3a59bd4a7c94))
+
 ## Version 2.3.0, released 2023-09-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3822,7 +3822,7 @@
     },
     {
       "id": "Google.Cloud.Run.V2",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "type": "grpc",
       "productName": "Cloud Run Admin",
       "productUrl": "https://cloud.google.com/run/docs",


### PR DESCRIPTION

Changes in this release:

BREAKING CHANGE: The removal of the TrafficTagsCleanupThreshold (introduced in 2.3.0 accidentally) is clearly a breaking change, but we hope we've released this update quickly enough to avoid any customers actually being affected. We believe that using a minor version is less disruptive to customers than using a major version bump in this particular case. We apologize for any inconvenience.

### Bug fixes

- Removes accidentally exposed field service.traffic_tags_cleanup_threshold in Cloud Run Service ([commit 6b18d1f](https://github.com/googleapis/google-cloud-dotnet/commit/6b18d1fdef57b8e2087a8a5e013e3a59bd4a7c94))

### Documentation improvements

- Minor comment fixes ([commit 6b18d1f](https://github.com/googleapis/google-cloud-dotnet/commit/6b18d1fdef57b8e2087a8a5e013e3a59bd4a7c94))
