### PR TITLE
Release Google.Cloud.Tools.SbomGenerator version 0.2.0

### DIFF
--- a/tools/Google.Cloud.Tools.SbomGenerator/Google.Cloud.Tools.SbomGenerator.csproj
+++ b/tools/Google.Cloud.Tools.SbomGenerator/Google.Cloud.Tools.SbomGenerator.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <Description>Tool used by Google .NET release processes to generate SBOMs. While there is nothing "secret" in this package, it is unlikely to be useful to other developers. (It currently hardcodes a Google organization, amongst other things.) It is only published as a matter of convenience for other Google .NET repositories.</Description>
     <ToolCommandName>generate-sbom</ToolCommandName>
   </PropertyGroup>


### PR DESCRIPTION
(This is a bump to 0.2.0 to avoid an empty commit, which causes issues when rebasing.)