### PR TITLE
Release Google.Cloud.PubSub.V1 version 3.9.0

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.8.0</Version>
+    <Version>3.9.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.</Description>

--- a/apis/Google.Cloud.PubSub.V1/docs/history.md
+++ b/apis/Google.Cloud.PubSub.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.9.0, released 2023-12-04
+
+### New features
+
+- Add `use_table_schema` field to BigQueryConfig ([commit c489a15](https://github.com/googleapis/google-cloud-dotnet/commit/c489a154b2e51add4442b2f9ba9ec6198df0bcee))
+
 ## Version 3.8.0, released 2023-11-03
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3639,7 +3639,7 @@
       "protoPath": "google/pubsub/v1",
       "productName": "Cloud Pub/Sub",
       "productUrl": "https://cloud.google.com/pubsub/",
-      "version": "3.8.0",
+      "version": "3.9.0",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.",


### PR DESCRIPTION

Changes in this release:

### New features

- Add `use_table_schema` field to BigQueryConfig ([commit c489a15](https://github.com/googleapis/google-cloud-dotnet/commit/c489a154b2e51add4442b2f9ba9ec6198df0bcee))
