### PR TITLE
Release Google.Cloud.Metastore.V1Beta version 2.0.0-beta07

### DIFF
--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.csproj
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta06</Version>
+    <Version>2.0.0-beta07</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Dataproc Metastore API (v1beta) which is used to manage the lifecycle and configuration of metastore services.</Description>

--- a/apis/Google.Cloud.Metastore.V1Beta/docs/history.md
+++ b/apis/Google.Cloud.Metastore.V1Beta/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.0.0-beta07, released 2023-10-02
+
+### New features
+
+- Added EndpointLocation (v1, v1beta, v1alpha) ([commit fe44771](https://github.com/googleapis/google-cloud-dotnet/commit/fe44771fd325b3e63ba63cbf518d4dfc362ceecc))
+
 ## Version 2.0.0-beta06, released 2023-07-13
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2994,7 +2994,7 @@
     },
     {
       "id": "Google.Cloud.Metastore.V1Beta",
-      "version": "2.0.0-beta06",
+      "version": "2.0.0-beta07",
       "type": "grpc",
       "productName": "Dataproc Metastore",
       "productUrl": "https://cloud.google.com/dataproc-metastore/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Added EndpointLocation (v1, v1beta, v1alpha) ([commit fe44771](https://github.com/googleapis/google-cloud-dotnet/commit/fe44771fd325b3e63ba63cbf518d4dfc362ceecc))
