### PR TITLE
Release Google.Cloud.RecaptchaEnterprise.V1 version 2.6.0

### DIFF
--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.csproj
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.5.0</Version>
+    <Version>2.6.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud reCAPTCHA for Enterprise API v1.</Description>

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/docs/history.md
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.6.0, released 2023-11-13
+
+### Documentation improvements
+
+- Updated comments explaining if a field is optional or required ([commit 91d1b84](https://github.com/googleapis/google-cloud-dotnet/commit/91d1b8400e4200f791e33b65a1521a87bf13625d))
+
 ## Version 2.5.0, released 2023-10-30
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3665,7 +3665,7 @@
       "protoPath": "google/cloud/recaptchaenterprise/v1",
       "productName": "Google Cloud reCAPTCHA Enterprise",
       "productUrl": "https://cloud.google.com/recaptcha-enterprise/",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud reCAPTCHA for Enterprise API v1.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### Documentation improvements

- Updated comments explaining if a field is optional or required ([commit 91d1b84](https://github.com/googleapis/google-cloud-dotnet/commit/91d1b8400e4200f791e33b65a1521a87bf13625d))
