### PR TITLE
Release Google.Cloud.Dataplex.V1 version 2.9.0

### DIFF
--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.csproj
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.8.0</Version>
+    <Version>2.9.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Dataplex API, which is used to manage the lifecycle of data lakes.</Description>

--- a/apis/Google.Cloud.Dataplex.V1/docs/history.md
+++ b/apis/Google.Cloud.Dataplex.V1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 2.9.0, released 2023-11-07
+
+### New features
+
+- DataQualityDimension is now part of the DataQualityDimensionResult message ([commit a879994](https://github.com/googleapis/google-cloud-dotnet/commit/a879994e8fce714e0e43135849dd392ebdd35741))
+- Add relativeResourceName and linkedResourceName to search result ([commit a879994](https://github.com/googleapis/google-cloud-dotnet/commit/a879994e8fce714e0e43135849dd392ebdd35741))
+
+### Documentation improvements
+
+- Updated comments for `DataQualityResult.dimensions` field ([commit 51657c7](https://github.com/googleapis/google-cloud-dotnet/commit/51657c71b91c57aee2c8ca95bd06eb81a4887dad))
+
 ## Version 2.8.0, released 2023-10-30
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1581,7 +1581,7 @@
     },
     {
       "id": "Google.Cloud.Dataplex.V1",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "type": "grpc",
       "productName": "Cloud Dataplex",
       "productUrl": "https://cloud.google.com/dataplex/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- DataQualityDimension is now part of the DataQualityDimensionResult message ([commit a879994](https://github.com/googleapis/google-cloud-dotnet/commit/a879994e8fce714e0e43135849dd392ebdd35741))
- Add relativeResourceName and linkedResourceName to search result ([commit a879994](https://github.com/googleapis/google-cloud-dotnet/commit/a879994e8fce714e0e43135849dd392ebdd35741))

### Documentation improvements

- Updated comments for `DataQualityResult.dimensions` field ([commit 51657c7](https://github.com/googleapis/google-cloud-dotnet/commit/51657c71b91c57aee2c8ca95bd06eb81a4887dad))
