### PR TITLE
Release Google.Cloud.Deploy.V1 version 2.11.0

### DIFF
--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.csproj
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.10.0</Version>
+    <Version>2.11.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Deploy API, which automates delivery of your applications to a series of target environments in a defined sequence.</Description>

--- a/apis/Google.Cloud.Deploy.V1/docs/history.md
+++ b/apis/Google.Cloud.Deploy.V1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 2.11.0, released 2023-12-04
+
+### New features
+
+- Add custom target type support ([commit 70af9a8](https://github.com/googleapis/google-cloud-dotnet/commit/70af9a8e2539e7f0fc7fb203cf9e0100888c4805))
+- Add revision tagging for one of the Cloud Run deployment strategies ([commit 70af9a8](https://github.com/googleapis/google-cloud-dotnet/commit/70af9a8e2539e7f0fc7fb203cf9e0100888c4805))
+
+### Documentation improvements
+
+- Fixed a number of comments. ([commit 70af9a8](https://github.com/googleapis/google-cloud-dotnet/commit/70af9a8e2539e7f0fc7fb203cf9e0100888c4805))
+
 ## Version 2.10.0, released 2023-11-07
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1726,7 +1726,7 @@
     },
     {
       "id": "Google.Cloud.Deploy.V1",
-      "version": "2.10.0",
+      "version": "2.11.0",
       "type": "grpc",
       "productName": "Google Cloud Deploy",
       "productUrl": "https://cloud.google.com/deploy/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add custom target type support ([commit 70af9a8](https://github.com/googleapis/google-cloud-dotnet/commit/70af9a8e2539e7f0fc7fb203cf9e0100888c4805))
- Add revision tagging for one of the Cloud Run deployment strategies ([commit 70af9a8](https://github.com/googleapis/google-cloud-dotnet/commit/70af9a8e2539e7f0fc7fb203cf9e0100888c4805))

### Documentation improvements

- Fixed a number of comments. ([commit 70af9a8](https://github.com/googleapis/google-cloud-dotnet/commit/70af9a8e2539e7f0fc7fb203cf9e0100888c4805))
