### PR TITLE
Release Google.Cloud.ArtifactRegistry.V1 version 2.4.0

### DIFF
--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.csproj
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Artifact Registry API v1, which stores and manages build artifacts in a scalable and integrated service built on Google infrastructure.</Description>

--- a/apis/Google.Cloud.ArtifactRegistry.V1/docs/history.md
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/docs/history.md
@@ -1,5 +1,22 @@
 # Version history
 
+## Version 2.4.0, released 2023-10-30
+
+### New features
+
+- Add support for virtual and remote repositories ([commit 766f731](https://github.com/googleapis/google-cloud-dotnet/commit/766f731eafdcded59f327e962976d35f5cb1d791))
+- Add support for cleanup policies ([commit 766f731](https://github.com/googleapis/google-cloud-dotnet/commit/766f731eafdcded59f327e962976d35f5cb1d791))
+- Add support for Docker immutable tags ([commit 766f731](https://github.com/googleapis/google-cloud-dotnet/commit/766f731eafdcded59f327e962976d35f5cb1d791))
+- Add support for Go and KFP repositories ([commit 766f731](https://github.com/googleapis/google-cloud-dotnet/commit/766f731eafdcded59f327e962976d35f5cb1d791))
+- Add support for Physical Zone Separation ([commit 766f731](https://github.com/googleapis/google-cloud-dotnet/commit/766f731eafdcded59f327e962976d35f5cb1d791))
+- Expose the size of the Repository resource ([commit 766f731](https://github.com/googleapis/google-cloud-dotnet/commit/766f731eafdcded59f327e962976d35f5cb1d791))
+
+### Documentation improvements
+
+- Use code font for resource name references ([commit 766f731](https://github.com/googleapis/google-cloud-dotnet/commit/766f731eafdcded59f327e962976d35f5cb1d791))
+- Mark the create_time and update_time in the Repository resource as output only fields ([commit 766f731](https://github.com/googleapis/google-cloud-dotnet/commit/766f731eafdcded59f327e962976d35f5cb1d791))
+- Mark the repository_id and repository fields in the CreateRepository request as required fields ([commit 766f731](https://github.com/googleapis/google-cloud-dotnet/commit/766f731eafdcded59f327e962976d35f5cb1d791))
+
 ## Version 2.3.0, released 2023-09-26
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -362,7 +362,7 @@
     },
     {
       "id": "Google.Cloud.ArtifactRegistry.V1",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "type": "grpc",
       "productName": "Artifact Registry",
       "productUrl": "https://cloud.google.com/artifact-registry",


### PR DESCRIPTION

Changes in this release:

### New features

- Add support for virtual and remote repositories ([commit 766f731](https://github.com/googleapis/google-cloud-dotnet/commit/766f731eafdcded59f327e962976d35f5cb1d791))
- Add support for cleanup policies ([commit 766f731](https://github.com/googleapis/google-cloud-dotnet/commit/766f731eafdcded59f327e962976d35f5cb1d791))
- Add support for Docker immutable tags ([commit 766f731](https://github.com/googleapis/google-cloud-dotnet/commit/766f731eafdcded59f327e962976d35f5cb1d791))
- Add support for Go and KFP repositories ([commit 766f731](https://github.com/googleapis/google-cloud-dotnet/commit/766f731eafdcded59f327e962976d35f5cb1d791))
- Add support for Physical Zone Separation ([commit 766f731](https://github.com/googleapis/google-cloud-dotnet/commit/766f731eafdcded59f327e962976d35f5cb1d791))
- Expose the size of the Repository resource ([commit 766f731](https://github.com/googleapis/google-cloud-dotnet/commit/766f731eafdcded59f327e962976d35f5cb1d791))

### Documentation improvements

- Use code font for resource name references ([commit 766f731](https://github.com/googleapis/google-cloud-dotnet/commit/766f731eafdcded59f327e962976d35f5cb1d791))
- Mark the create_time and update_time in the Repository resource as output only fields ([commit 766f731](https://github.com/googleapis/google-cloud-dotnet/commit/766f731eafdcded59f327e962976d35f5cb1d791))
- Mark the repository_id and repository fields in the CreateRepository request as required fields ([commit 766f731](https://github.com/googleapis/google-cloud-dotnet/commit/766f731eafdcded59f327e962976d35f5cb1d791))
