### PR TITLE
tests: Add smoke test for Google.Maps.Routing.V2

### DIFF
--- a/apis/Google.Maps.Routing.V2/smoketests.json
+++ b/apis/Google.Maps.Routing.V2/smoketests.json
@@ -1,0 +1,18 @@
+[
+  {
+    "method": "ComputeRoutes",
+    "client": "RoutesClient",
+    "fieldMask": "*",
+    "transports": [ "Grpc" ],
+    "arguments": {
+      "request": {
+        "origin": {
+          "address": "255 W Tasman Dr, San Jose, CA 95134"
+        },
+        "destination": {
+          "address": "1600 Amphitheatre Parkway, Mountain View, CA 94043"
+        }
+      }
+    }
+  }
+]


### PR DESCRIPTION
This validates that the library works with a service account for gRPC. It fails with the REST transport at the moemnt.