### PR TITLE
chore: Update xUnit dependencies for generated projects

### DIFF
--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/Google.Analytics.Admin.V1Alpha.GeneratedSnippets.csproj
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/Google.Analytics.Admin.V1Alpha.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.Snippets/Google.Analytics.Admin.V1Alpha.Snippets.csproj
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.Snippets/Google.Analytics.Admin.V1Alpha.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/Google.Analytics.Admin.V1Beta.GeneratedSnippets.csproj
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/Google.Analytics.Admin.V1Beta.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.Snippets/Google.Analytics.Admin.V1Beta.Snippets.csproj
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.Snippets/Google.Analytics.Admin.V1Beta.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/Google.Analytics.Data.V1Beta.GeneratedSnippets.csproj
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/Google.Analytics.Data.V1Beta.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.Snippets/Google.Analytics.Data.V1Beta.Snippets.csproj
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.Snippets/Google.Analytics.Data.V1Beta.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/Google.Area120.Tables.V1Alpha1.GeneratedSnippets.csproj
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/Google.Area120.Tables.V1Alpha1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.Snippets/Google.Area120.Tables.V1Alpha1.Snippets.csproj
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.Snippets/Google.Area120.Tables.V1Alpha1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/Google.Cloud.AIPlatform.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/Google.Cloud.AIPlatform.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/Google.Cloud.AIPlatform.V1.Snippets.csproj
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/Google.Cloud.AIPlatform.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Tests/Google.Cloud.AIPlatform.V1.Tests.csproj
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Tests/Google.Cloud.AIPlatform.V1.Tests.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/Google.Cloud.AccessApproval.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/Google.Cloud.AccessApproval.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.Snippets/Google.Cloud.AccessApproval.V1.Snippets.csproj
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.Snippets/Google.Cloud.AccessApproval.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.Snippets/Google.Cloud.AdvisoryNotifications.V1.Snippets.csproj
+++ b/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.Snippets/Google.Cloud.AdvisoryNotifications.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/Google.Cloud.AlloyDb.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/Google.Cloud.AlloyDb.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.Snippets/Google.Cloud.AlloyDb.V1.Snippets.csproj
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.Snippets/Google.Cloud.AlloyDb.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.Snippets/Google.Cloud.AlloyDb.V1Alpha.Snippets.csproj
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.Snippets/Google.Cloud.AlloyDb.V1Alpha.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.Snippets/Google.Cloud.AlloyDb.V1Beta.Snippets.csproj
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.Snippets/Google.Cloud.AlloyDb.V1Beta.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/Google.Cloud.ApiGateway.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/Google.Cloud.ApiGateway.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.Snippets/Google.Cloud.ApiGateway.V1.Snippets.csproj
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.Snippets/Google.Cloud.ApiGateway.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/Google.Cloud.ApiKeys.V2.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/Google.Cloud.ApiKeys.V2.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.Snippets/Google.Cloud.ApiKeys.V2.Snippets.csproj
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.Snippets/Google.Cloud.ApiKeys.V2.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1.GeneratedSnippets/Google.Cloud.ApigeeConnect.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1.GeneratedSnippets/Google.Cloud.ApigeeConnect.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1.Snippets/Google.Cloud.ApigeeConnect.V1.Snippets.csproj
+++ b/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1.Snippets/Google.Cloud.ApigeeConnect.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.Snippets/Google.Cloud.ApigeeRegistry.V1.Snippets.csproj
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.Snippets/Google.Cloud.ApigeeRegistry.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/Google.Cloud.AppEngine.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/Google.Cloud.AppEngine.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.Snippets/Google.Cloud.AppEngine.V1.Snippets.csproj
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.Snippets/Google.Cloud.AppEngine.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.Snippets/Google.Cloud.ArtifactRegistry.V1.Snippets.csproj
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.Snippets/Google.Cloud.ArtifactRegistry.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.Snippets/Google.Cloud.ArtifactRegistry.V1Beta2.Snippets.csproj
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.Snippets/Google.Cloud.ArtifactRegistry.V1Beta2.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/Google.Cloud.Asset.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/Google.Cloud.Asset.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.Snippets/Google.Cloud.Asset.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.Snippets/Google.Cloud.Asset.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.Snippets/Google.Cloud.AssuredWorkloads.V1.Snippets.csproj
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.Snippets/Google.Cloud.AssuredWorkloads.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.Snippets/Google.Cloud.AssuredWorkloads.V1Beta1.Snippets.csproj
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.Snippets/Google.Cloud.AssuredWorkloads.V1Beta1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/Google.Cloud.AutoML.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/Google.Cloud.AutoML.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.Snippets/Google.Cloud.AutoML.V1.Snippets.csproj
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.Snippets/Google.Cloud.AutoML.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.Snippets/Google.Cloud.BareMetalSolution.V2.Snippets.csproj
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.Snippets/Google.Cloud.BareMetalSolution.V2.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/Google.Cloud.Batch.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/Google.Cloud.Batch.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.Snippets/Google.Cloud.Batch.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.Snippets/Google.Cloud.Batch.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/Google.Cloud.Batch.V1Alpha.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/Google.Cloud.Batch.V1Alpha.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.Snippets/Google.Cloud.Batch.V1Alpha.Snippets.csproj
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.Snippets/Google.Cloud.Batch.V1Alpha.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.Snippets/Google.Cloud.BeyondCorp.AppConnections.V1.Snippets.csproj
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.Snippets/Google.Cloud.BeyondCorp.AppConnections.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.Snippets/Google.Cloud.BeyondCorp.AppConnectors.V1.Snippets.csproj
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.Snippets/Google.Cloud.BeyondCorp.AppConnectors.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.Snippets/Google.Cloud.BeyondCorp.AppGateways.V1.Snippets.csproj
+++ b/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.Snippets/Google.Cloud.BeyondCorp.AppGateways.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.Snippets/Google.Cloud.BeyondCorp.ClientGateways.V1.Snippets.csproj
+++ b/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.Snippets/Google.Cloud.BeyondCorp.ClientGateways.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.Snippets/Google.Cloud.BigQuery.AnalyticsHub.V1.Snippets.csproj
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.Snippets/Google.Cloud.BigQuery.AnalyticsHub.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.Snippets/Google.Cloud.BigQuery.Connection.V1.Snippets.csproj
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.Snippets/Google.Cloud.BigQuery.Connection.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.Snippets/Google.Cloud.BigQuery.DataExchange.V1Beta1.Snippets.csproj
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.Snippets/Google.Cloud.BigQuery.DataExchange.V1Beta1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.Snippets/Google.Cloud.BigQuery.DataPolicies.V1.Snippets.csproj
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.Snippets/Google.Cloud.BigQuery.DataPolicies.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.Snippets/Google.Cloud.BigQuery.DataPolicies.V1Beta1.Snippets.csproj
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.Snippets/Google.Cloud.BigQuery.DataPolicies.V1Beta1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.Snippets/Google.Cloud.BigQuery.DataTransfer.V1.Snippets.csproj
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.Snippets/Google.Cloud.BigQuery.DataTransfer.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.Snippets/Google.Cloud.BigQuery.Migration.V2.Snippets.csproj
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.Snippets/Google.Cloud.BigQuery.Migration.V2.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.Snippets/Google.Cloud.BigQuery.Reservation.V1.Snippets.csproj
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.Snippets/Google.Cloud.BigQuery.Reservation.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.Snippets/Google.Cloud.BigQuery.Storage.V1.Snippets.csproj
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.Snippets/Google.Cloud.BigQuery.Storage.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/Google.Cloud.BigQuery.V2.IntegrationTests.csproj
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/Google.Cloud.BigQuery.V2.IntegrationTests.csproj
@@ -15,8 +15,8 @@
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.Combinatorial" Version="1.6.24" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <ItemGroup>

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Snippets/Google.Cloud.BigQuery.V2.Snippets.csproj
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Snippets/Google.Cloud.BigQuery.V2.Snippets.csproj
@@ -15,8 +15,8 @@
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.Combinatorial" Version="1.6.24" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <!-- For BigQueryTableExtensions -->

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/Google.Cloud.BigQuery.V2.Tests.csproj
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/Google.Cloud.BigQuery.V2.Tests.csproj
@@ -15,8 +15,8 @@
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.Combinatorial" Version="1.6.24" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.Snippets/Google.Cloud.Bigtable.Admin.V2.Snippets.csproj
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.Snippets/Google.Cloud.Bigtable.Admin.V2.Snippets.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.Tests/Google.Cloud.Bigtable.Admin.V2.Tests.csproj
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.Tests/Google.Cloud.Bigtable.Admin.V2.Tests.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/Google.Cloud.Bigtable.V2.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/Google.Cloud.Bigtable.V2.GeneratedSnippets.csproj
@@ -15,8 +15,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.IntegrationTests/Google.Cloud.Bigtable.V2.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.IntegrationTests/Google.Cloud.Bigtable.V2.IntegrationTests.csproj
@@ -15,8 +15,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Snippets/Google.Cloud.Bigtable.V2.Snippets.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Snippets/Google.Cloud.Bigtable.V2.Snippets.csproj
@@ -15,8 +15,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <ItemGroup>

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/Google.Cloud.Bigtable.V2.Tests.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/Google.Cloud.Bigtable.V2.Tests.csproj
@@ -15,8 +15,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.Snippets/Google.Cloud.Billing.Budgets.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.Snippets/Google.Cloud.Billing.Budgets.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1.GeneratedSnippets/Google.Cloud.Billing.Budgets.V1Beta1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1.GeneratedSnippets/Google.Cloud.Billing.Budgets.V1Beta1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1.Snippets/Google.Cloud.Billing.Budgets.V1Beta1.Snippets.csproj
+++ b/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1.Snippets/Google.Cloud.Billing.Budgets.V1Beta1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/Google.Cloud.Billing.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/Google.Cloud.Billing.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.Snippets/Google.Cloud.Billing.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.Snippets/Google.Cloud.Billing.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.Snippets/Google.Cloud.BinaryAuthorization.V1.Snippets.csproj
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.Snippets/Google.Cloud.BinaryAuthorization.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.Snippets/Google.Cloud.BinaryAuthorization.V1Beta1.Snippets.csproj
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.Snippets/Google.Cloud.BinaryAuthorization.V1Beta1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/Google.Cloud.CertificateManager.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/Google.Cloud.CertificateManager.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.Snippets/Google.Cloud.CertificateManager.V1.Snippets.csproj
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.Snippets/Google.Cloud.CertificateManager.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/Google.Cloud.Channel.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/Google.Cloud.Channel.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.Snippets/Google.Cloud.Channel.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.Snippets/Google.Cloud.Channel.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/Google.Cloud.CloudBuild.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/Google.Cloud.CloudBuild.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.Snippets/Google.Cloud.CloudBuild.V1.Snippets.csproj
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.Snippets/Google.Cloud.CloudBuild.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/Google.Cloud.CloudBuild.V2.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/Google.Cloud.CloudBuild.V2.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.Snippets/Google.Cloud.CloudBuild.V2.Snippets.csproj
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.Snippets/Google.Cloud.CloudBuild.V2.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/Google.Cloud.CloudDms.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/Google.Cloud.CloudDms.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.Snippets/Google.Cloud.CloudDms.V1.Snippets.csproj
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.Snippets/Google.Cloud.CloudDms.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.Snippets/Google.Cloud.Commerce.Consumer.Procurement.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.Snippets/Google.Cloud.Commerce.Consumer.Procurement.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/Google.Cloud.Compute.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/Google.Cloud.Compute.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.IntegrationTests/Google.Cloud.Compute.V1.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.IntegrationTests/Google.Cloud.Compute.V1.IntegrationTests.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/Google.Cloud.Compute.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/Google.Cloud.Compute.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Tests/Google.Cloud.Compute.V1.Tests.csproj
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Tests/Google.Cloud.Compute.V1.Tests.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.GeneratedSnippets/Google.Cloud.ConfidentialComputing.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.GeneratedSnippets/Google.Cloud.ConfidentialComputing.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.Snippets/Google.Cloud.ConfidentialComputing.V1.Snippets.csproj
+++ b/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.Snippets/Google.Cloud.ConfidentialComputing.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ConfidentialComputing.V1Alpha1/Google.Cloud.ConfidentialComputing.V1Alpha1.GeneratedSnippets/Google.Cloud.ConfidentialComputing.V1Alpha1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.ConfidentialComputing.V1Alpha1/Google.Cloud.ConfidentialComputing.V1Alpha1.GeneratedSnippets/Google.Cloud.ConfidentialComputing.V1Alpha1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ConfidentialComputing.V1Alpha1/Google.Cloud.ConfidentialComputing.V1Alpha1.Snippets/Google.Cloud.ConfidentialComputing.V1Alpha1.Snippets.csproj
+++ b/apis/Google.Cloud.ConfidentialComputing.V1Alpha1/Google.Cloud.ConfidentialComputing.V1Alpha1.Snippets/Google.Cloud.ConfidentialComputing.V1Alpha1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/Google.Cloud.Config.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/Google.Cloud.Config.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.Snippets/Google.Cloud.Config.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.Snippets/Google.Cloud.Config.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/Google.Cloud.Connectors.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/Google.Cloud.Connectors.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.Snippets/Google.Cloud.Connectors.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.Snippets/Google.Cloud.Connectors.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.Snippets/Google.Cloud.ContactCenterInsights.V1.Snippets.csproj
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.Snippets/Google.Cloud.ContactCenterInsights.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/Google.Cloud.Container.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/Google.Cloud.Container.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.Snippets/Google.Cloud.Container.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.Snippets/Google.Cloud.Container.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.Snippets/Google.Cloud.DataCatalog.Lineage.V1.Snippets.csproj
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.Snippets/Google.Cloud.DataCatalog.Lineage.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/Google.Cloud.DataCatalog.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/Google.Cloud.DataCatalog.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.Snippets/Google.Cloud.DataCatalog.V1.Snippets.csproj
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.Snippets/Google.Cloud.DataCatalog.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/Google.Cloud.DataFusion.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/Google.Cloud.DataFusion.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.Snippets/Google.Cloud.DataFusion.V1.Snippets.csproj
+++ b/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.Snippets/Google.Cloud.DataFusion.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.DataLabeling.V1Beta1/Google.Cloud.DataLabeling.V1Beta1.GeneratedSnippets/Google.Cloud.DataLabeling.V1Beta1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.DataLabeling.V1Beta1/Google.Cloud.DataLabeling.V1Beta1.GeneratedSnippets/Google.Cloud.DataLabeling.V1Beta1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.DataLabeling.V1Beta1/Google.Cloud.DataLabeling.V1Beta1.Snippets/Google.Cloud.DataLabeling.V1Beta1.Snippets.csproj
+++ b/apis/Google.Cloud.DataLabeling.V1Beta1/Google.Cloud.DataLabeling.V1Beta1.Snippets/Google.Cloud.DataLabeling.V1Beta1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.DataQnA.V1Alpha/Google.Cloud.DataQnA.V1Alpha.GeneratedSnippets/Google.Cloud.DataQnA.V1Alpha.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.DataQnA.V1Alpha/Google.Cloud.DataQnA.V1Alpha.GeneratedSnippets/Google.Cloud.DataQnA.V1Alpha.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.DataQnA.V1Alpha/Google.Cloud.DataQnA.V1Alpha.Snippets/Google.Cloud.DataQnA.V1Alpha.Snippets.csproj
+++ b/apis/Google.Cloud.DataQnA.V1Alpha/Google.Cloud.DataQnA.V1Alpha.Snippets/Google.Cloud.DataQnA.V1Alpha.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.Snippets/Google.Cloud.Dataflow.V1Beta3.Snippets.csproj
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.Snippets/Google.Cloud.Dataflow.V1Beta3.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.Snippets/Google.Cloud.Dataform.V1Beta1.Snippets.csproj
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.Snippets/Google.Cloud.Dataform.V1Beta1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/Google.Cloud.Dataplex.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/Google.Cloud.Dataplex.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.Snippets/Google.Cloud.Dataplex.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.Snippets/Google.Cloud.Dataplex.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/Google.Cloud.Dataproc.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/Google.Cloud.Dataproc.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.Snippets/Google.Cloud.Dataproc.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.Snippets/Google.Cloud.Dataproc.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.GeneratedSnippets/Google.Cloud.Datastore.Admin.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.GeneratedSnippets/Google.Cloud.Datastore.Admin.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.Snippets/Google.Cloud.Datastore.Admin.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.Snippets/Google.Cloud.Datastore.Admin.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/Google.Cloud.Datastore.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/Google.Cloud.Datastore.V1.GeneratedSnippets.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/Google.Cloud.Datastore.V1.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/Google.Cloud.Datastore.V1.IntegrationTests.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/Google.Cloud.Datastore.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/Google.Cloud.Datastore.V1.Snippets.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Tests/Google.Cloud.Datastore.V1.Tests.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Tests/Google.Cloud.Datastore.V1.Tests.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/Google.Cloud.Datastream.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/Google.Cloud.Datastream.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.Snippets/Google.Cloud.Datastream.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.Snippets/Google.Cloud.Datastream.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.Snippets/Google.Cloud.Datastream.V1Alpha1.Snippets.csproj
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.Snippets/Google.Cloud.Datastream.V1Alpha1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/Google.Cloud.Deploy.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/Google.Cloud.Deploy.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.Snippets/Google.Cloud.Deploy.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.Snippets/Google.Cloud.Deploy.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.DevTools.Common/Google.Cloud.DevTools.Common.Tests/Google.Cloud.DevTools.Common.Tests.csproj
+++ b/apis/Google.Cloud.DevTools.Common/Google.Cloud.DevTools.Common.Tests/Google.Cloud.DevTools.Common.Tests.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.Snippets/Google.Cloud.DevTools.ContainerAnalysis.V1.Snippets.csproj
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.Snippets/Google.Cloud.DevTools.ContainerAnalysis.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.IntegrationTests/Google.Cloud.Diagnostics.AspNetCore3.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.IntegrationTests/Google.Cloud.Diagnostics.AspNetCore3.IntegrationTests.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <ItemGroup>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.Snippets/Google.Cloud.Diagnostics.AspNetCore3.Snippets.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.Snippets/Google.Cloud.Diagnostics.AspNetCore3.Snippets.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <ItemGroup>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.Tests/Google.Cloud.Diagnostics.AspNetCore3.Tests.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.Tests/Google.Cloud.Diagnostics.AspNetCore3.Tests.csproj
@@ -15,8 +15,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Google.Cloud.Diagnostics.Common.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Google.Cloud.Diagnostics.Common.IntegrationTests.csproj
@@ -22,8 +22,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Snippets/Google.Cloud.Diagnostics.Common.Snippets.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Snippets/Google.Cloud.Diagnostics.Common.Snippets.csproj
@@ -22,8 +22,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <ItemGroup>

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Google.Cloud.Diagnostics.Common.Tests.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Google.Cloud.Diagnostics.Common.Tests.csproj
@@ -16,8 +16,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <PropertyGroup>

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/Google.Cloud.Dialogflow.Cx.V3.Snippets.csproj
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/Google.Cloud.Dialogflow.Cx.V3.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/Google.Cloud.Dialogflow.V2.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/Google.Cloud.Dialogflow.V2.GeneratedSnippets.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/Google.Cloud.Dialogflow.V2.Snippets.csproj
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/Google.Cloud.Dialogflow.V2.Snippets.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/Google.Cloud.Dialogflow.V2Beta1.Snippets.csproj
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/Google.Cloud.Dialogflow.V2Beta1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/Google.Cloud.DiscoveryEngine.V1.Snippets.csproj
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/Google.Cloud.DiscoveryEngine.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/Google.Cloud.DiscoveryEngine.V1Beta.Snippets.csproj
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/Google.Cloud.DiscoveryEngine.V1Beta.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/Google.Cloud.Dlp.V2.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/Google.Cloud.Dlp.V2.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.Snippets/Google.Cloud.Dlp.V2.Snippets.csproj
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.Snippets/Google.Cloud.Dlp.V2.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/Google.Cloud.DocumentAI.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/Google.Cloud.DocumentAI.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.Snippets/Google.Cloud.DocumentAI.V1.Snippets.csproj
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.Snippets/Google.Cloud.DocumentAI.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.Snippets/Google.Cloud.DocumentAI.V1Beta3.Snippets.csproj
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.Snippets/Google.Cloud.DocumentAI.V1Beta3.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/Google.Cloud.Domains.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/Google.Cloud.Domains.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.Snippets/Google.Cloud.Domains.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.Snippets/Google.Cloud.Domains.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/Google.Cloud.Domains.V1Beta1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/Google.Cloud.Domains.V1Beta1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.Snippets/Google.Cloud.Domains.V1Beta1.Snippets.csproj
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.Snippets/Google.Cloud.Domains.V1Beta1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.Snippets/Google.Cloud.EnterpriseKnowledgeGraph.V1.Snippets.csproj
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.Snippets/Google.Cloud.EnterpriseKnowledgeGraph.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.Snippets/Google.Cloud.ErrorReporting.V1Beta1.Snippets.csproj
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.Snippets/Google.Cloud.ErrorReporting.V1Beta1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/Google.Cloud.EssentialContacts.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/Google.Cloud.EssentialContacts.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.Snippets/Google.Cloud.EssentialContacts.V1.Snippets.csproj
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.Snippets/Google.Cloud.EssentialContacts.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1.GeneratedSnippets/Google.Cloud.Eventarc.Publishing.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1.GeneratedSnippets/Google.Cloud.Eventarc.Publishing.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1.Snippets/Google.Cloud.Eventarc.Publishing.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1.Snippets/Google.Cloud.Eventarc.Publishing.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/Google.Cloud.Eventarc.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/Google.Cloud.Eventarc.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.Snippets/Google.Cloud.Eventarc.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.Snippets/Google.Cloud.Eventarc.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/Google.Cloud.Filestore.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/Google.Cloud.Filestore.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.Snippets/Google.Cloud.Filestore.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.Snippets/Google.Cloud.Filestore.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.Snippets/Google.Cloud.Firestore.Admin.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.Snippets/Google.Cloud.Firestore.Admin.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/Google.Cloud.Firestore.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/Google.Cloud.Firestore.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.Snippets/Google.Cloud.Firestore.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.Snippets/Google.Cloud.Firestore.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.Tests/Google.Cloud.Firestore.V1.Tests.csproj
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.Tests/Google.Cloud.Firestore.V1.Tests.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/Google.Cloud.Firestore.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/Google.Cloud.Firestore.IntegrationTests.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="Xunit.Combinatorial" Version="1.6.24" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/Google.Cloud.Firestore.Snippets.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/Google.Cloud.Firestore.Snippets.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="Xunit.Combinatorial" Version="1.6.24" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Google.Cloud.Firestore.Tests.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Google.Cloud.Firestore.Tests.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="Xunit.Combinatorial" Version="1.6.24" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <ItemGroup>

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/Google.Cloud.Functions.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/Google.Cloud.Functions.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.Snippets/Google.Cloud.Functions.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.Snippets/Google.Cloud.Functions.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/Google.Cloud.Functions.V2.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/Google.Cloud.Functions.V2.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.Snippets/Google.Cloud.Functions.V2.Snippets.csproj
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.Snippets/Google.Cloud.Functions.V2.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/Google.Cloud.Functions.V2Beta.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/Google.Cloud.Functions.V2Beta.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.Snippets/Google.Cloud.Functions.V2Beta.Snippets.csproj
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.Snippets/Google.Cloud.Functions.V2Beta.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.Snippets/Google.Cloud.GSuiteAddOns.V1.Snippets.csproj
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.Snippets/Google.Cloud.GSuiteAddOns.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/Google.Cloud.GkeBackup.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/Google.Cloud.GkeBackup.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.Snippets/Google.Cloud.GkeBackup.V1.Snippets.csproj
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.Snippets/Google.Cloud.GkeBackup.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.GkeConnect.Gateway.V1Beta1/Google.Cloud.GkeConnect.Gateway.V1Beta1.GeneratedSnippets/Google.Cloud.GkeConnect.Gateway.V1Beta1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.GkeConnect.Gateway.V1Beta1/Google.Cloud.GkeConnect.Gateway.V1Beta1.GeneratedSnippets/Google.Cloud.GkeConnect.Gateway.V1Beta1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.GkeConnect.Gateway.V1Beta1/Google.Cloud.GkeConnect.Gateway.V1Beta1.Snippets/Google.Cloud.GkeConnect.Gateway.V1Beta1.Snippets.csproj
+++ b/apis/Google.Cloud.GkeConnect.Gateway.V1Beta1/Google.Cloud.GkeConnect.Gateway.V1Beta1.Snippets/Google.Cloud.GkeConnect.Gateway.V1Beta1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/Google.Cloud.GkeHub.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/Google.Cloud.GkeHub.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.Snippets/Google.Cloud.GkeHub.V1.Snippets.csproj
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.Snippets/Google.Cloud.GkeHub.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.Snippets/Google.Cloud.GkeHub.V1Beta1.Snippets.csproj
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.Snippets/Google.Cloud.GkeHub.V1Beta1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.Snippets/Google.Cloud.GkeMultiCloud.V1.Snippets.csproj
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.Snippets/Google.Cloud.GkeMultiCloud.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/Google.Cloud.Iam.Admin.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/Google.Cloud.Iam.Admin.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.Snippets/Google.Cloud.Iam.Admin.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.Snippets/Google.Cloud.Iam.Admin.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.Snippets/Google.Cloud.Iam.Credentials.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.Snippets/Google.Cloud.Iam.Credentials.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.GeneratedSnippets/Google.Cloud.Iam.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.GeneratedSnippets/Google.Cloud.Iam.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.Snippets/Google.Cloud.Iam.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.Snippets/Google.Cloud.Iam.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.Tests/Google.Cloud.Iam.V1.Tests.csproj
+++ b/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.Tests/Google.Cloud.Iam.V1.Tests.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.GeneratedSnippets/Google.Cloud.Iam.V2.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.GeneratedSnippets/Google.Cloud.Iam.V2.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.Snippets/Google.Cloud.Iam.V2.Snippets.csproj
+++ b/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.Snippets/Google.Cloud.Iam.V2.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/Google.Cloud.Iap.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/Google.Cloud.Iap.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.Snippets/Google.Cloud.Iap.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.Snippets/Google.Cloud.Iap.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/Google.Cloud.Ids.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/Google.Cloud.Ids.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.Snippets/Google.Cloud.Ids.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.Snippets/Google.Cloud.Ids.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.GeneratedSnippets/Google.Cloud.Kms.Inventory.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.GeneratedSnippets/Google.Cloud.Kms.Inventory.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.Snippets/Google.Cloud.Kms.Inventory.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.Snippets/Google.Cloud.Kms.Inventory.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/Google.Cloud.Kms.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/Google.Cloud.Kms.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.Snippets/Google.Cloud.Kms.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.Snippets/Google.Cloud.Kms.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/Google.Cloud.Language.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/Google.Cloud.Language.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.Snippets/Google.Cloud.Language.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.Snippets/Google.Cloud.Language.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.Tests/Google.Cloud.Language.V1.Tests.csproj
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.Tests/Google.Cloud.Language.V1.Tests.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/Google.Cloud.Language.V2.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/Google.Cloud.Language.V2.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.Snippets/Google.Cloud.Language.V2.Snippets.csproj
+++ b/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.Snippets/Google.Cloud.Language.V2.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.LifeSciences.V2Beta/Google.Cloud.LifeSciences.V2Beta.GeneratedSnippets/Google.Cloud.LifeSciences.V2Beta.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.LifeSciences.V2Beta/Google.Cloud.LifeSciences.V2Beta.GeneratedSnippets/Google.Cloud.LifeSciences.V2Beta.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.LifeSciences.V2Beta/Google.Cloud.LifeSciences.V2Beta.Snippets/Google.Cloud.LifeSciences.V2Beta.Snippets.csproj
+++ b/apis/Google.Cloud.LifeSciences.V2Beta/Google.Cloud.LifeSciences.V2Beta.Snippets/Google.Cloud.LifeSciences.V2Beta.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Location/Google.Cloud.Location.GeneratedSnippets/Google.Cloud.Location.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Location/Google.Cloud.Location.GeneratedSnippets/Google.Cloud.Location.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Location/Google.Cloud.Location.Snippets/Google.Cloud.Location.Snippets.csproj
+++ b/apis/Google.Cloud.Location/Google.Cloud.Location.Snippets/Google.Cloud.Location.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Logging.Console/Google.Cloud.Logging.Console.Tests/Google.Cloud.Logging.Console.Tests.csproj
+++ b/apis/Google.Cloud.Logging.Console/Google.Cloud.Logging.Console.Tests/Google.Cloud.Logging.Console.Tests.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.IntegrationTests/Google.Cloud.Logging.Log4Net.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.IntegrationTests/Google.Cloud.Logging.Log4Net.IntegrationTests.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Snippets/Google.Cloud.Logging.Log4Net.Snippets.csproj
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Snippets/Google.Cloud.Logging.Log4Net.Snippets.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <ItemGroup>

--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Tests/Google.Cloud.Logging.Log4Net.Tests.csproj
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.Tests/Google.Cloud.Logging.Log4Net.Tests.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.IntegrationTests/Google.Cloud.Logging.NLog.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.IntegrationTests/Google.Cloud.Logging.NLog.IntegrationTests.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.Snippets/Google.Cloud.Logging.NLog.Snippets.csproj
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.Snippets/Google.Cloud.Logging.NLog.Snippets.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <ItemGroup>

--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.Tests/Google.Cloud.Logging.NLog.Tests.csproj
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.Tests/Google.Cloud.Logging.NLog.Tests.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net452'">

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/Google.Cloud.Logging.V2.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/Google.Cloud.Logging.V2.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.Snippets/Google.Cloud.Logging.V2.Snippets.csproj
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.Snippets/Google.Cloud.Logging.V2.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.Snippets/Google.Cloud.ManagedIdentities.V1.Snippets.csproj
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.Snippets/Google.Cloud.ManagedIdentities.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.MediaTranslation.V1Beta1/Google.Cloud.MediaTranslation.V1Beta1.GeneratedSnippets/Google.Cloud.MediaTranslation.V1Beta1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.MediaTranslation.V1Beta1/Google.Cloud.MediaTranslation.V1Beta1.GeneratedSnippets/Google.Cloud.MediaTranslation.V1Beta1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.MediaTranslation.V1Beta1/Google.Cloud.MediaTranslation.V1Beta1.Snippets/Google.Cloud.MediaTranslation.V1Beta1.Snippets.csproj
+++ b/apis/Google.Cloud.MediaTranslation.V1Beta1/Google.Cloud.MediaTranslation.V1Beta1.Snippets/Google.Cloud.MediaTranslation.V1Beta1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/Google.Cloud.Memcache.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/Google.Cloud.Memcache.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.Snippets/Google.Cloud.Memcache.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.Snippets/Google.Cloud.Memcache.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.Snippets/Google.Cloud.Memcache.V1Beta2.Snippets.csproj
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.Snippets/Google.Cloud.Memcache.V1Beta2.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/Google.Cloud.Metastore.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/Google.Cloud.Metastore.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.Snippets/Google.Cloud.Metastore.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.Snippets/Google.Cloud.Metastore.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.Snippets/Google.Cloud.Metastore.V1Alpha.Snippets.csproj
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.Snippets/Google.Cloud.Metastore.V1Alpha.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/Google.Cloud.Metastore.V1Beta.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/Google.Cloud.Metastore.V1Beta.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.Snippets/Google.Cloud.Metastore.V1Beta.Snippets.csproj
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.Snippets/Google.Cloud.Metastore.V1Beta.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/Google.Cloud.MigrationCenter.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/Google.Cloud.MigrationCenter.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.Snippets/Google.Cloud.MigrationCenter.V1.Snippets.csproj
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.Snippets/Google.Cloud.MigrationCenter.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/Google.Cloud.Monitoring.V3.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/Google.Cloud.Monitoring.V3.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/Google.Cloud.Monitoring.V3.Snippets.csproj
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/Google.Cloud.Monitoring.V3.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/Google.Cloud.NetApp.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/Google.Cloud.NetApp.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.Snippets/Google.Cloud.NetApp.V1.Snippets.csproj
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.Snippets/Google.Cloud.NetApp.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.Snippets/Google.Cloud.NetworkConnectivity.V1.Snippets.csproj
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.Snippets/Google.Cloud.NetworkConnectivity.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.Snippets/Google.Cloud.NetworkConnectivity.V1Alpha1.Snippets.csproj
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.Snippets/Google.Cloud.NetworkConnectivity.V1Alpha1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/Google.Cloud.NetworkManagement.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/Google.Cloud.NetworkManagement.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.Snippets/Google.Cloud.NetworkManagement.V1.Snippets.csproj
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.Snippets/Google.Cloud.NetworkManagement.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.Snippets/Google.Cloud.NetworkSecurity.V1Beta1.Snippets.csproj
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.Snippets/Google.Cloud.NetworkSecurity.V1Beta1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/Google.Cloud.Notebooks.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/Google.Cloud.Notebooks.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.Snippets/Google.Cloud.Notebooks.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.Snippets/Google.Cloud.Notebooks.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.Snippets/Google.Cloud.Notebooks.V1Beta1.Snippets.csproj
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.Snippets/Google.Cloud.Notebooks.V1Beta1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/Google.Cloud.Notebooks.V2.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/Google.Cloud.Notebooks.V2.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.Snippets/Google.Cloud.Notebooks.V2.Snippets.csproj
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.Snippets/Google.Cloud.Notebooks.V2.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Optimization.V1/Google.Cloud.Optimization.V1.GeneratedSnippets/Google.Cloud.Optimization.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Optimization.V1/Google.Cloud.Optimization.V1.GeneratedSnippets/Google.Cloud.Optimization.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Optimization.V1/Google.Cloud.Optimization.V1.Snippets/Google.Cloud.Optimization.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Optimization.V1/Google.Cloud.Optimization.V1.Snippets/Google.Cloud.Optimization.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.Snippets/Google.Cloud.Orchestration.Airflow.Service.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.Snippets/Google.Cloud.Orchestration.Airflow.Service.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/Google.Cloud.OrgPolicy.V2.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/Google.Cloud.OrgPolicy.V2.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.Snippets/Google.Cloud.OrgPolicy.V2.Snippets.csproj
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.Snippets/Google.Cloud.OrgPolicy.V2.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/Google.Cloud.OsConfig.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/Google.Cloud.OsConfig.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.Snippets/Google.Cloud.OsConfig.V1.Snippets.csproj
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.Snippets/Google.Cloud.OsConfig.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.Snippets/Google.Cloud.OsConfig.V1Alpha.Snippets.csproj
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.Snippets/Google.Cloud.OsConfig.V1Alpha.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/Google.Cloud.OsLogin.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/Google.Cloud.OsLogin.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.Snippets/Google.Cloud.OsLogin.V1.Snippets.csproj
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.Snippets/Google.Cloud.OsLogin.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.Snippets/Google.Cloud.OsLogin.V1Beta.Snippets.csproj
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.Snippets/Google.Cloud.OsLogin.V1Beta.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1.GeneratedSnippets/Google.Cloud.PhishingProtection.V1Beta1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1.GeneratedSnippets/Google.Cloud.PhishingProtection.V1Beta1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1.Snippets/Google.Cloud.PhishingProtection.V1Beta1.Snippets.csproj
+++ b/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1.Snippets/Google.Cloud.PhishingProtection.V1Beta1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/Google.Cloud.PolicySimulator.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/Google.Cloud.PolicySimulator.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.Snippets/Google.Cloud.PolicySimulator.V1.Snippets.csproj
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.Snippets/Google.Cloud.PolicySimulator.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.PolicyTroubleshooter.Iam.V3/Google.Cloud.PolicyTroubleshooter.Iam.V3.GeneratedSnippets/Google.Cloud.PolicyTroubleshooter.Iam.V3.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.PolicyTroubleshooter.Iam.V3/Google.Cloud.PolicyTroubleshooter.Iam.V3.GeneratedSnippets/Google.Cloud.PolicyTroubleshooter.Iam.V3.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.PolicyTroubleshooter.Iam.V3/Google.Cloud.PolicyTroubleshooter.Iam.V3.Snippets/Google.Cloud.PolicyTroubleshooter.Iam.V3.Snippets.csproj
+++ b/apis/Google.Cloud.PolicyTroubleshooter.Iam.V3/Google.Cloud.PolicyTroubleshooter.Iam.V3.Snippets/Google.Cloud.PolicyTroubleshooter.Iam.V3.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.PolicyTroubleshooter.V1/Google.Cloud.PolicyTroubleshooter.V1.GeneratedSnippets/Google.Cloud.PolicyTroubleshooter.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.PolicyTroubleshooter.V1/Google.Cloud.PolicyTroubleshooter.V1.GeneratedSnippets/Google.Cloud.PolicyTroubleshooter.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.PolicyTroubleshooter.V1/Google.Cloud.PolicyTroubleshooter.V1.Snippets/Google.Cloud.PolicyTroubleshooter.V1.Snippets.csproj
+++ b/apis/Google.Cloud.PolicyTroubleshooter.V1/Google.Cloud.PolicyTroubleshooter.V1.Snippets/Google.Cloud.PolicyTroubleshooter.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.PrivateCatalog.V1Beta1/Google.Cloud.PrivateCatalog.V1Beta1.GeneratedSnippets/Google.Cloud.PrivateCatalog.V1Beta1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.PrivateCatalog.V1Beta1/Google.Cloud.PrivateCatalog.V1Beta1.GeneratedSnippets/Google.Cloud.PrivateCatalog.V1Beta1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.PrivateCatalog.V1Beta1/Google.Cloud.PrivateCatalog.V1Beta1.Snippets/Google.Cloud.PrivateCatalog.V1Beta1.Snippets.csproj
+++ b/apis/Google.Cloud.PrivateCatalog.V1Beta1/Google.Cloud.PrivateCatalog.V1Beta1.Snippets/Google.Cloud.PrivateCatalog.V1Beta1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.GeneratedSnippets/Google.Cloud.Profiler.V2.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.GeneratedSnippets/Google.Cloud.Profiler.V2.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.Snippets/Google.Cloud.Profiler.V2.Snippets.csproj
+++ b/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.Snippets/Google.Cloud.Profiler.V2.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/Google.Cloud.PubSub.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/Google.Cloud.PubSub.V1.GeneratedSnippets.csproj
@@ -20,8 +20,8 @@
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="Xunit.Combinatorial" Version="1.6.24" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.IntegrationTests/Google.Cloud.PubSub.V1.IntegrationTests.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.IntegrationTests/Google.Cloud.PubSub.V1.IntegrationTests.csproj
@@ -20,8 +20,8 @@
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="Xunit.Combinatorial" Version="1.6.24" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/Google.Cloud.PubSub.V1.Snippets.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/Google.Cloud.PubSub.V1.Snippets.csproj
@@ -20,8 +20,8 @@
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="Xunit.Combinatorial" Version="1.6.24" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Tests/Google.Cloud.PubSub.V1.Tests.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Tests/Google.Cloud.PubSub.V1.Tests.csproj
@@ -20,8 +20,8 @@
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="Xunit.Combinatorial" Version="1.6.24" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.Snippets/Google.Cloud.RapidMigrationAssessment.V1.Snippets.csproj
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.Snippets/Google.Cloud.RapidMigrationAssessment.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.Snippets/Google.Cloud.RecaptchaEnterprise.V1.Snippets.csproj
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.Snippets/Google.Cloud.RecaptchaEnterprise.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.GeneratedSnippets/Google.Cloud.RecaptchaEnterprise.V1Beta1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.GeneratedSnippets/Google.Cloud.RecaptchaEnterprise.V1Beta1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.Snippets/Google.Cloud.RecaptchaEnterprise.V1Beta1.Snippets.csproj
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.Snippets/Google.Cloud.RecaptchaEnterprise.V1Beta1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.Snippets/Google.Cloud.RecommendationEngine.V1Beta1.Snippets.csproj
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.Snippets/Google.Cloud.RecommendationEngine.V1Beta1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/Google.Cloud.Recommender.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/Google.Cloud.Recommender.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.Snippets/Google.Cloud.Recommender.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.Snippets/Google.Cloud.Recommender.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/Google.Cloud.Redis.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/Google.Cloud.Redis.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.Snippets/Google.Cloud.Redis.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.Snippets/Google.Cloud.Redis.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/Google.Cloud.Redis.V1Beta1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/Google.Cloud.Redis.V1Beta1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.Snippets/Google.Cloud.Redis.V1Beta1.Snippets.csproj
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.Snippets/Google.Cloud.Redis.V1Beta1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/Google.Cloud.ResourceManager.V3.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/Google.Cloud.ResourceManager.V3.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.Snippets/Google.Cloud.ResourceManager.V3.Snippets.csproj
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.Snippets/Google.Cloud.ResourceManager.V3.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ResourceSettings.V1/Google.Cloud.ResourceSettings.V1.GeneratedSnippets/Google.Cloud.ResourceSettings.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.ResourceSettings.V1/Google.Cloud.ResourceSettings.V1.GeneratedSnippets/Google.Cloud.ResourceSettings.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ResourceSettings.V1/Google.Cloud.ResourceSettings.V1.Snippets/Google.Cloud.ResourceSettings.V1.Snippets.csproj
+++ b/apis/Google.Cloud.ResourceSettings.V1/Google.Cloud.ResourceSettings.V1.Snippets/Google.Cloud.ResourceSettings.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/Google.Cloud.Retail.V2.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/Google.Cloud.Retail.V2.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.Snippets/Google.Cloud.Retail.V2.Snippets.csproj
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.Snippets/Google.Cloud.Retail.V2.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/Google.Cloud.Run.V2.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/Google.Cloud.Run.V2.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.Snippets/Google.Cloud.Run.V2.Snippets.csproj
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.Snippets/Google.Cloud.Run.V2.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/Google.Cloud.Scheduler.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/Google.Cloud.Scheduler.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.Snippets/Google.Cloud.Scheduler.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.Snippets/Google.Cloud.Scheduler.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/Google.Cloud.SecretManager.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/Google.Cloud.SecretManager.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.Snippets/Google.Cloud.SecretManager.V1.Snippets.csproj
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.Snippets/Google.Cloud.SecretManager.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.Snippets/Google.Cloud.SecretManager.V1Beta1.Snippets.csproj
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.Snippets/Google.Cloud.SecretManager.V1Beta1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.SecureSourceManager.V1/Google.Cloud.SecureSourceManager.V1.GeneratedSnippets/Google.Cloud.SecureSourceManager.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.SecureSourceManager.V1/Google.Cloud.SecureSourceManager.V1.GeneratedSnippets/Google.Cloud.SecureSourceManager.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.SecureSourceManager.V1/Google.Cloud.SecureSourceManager.V1.Snippets/Google.Cloud.SecureSourceManager.V1.Snippets.csproj
+++ b/apis/Google.Cloud.SecureSourceManager.V1/Google.Cloud.SecureSourceManager.V1.Snippets/Google.Cloud.SecureSourceManager.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.Snippets/Google.Cloud.Security.PrivateCA.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.Snippets/Google.Cloud.Security.PrivateCA.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Security.PublicCA.V1Beta1/Google.Cloud.Security.PublicCA.V1Beta1.GeneratedSnippets/Google.Cloud.Security.PublicCA.V1Beta1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Security.PublicCA.V1Beta1/Google.Cloud.Security.PublicCA.V1Beta1.GeneratedSnippets/Google.Cloud.Security.PublicCA.V1Beta1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Security.PublicCA.V1Beta1/Google.Cloud.Security.PublicCA.V1Beta1.Snippets/Google.Cloud.Security.PublicCA.V1Beta1.Snippets.csproj
+++ b/apis/Google.Cloud.Security.PublicCA.V1Beta1/Google.Cloud.Security.PublicCA.V1Beta1.Snippets/Google.Cloud.Security.PublicCA.V1Beta1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.Snippets/Google.Cloud.SecurityCenter.Settings.V1Beta1.Snippets.csproj
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.Snippets/Google.Cloud.SecurityCenter.Settings.V1Beta1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/Google.Cloud.SecurityCenter.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/Google.Cloud.SecurityCenter.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.Snippets/Google.Cloud.SecurityCenter.V1.Snippets.csproj
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.Snippets/Google.Cloud.SecurityCenter.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.Snippets/Google.Cloud.SecurityCenter.V1P1Beta1.Snippets.csproj
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.Snippets/Google.Cloud.SecurityCenter.V1P1Beta1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1.GeneratedSnippets/Google.Cloud.ServiceControl.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1.GeneratedSnippets/Google.Cloud.ServiceControl.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1.Snippets/Google.Cloud.ServiceControl.V1.Snippets.csproj
+++ b/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1.Snippets/Google.Cloud.ServiceControl.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.Snippets/Google.Cloud.ServiceDirectory.V1.Snippets.csproj
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.Snippets/Google.Cloud.ServiceDirectory.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.Snippets/Google.Cloud.ServiceDirectory.V1Beta1.Snippets.csproj
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.Snippets/Google.Cloud.ServiceDirectory.V1Beta1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/Google.Cloud.ServiceManagement.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/Google.Cloud.ServiceManagement.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.Snippets/Google.Cloud.ServiceManagement.V1.Snippets.csproj
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.Snippets/Google.Cloud.ServiceManagement.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1.GeneratedSnippets/Google.Cloud.ServiceUsage.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1.GeneratedSnippets/Google.Cloud.ServiceUsage.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1.Snippets/Google.Cloud.ServiceUsage.V1.Snippets.csproj
+++ b/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1.Snippets/Google.Cloud.ServiceUsage.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.GeneratedSnippets/Google.Cloud.Shell.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.GeneratedSnippets/Google.Cloud.Shell.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.Snippets/Google.Cloud.Shell.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.Snippets/Google.Cloud.Shell.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.Snippets/Google.Cloud.Spanner.Admin.Database.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.Snippets/Google.Cloud.Spanner.Admin.Database.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.Tests/Google.Cloud.Spanner.Admin.Database.V1.Tests.csproj
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.Tests/Google.Cloud.Spanner.Admin.Database.V1.Tests.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.Snippets/Google.Cloud.Spanner.Admin.Instance.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.Snippets/Google.Cloud.Spanner.Admin.Instance.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.Tests/Google.Cloud.Spanner.Admin.Instance.V1.Tests.csproj
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.Tests/Google.Cloud.Spanner.Admin.Instance.V1.Tests.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/Google.Cloud.Spanner.Data.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/Google.Cloud.Spanner.Data.IntegrationTests.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.Combinatorial" Version="1.6.24" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/Google.Cloud.Spanner.Data.Snippets.csproj
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/Google.Cloud.Spanner.Data.Snippets.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.Combinatorial" Version="1.6.24" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/Google.Cloud.Spanner.Data.Tests.csproj
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/Google.Cloud.Spanner.Data.Tests.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.Combinatorial" Version="1.6.24" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/Google.Cloud.Spanner.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/Google.Cloud.Spanner.V1.GeneratedSnippets.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.Combinatorial" Version="1.6.24" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.Snippets/Google.Cloud.Spanner.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.Snippets/Google.Cloud.Spanner.V1.Snippets.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.Combinatorial" Version="1.6.24" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.Tests/Google.Cloud.Spanner.V1.Tests.csproj
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.Tests/Google.Cloud.Spanner.V1.Tests.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.Combinatorial" Version="1.6.24" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/Google.Cloud.Speech.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/Google.Cloud.Speech.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.Snippets/Google.Cloud.Speech.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.Snippets/Google.Cloud.Speech.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <ItemGroup>

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.Tests/Google.Cloud.Speech.V1.Tests.csproj
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.Tests/Google.Cloud.Speech.V1.Tests.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.Snippets/Google.Cloud.Speech.V1P1Beta1.Snippets.csproj
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.Snippets/Google.Cloud.Speech.V1P1Beta1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <ItemGroup>

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/Google.Cloud.Speech.V2.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/Google.Cloud.Speech.V2.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.Snippets/Google.Cloud.Speech.V2.Snippets.csproj
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.Snippets/Google.Cloud.Speech.V2.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/Google.Cloud.Storage.V1.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/Google.Cloud.Storage.V1.IntegrationTests.csproj
@@ -16,8 +16,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <ItemGroup>

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Snippets/Google.Cloud.Storage.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Snippets/Google.Cloud.Storage.V1.Snippets.csproj
@@ -16,8 +16,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/Google.Cloud.Storage.V1.Tests.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/Google.Cloud.Storage.V1.Tests.csproj
@@ -16,8 +16,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <ItemGroup>

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/Google.Cloud.StorageInsights.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/Google.Cloud.StorageInsights.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.Snippets/Google.Cloud.StorageInsights.V1.Snippets.csproj
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.Snippets/Google.Cloud.StorageInsights.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/Google.Cloud.StorageTransfer.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/Google.Cloud.StorageTransfer.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.Snippets/Google.Cloud.StorageTransfer.V1.Snippets.csproj
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.Snippets/Google.Cloud.StorageTransfer.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/Google.Cloud.Support.V2.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/Google.Cloud.Support.V2.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.Snippets/Google.Cloud.Support.V2.Snippets.csproj
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.Snippets/Google.Cloud.Support.V2.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/Google.Cloud.Talent.V4.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/Google.Cloud.Talent.V4.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.Snippets/Google.Cloud.Talent.V4.Snippets.csproj
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.Snippets/Google.Cloud.Talent.V4.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/Google.Cloud.Talent.V4Beta1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/Google.Cloud.Talent.V4Beta1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.Snippets/Google.Cloud.Talent.V4Beta1.Snippets.csproj
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.Snippets/Google.Cloud.Talent.V4Beta1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/Google.Cloud.Tasks.V2.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/Google.Cloud.Tasks.V2.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.Snippets/Google.Cloud.Tasks.V2.Snippets.csproj
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.Snippets/Google.Cloud.Tasks.V2.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.Snippets/Google.Cloud.Tasks.V2Beta3.Snippets.csproj
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.Snippets/Google.Cloud.Tasks.V2Beta3.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.GeneratedSnippets/Google.Cloud.TextToSpeech.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.GeneratedSnippets/Google.Cloud.TextToSpeech.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.Snippets/Google.Cloud.TextToSpeech.V1.Snippets.csproj
+++ b/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.Snippets/Google.Cloud.TextToSpeech.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.GeneratedSnippets/Google.Cloud.TextToSpeech.V1Beta1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.GeneratedSnippets/Google.Cloud.TextToSpeech.V1Beta1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.Snippets/Google.Cloud.TextToSpeech.V1Beta1.Snippets.csproj
+++ b/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.Snippets/Google.Cloud.TextToSpeech.V1Beta1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/Google.Cloud.Tpu.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/Google.Cloud.Tpu.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.Snippets/Google.Cloud.Tpu.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.Snippets/Google.Cloud.Tpu.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.GeneratedSnippets/Google.Cloud.Trace.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.GeneratedSnippets/Google.Cloud.Trace.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.Snippets/Google.Cloud.Trace.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.Snippets/Google.Cloud.Trace.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.GeneratedSnippets/Google.Cloud.Trace.V2.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.GeneratedSnippets/Google.Cloud.Trace.V2.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.Snippets/Google.Cloud.Trace.V2.Snippets.csproj
+++ b/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.Snippets/Google.Cloud.Trace.V2.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/Google.Cloud.Translate.V3.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/Google.Cloud.Translate.V3.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.Snippets/Google.Cloud.Translate.V3.Snippets.csproj
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.Snippets/Google.Cloud.Translate.V3.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.IntegrationTests/Google.Cloud.Translation.V2.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.IntegrationTests/Google.Cloud.Translation.V2.IntegrationTests.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <ItemGroup>

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.Snippets/Google.Cloud.Translation.V2.Snippets.csproj
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.Snippets/Google.Cloud.Translation.V2.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.Tests/Google.Cloud.Translation.V2.Tests.csproj
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.Tests/Google.Cloud.Translation.V2.Tests.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/Google.Cloud.VMMigration.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/Google.Cloud.VMMigration.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.Snippets/Google.Cloud.VMMigration.V1.Snippets.csproj
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.Snippets/Google.Cloud.VMMigration.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.Snippets/Google.Cloud.Video.LiveStream.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.Snippets/Google.Cloud.Video.LiveStream.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.Snippets/Google.Cloud.Video.Stitcher.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.Snippets/Google.Cloud.Video.Stitcher.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.Snippets/Google.Cloud.Video.Transcoder.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.Snippets/Google.Cloud.Video.Transcoder.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1.GeneratedSnippets/Google.Cloud.VideoIntelligence.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1.GeneratedSnippets/Google.Cloud.VideoIntelligence.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1.Snippets/Google.Cloud.VideoIntelligence.V1.Snippets.csproj
+++ b/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1.Snippets/Google.Cloud.VideoIntelligence.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1.Tests/Google.Cloud.VideoIntelligence.V1.Tests.csproj
+++ b/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1.Tests/Google.Cloud.VideoIntelligence.V1.Tests.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/Google.Cloud.Vision.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/Google.Cloud.Vision.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.IntegrationTests/Google.Cloud.Vision.V1.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.IntegrationTests/Google.Cloud.Vision.V1.IntegrationTests.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <ItemGroup>

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Snippets/Google.Cloud.Vision.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Snippets/Google.Cloud.Vision.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <ItemGroup>

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Tests/Google.Cloud.Vision.V1.Tests.csproj
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Tests/Google.Cloud.Vision.V1.Tests.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/Google.Cloud.VmwareEngine.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/Google.Cloud.VmwareEngine.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.Snippets/Google.Cloud.VmwareEngine.V1.Snippets.csproj
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.Snippets/Google.Cloud.VmwareEngine.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/Google.Cloud.VpcAccess.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/Google.Cloud.VpcAccess.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.Snippets/Google.Cloud.VpcAccess.V1.Snippets.csproj
+++ b/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.Snippets/Google.Cloud.VpcAccess.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/Google.Cloud.WebRisk.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/Google.Cloud.WebRisk.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.Snippets/Google.Cloud.WebRisk.V1.Snippets.csproj
+++ b/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.Snippets/Google.Cloud.WebRisk.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1.GeneratedSnippets/Google.Cloud.WebRisk.V1Beta1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1.GeneratedSnippets/Google.Cloud.WebRisk.V1Beta1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1.Snippets/Google.Cloud.WebRisk.V1Beta1.Snippets.csproj
+++ b/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1.Snippets/Google.Cloud.WebRisk.V1Beta1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.Snippets/Google.Cloud.WebSecurityScanner.V1.Snippets.csproj
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.Snippets/Google.Cloud.WebSecurityScanner.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.Snippets/Google.Cloud.Workflows.Executions.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.Snippets/Google.Cloud.Workflows.Executions.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.Snippets/Google.Cloud.Workflows.Executions.V1Beta.Snippets.csproj
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.Snippets/Google.Cloud.Workflows.Executions.V1Beta.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/Google.Cloud.Workflows.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/Google.Cloud.Workflows.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.Snippets/Google.Cloud.Workflows.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.Snippets/Google.Cloud.Workflows.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/Google.Cloud.Workflows.V1Beta.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/Google.Cloud.Workflows.V1Beta.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.Snippets/Google.Cloud.Workflows.V1Beta.Snippets.csproj
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.Snippets/Google.Cloud.Workflows.V1Beta.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/Google.Cloud.Workstations.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/Google.Cloud.Workstations.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.Snippets/Google.Cloud.Workstations.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.Snippets/Google.Cloud.Workstations.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/Google.Identity.AccessContextManager.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/Google.Identity.AccessContextManager.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.Snippets/Google.Identity.AccessContextManager.V1.Snippets.csproj
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.Snippets/Google.Identity.AccessContextManager.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.LongRunning/Google.LongRunning.GeneratedSnippets/Google.LongRunning.GeneratedSnippets.csproj
+++ b/apis/Google.LongRunning/Google.LongRunning.GeneratedSnippets/Google.LongRunning.GeneratedSnippets.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.LongRunning/Google.LongRunning.Snippets/Google.LongRunning.Snippets.csproj
+++ b/apis/Google.LongRunning/Google.LongRunning.Snippets/Google.LongRunning.Snippets.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.LongRunning/Google.LongRunning.Tests/Google.LongRunning.Tests.csproj
+++ b/apis/Google.LongRunning/Google.LongRunning.Tests/Google.LongRunning.Tests.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1.GeneratedSnippets/Google.Maps.AddressValidation.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1.GeneratedSnippets/Google.Maps.AddressValidation.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1.Snippets/Google.Maps.AddressValidation.V1.Snippets.csproj
+++ b/apis/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1.Snippets/Google.Maps.AddressValidation.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.Snippets/Google.Maps.MapsPlatformDatasets.V1.Snippets.csproj
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.Snippets/Google.Maps.MapsPlatformDatasets.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Maps.MapsPlatformDatasets.V1Alpha/Google.Maps.MapsPlatformDatasets.V1Alpha.GeneratedSnippets/Google.Maps.MapsPlatformDatasets.V1Alpha.GeneratedSnippets.csproj
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1Alpha/Google.Maps.MapsPlatformDatasets.V1Alpha.GeneratedSnippets/Google.Maps.MapsPlatformDatasets.V1Alpha.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Maps.MapsPlatformDatasets.V1Alpha/Google.Maps.MapsPlatformDatasets.V1Alpha.Snippets/Google.Maps.MapsPlatformDatasets.V1Alpha.Snippets.csproj
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1Alpha/Google.Maps.MapsPlatformDatasets.V1Alpha.Snippets/Google.Maps.MapsPlatformDatasets.V1Alpha.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.GeneratedSnippets/Google.Maps.Places.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.GeneratedSnippets/Google.Maps.Places.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.Snippets/Google.Maps.Places.V1.Snippets.csproj
+++ b/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.Snippets/Google.Maps.Places.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Maps.Routing.V2/Google.Maps.Routing.V2.GeneratedSnippets/Google.Maps.Routing.V2.GeneratedSnippets.csproj
+++ b/apis/Google.Maps.Routing.V2/Google.Maps.Routing.V2.GeneratedSnippets/Google.Maps.Routing.V2.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Maps.Routing.V2/Google.Maps.Routing.V2.Snippets/Google.Maps.Routing.V2.Snippets.csproj
+++ b/apis/Google.Maps.Routing.V2/Google.Maps.Routing.V2.Snippets/Google.Maps.Routing.V2.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets.csproj
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.Snippets/Google.Shopping.Merchant.Inventories.V1Beta.Snippets.csproj
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.Snippets/Google.Shopping.Merchant.Inventories.V1Beta.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/Grafeas.V1.GeneratedSnippets.csproj
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/Grafeas.V1.GeneratedSnippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/apis/Grafeas.V1/Grafeas.V1.Snippets/Grafeas.V1.Snippets.csproj
+++ b/apis/Grafeas.V1/Grafeas.V1.Snippets/Grafeas.V1.Snippets.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/tools/Google.Cloud.Tools.ReleaseManager/GenerateProjectsCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/GenerateProjectsCommand.cs
@@ -107,8 +107,8 @@ namespace Google.Cloud.Tools.ReleaseManager
         {
             { "Google.Cloud.ClientTesting", ProjectVersionValue }, // Needed for all snippets and some other tests - easiest to just default
             { "Microsoft.NET.Test.Sdk", "17.7.2" },
-            { "xunit", "2.5.1" },
-            { "xunit.runner.visualstudio", "2.5.1" },
+            { "xunit", "2.5.2" },
+            { "xunit.runner.visualstudio", "2.5.3" },
             { "Xunit.SkippableFact", "1.4.13" },
             { "NSubstitute", "5.1.0" },
             { "System.Linq.Async", "6.0.1" },


### PR DESCRIPTION
This should take care of most of #11172; regenerating that will find stragglers in terms of non-generated projects.