### PR TITLE
Release Google.Cloud.AlloyDb.V1 version 1.3.0

### DIFF
--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.csproj
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AlloyDB API (v1). AlloyDB for PostgreSQL is an open source-compatible database service that provides a powerful option for migrating, modernizing, or building commercial-grade applications.</Description>

--- a/apis/Google.Cloud.AlloyDb.V1/docs/history.md
+++ b/apis/Google.Cloud.AlloyDb.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.3.0, released 2023-10-02
+
+### New features
+
+- Add support to generate client certificate and get connection info for auth proxy in AlloyDB v1 ([commit 70f274b](https://github.com/googleapis/google-cloud-dotnet/commit/70f274b3403655350cb3db768ae678fda5543c22))
+
 ## Version 1.2.0, released 2023-09-25
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -133,7 +133,7 @@
     },
     {
       "id": "Google.Cloud.AlloyDb.V1",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "type": "grpc",
       "productName": "AlloyDB",
       "productUrl": "https://cloud.google.com/alloydb/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Add support to generate client certificate and get connection info for auth proxy in AlloyDB v1 ([commit 70f274b](https://github.com/googleapis/google-cloud-dotnet/commit/70f274b3403655350cb3db768ae678fda5543c22))
