### PR TITLE
Release Google.Cloud.MigrationCenter.V1 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.MigrationCenter.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.MigrationCenter.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.MigrationCenter.V1",
-  "release_level": "preview",
+  "release_level": "stable",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.MigrationCenter.V1/latest",
   "library_type": "GAPIC_AUTO",
   "language": "dotnet",

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.csproj
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Migration Center API, which is a unified platform that helps you accelerate your end-to-end cloud journey from your current on-premises or cloud environments to Google Cloud.</Description>

--- a/apis/Google.Cloud.MigrationCenter.V1/docs/history.md
+++ b/apis/Google.Cloud.MigrationCenter.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0, released 2023-11-01
+
+No API surface changes; just dependency updates and promotion to GA.
+
 ## Version 1.0.0-beta02, released 2023-09-18
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3037,7 +3037,7 @@
     },
     {
       "id": "Google.Cloud.MigrationCenter.V1",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Migration Center",
       "productUrl": "https://cloud.google.com/migration-center/docs/migration-center-overview",
@@ -3046,8 +3046,10 @@
         "migration"
       ],
       "dependencies": {
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Location": "2.0.0",
-        "Google.LongRunning": "3.0.0"
+        "Google.LongRunning": "3.0.0",
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/migrationcenter/v1",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates and promotion to GA.
