### PR TITLE
Release Google.Cloud.EdgeNetwork.V1 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.csproj
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Distributed Cloud Edge Network API, which enables a management for Distributed Cloud Edge.</Description>

--- a/apis/Google.Cloud.EdgeNetwork.V1/docs/history.md
+++ b/apis/Google.Cloud.EdgeNetwork.V1/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2023-12-04
+
+### Bug fixes
+
+- Change Java package (doesn't affect .NET) ([commit 11ad38c](https://github.com/googleapis/google-cloud-dotnet/commit/11ad38c1d18e1ac4e0fc75ea1b21606e19143ba1))
 ## Version 1.0.0-beta01, released 2023-11-14
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2085,7 +2085,7 @@
     },
     {
       "id": "Google.Cloud.EdgeNetwork.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Distributed Cloud Edge Network",
       "productUrl": "https://cloud.google.com/distributed-cloud/edge/latest/docs/overview",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Change Java package (doesn't affect .NET) ([commit 11ad38c](https://github.com/googleapis/google-cloud-dotnet/commit/11ad38c1d18e1ac4e0fc75ea1b21606e19143ba1))
