### PR TITLE
Release Google.Cloud.RecaptchaEnterprise.V1Beta1 version 2.0.0-beta04

### DIFF
--- a/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.csproj
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta03</Version>
+    <Version>2.0.0-beta04</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud reCAPTCHA for Enterprise API v1beta1.</Description>

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 2.0.0-beta04, released 2023-10-30
+
+### New features
+
+- Added FraudPreventionAssessment.behavioral_trust_verdict ([commit 3173b55](https://github.com/googleapis/google-cloud-dotnet/commit/3173b555a518bf91958a460ad0f5577fe7488595))
+
+### Documentation improvements
+
+- Formatting of resource names ([commit 3173b55](https://github.com/googleapis/google-cloud-dotnet/commit/3173b555a518bf91958a460ad0f5577fe7488595))
+
 ## Version 2.0.0-beta03, released 2023-03-20
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3673,7 +3673,7 @@
       "protoPath": "google/cloud/recaptchaenterprise/v1beta1",
       "productName": "Google Cloud reCAPTCHA Enterprise",
       "productUrl": "https://cloud.google.com/recaptcha-enterprise/",
-      "version": "2.0.0-beta03",
+      "version": "2.0.0-beta04",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud reCAPTCHA for Enterprise API v1beta1.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- Added FraudPreventionAssessment.behavioral_trust_verdict ([commit 3173b55](https://github.com/googleapis/google-cloud-dotnet/commit/3173b555a518bf91958a460ad0f5577fe7488595))

### Documentation improvements

- Formatting of resource names ([commit 3173b55](https://github.com/googleapis/google-cloud-dotnet/commit/3173b555a518bf91958a460ad0f5577fe7488595))
