### PR TITLE
docs: Update the general purpose authentication link that we direct users to.

### DIFF
--- a/docs/devsite-help/getting-started.md
+++ b/docs/devsite-help/getting-started.md
@@ -76,7 +76,7 @@ we're using, there's just `TranslationServiceClient`.
 
 Clients can be configured in a number of ways, but in many cases the defaults are fine. The most
 common reason to use explicit configuration is to use specific credentials for
-[authentication](https://cloud.google.com/docs/authentication/getting-started). For this example, we'll just use the
+[authentication](https://cloud.google.com/docs/authentication/use-cases). For this example, we'll just use the
 [application default credentials](https://cloud.google.com/docs/authentication/production#automatically).
 
 Each client class has static `Create` and `CreateAsync` methods to create clients using all the default settings.

--- a/tools/Google.Cloud.Tools.GenerateDocfxSources/Program.cs
+++ b/tools/Google.Cloud.Tools.GenerateDocfxSources/Program.cs
@@ -209,8 +209,8 @@ When running on Google Cloud, no action needs to be taken to authenticate.
 
 Otherwise, the simplest way of authenticating your API calls is to
 download a service account JSON file then set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to refer to it.
-The credentials will automatically be used to authenticate. See the [Getting Started With
-Authentication](https://cloud.google.com/docs/authentication/getting-started) guide for more details.";
+The credentials will automatically be used to authenticate. See the [Authentication
+use cases](https://cloud.google.com/docs/authentication/use-cases) guide for more details.";
 
             var clients = GetClientClasses(api);
             string clientClasses = text.Contains("{{client-classes}}") ?


### PR DESCRIPTION
I think this link covers more use cases than the one we previousl had. But happy if you prefer to keep the one we currently have.