### PR TITLE
Release Google.Cloud.BigQuery.V2 version 3.5.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.4.0</Version>
+    <Version>3.5.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery API. It wraps the Google.Apis.Bigquery.v2 client library, making common operations simpler in client code. BigQuery is a data platform for customers to create, manage, share and query data.</Description>

--- a/apis/Google.Cloud.BigQuery.V2/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.V2/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 3.5.0, released 2023-10-13
+
+### New features
+
+- Adds config modifier to BigQuery job options ([commit fbacbb8](https://github.com/googleapis/google-cloud-dotnet/commit/fbacbb8315d62ac10b2960e18fe239e0754420c3))
+- Adds support for policy tags ([commit 730a30e](https://github.com/googleapis/google-cloud-dotnet/commit/730a30e2ae3a4e7e94877918df82641e527a4708))
+
 ## Version 3.4.0, released 2023-06-07
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -881,7 +881,7 @@
       "id": "Google.Cloud.BigQuery.V2",
       "productName": "Google BigQuery",
       "productUrl": "https://cloud.google.com/bigquery/",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "type": "rest",
       "description": "Recommended Google client library to access the BigQuery API. It wraps the Google.Apis.Bigquery.v2 client library, making common operations simpler in client code. BigQuery is a data platform for customers to create, manage, share and query data.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Adds config modifier to BigQuery job options ([commit fbacbb8](https://github.com/googleapis/google-cloud-dotnet/commit/fbacbb8315d62ac10b2960e18fe239e0754420c3))
- Adds support for policy tags ([commit 730a30e](https://github.com/googleapis/google-cloud-dotnet/commit/730a30e2ae3a4e7e94877918df82641e527a4708))
