### PR TITLE
feat: First pass at Storage v2 upload/download

### DIFF
--- a/apis/Google.Cloud.Storage.V2/Google.Cloud.Storage.V2.IntegrationTests/Google.Cloud.Storage.V2.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Storage.V2/Google.Cloud.Storage.V2.IntegrationTests/Google.Cloud.Storage.V2.IntegrationTests.csproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;net462</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">net6.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
+    <PackageReference Include="Google.Cloud.Storage.V1" Version="[4.6.0, 5.0.0)" />
+    <ProjectReference Include="..\Google.Cloud.Storage.V2\Google.Cloud.Storage.V2.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+</Project>

--- a/apis/Google.Cloud.Storage.V2/Google.Cloud.Storage.V2.IntegrationTests/StorageDownloaderTest.cs
+++ b/apis/Google.Cloud.Storage.V2/Google.Cloud.Storage.V2.IntegrationTests/StorageDownloaderTest.cs
@@ -1,0 +1,52 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+using System.IO;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Cloud.Storage.V2.IntegrationTests;
+
+[Collection(nameof(StorageFixture))]
+public class StorageDownloaderTest
+{
+    private readonly StorageFixture _fixture;
+
+    public StorageDownloaderTest(StorageFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [SkippableTheory]
+    [InlineData(50)]
+    [InlineData(5_000_000)]
+    [InlineData(50_000_000)]
+    public async Task DownloadObjectAsync_RandomData(int size)
+    {
+        Skip.If(!_fixture.Enabled);
+
+        // Upload using v1
+        var bytes = new byte[size];
+        RandomNumberGenerator.Create().GetBytes(bytes);
+        var obj = _fixture.GenerateObjectName();
+        await _fixture.V1Client.UploadObjectAsync(_fixture.ReadWriteBucket.BucketId, obj, null, new MemoryStream(bytes));
+
+        // Download using v2
+        var downloader = new StorageDownloader(_fixture.Client);
+        var stream = new MemoryStream();
+        await downloader.DownloadObjectAsync(_fixture.ReadWriteBucket, obj, stream);
+        Assert.Equal(bytes, stream.ToArray());
+    }
+}

--- a/apis/Google.Cloud.Storage.V2/Google.Cloud.Storage.V2.IntegrationTests/StorageFixture.cs
+++ b/apis/Google.Cloud.Storage.V2/Google.Cloud.Storage.V2.IntegrationTests/StorageFixture.cs
@@ -1,0 +1,100 @@
+using Google.Api.Gax;
+using Google.Api.Gax.Grpc;
+using Google.Api.Gax.ResourceNames;
+using Google.Cloud.ClientTesting;
+using Grpc.Core;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Xunit;
+
+namespace Google.Cloud.Storage.V2.IntegrationTests;
+/// <summary>
+/// Fixture which is set up at the start of the test run, and torn down at the end.
+/// This creates new buckets with test data, and deletes them at the end of the test.
+/// The Google Cloud Project name is fetched from the TEST_PROJECT environment variable.
+/// </summary>
+
+[CollectionDefinition(nameof(StorageFixture))]
+[FileLoggerBeforeAfterTest]
+public sealed class StorageFixture : CloudProjectFixtureBase, ICollectionFixture<StorageFixture>
+{
+    // The prefix to apply when generating the run-specific prefix. This must be allow-listed.
+    // If the environment variable isn't set, or is empty, all tests will be skipped.
+    private static string GlobalBucketPrefix { get; } = Environment.GetEnvironmentVariable("STORAGE_V2_TEST_BUCKET_PREFIX");
+
+    private readonly List<BucketName> _bucketsToDelete = new();
+    public string BucketPrefix { get; }
+    public BucketName ReadWriteBucket => new BucketName(ProjectId, BucketPrefix + "readwrite");
+    public ProjectName ProjectName => new ProjectName(ProjectId);
+    public ProjectName GlobalProjectName { get; } = new ProjectName("_");
+
+    public StorageClient Client { get; }
+    public V1.StorageClient V1Client { get; }
+    public bool Enabled => !string.IsNullOrEmpty(GlobalBucketPrefix);
+
+    public StorageFixture()
+    {
+        // We don't want to fail tests if we don't haven't set the environment variable.
+        if (!Enabled)
+        {
+            return;
+        }
+
+        // TODO: Work out why this has a retry...
+        var settings = new StorageSettings
+        {
+            WriteObjectSettings = CallSettings.FromExpiration(Expiration.FromTimeout(TimeSpan.FromMilliseconds(60000)))
+        };
+        Client = new StorageClientBuilder { Settings = settings }.Build();
+        V1Client = V1.StorageClient.Create();
+        BucketPrefix = IdGenerator.FromDateTime(prefix: GlobalBucketPrefix + "-", suffix: "-"); 
+        CreateBucket(ReadWriteBucket.BucketId);
+    }
+
+    internal Bucket CreateBucket(string bucketId)
+    {
+        var bucket = Client.CreateBucket(GlobalProjectName, new Bucket { ProjectAsProjectName = ProjectName }, bucketId);
+        SleepAfterBucketCreateDelete();
+        RegisterBucketToDelete(bucket.BucketName);
+        return bucket;
+    }
+
+    internal string GenerateObjectName() => IdGenerator.FromGuid();
+
+    internal string GenerateBucketName() => IdGenerator.FromGuid(prefix: BucketPrefix, separator: "", maxLength: 63);
+
+    /// <summary>
+    /// Bucket creation/deletion is rate-limited. To avoid making the tests flaky, we sleep after each operation.
+    /// </summary>
+    internal static void SleepAfterBucketCreateDelete() => Thread.Sleep(2000);
+
+    internal void RegisterBucketToDelete(BucketName bucket) => _bucketsToDelete.Add(bucket);
+
+    public override void Dispose()
+    {
+        var client = StorageClient.Create();
+        foreach (var bucket in _bucketsToDelete)
+        {
+            DeleteBucket(client, bucket);
+        }
+    }
+
+    private void DeleteBucket(StorageClient client, BucketName bucket)
+    {
+        try
+        {
+            foreach (var obj in client.ListObjects(bucket))
+            {
+                client.DeleteObject(bucket, obj.Name);
+            }
+            client.DeleteBucket(bucket);
+        }
+        catch (RpcException)
+        {
+            // Some tests fail to delete buckets due to object retention locks etc.
+            // They can be cleaned up later.
+        }
+        SleepAfterBucketCreateDelete();
+    }
+}

--- a/apis/Google.Cloud.Storage.V2/Google.Cloud.Storage.V2.IntegrationTests/StorageUploaderTest.cs
+++ b/apis/Google.Cloud.Storage.V2/Google.Cloud.Storage.V2.IntegrationTests/StorageUploaderTest.cs
@@ -1,0 +1,52 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+using System.IO;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Cloud.Storage.V2.IntegrationTests;
+
+[Collection(nameof(StorageFixture))]
+public class StorageUploaderTest
+{
+    private readonly StorageFixture _fixture;
+
+    public StorageUploaderTest(StorageFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [SkippableTheory]
+    [InlineData(50)]
+    [InlineData(5_000_000)]
+    [InlineData(50_000_000)]
+    public async Task UploadObjectAsync_RandomData(int size)
+    {
+        Skip.If(!_fixture.Enabled);
+
+        // Upload using v2
+        var bytes = new byte[size];
+        RandomNumberGenerator.Create().GetBytes(bytes);
+        var obj = _fixture.GenerateObjectName();
+        var uploader = new StorageUploader(_fixture.Client);
+        await uploader.UploadObjectAsync(_fixture.ReadWriteBucket, obj, new MemoryStream(bytes));
+
+        // Download using v1
+        var stream = new MemoryStream();
+        await _fixture.V1Client.DownloadObjectAsync(_fixture.ReadWriteBucket.BucketId, obj, stream);
+        Assert.Equal(bytes, stream.ToArray());
+    }
+}

--- a/apis/Google.Cloud.Storage.V2/Google.Cloud.Storage.V2.IntegrationTests/coverage.xml
+++ b/apis/Google.Cloud.Storage.V2/Google.Cloud.Storage.V2.IntegrationTests/coverage.xml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
+  <Filters>
+    <IncludeFilters>
+      <FilterEntry>
+        <ModuleMask>Google.Cloud.Storage.V2</ModuleMask>
+      </FilterEntry>
+    </IncludeFilters>
+  </Filters>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Storage.V2.IntegrationTests.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Storage.V2/Google.Cloud.Storage.V2.sln
+++ b/apis/Google.Cloud.Storage.V2/Google.Cloud.Storage.V2.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.ClientTesting"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Storage.V2.Snippets", "Google.Cloud.Storage.V2.Snippets\Google.Cloud.Storage.V2.Snippets.csproj", "{E73BB4A8-3B38-4FD9-AE75-CE75F06F0854}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Storage.V2.IntegrationTests", "Google.Cloud.Storage.V2.IntegrationTests\Google.Cloud.Storage.V2.IntegrationTests.csproj", "{27E75672-70D4-4DC7-A240-FD1775A3BBAF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -36,5 +38,9 @@ Global
 		{E73BB4A8-3B38-4FD9-AE75-CE75F06F0854}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E73BB4A8-3B38-4FD9-AE75-CE75F06F0854}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E73BB4A8-3B38-4FD9-AE75-CE75F06F0854}.Release|Any CPU.Build.0 = Release|Any CPU
+		{27E75672-70D4-4DC7-A240-FD1775A3BBAF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{27E75672-70D4-4DC7-A240-FD1775A3BBAF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{27E75672-70D4-4DC7-A240-FD1775A3BBAF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{27E75672-70D4-4DC7-A240-FD1775A3BBAF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/apis/Google.Cloud.Storage.V2/Google.Cloud.Storage.V2/StorageDownloader.cs
+++ b/apis/Google.Cloud.Storage.V2/Google.Cloud.Storage.V2/StorageDownloader.cs
@@ -1,0 +1,70 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+using Google.Api.Gax;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Google.Cloud.Storage.V2;
+
+/// <summary>
+/// Helper class to manage downloads. Eventually we'd probably use a partial class to put
+/// this code directly in StorageClient, but that can come later after a lot of design work.
+/// </summary>
+public class StorageDownloader
+{
+    private readonly StorageClient _client;
+
+    /// <summary>
+    /// Creates a new downloader wrapping the given client.
+    /// </summary>
+    /// <param name="client">The client to use for downloading. Must not be null.</param>
+    public StorageDownloader(StorageClient client)
+    {
+        this._client = GaxPreconditions.CheckNotNull(client, nameof(client));
+    }
+
+    /// <summary>
+    /// Downloads an object, writing the data into the given stream.
+    /// </summary>
+    /// <param name="bucket">The bucket containing the object.</param>
+    /// <param name="objectName">The name of the object within the bucket.</param>
+    /// <param name="stream">The stream to write the content into.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public async Task DownloadObjectAsync(BucketName bucket, string objectName, Stream stream)
+    {
+        GaxPreconditions.CheckNotNull(bucket, nameof(bucket));
+        GaxPreconditions.CheckNotNullOrEmpty(objectName, nameof(objectName));
+        GaxPreconditions.CheckNotNull(stream, nameof(stream));
+
+        var request = new ReadObjectRequest { BucketAsBucketName = bucket, Object = objectName };
+        using var readStream = _client.ReadObject(request);
+        long bytesReceived = 0;
+
+        IAsyncEnumerable<ReadObjectResponse> responseStream = readStream.GetResponseStream();
+        await foreach (var response in responseStream.ConfigureAwait(false))
+        {
+            bytesReceived += response.ChecksummedData.Content.Length;
+            // TODO: See if we can add a ByteString.WriteAsync(Stream) method to avoid the copying
+            // in .NET 4.6.2.
+#if NETSTANDARD2_1_OR_GREATER
+            await stream.WriteAsync(response.ChecksummedData.Content.Memory).ConfigureAwait(false);
+#else
+            byte[] bytes = response.ChecksummedData.Content.ToByteArray();
+            await stream.WriteAsync(bytes, 0, bytes.Length).ConfigureAwait(false);
+#endif
+        }
+    }
+}

--- a/apis/Google.Cloud.Storage.V2/Google.Cloud.Storage.V2/StorageUploader.cs
+++ b/apis/Google.Cloud.Storage.V2/Google.Cloud.Storage.V2/StorageUploader.cs
@@ -1,0 +1,128 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+using Google.Api.Gax;
+using Google.Api.Gax.Grpc;
+using Google.Protobuf;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Google.Cloud.Storage.V2;
+
+/// <summary>
+/// Helper class to manage uploads. Eventually we'd probably use a partial class to put
+/// this code directly in StorageClient, but that can come later after a lot of design work.
+/// </summary>
+public class StorageUploader
+{
+    private const int ChunkSize = 1 << 21;
+    private readonly StorageClient _client;
+
+    /// <summary>
+    /// Creates a new uploader wrapping the given client.
+    /// </summary>
+    /// <param name="client">The client to use for uploading. Must not be null.</param>
+    public StorageUploader(StorageClient client)
+    {
+        this._client = GaxPreconditions.CheckNotNull(client, nameof(client));
+    }
+
+    /// <summary>
+    /// Uploads an object with data read from a stream.
+    /// </summary>
+    /// <param name="bucket">The bucket to upload to. Must not be null.</param>
+    /// <param name="objectName">The name of the object within the bucket. Must not be null.</param>
+    /// <param name="stream">The stream containing data to upload. Must not be null.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public async Task<Object> UploadObjectAsync(BucketName bucket, string objectName, Stream stream)
+    {
+        GaxPreconditions.CheckNotNull(bucket, nameof(bucket));
+        GaxPreconditions.CheckNotNullOrEmpty(objectName, nameof(objectName));
+        GaxPreconditions.CheckNotNull(stream, nameof(stream));
+
+        var headerCallSettings = CallSettings.FromHeader("x-goog-request-params", $"bucket={Uri.EscapeDataString(bucket.ToString())}");
+        using var requestStream = _client.WriteObject(headerCallSettings);
+
+        // TODO: Ouch! Can we avoid this?
+        byte[] buffer = new byte[ChunkSize];
+
+        long bytesWritten = 0;
+        bool firstRequest = true;
+        bool finished = false;
+        Task currentWriteTask = null;
+
+        while (!finished)
+        {
+            int bytesRead = await FillBufferAsync().ConfigureAwait(false);
+
+            if (currentWriteTask is not null)
+            {
+                await currentWriteTask.ConfigureAwait(false);
+            }
+
+            // TODO: This ends up with an unnecessary request at the end, if we've read precisely as far as the
+            // buffer. The simplicity is appealing though.
+            // Note that we can't just break out of the loop if bytesRead is 0 and it's not the first request,
+            // because we need to send a request with FinishWrite=true.
+            finished = bytesRead != ChunkSize;
+            var request = new WriteObjectRequest
+            {
+                ChecksummedData = new ChecksummedData { Content = ByteString.CopyFrom(buffer, 0, bytesRead) },
+                FinishWrite = finished,
+                WriteOffset = bytesWritten
+            };
+            if (firstRequest)
+            {
+                request.WriteObjectSpec = new WriteObjectSpec
+                {
+                    Resource = new Object
+                    {
+                        BucketAsBucketName = bucket,
+                        Name = objectName
+                    }
+                };
+                firstRequest = false;
+            }
+            // Don't wait on the write: we can parallelize "fill the buffer" and "write over the network".
+            currentWriteTask = requestStream.WriteAsync(request);
+            bytesWritten += bytesRead;
+        }
+
+        if (currentWriteTask is not null)
+        {
+            await currentWriteTask.ConfigureAwait(false);
+        }
+
+        await requestStream.WriteCompleteAsync().ConfigureAwait(false);
+
+        var response = await requestStream.ResponseAsync.ConfigureAwait(false);
+        return response.Resource;
+
+        async Task<int> FillBufferAsync()
+        {
+            int position = 0;
+            while (position < buffer.Length)
+            {
+                int bytesRead = await stream.ReadAsync(buffer, position, buffer.Length - position).ConfigureAwait(false);
+                if (bytesRead == 0)
+                {
+                    break;
+                }
+                position += bytesRead;
+            }
+            return position;
+        }
+    }
+}


### PR DESCRIPTION
Requires an environment variable to run the tests (an allow-listed bucket prefix); tests are skipped otherwise. Currently this test is very slow due to Assert.Equal being really slow. This looks like an xUnit regression; will investigate.