### PR TITLE
chore: Create indexes in parallel

### DIFF
--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/FirestoreFixture.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/FirestoreFixture.cs
@@ -89,9 +89,13 @@ namespace Google.Cloud.Firestore.IntegrationTests
 
         private async Task PopulateCollections()
         {
-            await CreateIndex(HighScoreCollection, AscendingField("Score"), AscendingField("Level"));
-            await CreateIndex(HighScoreCollection, AscendingField("Score"), DescendingField("Level"));
-            await CreateIndex(StudentCollection, AscendingField("EnglishScore"), AscendingField("Level"), AscendingField("MathScore"), AscendingField("Name"));
+            var indexTasks = new[]
+            {
+                CreateIndex(HighScoreCollection, AscendingField("Score"), AscendingField("Level")),
+                CreateIndex(HighScoreCollection, AscendingField("Score"), DescendingField("Level")),
+                CreateIndex(StudentCollection, AscendingField("EnglishScore"), AscendingField("Level"), AscendingField("MathScore"), AscendingField("Name"))
+            };
+            await Task.WhenAll(indexTasks);
             await PopulateCollection(HighScoreCollection, HighScore.Data);
             await PopulateCollection(ArrayQueryCollection, ArrayDocument.Data);
             await PopulateCollection(StudentCollection, Student.Data);


### PR DESCRIPTION
(On my box, for .NET 6 integration tests, this chops the time down from 9m 24s to 5m 25s... so definitely worth doing. There's one other CreateIndex call, but that's for a collection only used in a single test, so it's harder to parallelize.)