### PR TITLE
Release Google.Cloud.SecurityCenter.V1 version 3.13.0

### DIFF
--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.csproj
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.12.0</Version>
+    <Version>3.13.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Security Command Center API, which helps security teams gather data, identify threats, and act on them before they result in business damage or loss.</Description>

--- a/apis/Google.Cloud.SecurityCenter.V1/docs/history.md
+++ b/apis/Google.Cloud.SecurityCenter.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.13.0, released 2023-10-30
+
+### New features
+
+- Add SimulateSecurityHealthAnalyticsCustomModule API for testing SHA custom module ([commit bdb2a81](https://github.com/googleapis/google-cloud-dotnet/commit/bdb2a813c2b0d35f40beeabfd5524ac52d536e01))
+
 ## Version 3.12.0, released 2023-06-27
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4055,7 +4055,7 @@
       "protoPath": "google/cloud/securitycenter/v1",
       "productName": "Google Cloud Security Command Center",
       "productUrl": "https://cloud.google.com/security-command-center/",
-      "version": "3.12.0",
+      "version": "3.13.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Security Command Center API, which helps security teams gather data, identify threats, and act on them before they result in business damage or loss.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Add SimulateSecurityHealthAnalyticsCustomModule API for testing SHA custom module ([commit bdb2a81](https://github.com/googleapis/google-cloud-dotnet/commit/bdb2a813c2b0d35f40beeabfd5524ac52d536e01))
