### PR TITLE
Release Google.Cloud.Container.V1 version 3.19.0

### DIFF
--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.18.0</Version>
+    <Version>3.19.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.</Description>

--- a/apis/Google.Cloud.Container.V1/docs/history.md
+++ b/apis/Google.Cloud.Container.V1/docs/history.md
@@ -1,5 +1,18 @@
 # Version history
 
+## Version 3.19.0, released 2023-11-07
+
+### New features
+
+- Added EnterpriseConfig ([commit 1b8f34d](https://github.com/googleapis/google-cloud-dotnet/commit/1b8f34d75719dd07a01fd491bbd586074399b168))
+- Add a new cluster field for the cluster tier of GKE clusters ([commit 1b8f34d](https://github.com/googleapis/google-cloud-dotnet/commit/1b8f34d75719dd07a01fd491bbd586074399b168))
+- Add ResourceManagerTags API to attach tags on the underlying Compute Engine VMs of GKE Nodes which can be used to selectively enforce Cloud Firewall network firewall policies ([commit bae6344](https://github.com/googleapis/google-cloud-dotnet/commit/bae634446d206a97a5c25801c938427ffc963175))
+- Add CompleteConvertToAutopilot API to commit Autopilot conversion operation ([commit bae6344](https://github.com/googleapis/google-cloud-dotnet/commit/bae634446d206a97a5c25801c938427ffc963175))
+
+### Documentation improvements
+
+- Updated comments ([commit bae6344](https://github.com/googleapis/google-cloud-dotnet/commit/bae634446d206a97a5c25801c938427ffc963175))
+
 ## Version 3.18.0, released 2023-09-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1415,7 +1415,7 @@
       "protoPath": "google/container/v1",
       "productName": "Google Kubernetes Engine",
       "productUrl": "https://cloud.google.com/kubernetes-engine/docs/reference/rest/",
-      "version": "3.18.0",
+      "version": "3.19.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Added EnterpriseConfig ([commit 1b8f34d](https://github.com/googleapis/google-cloud-dotnet/commit/1b8f34d75719dd07a01fd491bbd586074399b168))
- Add a new cluster field for the cluster tier of GKE clusters ([commit 1b8f34d](https://github.com/googleapis/google-cloud-dotnet/commit/1b8f34d75719dd07a01fd491bbd586074399b168))
- Add ResourceManagerTags API to attach tags on the underlying Compute Engine VMs of GKE Nodes which can be used to selectively enforce Cloud Firewall network firewall policies ([commit bae6344](https://github.com/googleapis/google-cloud-dotnet/commit/bae634446d206a97a5c25801c938427ffc963175))
- Add CompleteConvertToAutopilot API to commit Autopilot conversion operation ([commit bae6344](https://github.com/googleapis/google-cloud-dotnet/commit/bae634446d206a97a5c25801c938427ffc963175))

### Documentation improvements

- Updated comments ([commit bae6344](https://github.com/googleapis/google-cloud-dotnet/commit/bae634446d206a97a5c25801c938427ffc963175))
