### PR TITLE
Release Google.Cloud.Container.V1 version 3.20.0

### DIFF
--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.19.0</Version>
+    <Version>3.20.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.</Description>

--- a/apis/Google.Cloud.Container.V1/docs/history.md
+++ b/apis/Google.Cloud.Container.V1/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 3.20.0, released 2023-12-04
+
+### New features
+
+- Add enable_relay field to advanced_datapath_observability_config ([commit f986a27](https://github.com/googleapis/google-cloud-dotnet/commit/f986a278ad02e845461a3e4ce3a117ccde289cf1))
+- Enable Enterprise Flag to allow configuring Advanced Vuln Insights ([commit f986a27](https://github.com/googleapis/google-cloud-dotnet/commit/f986a278ad02e845461a3e4ce3a117ccde289cf1))
+- Add Provisioning Request API ([commit be2bfbd](https://github.com/googleapis/google-cloud-dotnet/commit/be2bfbdffcd33b0c045ffe3f7edd9bb25b33a69d))
+
 ## Version 3.19.0, released 2023-11-07
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1415,7 +1415,7 @@
       "protoPath": "google/container/v1",
       "productName": "Google Kubernetes Engine",
       "productUrl": "https://cloud.google.com/kubernetes-engine/docs/reference/rest/",
-      "version": "3.19.0",
+      "version": "3.20.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Add enable_relay field to advanced_datapath_observability_config ([commit f986a27](https://github.com/googleapis/google-cloud-dotnet/commit/f986a278ad02e845461a3e4ce3a117ccde289cf1))
- Enable Enterprise Flag to allow configuring Advanced Vuln Insights ([commit f986a27](https://github.com/googleapis/google-cloud-dotnet/commit/f986a278ad02e845461a3e4ce3a117ccde289cf1))
- Add Provisioning Request API ([commit be2bfbd](https://github.com/googleapis/google-cloud-dotnet/commit/be2bfbdffcd33b0c045ffe3f7edd9bb25b33a69d))
