### PR TITLE
fix: Set x-goog-request-params for streaming pull requests from SubscriberClient

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberClient.ClientCreationSettings.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberClient.ClientCreationSettings.cs
@@ -25,7 +25,7 @@ public abstract partial class SubscriberClient
     /// This type is now obsolete; please use <see cref="SubscriberClientBuilder"/> which provides an
     /// API surface consistent with other clients (as well as additional Pub/Sub-specific properties such as <see cref="SubscriberClientBuilder.ClientCount"/>).
     /// </summary>
-    [Obsolete("Use PublisherClientBuilder to customize client settings.")]
+    [Obsolete("Use SubscriberClientBuilder to customize client settings.")]
     public sealed class ClientCreationSettings
     {
         /// <summary>

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberClientBuilder.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberClientBuilder.cs
@@ -144,6 +144,30 @@ public sealed class SubscriberClientBuilder : ClientBuilderBase<SubscriberClient
 
             return channel.ShutdownAsync();
         }
+
+    }
+
+    /// <summary>
+    /// Returns the *effective* API settings to use, with any additional CallSettings applied.
+    /// </summary>
+    internal SubscriberServiceApiSettings GetEffectiveApiSettings()
+    {
+        // We should never end up being called without a subscription name, but let's
+        // be careful anyway. If we don't have a subscription name, we don't need to modify
+        // the settings.
+        if (SubscriptionName is not SubscriptionName subscriptionName)
+        {
+            return ApiSettings;
+        }
+
+        // We never modify a settings object that the user code has specified explicitly.
+        var settingsToModify = ApiSettings?.Clone() ?? new SubscriberServiceApiSettings();
+
+        // TODO: Use CallSettings.FromGoogleRequestParamsHeader when
+        // https://github.com/googleapis/gax-dotnet/issues/733 is fixed and released.
+        settingsToModify.StreamingPullSettings = settingsToModify.StreamingPullSettings
+            .WithHeader("x-goog-request-params", $"subscription={Uri.EscapeDataString(subscriptionName.ToString())}");
+        return settingsToModify;        
     }
 
     /// <inheritdoc />

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberServiceApiClientBuilder.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberServiceApiClientBuilder.cs
@@ -56,7 +56,7 @@ namespace Google.Cloud.PubSub.V1
         internal SubscriberServiceApiClientBuilder(SubscriberClientBuilder otherBuilder, GrpcChannelOptions extraChannelOptions) : this()
         {
             CopyCommonSettings(otherBuilder);
-            Settings = otherBuilder.ApiSettings;
+            Settings = otherBuilder.GetEffectiveApiSettings();
             ChannelPoolDisabled = true;
             ChannelOptions = extraChannelOptions;
         }


### PR DESCRIPTION
This is an alternative to #11288, setting a single CallSettings that is applied to every StreamingPull call.

(It's significantly more code, but feels more appropriate to me in terms of setting things up a single time so that any call to StreamingPull just does the right thing naturally.)

I'd like review from both @kamalaboulhosn and @Rishabh-V. I tried to work out a way to test it, but there are no simple injection points for this, and it didn't seem worth adding them just for this fix.