### PR TITLE
feat: Multi-db support in Datastore.

### DIFF
--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/Google.Cloud.Datastore.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/Google.Cloud.Datastore.V1.GeneratedSnippets.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Datastore.V1\Google.Cloud.Datastore.V1.csproj" />
+    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.3.0, 4.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />
     <PackageReference Include="System.Linq.Async" Version="$(SystemLinqAsyncVersion)" />

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/Google.Cloud.Datastore.V1.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/Google.Cloud.Datastore.V1.IntegrationTests.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Datastore.V1\Google.Cloud.Datastore.V1.csproj" />
+    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.3.0, 4.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />
     <PackageReference Include="System.Linq.Async" Version="$(SystemLinqAsyncVersion)" />

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/Google.Cloud.Datastore.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/Google.Cloud.Datastore.V1.Snippets.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Datastore.V1\Google.Cloud.Datastore.V1.csproj" />
+    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.3.0, 4.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />
     <PackageReference Include="System.Linq.Async" Version="$(SystemLinqAsyncVersion)" />

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Tests/Google.Cloud.Datastore.V1.Tests.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Tests/Google.Cloud.Datastore.V1.Tests.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Datastore.V1\Google.Cloud.Datastore.V1.csproj" />
+    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.3.0, 4.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />
     <PackageReference Include="System.Linq.Async" Version="$(SystemLinqAsyncVersion)" />

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Tests/KeyFactoryTest.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Tests/KeyFactoryTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,11 +22,11 @@ namespace Google.Cloud.Datastore.V1.Tests
         [Fact]
         public void PartitionOnlyFactory()
         {
-            var factory = new KeyFactory("project", "ns", "book");
+            var factory = new KeyFactory("project", "ns", "db", "book");
             var actual = factory.CreateKey(10L);
             var expected = new Key
             {
-                PartitionId = new PartitionId { ProjectId = "project", NamespaceId = "ns" },
+                PartitionId = new PartitionId { ProjectId = "project", NamespaceId = "ns", DatabaseId = "db" },
                 Path = { new PathElement { Id = 10L, Kind = "book" } }
             };
             Assert.Equal(expected, actual);
@@ -37,14 +37,14 @@ namespace Google.Cloud.Datastore.V1.Tests
         {
             var parentKey = new Key
             {
-                PartitionId = new PartitionId { ProjectId = "project", NamespaceId = "ns" },
+                PartitionId = new PartitionId { ProjectId = "project", NamespaceId = "ns", DatabaseId = "db" },
                 Path = { new PathElement { Id = 10L, Kind = "author" } }
             };
             var factory = new KeyFactory(parentKey, "book");
             var actual = factory.CreateKey("subkey-name");
             var expected = new Key
             {
-                PartitionId = new PartitionId { ProjectId = "project", NamespaceId = "ns" },
+                PartitionId = new PartitionId { ProjectId = "project", NamespaceId = "ns", DatabaseId = "db" },
                 Path = {
                     new PathElement { Id = 10L, Kind = "author" },
                     new PathElement { Name = "subkey-name", Kind = "book" }
@@ -58,7 +58,7 @@ namespace Google.Cloud.Datastore.V1.Tests
         {
             var parentKey = new Key
             {
-                PartitionId = new PartitionId { ProjectId = "project", NamespaceId = "ns" },
+                PartitionId = new PartitionId { ProjectId = "project", NamespaceId = "ns", DatabaseId = "db" },
                 Path = { new PathElement { Id = 10L, Kind = "author" } }
             };
             var book = new Entity { Key = parentKey };
@@ -66,7 +66,7 @@ namespace Google.Cloud.Datastore.V1.Tests
             var actual = factory.CreateKey(20L);
             var expected = new Key
             {
-                PartitionId = new PartitionId { ProjectId = "project", NamespaceId = "ns" },
+                PartitionId = new PartitionId { ProjectId = "project", NamespaceId = "ns", DatabaseId = "db" },
                 Path = {
                     new PathElement { Id = 10L, Kind = "author" },
                     new PathElement { Id = 20L, Kind = "book" }

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreDb.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreDb.cs
@@ -58,6 +58,8 @@ namespace Google.Cloud.Datastore.V1
     {
         internal const string DefaultNamespaceId = "";
 
+        internal const string DefaultDatabaseId = "";
+
         /// <summary>
         /// The <see cref="DatastoreClient"/> used for all remote operations.
         /// </summary>
@@ -72,6 +74,11 @@ namespace Google.Cloud.Datastore.V1
         /// The ID of the namespace this instance operates on.
         /// </summary>
         public virtual string NamespaceId { get { throw new NotImplementedException(); } }
+
+        /// <summary>
+        /// The ID of the database against which the request is to be made.
+        /// </summary>
+        public virtual string DatabaseId { get { throw new NotImplementedException(); } }
 
         /// <summary>
         /// Creates a <see cref="DatastoreDb"/> to operate on the partition identified by <paramref name="projectId"/>
@@ -509,6 +516,7 @@ namespace Google.Cloud.Datastore.V1
         internal static IReadOnlyList<Entity> LookupImpl(
             DatastoreClient client,
             string projectId,
+            string databaseId,
             ReadOptions readOptions,
             IEnumerable<Key> keys,
             CallSettings callSettings)
@@ -522,7 +530,15 @@ namespace Google.Cloud.Datastore.V1
             // TODO: Limit how many times we go round? Ensure that we make progress on each iteration?
             while (keysToFetch.Count() > 0)
             {
-                var response = client.Lookup(projectId, readOptions, keysToFetch, callSettings);
+                var lookupRequest = new LookupRequest
+                {
+                    ProjectId = projectId,
+                    DatabaseId = databaseId,
+                    ReadOptions = readOptions,
+                    Keys = { keysToFetch },
+                };
+
+                var response = client.Lookup(lookupRequest, callSettings);
                 foreach (var found in response.Found)
                 {
                     foreach (var index in keyToIndex[found.Entity.Key])
@@ -539,6 +555,7 @@ namespace Google.Cloud.Datastore.V1
         internal static async Task<IReadOnlyList<Entity>> LookupImplAsync(
             DatastoreClient client,
             string projectId,
+            string databaseId,
             ReadOptions readOptions,
             IEnumerable<Key> keys,
             CallSettings callSettings)
@@ -552,7 +569,15 @@ namespace Google.Cloud.Datastore.V1
             // TODO: Limit how many times we go round? Ensure that we make progress on each iteration?
             while (keysToFetch.Count() > 0)
             {
-                var response = await client.LookupAsync(projectId, readOptions, keysToFetch, callSettings).ConfigureAwait(false);
+                var lookupRequest = new LookupRequest
+                {
+                    ProjectId = projectId,
+                    DatabaseId = databaseId,
+                    ReadOptions = readOptions,
+                    Keys = { keysToFetch },
+                };
+
+                var response = await client.LookupAsync(lookupRequest, callSettings).ConfigureAwait(false);
                 foreach (var found in response.Found)
                 {
                     foreach (var index in keyToIndex[found.Entity.Key])

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreDbImpl.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreDbImpl.cs
@@ -43,6 +43,9 @@ namespace Google.Cloud.Datastore.V1
         /// <inheritdoc/>
         public override string NamespaceId { get; }
 
+        /// <inheritdoc/>
+        public override string DatabaseId { get; }
+
         private readonly PartitionId _partitionId;
 
         /// <summary>
@@ -54,11 +57,22 @@ namespace Google.Cloud.Datastore.V1
         /// <param name="projectId">The project ID. Must not be null.</param>
         /// <param name="namespaceId">The namespace ID. Must not be null.</param>
         /// <param name="client">The client to use for underlying operations. Must not be null.</param>
-        public DatastoreDbImpl(string projectId, string namespaceId, DatastoreClient client) : base()
+        public DatastoreDbImpl(string projectId, string namespaceId, DatastoreClient client) : this(projectId, namespaceId, DefaultDatabaseId, client)
+        { }
+
+        /// <summary>
+        /// Constructs an instance from the given project ID, namespace ID and client.
+        /// </summary>
+        /// <param name="projectId">The project ID. Must not be null.</param>
+        /// <param name="namespaceId">The namespace ID. Must not be null.</param>
+        /// <param name="databaseId">The database ID. Must not be null.</param>
+        /// <param name="client">The client to use for underlying operations. Must not be null.</param>
+        public DatastoreDbImpl(string projectId, string namespaceId, string databaseId, DatastoreClient client) : base()
         {
             ProjectId = GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
             NamespaceId = GaxPreconditions.CheckNotNull(namespaceId, nameof(namespaceId));
-            _partitionId = new PartitionId(projectId, namespaceId);
+            DatabaseId = GaxPreconditions.CheckNotNull(databaseId, nameof(databaseId));
+            _partitionId = new PartitionId(projectId, namespaceId, databaseId);
             Client = GaxPreconditions.CheckNotNull(client, nameof(client));
         }
 
@@ -75,6 +89,7 @@ namespace Google.Cloud.Datastore.V1
             var request = new RunQueryRequest
             {
                 ProjectId = ProjectId,
+                DatabaseId = DatabaseId,
                 PartitionId = _partitionId,
                 Query = query,
                 ReadOptions = GetReadOptions(readConsistency)
@@ -90,6 +105,7 @@ namespace Google.Cloud.Datastore.V1
             {
                 AggregationQuery = query,
                 ProjectId = ProjectId,
+                DatabaseId = DatabaseId,
                 PartitionId = _partitionId,
                 ReadOptions = GetReadOptions(readConsistency)
             };
@@ -104,6 +120,7 @@ namespace Google.Cloud.Datastore.V1
             {
                 GqlQuery = query,
                 ProjectId = ProjectId,
+                DatabaseId = DatabaseId,
                 PartitionId = _partitionId,
                 ReadOptions = GetReadOptions(readConsistency)
             };
@@ -118,6 +135,7 @@ namespace Google.Cloud.Datastore.V1
             {
                 AggregationQuery = query,
                 ProjectId = ProjectId,
+                DatabaseId = DatabaseId,
                 PartitionId = _partitionId,
                 ReadOptions = GetReadOptions(readConsistency)
             };
@@ -132,6 +150,7 @@ namespace Google.Cloud.Datastore.V1
             {
                 GqlQuery = query,
                 ProjectId = ProjectId,
+                DatabaseId = DatabaseId,
                 PartitionId = _partitionId,
                 ReadOptions = GetReadOptions(readConsistency)
             };
@@ -149,6 +168,7 @@ namespace Google.Cloud.Datastore.V1
             var request = new RunQueryRequest
             {
                 ProjectId = ProjectId,
+                DatabaseId = DatabaseId,
                 PartitionId = _partitionId,
                 Query = query,
                 ReadOptions = GetReadOptions(readConsistency)
@@ -167,6 +187,7 @@ namespace Google.Cloud.Datastore.V1
             var request = new RunQueryRequest
             {
                 ProjectId = ProjectId,
+                DatabaseId = DatabaseId,
                 PartitionId = _partitionId,
                 GqlQuery = gqlQuery,
                 ReadOptions = GetReadOptions(readConsistency)
@@ -185,6 +206,7 @@ namespace Google.Cloud.Datastore.V1
             var request = new RunQueryRequest
             {
                 ProjectId = ProjectId,
+                DatabaseId = DatabaseId,
                 PartitionId = _partitionId,
                 GqlQuery = gqlQuery,
                 ReadOptions = GetReadOptions(readConsistency)
@@ -195,29 +217,29 @@ namespace Google.Cloud.Datastore.V1
 
         /// <inheritdoc/>
         public override DatastoreTransaction BeginTransaction(CallSettings callSettings = null) =>
-            DatastoreTransaction.Create(Client, ProjectId, NamespaceId, Client.BeginTransaction(ProjectId, callSettings).Transaction);
+            DatastoreTransaction.Create(Client, ProjectId, NamespaceId, DatabaseId, Client.BeginTransaction(ProjectId, callSettings).Transaction);
 
         /// <inheritdoc/>
         public override async Task<DatastoreTransaction> BeginTransactionAsync(CallSettings callSettings = null)
         {
             var response = await Client.BeginTransactionAsync(ProjectId, callSettings).ConfigureAwait(false);
-            return DatastoreTransaction.Create(Client, ProjectId, NamespaceId, response.Transaction);
+            return DatastoreTransaction.Create(Client, ProjectId, NamespaceId, DatabaseId, response.Transaction);
         }
 
         /// <inheritdoc/>
         public override DatastoreTransaction BeginTransaction(TransactionOptions options, CallSettings callSettings = null)
         {
-            var request = new BeginTransactionRequest { ProjectId = ProjectId, TransactionOptions = options };
+            var request = new BeginTransactionRequest { ProjectId = ProjectId, DatabaseId = DatabaseId, TransactionOptions = options };
             var response = Client.BeginTransaction(request, callSettings);
-            return DatastoreTransaction.Create(Client, ProjectId, NamespaceId, response.Transaction);
+            return DatastoreTransaction.Create(Client, ProjectId, NamespaceId, DatabaseId, response.Transaction);
         }
 
         /// <inheritdoc/>
         public override async Task<DatastoreTransaction> BeginTransactionAsync(TransactionOptions options, CallSettings callSettings = null)
         {
-            var request = new BeginTransactionRequest { ProjectId = ProjectId, TransactionOptions = options };
+            var request = new BeginTransactionRequest { ProjectId = ProjectId, DatabaseId = DatabaseId, TransactionOptions = options };
             var response = await Client.BeginTransactionAsync(request, callSettings).ConfigureAwait(false);
-            return DatastoreTransaction.Create(Client, ProjectId, NamespaceId, response.Transaction);
+            return DatastoreTransaction.Create(Client, ProjectId, NamespaceId, DatabaseId, response.Transaction);
         }
 
         /// <inheritdoc/>
@@ -226,7 +248,13 @@ namespace Google.Cloud.Datastore.V1
             // TODO: Validation. All keys should be non-null, and have a filled in path element
             // until the final one, which should just have a kind. Or we could just let the server validate...
             keys = GaxPreconditions.CheckNotNull(keys, nameof(keys)).ToList();
-            var response = Client.AllocateIds(ProjectId, keys, callSettings);
+            var allocateIdsRequest = new AllocateIdsRequest
+            {
+                ProjectId = ProjectId,
+                DatabaseId = DatabaseId,
+                Keys = { keys, }
+            };
+            var response = Client.AllocateIds(allocateIdsRequest, callSettings);
             return response.Keys.ToList();
         }
 
@@ -236,17 +264,23 @@ namespace Google.Cloud.Datastore.V1
             // TODO: Validation. All keys should be non-null, and have a filled in path element
             // until the final one, which should just have a kind. Or we could just let the server validate...
             keys = GaxPreconditions.CheckNotNull(keys, nameof(keys)).ToList();
-            var response = await Client.AllocateIdsAsync(ProjectId, keys, callSettings).ConfigureAwait(false);
+            var allocateIdsRequest = new AllocateIdsRequest
+            {
+                ProjectId = ProjectId,
+                DatabaseId = DatabaseId,
+                Keys = { keys, }
+            };
+            var response = await Client.AllocateIdsAsync(allocateIdsRequest, callSettings).ConfigureAwait(false);
             return response.Keys.ToList();
         }
 
         /// <inheritdoc/>
         public override IReadOnlyList<Entity> Lookup(IEnumerable<Key> keys, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
-            => LookupImpl(Client, ProjectId, GetReadOptions(readConsistency), keys, callSettings);
+            => LookupImpl(Client, ProjectId, DatabaseId, GetReadOptions(readConsistency), keys, callSettings);
 
         /// <inheritdoc/>
         public override Task<IReadOnlyList<Entity>> LookupAsync(IEnumerable<Key> keys, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
-            => LookupImplAsync(Client, ProjectId, GetReadOptions(readConsistency), keys, callSettings);
+            => LookupImplAsync(Client, ProjectId, DatabaseId, GetReadOptions(readConsistency), keys, callSettings);
 
         // Non-transactional mutations
 
@@ -296,7 +330,17 @@ namespace Google.Cloud.Datastore.V1
 
             // Ensure we only iterate over values once
             var valuesList = values.ToList();
-            var response = Client.Commit(ProjectId, Mode.NonTransactional, valuesList.Select(conversion), callSettings);
+            var commitRequest = new CommitRequest
+            {
+                ProjectId = ProjectId,
+                DatabaseId = DatabaseId,
+                Mode = Mode.NonTransactional,
+                Mutations =
+                {
+                    valuesList.Select(conversion) ?? Enumerable.Empty<Mutation>(),
+                },
+            };
+            var response = Client.Commit(commitRequest, callSettings);
             PropagateKeys(valuesList, response, keyPropagation);
 
             return response.MutationResults.Select(mr => mr.Key).ToList();
@@ -308,7 +352,17 @@ namespace Google.Cloud.Datastore.V1
 
             // Ensure we only iterate over values once
             var valuesList = values.ToList();
-            var response = await Client.CommitAsync(ProjectId, Mode.NonTransactional, values.Select(conversion), callSettings).ConfigureAwait(false);
+            var commitRequest = new CommitRequest
+            {
+                ProjectId = ProjectId,
+                DatabaseId = DatabaseId,
+                Mode = Mode.NonTransactional,
+                Mutations =
+                {
+                    valuesList.Select(conversion) ?? Enumerable.Empty<Mutation>(),
+                },
+            };
+            var response = await Client.CommitAsync(commitRequest, callSettings).ConfigureAwait(false);
             PropagateKeys(valuesList, response, keyPropagation);
 
             return response.MutationResults.Select(mr => mr.Key).ToList();

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreTransaction.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreTransaction.cs
@@ -74,6 +74,24 @@ namespace Google.Cloud.Datastore.V1
             => new DatastoreTransactionImpl(client, projectId, namespaceId, transactionId);
 
         /// <summary>
+        /// Constructs an instance of <see cref="DatastoreClientImpl"/> with the given arguments.
+        /// Clients using the <see cref="DatastoreDb"/> abstraction layer would normally call
+        /// <see cref="DatastoreDb.BeginTransaction(CallSettings)"/> or <see cref="DatastoreDb.BeginTransactionAsync(CallSettings)"/>
+        /// instead of calling this method directly.
+        /// </summary>
+        /// <param name="client">The client to use for Datastore operations. Must not be null.</param>
+        /// <param name="projectId">The ID of the project of the Datastore operations. Must not be null.</param>
+        /// <param name="namespaceId">The ID of the namespace which is combined with <paramref name="projectId"/> and <paramref name="databaseId"/> to form a partition ID
+        /// to use in query operations. May be null.</param>
+        /// <param name="databaseId">The ID of the database which is combined with <paramref name="projectId"/> and <paramref name="namespaceId"/> to form a partition ID
+        /// to use in query operations. May be null.</param>
+        /// <param name="transactionId">The transaction obtained by an earlier <see cref="DatastoreClient.BeginTransaction(string, CallSettings)"/>
+        /// or the asynchronous equivalent. Must not be null</param>
+        /// <returns>A <see cref="DatastoreTransaction"/> representation of the specified transaction.</returns>,
+        public static DatastoreTransaction Create(DatastoreClient client, string projectId, string namespaceId, string databaseId, ByteString transactionId)
+            => new DatastoreTransactionImpl(client, projectId, namespaceId, databaseId, transactionId);
+
+        /// <summary>
         /// Runs the given query eagerly in this transaction, retrieving all results in memory and indicating whether more
         /// results may be available beyond the query's limit. Use this method when your query has a limited
         /// number of results, for example to build a web application which fetches results in pages.
@@ -404,7 +422,7 @@ namespace Google.Cloud.Datastore.V1
         /// </summary>
         /// <remarks>This method delegates to <see cref="Upsert(IEnumerable{Entity})"/>.</remarks>
         /// <param name="entities">The entities to upsert. Must not be null.</param>
-        public virtual void Upsert(params Entity[] entities) => Upsert((IEnumerable<Entity>)entities);
+        public virtual void Upsert(params Entity[] entities) => Upsert((IEnumerable<Entity>) entities);
 
         /// <summary>
         /// Adds update operations for all the specified keys to this transaction.
@@ -419,7 +437,7 @@ namespace Google.Cloud.Datastore.V1
         /// </summary>
         /// <remarks>This method delegates to <see cref="Update(IEnumerable{Entity})"/>.</remarks>
         /// <param name="entities">The entities to update. Must not be null.</param>
-        public virtual void Update(params Entity[] entities) => Update((IEnumerable<Entity>)entities);
+        public virtual void Update(params Entity[] entities) => Update((IEnumerable<Entity>) entities);
 
         /// <summary>
         /// Adds insert operations for all the specified keys to this transaction.
@@ -434,7 +452,7 @@ namespace Google.Cloud.Datastore.V1
         /// </summary>
         /// <remarks>This method delegates to <see cref="Insert(IEnumerable{Entity})"/>.</remarks>
         /// <param name="entities">The entities to insert. Must not be null.</param>
-        public virtual void Insert(params Entity[] entities) => Insert((IEnumerable<Entity>)entities);
+        public virtual void Insert(params Entity[] entities) => Insert((IEnumerable<Entity>) entities);
 
         /// <summary>
         /// Adds delete operations for all the specified keys to this transaction.
@@ -449,7 +467,7 @@ namespace Google.Cloud.Datastore.V1
         /// </summary>
         /// <remarks>This method delegates to <see cref="Delete(IEnumerable{Entity})"/>.</remarks>
         /// <param name="entities">The entities to delete. Must not be null.</param>
-        public virtual void Delete(params Entity[] entities) => Delete((IEnumerable<Entity>)entities);
+        public virtual void Delete(params Entity[] entities) => Delete((IEnumerable<Entity>) entities);
 
         /// <summary>
         /// Adds deletion operations for all the specified keys to this transaction.
@@ -464,7 +482,7 @@ namespace Google.Cloud.Datastore.V1
         /// </summary>
         /// <remarks>This method delegates to <see cref="Delete(IEnumerable{Key})"/>.</remarks>
         /// <param name="keys">The keys to delete. Must not be null.</param>
-        public virtual void Delete(params Key[] keys) => Delete((IEnumerable<Key>)keys);
+        public virtual void Delete(params Key[] keys) => Delete((IEnumerable<Key>) keys);
 
         /// <summary>
         /// Commits all mutations in this transaction.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/KeyFactory.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/KeyFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -49,10 +49,20 @@ namespace Google.Cloud.Datastore.V1
         /// <param name="projectId">The project ID for the factory. Must not be null.</param>
         /// <param name="namespaceId">The namespace ID for the factory. May be null in which case an empty string is used.</param>
         /// <param name="kind">The kind of root entity keys to create. Must not be null.</param>
-        public KeyFactory(string projectId, string namespaceId, string kind)
+        public KeyFactory(string projectId, string namespaceId, string kind) : this(projectId, namespaceId, null, kind)
+        { }
+
+        /// <summary>
+        /// Creates a key factory for the root of a partition.
+        /// </summary>
+        /// <param name="projectId">The project ID for the factory. Must not be null.</param>
+        /// <param name="namespaceId">The namespace ID for the factory. May be null in which case an empty string is used.</param>
+        /// <param name="databaseId">The database ID for the factory. May be null in which case an empty string is used.</param>
+        /// <param name="kind">The kind of root entity keys to create. Must not be null.</param>
+        public KeyFactory(string projectId, string namespaceId, string databaseId, string kind)
         {
             GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
-            _parent = new Key { PartitionId = new PartitionId(projectId, namespaceId ?? "") };
+            _parent = new Key { PartitionId = new PartitionId(projectId, namespaceId ?? "", databaseId ?? "") };
             _kind = GaxPreconditions.CheckNotNull(kind, nameof(kind));
         }
 

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/KeyPartial.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/KeyPartial.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -118,7 +118,7 @@ namespace Google.Cloud.Datastore.V1
         internal Key NormalizeToProjectId(string projectId)
         {
             return string.IsNullOrEmpty(PartitionId?.ProjectId)
-                ? new Key(this) { PartitionId = new PartitionId(projectId, PartitionId?.NamespaceId ?? "") }
+                ? new Key(this) { PartitionId = new PartitionId(projectId, PartitionId?.NamespaceId ?? "", PartitionId?.DatabaseId ?? "") }
                 : this;
         }
     }

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/PartitionIdPartial.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/PartitionIdPartial.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,12 +23,23 @@ namespace Google.Cloud.Datastore.V1
         /// </summary>
         /// <param name="projectId">The project ID of the partition. Must not be null.</param>
         /// <param name="namespaceId">The namespace ID of the partition. Must not be null.</param>
-        public PartitionId(string projectId, string namespaceId = "") : this()
+        public PartitionId(string projectId, string namespaceId = "") : this(projectId, namespaceId, "")
+        { }
+
+        /// <summary>
+        /// Creates a partition ID from the given project ID , namespace ID and database ID.
+        /// </summary>
+        /// <param name="projectId">The project ID of the partition. Must not be null.</param>
+        /// <param name="namespaceId">The namespace ID of the partition. Pass empty string for default. Must not be null.</param>
+        /// <param name="databaseId">The database ID of the partition. Pass empty string for default. Must not be null.</param>
+        public PartitionId(string projectId, string namespaceId, string databaseId) : this()
         {
             // TODO: Validate that the project ID is non-empty?
             // TODO: Validate the IDs against a regex?
+            // TODO: Merge the constructor overloads into one in major version release. 
             ProjectId = GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
             NamespaceId = GaxPreconditions.CheckNotNull(namespaceId, nameof(namespaceId));
+            DatabaseId = GaxPreconditions.CheckNotNull(databaseId, nameof(databaseId));
         }
     }
 }

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1670,7 +1670,8 @@
         "System.Linq.Async": "6.0.1"
       },
       "testDependencies": {
-        "Google.Api.Gax.Grpc.Testing": "4.4.0"
+        "Google.Api.Gax.Grpc.Testing": "4.4.0",
+        "Google.Cloud.Firestore.Admin.V1": "3.3.0"
       },
       "shortName": "datastore",
       "serviceConfigFile": "datastore_v1.yaml",


### PR DESCRIPTION
This PR contains:
- Changes to support multi-db in Datastore client library
- Tests for the changes.
- Update in apis.json file to add Firestore admin client dependency for Datastore integration tests.