### PR TITLE
Release Google.Cloud.Datastore.V1 version 4.7.0-beta01

### DIFF
--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.6.0</Version>
+    <Version>4.7.0-beta01</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Datastore API, which accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.</Description>

--- a/apis/Google.Cloud.Datastore.V1/docs/history.md
+++ b/apis/Google.Cloud.Datastore.V1/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 4.7.0-beta01, released 2023-11-29
+
+Note: this is a beta release as multiple database support in Datastore is still in preview. We don't expect the API surface to change between now and the final release, but we don't guarantee that.
+
+### New features
+
+- Multi-db support in Datastore. ([commit 4e7700f](https://github.com/googleapis/google-cloud-dotnet/commit/4e7700ffb1850e405654a4893ad1a3fe87ed5c2f))
+
 ## Version 4.6.0, released 2023-08-22
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1656,7 +1656,7 @@
       "protoPath": "google/datastore/v1",
       "productName": "Google Cloud Datastore",
       "productUrl": "https://cloud.google.com/datastore/docs/concepts/overview",
-      "version": "4.6.0",
+      "version": "4.7.0-beta01",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Datastore API, which accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.",


### PR DESCRIPTION

Changes in this release:

Note: this is a beta release as multiple database support in Datastore is still in preview. We don't expect the API surface to change between now and the final release, but we don't guarantee that.

### New features

- Multi-db support in Datastore. ([commit 4e7700f](https://github.com/googleapis/google-cloud-dotnet/commit/4e7700ffb1850e405654a4893ad1a3fe87ed5c2f))
