### PR TITLE
Release Google.Cloud.DataCatalog.Lineage.V1 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.csproj
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Dataplex Data Lineage API</Description>

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/docs/history.md
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 1.1.0, released 2023-11-07
+
+### Bug fixes
+
+- Change `start_time` in message `.google.cloud.datacatalog.lineage.v1.LineageEvent` to `required` as intended by api ([commit 05e8e92](https://github.com/googleapis/google-cloud-dotnet/commit/05e8e92352afedb7dc08a3b6a5ae60001b2462df))
+
+### New features
+
+- Add open lineage support ([commit 05e8e92](https://github.com/googleapis/google-cloud-dotnet/commit/05e8e92352afedb7dc08a3b6a5ae60001b2462df))
+
 ## Version 1.0.0, released 2023-03-27
 
 Initial GA release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1431,7 +1431,7 @@
     },
     {
       "id": "Google.Cloud.DataCatalog.Lineage.V1",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "grpc",
       "productName": "Data Lineage",
       "productUrl": "https://cloud.google.com/data-catalog/docs/concepts/about-data-lineage",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Change `start_time` in message `.google.cloud.datacatalog.lineage.v1.LineageEvent` to `required` as intended by api ([commit 05e8e92](https://github.com/googleapis/google-cloud-dotnet/commit/05e8e92352afedb7dc08a3b6a5ae60001b2462df))

### New features

- Add open lineage support ([commit 05e8e92](https://github.com/googleapis/google-cloud-dotnet/commit/05e8e92352afedb7dc08a3b6a5ae60001b2462df))
