### PR TITLE
chore: Fix some warnings in the Bigtable client generator

### DIFF
--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GenerateClient/Google.Cloud.Bigtable.V2.GenerateClient.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GenerateClient/Google.Cloud.Bigtable.V2.GenerateClient.csproj
@@ -11,6 +11,12 @@
     <PackageReference Include="Microsoft.Build.Locator" Version="1.6.10" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.8.0" />
+    <!--
+      - For some reason, the above packages introduce a dependency somewhere on version 3.0.3
+      - of Microsoft.Extensions.Logging.Abstractions, so MSBuild gets confused. It's simplest
+      - to just specify v6 ourselves.
+      -->
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
It's weird that they came up at all, but easy to fix.