### PR TITLE
Release Google.Cloud.Batch.V1 version 2.6.0

### DIFF
--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.csproj
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.5.0</Version>
+    <Version>2.6.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Batch API (v1), which allows you to manage the running of batch jobs on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Batch.V1/docs/history.md
+++ b/apis/Google.Cloud.Batch.V1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 2.6.0, released 2023-12-05
+
+### New features
+
+- Add a CloudLoggingOption and use_generic_task_monitored_resource fields for users to opt out new batch monitored resource in cloud logging ([commit 838c6df](https://github.com/googleapis/google-cloud-dotnet/commit/838c6df45974d62021bb93080696f7f7c38d104a))
+
+### Documentation improvements
+
+- Update comment for AllocationPolicy.network ([commit 838c6df](https://github.com/googleapis/google-cloud-dotnet/commit/838c6df45974d62021bb93080696f7f7c38d104a))
+- Update default max parallel tasks per job ([commit 06a26bf](https://github.com/googleapis/google-cloud-dotnet/commit/06a26bfa140a0a01373ddc4fbc8fc9d0815cad1f))
+
 ## Version 2.5.0, released 2023-10-30
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -550,7 +550,7 @@
     },
     {
       "id": "Google.Cloud.Batch.V1",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "type": "grpc",
       "productName": "Batch",
       "productUrl": "https://cloud.google.com/batch/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add a CloudLoggingOption and use_generic_task_monitored_resource fields for users to opt out new batch monitored resource in cloud logging ([commit 838c6df](https://github.com/googleapis/google-cloud-dotnet/commit/838c6df45974d62021bb93080696f7f7c38d104a))

### Documentation improvements

- Update comment for AllocationPolicy.network ([commit 838c6df](https://github.com/googleapis/google-cloud-dotnet/commit/838c6df45974d62021bb93080696f7f7c38d104a))
- Update default max parallel tasks per job ([commit 06a26bf](https://github.com/googleapis/google-cloud-dotnet/commit/06a26bfa140a0a01373ddc4fbc8fc9d0815cad1f))
