### PR TITLE
Release Google.Cloud.Speech.V2 version 1.0.0-beta07

### DIFF
--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.csproj
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta06</Version>
+    <Version>1.0.0-beta07</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Speech-to-Text API (v2) which converts audio to text by applying powerful neural network models.</Description>

--- a/apis/Google.Cloud.Speech.V2/docs/history.md
+++ b/apis/Google.Cloud.Speech.V2/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 1.0.0-beta07, released 2023-11-07
+
+### New features
+
+- Add transcript normalization + m4a audio format support ([commit 368d1e1](https://github.com/googleapis/google-cloud-dotnet/commit/368d1e1643c80b968fb5eab8d5db9b00fa05725c))
+- Deprecate `BatchRecognizeFileResult.uri` in favor of `cloud_storage_result.native_format_uri` ([commit 368d1e1](https://github.com/googleapis/google-cloud-dotnet/commit/368d1e1643c80b968fb5eab8d5db9b00fa05725c))
+- Deprecate `BatchRecognizeFileResult.transcript` in favor of `inline_result.transcript` ([commit 368d1e1](https://github.com/googleapis/google-cloud-dotnet/commit/368d1e1643c80b968fb5eab8d5db9b00fa05725c))
+
+### Documentation improvements
+
+- Clarify alternatives for deprecated fields ([commit 368d1e1](https://github.com/googleapis/google-cloud-dotnet/commit/368d1e1643c80b968fb5eab8d5db9b00fa05725c))
+
 ## Version 1.0.0-beta06, released 2023-07-13
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4415,7 +4415,7 @@
     },
     {
       "id": "Google.Cloud.Speech.V2",
-      "version": "1.0.0-beta06",
+      "version": "1.0.0-beta07",
       "type": "grpc",
       "productName": "Cloud Speech-to-Text",
       "productUrl": "https://cloud.google.com/speech",


### PR DESCRIPTION

Changes in this release:

### New features

- Add transcript normalization + m4a audio format support ([commit 368d1e1](https://github.com/googleapis/google-cloud-dotnet/commit/368d1e1643c80b968fb5eab8d5db9b00fa05725c))
- Deprecate `BatchRecognizeFileResult.uri` in favor of `cloud_storage_result.native_format_uri` ([commit 368d1e1](https://github.com/googleapis/google-cloud-dotnet/commit/368d1e1643c80b968fb5eab8d5db9b00fa05725c))
- Deprecate `BatchRecognizeFileResult.transcript` in favor of `inline_result.transcript` ([commit 368d1e1](https://github.com/googleapis/google-cloud-dotnet/commit/368d1e1643c80b968fb5eab8d5db9b00fa05725c))

### Documentation improvements

- Clarify alternatives for deprecated fields ([commit 368d1e1](https://github.com/googleapis/google-cloud-dotnet/commit/368d1e1643c80b968fb5eab8d5db9b00fa05725c))
