### PR TITLE
Release Google.Cloud.Config.V1 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.Config.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.Config.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.Config.V1",
-  "release_level": "preview",
+  "release_level": "stable",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Config.V1/latest",
   "library_type": "GAPIC_AUTO",
   "language": "dotnet",

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1/Google.Cloud.Config.V1.csproj
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1/Google.Cloud.Config.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Infrastructure Manager API, which creates and manages Google Cloud Platform resources and infrastructure.</Description>

--- a/apis/Google.Cloud.Config.V1/docs/history.md
+++ b/apis/Google.Cloud.Config.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0, released 2023-11-01
+
+No API surface changes; just dependency updates and promotion to GA.
+
 ## Version 1.0.0-beta02, released 2023-09-25
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1329,7 +1329,7 @@
     },
     {
       "id": "Google.Cloud.Config.V1",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Infrastructure Manager",
       "productUrl": "https://cloud.google.com/infrastructure-manager/docs/overview",
@@ -1340,9 +1340,11 @@
         "resources"
       ],
       "dependencies": {
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
-        "Google.LongRunning": "3.0.0"
+        "Google.LongRunning": "3.0.0",
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/config/v1",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates and promotion to GA.
