### PR TITLE
Release Google.Cloud.CloudBuild.V2 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.CloudBuild.V2/.repo-metadata.json
+++ b/apis/Google.Cloud.CloudBuild.V2/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.CloudBuild.V2",
-  "release_level": "preview",
+  "release_level": "stable",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.CloudBuild.V2/latest",
   "library_type": "GAPIC_AUTO",
   "language": "dotnet",

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.csproj
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta03</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Build API v2, which creates and manages builds on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.CloudBuild.V2/docs/history.md
+++ b/apis/Google.Cloud.CloudBuild.V2/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0, released 2023-11-01
+
+No API surface changes; just dependency updates and promotion to GA.
+
 ## Version 1.0.0-beta03, released 2023-07-13
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1169,7 +1169,7 @@
     },
     {
       "id": "Google.Cloud.CloudBuild.V2",
-      "version": "1.0.0-beta03",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Cloud Build",
       "description": "Recommended Google client library to access the Google Cloud Build API v2, which creates and manages builds on Google Cloud Platform.",
@@ -1178,9 +1178,11 @@
         "cloudbuild"
       ],
       "dependencies": {
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
-        "Google.LongRunning": "3.0.0"
+        "Google.LongRunning": "3.0.0",
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/devtools/cloudbuild/v2",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates and promotion to GA.
