### PR TITLE
tests: Skip REST test for Google.Maps.Places.V1

### DIFF
--- a/apis/Google.Maps.Places.V1/smoketests.json
+++ b/apis/Google.Maps.Places.V1/smoketests.json
@@ -3,6 +3,7 @@
     "method": "SearchText",
     "client": "PlacesClient",
     "fieldMask": "places.formattedAddress",
+    "transports": [ "Grpc" ],
     "arguments": {
       "request": {
         "textQuery": "Google, 1600 Amphitheatre Parkway, CA"


### PR DESCRIPTION
See #11261 and b/308895602 for Google.Maps.Rounting.V2. And I've created b/315531117 for Google.Maps.Places.V1.

@jskeet this is because of the same as Google.Maps.Routing.V2 fails in #11261. If we scope the credential then Google.Maps.Places.V1 REST works as well.

Surprisingly, Google.Maps.Routing.V2 is working in CI and in my local environment for both REST and gRPC without the scope?

And Google.Maps.Places.V1 had been working until yesterday. There's, suspiciously, #11411 from yesterday, but as far as I can see that's just documentation changes.