### PR TITLE
chore: Temporary workaround for Fleet Engine Delivery API gRPC service config

### DIFF
--- a/apis/Google.Maps.FleetEngine.Delivery.V1/.OwlBot-ForceRegeneration.txt
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/.OwlBot-ForceRegeneration.txt
@@ -1,0 +1,1 @@
+API requires pre-generation tweaks.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/postgeneration.sh
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/postgeneration.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+# Remove the pre-generation-copied gRPC service config file.
+rm $GOOGLEAPIS/google/maps/fleetengine/delivery/v1/fleetengine_delivery_grpc_service_config.json
+
 # Suppress deprecation warnings in generated gRPC code.
 # (If this becomes a common problem, we'll want a more robust fix.
 # It'll do for now.)

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/pregeneration.sh
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/pregeneration.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+# The fleetengine.v1 gRPC service config contains entries for fleetengine.delivery.v1
+# as well. We expect the API to be self-contained, so copy the config.
+cp $GOOGLEAPIS/google/maps/fleetengine/v1/fleetengine_grpc_service_config.json \
+  $GOOGLEAPIS/google/maps/fleetengine/delivery/v1/fleetengine_delivery_grpc_service_config.json


### PR DESCRIPTION
(Our local generation assumes the gRPC service config is in the same directory as the rest of the API definition. This isn't currently true for Fleet Engine Delivery, but I'm working on it.)