### PR TITLE
Release Google.Cloud.OsLogin.V1Beta version 3.0.0-beta04

### DIFF
--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.csproj
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0-beta03</Version>
+    <Version>3.0.0-beta04</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to manages OS login configuration for Google account users.</Description>

--- a/apis/Google.Cloud.OsLogin.V1Beta/docs/history.md
+++ b/apis/Google.Cloud.OsLogin.V1Beta/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.0.0-beta04, released 2023-10-02
+
+### New features
+
+- Added SecurityKey.device_nickname ([commit 37ff7f1](https://github.com/googleapis/google-cloud-dotnet/commit/37ff7f1392bd794af3bd44281df320f8ff4c0e91))
+
 ## Version 3.0.0-beta03, released 2023-08-16
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3430,7 +3430,7 @@
       "protoPath": "google/cloud/oslogin/v1beta",
       "productName": "Google Cloud OS Login",
       "productUrl": "https://cloud.google.com/compute/docs/instances/managing-instance-access",
-      "version": "3.0.0-beta03",
+      "version": "3.0.0-beta04",
       "releaseLevelOverride": "preview",
       "type": "grpc",
       "description": "Recommended Google client library to manages OS login configuration for Google account users.",


### PR DESCRIPTION

Changes in this release:

### New features

- Added SecurityKey.device_nickname ([commit 37ff7f1](https://github.com/googleapis/google-cloud-dotnet/commit/37ff7f1392bd794af3bd44281df320f8ff4c0e91))
