### PR TITLE
Release Google.Cloud.Dataform.V1Beta1 version 1.0.0-beta03

### DIFF
--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.csproj
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Dataform API (v1beta1) which allows you to develop and operationalize scalable data transformations pipelines in BigQuery using SQL.</Description>

--- a/apis/Google.Cloud.Dataform.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.Dataform.V1Beta1/docs/history.md
@@ -1,5 +1,27 @@
 # Version history
 
+## Version 1.0.0-beta03, released 2023-10-30
+
+### Bug fixes
+
+- Rearrange several messages, thus changing field types ([commit 9d2b3d8](https://github.com/googleapis/google-cloud-dotnet/commit/9d2b3d87af20c88bce3d585098a33420aa33085d))
+
+### New features
+
+- Support for ReleaseConfigs ([commit 9d2b3d8](https://github.com/googleapis/google-cloud-dotnet/commit/9d2b3d87af20c88bce3d585098a33420aa33085d))
+- Support for WorkflowConfigs ([commit 9d2b3d8](https://github.com/googleapis/google-cloud-dotnet/commit/9d2b3d87af20c88bce3d585098a33420aa33085d))
+- Support new first-party repository methods for committing, listing/reading files, and fetching history ([commit 9d2b3d8](https://github.com/googleapis/google-cloud-dotnet/commit/9d2b3d87af20c88bce3d585098a33420aa33085d))
+- Support new ComputeRepositoryAccessTokenStatus repository method ([commit 9d2b3d8](https://github.com/googleapis/google-cloud-dotnet/commit/9d2b3d87af20c88bce3d585098a33420aa33085d))
+- Support SSH based git authentication configuration ([commit 9d2b3d8](https://github.com/googleapis/google-cloud-dotnet/commit/9d2b3d87af20c88bce3d585098a33420aa33085d))
+- Support workspace compilation override fields ([commit 9d2b3d8](https://github.com/googleapis/google-cloud-dotnet/commit/9d2b3d87af20c88bce3d585098a33420aa33085d))
+- Support NPMRC environment variables ([commit 9d2b3d8](https://github.com/googleapis/google-cloud-dotnet/commit/9d2b3d87af20c88bce3d585098a33420aa33085d))
+- Support labels on repositories ([commit 9d2b3d8](https://github.com/googleapis/google-cloud-dotnet/commit/9d2b3d87af20c88bce3d585098a33420aa33085d))
+- Support custom service account repository configuration ([commit 9d2b3d8](https://github.com/googleapis/google-cloud-dotnet/commit/9d2b3d87af20c88bce3d585098a33420aa33085d))
+
+### Documentation improvements
+
+- Several comments reformatted ([commit 9d2b3d8](https://github.com/googleapis/google-cloud-dotnet/commit/9d2b3d87af20c88bce3d585098a33420aa33085d))
+
 ## Version 1.0.0-beta02, released 2023-01-19
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1547,7 +1547,7 @@
     },
     {
       "id": "Google.Cloud.Dataform.V1Beta1",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0-beta03",
       "type": "grpc",
       "productName": "Dataform",
       "productUrl": "https://cloud.google.com/dataform",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Rearrange several messages, thus changing field types ([commit 9d2b3d8](https://github.com/googleapis/google-cloud-dotnet/commit/9d2b3d87af20c88bce3d585098a33420aa33085d))

### New features

- Support for ReleaseConfigs ([commit 9d2b3d8](https://github.com/googleapis/google-cloud-dotnet/commit/9d2b3d87af20c88bce3d585098a33420aa33085d))
- Support for WorkflowConfigs ([commit 9d2b3d8](https://github.com/googleapis/google-cloud-dotnet/commit/9d2b3d87af20c88bce3d585098a33420aa33085d))
- Support new first-party repository methods for committing, listing/reading files, and fetching history ([commit 9d2b3d8](https://github.com/googleapis/google-cloud-dotnet/commit/9d2b3d87af20c88bce3d585098a33420aa33085d))
- Support new ComputeRepositoryAccessTokenStatus repository method ([commit 9d2b3d8](https://github.com/googleapis/google-cloud-dotnet/commit/9d2b3d87af20c88bce3d585098a33420aa33085d))
- Support SSH based git authentication configuration ([commit 9d2b3d8](https://github.com/googleapis/google-cloud-dotnet/commit/9d2b3d87af20c88bce3d585098a33420aa33085d))
- Support workspace compilation override fields ([commit 9d2b3d8](https://github.com/googleapis/google-cloud-dotnet/commit/9d2b3d87af20c88bce3d585098a33420aa33085d))
- Support NPMRC environment variables ([commit 9d2b3d8](https://github.com/googleapis/google-cloud-dotnet/commit/9d2b3d87af20c88bce3d585098a33420aa33085d))
- Support labels on repositories ([commit 9d2b3d8](https://github.com/googleapis/google-cloud-dotnet/commit/9d2b3d87af20c88bce3d585098a33420aa33085d))
- Support custom service account repository configuration ([commit 9d2b3d8](https://github.com/googleapis/google-cloud-dotnet/commit/9d2b3d87af20c88bce3d585098a33420aa33085d))

### Documentation improvements

- Several comments reformatted ([commit 9d2b3d8](https://github.com/googleapis/google-cloud-dotnet/commit/9d2b3d87af20c88bce3d585098a33420aa33085d))
