### PR TITLE
Release Google.Cloud.Metastore.V1 version 2.5.0

### DIFF
--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.csproj
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.4.0</Version>
+    <Version>2.5.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Dataproc Metastore API which is used to manage the lifecycle and configuration of metastore services.</Description>

--- a/apis/Google.Cloud.Metastore.V1/docs/history.md
+++ b/apis/Google.Cloud.Metastore.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.5.0, released 2023-10-02
+
+### New features
+
+- Added EndpointLocation (v1, v1beta, v1alpha) ([commit 264ddbe](https://github.com/googleapis/google-cloud-dotnet/commit/264ddbe6cb6038cc68573ca7230a2e8446554490))
+
 ## Version 2.4.0, released 2023-07-13
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2946,7 +2946,7 @@
     },
     {
       "id": "Google.Cloud.Metastore.V1",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "type": "grpc",
       "productName": "Dataproc Metastore",
       "productUrl": "https://cloud.google.com/dataproc-metastore/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Added EndpointLocation (v1, v1beta, v1alpha) ([commit 264ddbe](https://github.com/googleapis/google-cloud-dotnet/commit/264ddbe6cb6038cc68573ca7230a2e8446554490))
