### PR TITLE
Release Google.Cloud.Datastore.V1 version 4.7.0-beta02

### DIFF
--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.7.0-beta01</Version>
+    <Version>4.7.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Datastore API, which accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.</Description>

--- a/apis/Google.Cloud.Datastore.V1/docs/history.md
+++ b/apis/Google.Cloud.Datastore.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 4.7.0-beta02, released 2023-12-05
+
+### Bug fixes
+
+- Specify the database ID in transaction-oriented operations. Fixes [issue 11375](https://github.com/googleapis/google-cloud-dotnet/issues/11375). ([commit 715167e](https://github.com/googleapis/google-cloud-dotnet/commit/715167eee78a8c129f0dd2b21714ebecda6310ba))
+
 ## Version 4.7.0-beta01, released 2023-11-29
 
 Note: this is a beta release as multiple database support in Datastore is still in preview. We don't expect the API surface to change between now and the final release, but we don't guarantee that.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1656,7 +1656,7 @@
       "protoPath": "google/datastore/v1",
       "productName": "Google Cloud Datastore",
       "productUrl": "https://cloud.google.com/datastore/docs/concepts/overview",
-      "version": "4.7.0-beta01",
+      "version": "4.7.0-beta02",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Datastore API, which accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Specify the database ID in transaction-oriented operations. Fixes [issue 11375](https://github.com/googleapis/google-cloud-dotnet/issues/11375). ([commit 715167e](https://github.com/googleapis/google-cloud-dotnet/commit/715167eee78a8c129f0dd2b21714ebecda6310ba))
