### PR TITLE
Release Google.Cloud.PubSub.V1 version 3.8.0

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.7.0</Version>
+    <Version>3.8.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.</Description>

--- a/apis/Google.Cloud.PubSub.V1/docs/history.md
+++ b/apis/Google.Cloud.PubSub.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 3.8.0, released 2023-11-03
+
+### Bug fixes
+
+- Set x-goog-request-params for streaming pull requests from SubscriberClient ([commit 7b6ec74](https://github.com/googleapis/google-cloud-dotnet/commit/7b6ec741956745af04950cd60a2eb83270f6136c))
+
+### Documentation improvements
+
+- Modified some descriptions ([commit 1dd516c](https://github.com/googleapis/google-cloud-dotnet/commit/1dd516c0c949db896d898808457a4b1e97013499))
+
 ## Version 3.7.0, released 2023-09-06
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3614,7 +3614,7 @@
       "protoPath": "google/pubsub/v1",
       "productName": "Cloud Pub/Sub",
       "productUrl": "https://cloud.google.com/pubsub/",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Set x-goog-request-params for streaming pull requests from SubscriberClient ([commit 7b6ec74](https://github.com/googleapis/google-cloud-dotnet/commit/7b6ec741956745af04950cd60a2eb83270f6136c))

### Documentation improvements

- Modified some descriptions ([commit 1dd516c](https://github.com/googleapis/google-cloud-dotnet/commit/1dd516c0c949db896d898808457a4b1e97013499))
