### PR TITLE
chore: Update docfx to 2.71.0

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "docfx": {
-      "version": "2.65.3",
+      "version": "2.71.0",
       "commands": [
         "docfx"
       ]


### PR DESCRIPTION
It looks like some breakage between the current version we're using and the latest version (in terms of accepting a path to docfx.json) has been fixed. As far as I can tell, this update shouldn't break us...