### PR TITLE
chore: Use the new SBOM generator tool during the release process

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -19,6 +19,12 @@
       "commands": [
         "release-progress-reporter"
       ]
+    },
+    "Google.Cloud.Tools.SbomGenerator": {
+      "version": "0.2.0",
+      "commands": [
+        "generate-sbom"
+      ]
     }
   }
 }

--- a/.kokoro/release.sh
+++ b/.kokoro/release.sh
@@ -55,6 +55,11 @@ echo "Building with commit $COMMITTISH"
 # Build the release and run the tests.
 ./buildrelease.sh $COMMITTISH
 
+# Restore tools just in case we haven't done so already.
+# (If we're using autorelease, this should have happened, but
+# doing it again is harmless.) This will make the SBOM generator available.
+dotnet tool restore
+
 if [[ $SKIP_NUGET_PUSH = "" ]]
 then
   echo "Pushing NuGet packages"
@@ -87,7 +92,8 @@ then
        echo "No NuGet API key found for package owner $package_owner"
        exit 1
     esac
-    
+
+    dotnet generate-sbom $pkg
     dotnet nuget push -s https://api.nuget.org/v3/index.json -k $pkg_nuget_api_key $pkg
   done
   cd ../..


### PR DESCRIPTION
Any NuGet package that we're going to push, we first generate the SBOM for.