### PR TITLE
Release Google.Cloud.Batch.V1Alpha version 1.0.0-alpha19

### DIFF
--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.csproj
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha18</Version>
+    <Version>1.0.0-alpha19</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Batch API (v1alpha), which allows you to manage the running of batch jobs on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Batch.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.Batch.V1Alpha/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 1.0.0-alpha19, released 2023-12-04
+
+### New features
+
+- Add TaskGroup.enable_oslogin to give the Batch job submitter the ability to run runnables as non-root controlled by IAM ([commit 05eda0b](https://github.com/googleapis/google-cloud-dotnet/commit/05eda0ba0e08de129af6683a1404459b7afcbb22))
+- Add a CloudLoggingOption and use_generic_task_monitored_resource fields for users to opt out new batch monitored resource in cloud logging ([commit eecc6fa](https://github.com/googleapis/google-cloud-dotnet/commit/eecc6fa0be5ee899a2d811079ea893bf3242ea9a))
+
+### Documentation improvements
+
+- Update documentation for the network field of AllocationPolicy ([commit 05eda0b](https://github.com/googleapis/google-cloud-dotnet/commit/05eda0ba0e08de129af6683a1404459b7afcbb22))
+- Add clarification for `TaskGroup.parallelism` ([commit cbd5658](https://github.com/googleapis/google-cloud-dotnet/commit/cbd5658d43f63df5aace1dd96df77950425da37f))
+
 ## Version 1.0.0-alpha18, released 2023-10-30
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -574,7 +574,7 @@
     },
     {
       "id": "Google.Cloud.Batch.V1Alpha",
-      "version": "1.0.0-alpha18",
+      "version": "1.0.0-alpha19",
       "type": "grpc",
       "productName": "Batch",
       "productUrl": "https://cloud.google.com/batch/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add TaskGroup.enable_oslogin to give the Batch job submitter the ability to run runnables as non-root controlled by IAM ([commit 05eda0b](https://github.com/googleapis/google-cloud-dotnet/commit/05eda0ba0e08de129af6683a1404459b7afcbb22))
- Add a CloudLoggingOption and use_generic_task_monitored_resource fields for users to opt out new batch monitored resource in cloud logging ([commit eecc6fa](https://github.com/googleapis/google-cloud-dotnet/commit/eecc6fa0be5ee899a2d811079ea893bf3242ea9a))

### Documentation improvements

- Update documentation for the network field of AllocationPolicy ([commit 05eda0b](https://github.com/googleapis/google-cloud-dotnet/commit/05eda0ba0e08de129af6683a1404459b7afcbb22))
- Add clarification for `TaskGroup.parallelism` ([commit cbd5658](https://github.com/googleapis/google-cloud-dotnet/commit/cbd5658d43f63df5aace1dd96df77950425da37f))
