### PR TITLE
chore: Remove workaround for FleetEngine Delivery API

### DIFF
--- a/apis/Google.Maps.FleetEngine.Delivery.V1/.OwlBot-ForceRegeneration.txt
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/.OwlBot-ForceRegeneration.txt
@@ -1,1 +1,0 @@
-API requires pre-generation tweaks.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/postgeneration.sh
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/postgeneration.sh
@@ -2,9 +2,6 @@
 
 set -e
 
-# Remove the pre-generation-copied gRPC service config file.
-rm $GOOGLEAPIS/google/maps/fleetengine/delivery/v1/fleetengine_delivery_grpc_service_config.json
-
 # Suppress deprecation warnings in generated gRPC code.
 # (If this becomes a common problem, we'll want a more robust fix.
 # It'll do for now.)

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/pregeneration.sh
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/pregeneration.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-set -e
-
-# The fleetengine.v1 gRPC service config contains entries for fleetengine.delivery.v1
-# as well. We expect the API to be self-contained, so copy the config.
-cp $GOOGLEAPIS/google/maps/fleetengine/v1/fleetengine_grpc_service_config.json \
-  $GOOGLEAPIS/google/maps/fleetengine/delivery/v1/fleetengine_delivery_grpc_service_config.json


### PR DESCRIPTION
The gRPC service config for the Delivery API is now in the same directory, so we don't need this any more.