### PR TITLE
chore: Update to docfx 2.71.1, including changing docfx.json

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "docfx": {
-      "version": "2.71.0",
+      "version": "2.71.1",
       "commands": [
         "docfx"
       ]

--- a/tools/Google.Cloud.Tools.GenerateDocfxSources/Program.cs
+++ b/tools/Google.Cloud.Tools.GenerateDocfxSources/Program.cs
@@ -79,7 +79,7 @@ namespace Google.Cloud.Tools.GenerateDocfxSources
                         ["src"] = new JObject
                         {
                             ["files"] = new JArray { $"{rootApi.Id}/{rootApi.Id}.csproj" },
-                            ["cwd"] = $"../../../apis/{rootApi.Id}"
+                            ["src"] = $"../../../apis/{rootApi.Id}"
                         },
                         ["dest"] = "obj/api",
                         ["filter"] = "filterConfig.yml",
@@ -136,7 +136,7 @@ namespace Google.Cloud.Tools.GenerateDocfxSources
                         ["src"] = new JObject
                         {
                             ["files"] = new JArray { $"{rootApi.Id}/{rootApi.Id}.csproj" },
-                            ["cwd"] = $"../../../apis/{rootApi.Id}"
+                            ["src"] = $"../../../apis/{rootApi.Id}"
                         },
                         ["dest"] = "obj/bareapi",
                         ["filter"] = "filterConfig.yml"


### PR DESCRIPTION
We need to specify "src" instead of "cwd" now. Easy enough to do, it turns out. Just took time to work out...