### PR TITLE
Release Google.Maps.FleetEngine.V1 version 1.0.0

### DIFF
--- a/apis/Google.Maps.FleetEngine.V1/.repo-metadata.json
+++ b/apis/Google.Maps.FleetEngine.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Maps.FleetEngine.V1",
-  "release_level": "preview",
+  "release_level": "stable",
   "client_documentation": "https://googleapis.dev/dotnet/Google.Maps.FleetEngine.V1/latest",
   "library_type": "GAPIC_AUTO",
   "language": "dotnet",

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.csproj
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Maps Fleet Engine API (v1), which enables access to On Demand Rides and Deliveries and Last Mile Fleet Solutions.</Description>

--- a/apis/Google.Maps.FleetEngine.V1/docs/history.md
+++ b/apis/Google.Maps.FleetEngine.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0, released 2023-12-04
+
+No API surface changes; just dependency updates and promotion to GA.
+
 ## Version 1.0.0-beta01, released 2023-11-06
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5365,7 +5365,7 @@
     },
     {
       "id": "Google.Maps.FleetEngine.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Local Rides and Deliveries",
       "productUrl": "https://developers.google.com/maps/documentation/transportation-logistics/mobility",
@@ -5377,7 +5377,9 @@
         "fleet"
       ],
       "dependencies": {
-        "Google.Geo.Type": "1.0.0"
+        "Google.Api.Gax.Grpc": "4.4.0",
+        "Google.Geo.Type": "1.0.0",
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/maps/fleetengine/v1",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates and promotion to GA.
