### PR TITLE
Release Google.Cloud.OsLogin.V1Beta version 3.0.0-beta05

### DIFF
--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.csproj
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0-beta04</Version>
+    <Version>3.0.0-beta05</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to manages OS login configuration for Google account users.</Description>

--- a/apis/Google.Cloud.OsLogin.V1Beta/docs/history.md
+++ b/apis/Google.Cloud.OsLogin.V1Beta/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.0.0-beta05, released 2023-10-30
+
+### New features
+
+- Location-based HTTP binding for SignSshPublicKey ([commit ff031f2](https://github.com/googleapis/google-cloud-dotnet/commit/ff031f2f1d40c147ad8c078f09b3fe09c7a23615))
+
 ## Version 3.0.0-beta04, released 2023-10-02
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3450,7 +3450,7 @@
       "protoPath": "google/cloud/oslogin/v1beta",
       "productName": "Google Cloud OS Login",
       "productUrl": "https://cloud.google.com/compute/docs/instances/managing-instance-access",
-      "version": "3.0.0-beta04",
+      "version": "3.0.0-beta05",
       "releaseLevelOverride": "preview",
       "type": "grpc",
       "description": "Recommended Google client library to manages OS login configuration for Google account users.",


### PR DESCRIPTION

Changes in this release:

### New features

- Location-based HTTP binding for SignSshPublicKey ([commit ff031f2](https://github.com/googleapis/google-cloud-dotnet/commit/ff031f2f1d40c147ad8c078f09b3fe09c7a23615))
