### PR TITLE
Release Google.Cloud.Dialogflow.V2 version 4.14.0

### DIFF
--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.csproj
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.13.0</Version>
+    <Version>4.14.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Dialogflow API (v2).</Description>

--- a/apis/Google.Cloud.Dialogflow.V2/docs/history.md
+++ b/apis/Google.Cloud.Dialogflow.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 4.14.0, released 2023-10-02
+
+### New features
+
+- Add the enable_extended_streaming flag ([commit 7db6a56](https://github.com/googleapis/google-cloud-dotnet/commit/7db6a5666de3ea07b6321f28e5df8dc42db2097d))
+
 ## Version 4.13.0, released 2023-09-06
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1847,7 +1847,7 @@
       "protoPath": "google/cloud/dialogflow/v2",
       "productName": "Google Cloud Dialogflow",
       "productUrl": "https://cloud.google.com/dialogflow-enterprise/",
-      "version": "4.13.0",
+      "version": "4.14.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Dialogflow API (v2).",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- Add the enable_extended_streaming flag ([commit 7db6a56](https://github.com/googleapis/google-cloud-dotnet/commit/7db6a5666de3ea07b6321f28e5df8dc42db2097d))
