### PR TITLE
Release Google.Cloud.Batch.V1 version 2.5.0

### DIFF
--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.csproj
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.4.0</Version>
+    <Version>2.5.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Batch API (v1), which allows you to manage the running of batch jobs on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Batch.V1/docs/history.md
+++ b/apis/Google.Cloud.Batch.V1/docs/history.md
@@ -1,5 +1,21 @@
 # Version history
 
+## Version 2.5.0, released 2023-10-30
+
+### New features
+
+- Expose display_name to batch v1 API ([commit 86e0579](https://github.com/googleapis/google-cloud-dotnet/commit/86e05791a54db2eb17b2ffc3df5b6798dad19346))
+- Add InstancePolicy.reservation field for restricting jobs to a specific reservation ([commit 10652c4](https://github.com/googleapis/google-cloud-dotnet/commit/10652c4c689519e9441ea1afce46fbd07c81c456))
+
+### Documentation improvements
+
+- Elaborate the usage of Container.volumes proto field ([commit 10652c4](https://github.com/googleapis/google-cloud-dotnet/commit/10652c4c689519e9441ea1afce46fbd07c81c456))
+- Update batch PD interface support ([commit 0ab1964](https://github.com/googleapis/google-cloud-dotnet/commit/0ab196479719787fdec7819d6e621171bb108027))
+- Update description on size_gb in disk field ([commit d78ee5c](https://github.com/googleapis/google-cloud-dotnet/commit/d78ee5ccdfa976242867f5c6d48d47119a648f46))
+- Revert HTML formats in comments ([commit 0700ba4](https://github.com/googleapis/google-cloud-dotnet/commit/0700ba4b0f246ae6622cf8249eecbbc3ecf13495))
+- Expand compute resource API docs to match with VM's machine type field ([commit 0700ba4](https://github.com/googleapis/google-cloud-dotnet/commit/0700ba4b0f246ae6622cf8249eecbbc3ecf13495))
+- Clarify Batch API proto doc about pubsub notifications ([commit 0700ba4](https://github.com/googleapis/google-cloud-dotnet/commit/0700ba4b0f246ae6622cf8249eecbbc3ecf13495))
+
 ## Version 2.4.0, released 2023-08-16
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -550,7 +550,7 @@
     },
     {
       "id": "Google.Cloud.Batch.V1",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "type": "grpc",
       "productName": "Batch",
       "productUrl": "https://cloud.google.com/batch/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Expose display_name to batch v1 API ([commit 86e0579](https://github.com/googleapis/google-cloud-dotnet/commit/86e05791a54db2eb17b2ffc3df5b6798dad19346))
- Add InstancePolicy.reservation field for restricting jobs to a specific reservation ([commit 10652c4](https://github.com/googleapis/google-cloud-dotnet/commit/10652c4c689519e9441ea1afce46fbd07c81c456))

### Documentation improvements

- Elaborate the usage of Container.volumes proto field ([commit 10652c4](https://github.com/googleapis/google-cloud-dotnet/commit/10652c4c689519e9441ea1afce46fbd07c81c456))
- Update batch PD interface support ([commit 0ab1964](https://github.com/googleapis/google-cloud-dotnet/commit/0ab196479719787fdec7819d6e621171bb108027))
- Update description on size_gb in disk field ([commit d78ee5c](https://github.com/googleapis/google-cloud-dotnet/commit/d78ee5ccdfa976242867f5c6d48d47119a648f46))
- Revert HTML formats in comments ([commit 0700ba4](https://github.com/googleapis/google-cloud-dotnet/commit/0700ba4b0f246ae6622cf8249eecbbc3ecf13495))
- Expand compute resource API docs to match with VM's machine type field ([commit 0700ba4](https://github.com/googleapis/google-cloud-dotnet/commit/0700ba4b0f246ae6622cf8249eecbbc3ecf13495))
- Clarify Batch API proto doc about pubsub notifications ([commit 0700ba4](https://github.com/googleapis/google-cloud-dotnet/commit/0700ba4b0f246ae6622cf8249eecbbc3ecf13495))
