### PR TITLE
Release Google.Analytics.Admin.V1Alpha version 2.0.0-alpha14

### DIFF
--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha13</Version>
+    <Version>2.0.0-alpha14</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Analytics Admin API (v1alpha)</Description>

--- a/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
+++ b/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
@@ -1,5 +1,19 @@
 # Version history
 
+## Version 2.0.0-alpha14, released 2023-10-25
+
+### Bug fixes
+
+- **BREAKING CHANGE** Delete `BatchDeleteUserLinks`, `DeleteUserLink`, `BatchUpdateUserLinks`, `UpdateUserLink`, `BatchCreateUserLinks`, `CreateUserLink`, `AuditUserLinks`, `ListUserLinks`, `BatchGetUserLinks`, `GetUserLink` from the Admin API v1 alpha as per the announcement in https://bit.ly/46yBIDt ([commit 5948499](https://github.com/googleapis/google-cloud-dotnet/commit/5948499acbe3711fe1e3a05c691a41918b26ea1c))
+
+### New features
+
+- Add `UpdateDataRedactionSettings`, `CreateRollupProperty`, `GetRollupPropertySourceLink`, `ListRollupPropertySourceLinks`, `CreateRollupPropertySourceLink`, `DeleteRollupPropertySourceLink`, `CreateSubproperty`, `CreateSubpropertyEventFilter`, `CreateSubpropertyEventFilter`, `ListSubpropertyEventFilters`, `UpdateSubpropertyEventFilter`, `DeleteSubpropertyEventFilter` methods to the Admin API v1 alpha ([commit 5948499](https://github.com/googleapis/google-cloud-dotnet/commit/5948499acbe3711fe1e3a05c691a41918b26ea1c))
+- Add `include_all_users`, `expand_groups` fields to `RunAccessReportRequest` ([commit 5948499](https://github.com/googleapis/google-cloud-dotnet/commit/5948499acbe3711fe1e3a05c691a41918b26ea1c))
+- Add `DataRedactionSettings`, `RollupPropertySourceLink`, `SubpropertyEventFilterCondition`, `SubpropertyEventFilterExpression`, `SubpropertyEventFilterExpressionList`, `SubpropertyEventFilterClause`, `SubpropertyEventFilter` types ([commit 5948499](https://github.com/googleapis/google-cloud-dotnet/commit/5948499acbe3711fe1e3a05c691a41918b26ea1c))
+- Add the `DATA_REDACTION_SETTINGS` option to the `ChangeHistoryResourceType` enum ([commit 5948499](https://github.com/googleapis/google-cloud-dotnet/commit/5948499acbe3711fe1e3a05c691a41918b26ea1c))
+- Add the `data_redaction_settings` field to the `ChangeHistoryResource.resource` oneof field ([commit 5948499](https://github.com/googleapis/google-cloud-dotnet/commit/5948499acbe3711fe1e3a05c691a41918b26ea1c))
+
 ## Version 2.0.0-alpha13, released 2023-09-01
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2,7 +2,7 @@
   "apis": [
     {
       "id": "Google.Analytics.Admin.V1Alpha",
-      "version": "2.0.0-alpha13",
+      "version": "2.0.0-alpha14",
       "type": "grpc",
       "productName": "Analytics Admin",
       "productUrl": "https://developers.google.com/analytics",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- **BREAKING CHANGE** Delete `BatchDeleteUserLinks`, `DeleteUserLink`, `BatchUpdateUserLinks`, `UpdateUserLink`, `BatchCreateUserLinks`, `CreateUserLink`, `AuditUserLinks`, `ListUserLinks`, `BatchGetUserLinks`, `GetUserLink` from the Admin API v1 alpha as per the announcement in https://bit.ly/46yBIDt ([commit 5948499](https://github.com/googleapis/google-cloud-dotnet/commit/5948499acbe3711fe1e3a05c691a41918b26ea1c))

### New features

- Add `UpdateDataRedactionSettings`, `CreateRollupProperty`, `GetRollupPropertySourceLink`, `ListRollupPropertySourceLinks`, `CreateRollupPropertySourceLink`, `DeleteRollupPropertySourceLink`, `CreateSubproperty`, `CreateSubpropertyEventFilter`, `CreateSubpropertyEventFilter`, `ListSubpropertyEventFilters`, `UpdateSubpropertyEventFilter`, `DeleteSubpropertyEventFilter` methods to the Admin API v1 alpha ([commit 5948499](https://github.com/googleapis/google-cloud-dotnet/commit/5948499acbe3711fe1e3a05c691a41918b26ea1c))
- Add `include_all_users`, `expand_groups` fields to `RunAccessReportRequest` ([commit 5948499](https://github.com/googleapis/google-cloud-dotnet/commit/5948499acbe3711fe1e3a05c691a41918b26ea1c))
- Add `DataRedactionSettings`, `RollupPropertySourceLink`, `SubpropertyEventFilterCondition`, `SubpropertyEventFilterExpression`, `SubpropertyEventFilterExpressionList`, `SubpropertyEventFilterClause`, `SubpropertyEventFilter` types ([commit 5948499](https://github.com/googleapis/google-cloud-dotnet/commit/5948499acbe3711fe1e3a05c691a41918b26ea1c))
- Add the `DATA_REDACTION_SETTINGS` option to the `ChangeHistoryResourceType` enum ([commit 5948499](https://github.com/googleapis/google-cloud-dotnet/commit/5948499acbe3711fe1e3a05c691a41918b26ea1c))
- Add the `data_redaction_settings` field to the `ChangeHistoryResource.resource` oneof field ([commit 5948499](https://github.com/googleapis/google-cloud-dotnet/commit/5948499acbe3711fe1e3a05c691a41918b26ea1c))
