### PR TITLE
Release Google.Cloud.AlloyDb.V1 version 1.4.0

### DIFF
--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.csproj
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AlloyDB API (v1). AlloyDB for PostgreSQL is an open source-compatible database service that provides a powerful option for migrating, modernizing, or building commercial-grade applications.</Description>

--- a/apis/Google.Cloud.AlloyDb.V1/docs/history.md
+++ b/apis/Google.Cloud.AlloyDb.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 1.4.0, released 2023-11-07
+
+### New features
+
+- Add new field in `GenerateClientCertificate` v1 API to allow AlloyDB connectors request client certs with metadata exchange support ([commit adc660e](https://github.com/googleapis/google-cloud-dotnet/commit/adc660e37b842eac165982bd8d1c8e479a11ba65))
+
+### Documentation improvements
+
+- Clarify that `readPoolConfig` is required under certain circumstances, and fix doc formatting on `allocatedIpRange`. ([commit adc660e](https://github.com/googleapis/google-cloud-dotnet/commit/adc660e37b842eac165982bd8d1c8e479a11ba65))
+
 ## Version 1.3.0, released 2023-10-02
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -133,7 +133,7 @@
     },
     {
       "id": "Google.Cloud.AlloyDb.V1",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "type": "grpc",
       "productName": "AlloyDB",
       "productUrl": "https://cloud.google.com/alloydb/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Add new field in `GenerateClientCertificate` v1 API to allow AlloyDB connectors request client certs with metadata exchange support ([commit adc660e](https://github.com/googleapis/google-cloud-dotnet/commit/adc660e37b842eac165982bd8d1c8e479a11ba65))

### Documentation improvements

- Clarify that `readPoolConfig` is required under certain circumstances, and fix doc formatting on `allocatedIpRange`. ([commit adc660e](https://github.com/googleapis/google-cloud-dotnet/commit/adc660e37b842eac165982bd8d1c8e479a11ba65))
