### PR TITLE
Release Google.Cloud.Support.V2 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.Support.V2/.repo-metadata.json
+++ b/apis/Google.Cloud.Support.V2/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.Support.V2",
-  "release_level": "preview",
+  "release_level": "stable",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Support.V2/latest",
   "library_type": "GAPIC_AUTO",
   "language": "dotnet",

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2/Google.Cloud.Support.V2.csproj
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2/Google.Cloud.Support.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Support API (v2), which manages Google Cloud technical support cases for Customer Care support offerings.</Description>

--- a/apis/Google.Cloud.Support.V2/docs/history.md
+++ b/apis/Google.Cloud.Support.V2/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0, released 2023-11-01
+
+No API surface changes; just dependency updates and promotion to GA.
+
 ## Version 1.0.0-beta01, released 2023-06-28
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4521,7 +4521,7 @@
     },
     {
       "id": "Google.Cloud.Support.V2",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Google Cloud Support",
       "productUrl": "https://cloud.google.com/support/docs/reference/support-api",
@@ -4529,7 +4529,10 @@
       "tags": [
         "support"
       ],
-      "dependencies": {},
+      "dependencies": {
+        "Google.Api.Gax.Grpc": "4.4.0",
+        "Grpc.Core": "2.46.6"
+      },
       "generator": "micro",
       "protoPath": "google/cloud/support/v2",
       "shortName": "cloudsupport",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates and promotion to GA.
