### PR TITLE
Release Google.Cloud.AIPlatform.V1 version 2.20.0

### DIFF
--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.19.0</Version>
+    <Version>2.20.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AI Platform API, which allows you to train high-quality custom machine learning models with minimal machine learning expertise and effort.</Description>

--- a/apis/Google.Cloud.AIPlatform.V1/docs/history.md
+++ b/apis/Google.Cloud.AIPlatform.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 2.20.0, released 2023-10-26
+
+### New features
+
+- Add DatasetVersion and dataset version RPCs to DatasetService ([commit fe2818c](https://github.com/googleapis/google-cloud-dotnet/commit/fe2818c21082a33ec5a8ee8f74e99628bee9333e))
+- Add PersistentDiskSpec ([commit fe2818c](https://github.com/googleapis/google-cloud-dotnet/commit/fe2818c21082a33ec5a8ee8f74e99628bee9333e))
+
 ## Version 2.19.0, released 2023-09-11
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -227,7 +227,7 @@
     },
     {
       "id": "Google.Cloud.AIPlatform.V1",
-      "version": "2.19.0",
+      "version": "2.20.0",
       "type": "grpc",
       "productName": "Cloud AI Platform",
       "productUrl": "https://cloud.google.com/ai-platform/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add DatasetVersion and dataset version RPCs to DatasetService ([commit fe2818c](https://github.com/googleapis/google-cloud-dotnet/commit/fe2818c21082a33ec5a8ee8f74e99628bee9333e))
- Add PersistentDiskSpec ([commit fe2818c](https://github.com/googleapis/google-cloud-dotnet/commit/fe2818c21082a33ec5a8ee8f74e99628bee9333e))
