### PR TITLE
Release Google.Cloud.Deploy.V1 version 2.9.0

### DIFF
--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.csproj
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.8.0</Version>
+    <Version>2.9.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Deploy API, which automates delivery of your applications to a series of target environments in a defined sequence.</Description>

--- a/apis/Google.Cloud.Deploy.V1/docs/history.md
+++ b/apis/Google.Cloud.Deploy.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.9.0, released 2023-10-30
+
+### New features
+
+- Added platform log RolloutUpdateEvent ([commit 13c15ec](https://github.com/googleapis/google-cloud-dotnet/commit/13c15ec88b53fa95cc4cb4732d21f5b9be443ba9))
+
 ## Version 2.8.0, released 2023-08-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1715,7 +1715,7 @@
     },
     {
       "id": "Google.Cloud.Deploy.V1",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "type": "grpc",
       "productName": "Google Cloud Deploy",
       "productUrl": "https://cloud.google.com/deploy/",


### PR DESCRIPTION

Changes in this release:

### New features

- Added platform log RolloutUpdateEvent ([commit 13c15ec](https://github.com/googleapis/google-cloud-dotnet/commit/13c15ec88b53fa95cc4cb4732d21f5b9be443ba9))
