### PR TITLE
tests: Modify tests to account for XUnit issue.

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/DatasetsLabelsTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/DatasetsLabelsTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// Copyright 2017 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 using Google.Apis.Http;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -71,7 +72,7 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
                 ["lab6"] = null,
             };
 
-            Assert.Equal(expectedResult, result);
+            Assert.Collection(result, DictionaryElementInspectors(expectedResult));
 
             var finalLabels = client.GetDataset(datasetId).Resource.Labels;
             var expectedFinalLabels = new Dictionary<string, string>
@@ -83,6 +84,10 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             };
 
             Assert.Equal(expectedFinalLabels, finalLabels);
+
+            Action<KeyValuePair<string, string>>[] DictionaryElementInspectors(Dictionary<string, string> expectedElements) =>
+                expectedElements.Select<KeyValuePair<string, string>, Action<KeyValuePair<string, string>>>(expected =>
+                    (actual) => Assert.Equal(expected, actual)).ToArray();
         }
 
         [Theory]

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/ModifyBucketLabelsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/ModifyBucketLabelsTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// Copyright 2017 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ using Google.Apis.Http;
 using Google.Cloud.ClientTesting;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
@@ -73,7 +74,7 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
                 ["lab6"] = null,
             };
 
-            Assert.Equal(expectedResult, result);
+            Assert.Collection(result, DictionaryElementInspectors(expectedResult));
 
             var finalLabels = client.GetBucket(bucketName).Labels;
             var expectedFinalLabels = new Dictionary<string, string>
@@ -85,6 +86,10 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
             };
 
             Assert.Equal(expectedFinalLabels, finalLabels);
+
+            Action<KeyValuePair<string, string>>[] DictionaryElementInspectors(Dictionary<string, string> expectedElements) =>
+                expectedElements.Select<KeyValuePair<string, string>, Action<KeyValuePair<string, string>>>(expected =>
+                    (actual) => Assert.Equal(expected, actual)).ToArray();
         }
 
         [Theory]


### PR DESCRIPTION
Assert.Equal gives a false negative if dictionaries being compared contain null elements.

See https://github.com/xunit/xunit/issues/2824