### PR TITLE
Release Google.Cloud.BinaryAuthorization.V1Beta1 version 2.0.0-beta05

### DIFF
--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.csproj
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta04</Version>
+    <Version>2.0.0-beta05</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Binary Authorization API v1beta1, providing policy control for images deployed to Kubernetes Engine clusters.</Description>

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.0.0-beta05, released 2023-12-04
+
+### New features
+
+- Add container_name, container_type fields to Continuous Validation Logs ([commit 38aeca4](https://github.com/googleapis/google-cloud-dotnet/commit/38aeca45b2cfd63ffb1dff7af40b36b324334ebe))
+
 ## Version 2.0.0-beta04, released 2023-08-16
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1076,7 +1076,7 @@
     },
     {
       "id": "Google.Cloud.BinaryAuthorization.V1Beta1",
-      "version": "2.0.0-beta04",
+      "version": "2.0.0-beta05",
       "type": "grpc",
       "productName": "Binary Authorization",
       "productUrl": "https://cloud.google.com/binary-authorization/docs/reference/rpc",


### PR DESCRIPTION

Changes in this release:

### New features

- Add container_name, container_type fields to Continuous Validation Logs ([commit 38aeca4](https://github.com/googleapis/google-cloud-dotnet/commit/38aeca45b2cfd63ffb1dff7af40b36b324334ebe))
