### PR TITLE
Release Google.Cloud.Firestore.Admin.V1 version 3.4.0

### DIFF
--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.csproj
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.3.0</Version>
+    <Version>3.4.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Firestore Admin API.</Description>

--- a/apis/Google.Cloud.Firestore.Admin.V1/docs/history.md
+++ b/apis/Google.Cloud.Firestore.Admin.V1/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 3.4.0, released 2023-12-05
+
+### New features
+
+- Expose Firestore PITR fields in Database to stable ([commit 164e151](https://github.com/googleapis/google-cloud-dotnet/commit/164e151633aa4d82861a61d4a95ff496d38b87ef))
+- Expose Firestore snapshot_time field in export API to stable ([commit 164e151](https://github.com/googleapis/google-cloud-dotnet/commit/164e151633aa4d82861a61d4a95ff496d38b87ef))
+- Expose Firestore namespace ID fields in import/export APIs to stable ([commit 164e151](https://github.com/googleapis/google-cloud-dotnet/commit/164e151633aa4d82861a61d4a95ff496d38b87ef))
+
+### Documentation improvements
+
+- Assorted typo fixes and whitespace updates ([commit 164e151](https://github.com/googleapis/google-cloud-dotnet/commit/164e151633aa4d82861a61d4a95ff496d38b87ef))
+
 ## Version 3.3.0, released 2023-06-05
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2240,7 +2240,7 @@
       "productUrl": "https://firebase.google.com",
       "targetFrameworks": "netstandard2.1;net462",
       "testTargetFrameworks": "net6.0;net462",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Firestore Admin API.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- Expose Firestore PITR fields in Database to stable ([commit 164e151](https://github.com/googleapis/google-cloud-dotnet/commit/164e151633aa4d82861a61d4a95ff496d38b87ef))
- Expose Firestore snapshot_time field in export API to stable ([commit 164e151](https://github.com/googleapis/google-cloud-dotnet/commit/164e151633aa4d82861a61d4a95ff496d38b87ef))
- Expose Firestore namespace ID fields in import/export APIs to stable ([commit 164e151](https://github.com/googleapis/google-cloud-dotnet/commit/164e151633aa4d82861a61d4a95ff496d38b87ef))

### Documentation improvements

- Assorted typo fixes and whitespace updates ([commit 164e151](https://github.com/googleapis/google-cloud-dotnet/commit/164e151633aa4d82861a61d4a95ff496d38b87ef))
