### PR TITLE
(DO NOT MERGE) Prototype of using API key support in GAX

### DIFF
--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.Snippets/LanguageServiceClientSnippets.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.Snippets/LanguageServiceClientSnippets.cs
@@ -138,21 +138,11 @@ namespace Google.Cloud.Language.V1.Snippets
             Skip.If(string.IsNullOrEmpty(apiKey));
 
             // Sample: ApiKey
-            // Create a LanguageServiceSettings that applies the X-Goog-Api-Key
-            // header on every request
-            LanguageServiceSettings settings = new LanguageServiceSettings
-            {
-                CallSettings = CallSettings.FromHeader("X-Goog-Api-Key", apiKey)
-            };
-
-            // Create a LanguageServiceClient which uses the settings to apply
-            // the API key to every request. The ChannelCredentials are set to
-            // just SSL; we don't authenticate at the channel level when
-            // applying API keys.
+            // Create a LanguageServiceClient which uses an API key instead of
+            // full credentials.
             LanguageServiceClient client = new LanguageServiceClientBuilder
             {
-                ChannelCredentials = ChannelCredentials.SecureSsl,
-                Settings = settings
+                ApiKey = apiKey
             }.Build();
 
             // After creating the client with an API key configured, we can use it

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/Google.Cloud.Language.V1.csproj
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/Google.Cloud.Language.V1.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="4.5.0-apikey-1" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/LanguageServiceClient.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/LanguageServiceClient.g.cs
@@ -209,6 +209,16 @@ namespace Google.Cloud.Language.V1
         /// <summary>The settings to use for RPCs, or <c>null</c> for the default settings.</summary>
         public LanguageServiceSettings Settings { get; set; }
 
+        /// <summary>
+        /// The API key to use instead of full credentials. When this is non-null, no other
+        /// form of credentials or quota project should be set.
+        /// </summary>
+        public new string ApiKey
+        {
+            get => base.ApiKey;
+            set => base.ApiKey = value;
+        }
+
         /// <summary>Creates a new builder with default settings.</summary>
         public LanguageServiceClientBuilder() : base(LanguageServiceClient.ServiceMetadata)
         {
@@ -238,14 +248,14 @@ namespace Google.Cloud.Language.V1
         {
             Validate();
             grpccore::CallInvoker callInvoker = CreateCallInvoker();
-            return LanguageServiceClient.Create(callInvoker, Settings, Logger);
+            return LanguageServiceClient.Create(callInvoker, GetEffectiveSettings(Settings?.Clone()), Logger);
         }
 
         private async stt::Task<LanguageServiceClient> BuildAsyncImpl(st::CancellationToken cancellationToken)
         {
             Validate();
             grpccore::CallInvoker callInvoker = await CreateCallInvokerAsync(cancellationToken).ConfigureAwait(false);
-            return LanguageServiceClient.Create(callInvoker, Settings, Logger);
+            return LanguageServiceClient.Create(callInvoker, GetEffectiveSettings(Settings?.Clone()), Logger);
         }
 
         /// <summary>Returns the channel pool to use when no other options are specified.</summary>


### PR DESCRIPTION
This isn't *expected* to build, btw - but it works locally, where I have the prototype GAX package.

I suspect we'd want to add something in the service config to instruct the generator to generate things differently, rather than do it by hand. (This modifies existing generated code rather than being purely additive.)