### PR TITLE
Release Google.Cloud.Dataproc.V1 version 5.8.0

### DIFF
--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.csproj
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>5.7.0</Version>
+    <Version>5.8.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Dataproc API, which manages Hadoop-based clusters and jobs on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Dataproc.V1/docs/history.md
+++ b/apis/Google.Cloud.Dataproc.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 5.8.0, released 2023-11-07
+
+### New features
+
+- Support required_registration_fraction for secondary workers ([commit cccf5b6](https://github.com/googleapis/google-cloud-dotnet/commit/cccf5b636972ff9efa55d5af9032db957957f3a7))
+
 ## Version 5.7.0, released 2023-09-18
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1610,7 +1610,7 @@
       "protoPath": "google/cloud/dataproc/v1",
       "productName": "Google Cloud Dataproc",
       "productUrl": "https://cloud.google.com/dataproc/docs/concepts/overview",
-      "version": "5.7.0",
+      "version": "5.8.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Dataproc API, which manages Hadoop-based clusters and jobs on Google Cloud Platform.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- Support required_registration_fraction for secondary workers ([commit cccf5b6](https://github.com/googleapis/google-cloud-dotnet/commit/cccf5b636972ff9efa55d5af9032db957957f3a7))
