### PR TITLE
Release Google.Shopping.Type version 1.0.0-beta02

### DIFF
--- a/apis/Google.Shopping.Type/Google.Shopping.Type/Google.Shopping.Type.csproj
+++ b/apis/Google.Shopping.Type/Google.Shopping.Type/Google.Shopping.Type.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Version-agnostic types for Shopping APIs.</Description>

--- a/apis/Google.Shopping.Type/docs/history.md
+++ b/apis/Google.Shopping.Type/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2023-10-13
+
+### Bug fixes
+
+- **BREAKING CHANGE** Destination enum is wrapped in a message ([commit 3fbf033](https://github.com/googleapis/google-cloud-dotnet/commit/3fbf0338b4d53ca9d480b1991c08c59aab7f55b7))
+- **BREAKING CHANGE** Update go_package and Go importpath: ([commit 3422995](https://github.com/googleapis/google-cloud-dotnet/commit/3422995ac6523162e4eefbadd9ef841c84b39e69))
+
+### New features
+
+- Channel enum is added ([commit 7491a30](https://github.com/googleapis/google-cloud-dotnet/commit/7491a30e938a34cd3e8d1c25ada0d0a5207673eb))
+- ReportingContext enum is added ([commit 3fbf033](https://github.com/googleapis/google-cloud-dotnet/commit/3fbf0338b4d53ca9d480b1991c08c59aab7f55b7))
+
 ## Version 1.0.0-beta01, released 2023-10-09
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5286,7 +5286,7 @@
     },
     {
       "id": "Google.Shopping.Type",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "targetFrameworks": "netstandard2.1;net462",
       "type": "other",
       "description": "Version-agnostic types for Shopping APIs.",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- **BREAKING CHANGE** Destination enum is wrapped in a message ([commit 3fbf033](https://github.com/googleapis/google-cloud-dotnet/commit/3fbf0338b4d53ca9d480b1991c08c59aab7f55b7))
- **BREAKING CHANGE** Update go_package and Go importpath: ([commit 3422995](https://github.com/googleapis/google-cloud-dotnet/commit/3422995ac6523162e4eefbadd9ef841c84b39e69))

### New features

- Channel enum is added ([commit 7491a30](https://github.com/googleapis/google-cloud-dotnet/commit/7491a30e938a34cd3e8d1c25ada0d0a5207673eb))
- ReportingContext enum is added ([commit 3fbf033](https://github.com/googleapis/google-cloud-dotnet/commit/3fbf0338b4d53ca9d480b1991c08c59aab7f55b7))
