### PR TITLE
Release Google.Cloud.NetworkConnectivity.V1 version 2.5.0

### DIFF
--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.csproj
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.4.0</Version>
+    <Version>2.5.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Network Connectivity API, which provides access to Network Connectivity Center.</Description>

--- a/apis/Google.Cloud.NetworkConnectivity.V1/docs/history.md
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.5.0, released 2023-10-02
+
+### New features
+
+- Add Network Connectivity Center APIs related to VPC spokes ([commit f99d9ad](https://github.com/googleapis/google-cloud-dotnet/commit/f99d9ad52e49ae453e8b0007d6b2a2f6f6b85b31))
+
 ## Version 2.4.0, released 2023-09-18
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3081,7 +3081,7 @@
     },
     {
       "id": "Google.Cloud.NetworkConnectivity.V1",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "type": "grpc",
       "productName": "Network Connectivity",
       "productUrl": "https://cloud.google.com/network-connectivity/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add Network Connectivity Center APIs related to VPC spokes ([commit f99d9ad](https://github.com/googleapis/google-cloud-dotnet/commit/f99d9ad52e49ae453e8b0007d6b2a2f6f6b85b31))
