### PR TITLE
Release Google.Cloud.Dialogflow.V2Beta1 version 1.0.0-beta11

### DIFF
--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.csproj
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta10</Version>
+    <Version>1.0.0-beta11</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Dialogflow API (v2beta1).</Description>

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/docs/history.md
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 1.0.0-beta11, released 2023-10-02
+
+### New features
+
+- Add the enable_extended_streaming flag ([commit 68ba677](https://github.com/googleapis/google-cloud-dotnet/commit/68ba67718434f26f89829706f77c2297bb2a3f5d))
+- Remove backend API deadline ([commit 68ba677](https://github.com/googleapis/google-cloud-dotnet/commit/68ba67718434f26f89829706f77c2297bb2a3f5d))
+
 ## Version 1.0.0-beta10, released 2023-09-06
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1870,7 +1870,7 @@
     },
     {
       "id": "Google.Cloud.Dialogflow.V2Beta1",
-      "version": "1.0.0-beta10",
+      "version": "1.0.0-beta11",
       "type": "grpc",
       "productName": "Google Cloud Dialogflow",
       "productUrl": "https://cloud.google.com/dialogflow-enterprise/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add the enable_extended_streaming flag ([commit 68ba677](https://github.com/googleapis/google-cloud-dotnet/commit/68ba67718434f26f89829706f77c2297bb2a3f5d))
- Remove backend API deadline ([commit 68ba677](https://github.com/googleapis/google-cloud-dotnet/commit/68ba67718434f26f89829706f77c2297bb2a3f5d))
