### PR TITLE
Release Google.Cloud.ConfidentialComputing.V1 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.csproj
+++ b/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Confidential Computing API (v1)</Description>

--- a/apis/Google.Cloud.ConfidentialComputing.V1/docs/history.md
+++ b/apis/Google.Cloud.ConfidentialComputing.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.1.0, released 2023-11-13
+
+### New features
+
+- Add a new field `token_type` to `TokenOptions` message proto ([commit e15fa62](https://github.com/googleapis/google-cloud-dotnet/commit/e15fa62d37e78fb4d17f9431af1453836bb58d4f))
+
 ## Version 1.0.0, released 2023-11-01
 
 No API surface changes; just dependency updates and promotion to GA.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1289,7 +1289,7 @@
     },
     {
       "id": "Google.Cloud.ConfidentialComputing.V1",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "grpc",
       "productName": "Confidential Computing",
       "productUrl": "https://cloud.google.com/confidential-computing",


### PR DESCRIPTION

Changes in this release:

### New features

- Add a new field `token_type` to `TokenOptions` message proto ([commit e15fa62](https://github.com/googleapis/google-cloud-dotnet/commit/e15fa62d37e78fb4d17f9431af1453836bb58d4f))
