### PR TITLE
Release Google.Cloud.DataCatalog.V1 version 2.7.0

### DIFF
--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.csproj
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Data Catalog API. Data Catalog is a fully managed and highly scalable data discovery and metadata management service.</Description>

--- a/apis/Google.Cloud.DataCatalog.V1/docs/history.md
+++ b/apis/Google.Cloud.DataCatalog.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 2.7.0, released 2023-10-02
+
+### New features
+
+- Enable Vertex AI Ingestion on DataPlex ([commit af6cde6](https://github.com/googleapis/google-cloud-dotnet/commit/af6cde6b66d1a9054bc2353cd9a01105de6f36ee))
+
+### Documentation improvements
+
+- Fix typo ([commit 3924eff](https://github.com/googleapis/google-cloud-dotnet/commit/3924eff8ce3cd348873825d667b537da884c8f4a))
+
 ## Version 2.6.0, released 2023-08-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1430,7 +1430,7 @@
       "protoPath": "google/cloud/datacatalog/v1",
       "productName": "Data Catalog",
       "productUrl": "https://cloud.google.com/data-catalog/docs",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Data Catalog API. Data Catalog is a fully managed and highly scalable data discovery and metadata management service.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- Enable Vertex AI Ingestion on DataPlex ([commit af6cde6](https://github.com/googleapis/google-cloud-dotnet/commit/af6cde6b66d1a9054bc2353cd9a01105de6f36ee))

### Documentation improvements

- Fix typo ([commit 3924eff](https://github.com/googleapis/google-cloud-dotnet/commit/3924eff8ce3cd348873825d667b537da884c8f4a))
