### PR TITLE
Release Firestore libraries version 3.4.0

### DIFF
--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.csproj
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.3.0</Version>
+    <Version>3.4.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Low-level Google client library to access the Firestore API. Users are recommended to use the Google.Cloud.Firestore package instead.</Description>

--- a/apis/Google.Cloud.Firestore.V1/docs/history.md
+++ b/apis/Google.Cloud.Firestore.V1/docs/history.md
@@ -4,6 +4,13 @@ This package is primarily a dependency of Google.Cloud.Firestore. See the
 [Google.Cloud.Firestore version history](https://googleapis.dev/dotnet/Google.Cloud.Firestore/latest/history.html)
 for more details.
 
+## Version 3.4.0, released 2023-10-04
+
+### New features
+
+- Publish proto definitions for SUM/AVG in Firestore ([commit 9931b9d](https://github.com/googleapis/google-cloud-dotnet/commit/9931b9db0820aeda79300914c7e0ddb5edb647c4))
+- Add bloom filter related proto fields ([commit c9dbc16](https://github.com/googleapis/google-cloud-dotnet/commit/c9dbc16b36d6fdfb0e6697585f6aa6fe26c01740))
+
 ## Version 3.3.0, released 2023-05-03
 
 ### Bug fixes

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Google.Cloud.Firestore.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Google.Cloud.Firestore.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.3.0</Version>
+    <Version>3.4.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Firestore API.</Description>

--- a/apis/Google.Cloud.Firestore/docs/history.md
+++ b/apis/Google.Cloud.Firestore/docs/history.md
@@ -1,5 +1,21 @@
 # Version history
 
+## Version 3.4.0, released 2023-10-04
+
+### Bug fixes
+
+- Dispose of the gRPC call in the WatchStream even if non-RpcExceptions are thrown ([commit f89ba63](https://github.com/googleapis/google-cloud-dotnet/commit/f89ba6306059149d4d7a6ee4458d9e88c4c99761))
+- Dispose of gRPC streaming calls appropriately ([commit 541d439](https://github.com/googleapis/google-cloud-dotnet/commit/541d43955ebde4b536d70cfe70d802ddb6703e6a))
+- Simple disposals within Firestore ([commit cdc22d2](https://github.com/googleapis/google-cloud-dotnet/commit/cdc22d28a2605a43f2efec54c947f47c7e4adc24))
+
+### New features
+
+- Add sum and average aggregates ([commit 9a8bfd5](https://github.com/googleapis/google-cloud-dotnet/commit/9a8bfd50c29e8bd133e1f92cb62c9b5bb05ef436))
+
+### Documentation improvements
+
+- Change Google Cloud Platform to Google Cloud in handwritten code ([commit cef5f43](https://github.com/googleapis/google-cloud-dotnet/commit/cef5f43dd2dc2817d091a398ac4620a357d535c5))
+
 ## Version 3.3.0, released 2023-05-03
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2210,7 +2210,7 @@
       "productName": "Firestore",
       "productUrl": "https://firebase.google.com/docs/firestore/",
       "listingDescription": "Firestore high-level library",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "type": "other",
       "metadataType": "GAPIC_MANUAL",
       "targetFrameworks": "netstandard2.1;net462",
@@ -2229,10 +2229,10 @@
       "testDependencies": {
         "Google.Api.Gax.Grpc.Testing": "4.4.0",
         "Google.Api.Gax.Testing": "4.4.0",
+        "Google.Cloud.Firestore.Admin.V1": "3.3.0",
         "Grpc.Core.Testing": "2.46.6",
         "System.ValueTuple": "4.5.0",
-        "Xunit.Combinatorial": "1.6.24",
-        "Google.Cloud.Firestore.Admin.V1": "3.3.0"
+        "Xunit.Combinatorial": "1.6.24"
       },
       "shortName": "firestore"
     },
@@ -2243,7 +2243,7 @@
       "productName": "Firestore",
       "productUrl": "https://firebase.google.com",
       "listingDescription": "Firestore low-level API access",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "type": "grpc",
       "targetFrameworks": "netstandard2.1;net462",
       "testTargetFrameworks": "net6.0;net462",


### PR DESCRIPTION

Changes in Google.Cloud.Firestore version 3.4.0:

### Bug fixes

- Dispose of the gRPC call in the WatchStream even if non-RpcExceptions are thrown ([commit f89ba63](https://github.com/googleapis/google-cloud-dotnet/commit/f89ba6306059149d4d7a6ee4458d9e88c4c99761))
- Dispose of gRPC streaming calls appropriately ([commit 541d439](https://github.com/googleapis/google-cloud-dotnet/commit/541d43955ebde4b536d70cfe70d802ddb6703e6a))
- Simple disposals within Firestore ([commit cdc22d2](https://github.com/googleapis/google-cloud-dotnet/commit/cdc22d28a2605a43f2efec54c947f47c7e4adc24))

### New features

- Add sum and average aggregates ([commit 9a8bfd5](https://github.com/googleapis/google-cloud-dotnet/commit/9a8bfd50c29e8bd133e1f92cb62c9b5bb05ef436))

### Documentation improvements

- Change Google Cloud Platform to Google Cloud in handwritten code ([commit cef5f43](https://github.com/googleapis/google-cloud-dotnet/commit/cef5f43dd2dc2817d091a398ac4620a357d535c5))

Changes in Google.Cloud.Firestore.V1 version 3.4.0:

### New features

- Publish proto definitions for SUM/AVG in Firestore ([commit 9931b9d](https://github.com/googleapis/google-cloud-dotnet/commit/9931b9db0820aeda79300914c7e0ddb5edb647c4))
- Add bloom filter related proto fields ([commit c9dbc16](https://github.com/googleapis/google-cloud-dotnet/commit/c9dbc16b36d6fdfb0e6697585f6aa6fe26c01740))

Packages in this release:
- Release Google.Cloud.Firestore version 3.4.0
- Release Google.Cloud.Firestore.V1 version 3.4.0
