### PR TITLE
Release Google.Cloud.CloudBuild.V1 version 2.7.0

### DIFF
--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.csproj
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Build API v1, which creates and manages builds on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.CloudBuild.V1/docs/history.md
+++ b/apis/Google.Cloud.CloudBuild.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.7.0, released 2023-11-07
+
+### New features
+
+- Add optional field "SourceFetcher" to choose source fetcher tool ([commit 5740cd2](https://github.com/googleapis/google-cloud-dotnet/commit/5740cd23080c15d0d2c7e872cc2c3e55307a7a27))
+
 ## Version 2.6.0, released 2023-08-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1146,7 +1146,7 @@
     },
     {
       "id": "Google.Cloud.CloudBuild.V1",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "type": "grpc",
       "productName": "Cloud Build",
       "productUrl": "https://cloud.google.com/cloud-build",


### PR DESCRIPTION

Changes in this release:

### New features

- Add optional field "SourceFetcher" to choose source fetcher tool ([commit 5740cd2](https://github.com/googleapis/google-cloud-dotnet/commit/5740cd23080c15d0d2c7e872cc2c3e55307a7a27))
