### PR TITLE
Release Google.Cloud.Workstations.V1 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.Workstations.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.Workstations.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.Workstations.V1",
-  "release_level": "preview",
+  "release_level": "stable",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Workstations.V1/latest",
   "library_type": "GAPIC_AUTO",
   "language": "dotnet",

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.csproj
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Allows administrators to create managed developer environments in the cloud.</Description>

--- a/apis/Google.Cloud.Workstations.V1/docs/history.md
+++ b/apis/Google.Cloud.Workstations.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0, released 2023-11-01
+
+No API surface changes; just dependency updates and promotion to GA.
+
 ## Version 1.0.0-beta02, released 2023-09-06
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5153,7 +5153,7 @@
     },
     {
       "id": "Google.Cloud.Workstations.V1",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Cloud Workstations",
       "productUrl": "https://cloud.google.com/workstations/docs",
@@ -5163,9 +5163,11 @@
         "workstations"
       ],
       "dependencies": {
+        "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
-        "Google.LongRunning": "3.0.0"
+        "Google.LongRunning": "3.0.0",
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/workstations/v1",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates and promotion to GA.
