### PR TITLE
fix: Make SpannerTransaction check for disposal before executing any command.

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/SpannerConnectionSnippets.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/SpannerConnectionSnippets.cs
@@ -287,6 +287,7 @@ namespace Google.Cloud.Spanner.Data.Snippets
                     // Insert a second row
                     cmd.Parameters["Id"].Value = 11L;
                     cmd.Parameters["Name"].Value = "Demo 2";
+                    cmd.Transaction = transaction;
                     rowsAffected += await cmd.ExecuteNonQueryAsync();
                 });
 

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/SpannerConnectionSnippets.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/SpannerConnectionSnippets.cs
@@ -332,6 +332,7 @@ namespace Google.Cloud.Spanner.Data.Snippets
                     // Read the first two keys in the database.
                     List<string> keys = new List<string>();
                     SpannerCommand selectCmd = connection.CreateSelectCommand("SELECT * FROM TestTable");
+                    selectCmd.Transaction = transaction;
                     using (SpannerDataReader reader = await selectCmd.ExecuteReaderAsync())
                     {
                         while (keys.Count < 3 && await reader.ReadAsync())
@@ -345,11 +346,13 @@ namespace Google.Cloud.Spanner.Data.Snippets
                     SpannerCommand updateCmd = connection.CreateUpdateCommand("TestTable");
                     updateCmd.Parameters.Add("Key", SpannerDbType.String, keys[0]);
                     updateCmd.Parameters.Add("Int64Value", SpannerDbType.Int64, 0L);
+                    updateCmd.Transaction = transaction;
                     await updateCmd.ExecuteNonQueryAsync();
 
                     // Delete row for keys[1]
                     SpannerCommand deleteCmd = connection.CreateDeleteCommand("TestTable");
                     deleteCmd.Parameters.Add("Key", SpannerDbType.String, keys[1]);
+                    deleteCmd.Transaction = transaction;
                     await deleteCmd.ExecuteNonQueryAsync();
                 });
                 // End sample


### PR DESCRIPTION
@jskeet This fixes a bug caught by the implementation in #11360 . Once this is merged, I'll rebase inline transaction on this one and a couple of my answers might be clearer.