### PR TITLE
Release Google.Cloud.Connectors.V1 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.Connectors.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.Connectors.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.Connectors.V1",
-  "release_level": "preview",
+  "release_level": "stable",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Connectors.V1/latest",
   "library_type": "GAPIC_AUTO",
   "language": "dotnet",

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.csproj
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Integration Connectors API, which enables users to create and manage connections to Google Cloud services and third-party business applications using the Connectors interface.</Description>

--- a/apis/Google.Cloud.Connectors.V1/docs/history.md
+++ b/apis/Google.Cloud.Connectors.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0, released 2023-11-01
+
+No API surface changes; just dependency updates and promotion to GA.
+
 ## Version 1.0.0-beta01, released 2023-06-13
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1352,7 +1352,7 @@
     },
     {
       "id": "Google.Cloud.Connectors.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Integration Connectors",
       "productUrl": "https://cloud.google.com/integration-connectors/docs",
@@ -1364,9 +1364,11 @@
         "integration"
       ],
       "dependencies": {
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
-        "Google.LongRunning": "3.0.0"
+        "Google.LongRunning": "3.0.0",
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/connectors/v1",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates and promotion to GA.
