### PR TITLE
Release Google.Analytics.Data.V1Beta version 2.0.0-beta04

### DIFF
--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.csproj
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta03</Version>
+    <Version>2.0.0-beta04</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Analytics Data API (v1beta)</Description>

--- a/apis/Google.Analytics.Data.V1Beta/docs/history.md
+++ b/apis/Google.Analytics.Data.V1Beta/docs/history.md
@@ -1,5 +1,23 @@
 # Version history
 
+## Version 2.0.0-beta04, released 2023-12-11
+
+### Bug fixes
+
+- **BREAKING CHANGE** Add `optional` label to `consumed`, `remaining` fields of the `QuotaStatus` type ([commit a5715d6](https://github.com/googleapis/google-cloud-dotnet/commit/a5715d6a230fc24222a6cdc8e2840040f93c9e59))
+
+### New features
+
+- Add `CreateAudienceExport`, `QueryAudienceExport`, `GetAudienceExport`, `ListAudienceExports` methods to the Data API v1 beta ([commit a5715d6](https://github.com/googleapis/google-cloud-dotnet/commit/a5715d6a230fc24222a6cdc8e2840040f93c9e59))
+- Add `sampling_metadatas` field to `ResponseMetaData` ([commit a5715d6](https://github.com/googleapis/google-cloud-dotnet/commit/a5715d6a230fc24222a6cdc8e2840040f93c9e59))
+- Add `SamplingMetadata`, `AudienceExport`, `AudienceExportMetadata`, `AudienceDimensionValue` types ([commit a5715d6](https://github.com/googleapis/google-cloud-dotnet/commit/a5715d6a230fc24222a6cdc8e2840040f93c9e59))
+
+### Documentation improvements
+
+- Updated comments ([commit a5715d6](https://github.com/googleapis/google-cloud-dotnet/commit/a5715d6a230fc24222a6cdc8e2840040f93c9e59))
+- Minor formatting ([commit 8c49dd7](https://github.com/googleapis/google-cloud-dotnet/commit/8c49dd73c4e337e7e67db23a8726b5d01d073317))
+- Add clarifications ([commit 8c49dd7](https://github.com/googleapis/google-cloud-dotnet/commit/8c49dd73c4e337e7e67db23a8726b5d01d073317))
+
 ## Version 2.0.0-beta03, released 2023-01-19
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -38,7 +38,7 @@
     },
     {
       "id": "Google.Analytics.Data.V1Beta",
-      "version": "2.0.0-beta03",
+      "version": "2.0.0-beta04",
       "type": "grpc",
       "productName": "Google Analytics Data",
       "productUrl": "https://developers.google.com/analytics",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- **BREAKING CHANGE** Add `optional` label to `consumed`, `remaining` fields of the `QuotaStatus` type ([commit a5715d6](https://github.com/googleapis/google-cloud-dotnet/commit/a5715d6a230fc24222a6cdc8e2840040f93c9e59))

### New features

- Add `CreateAudienceExport`, `QueryAudienceExport`, `GetAudienceExport`, `ListAudienceExports` methods to the Data API v1 beta ([commit a5715d6](https://github.com/googleapis/google-cloud-dotnet/commit/a5715d6a230fc24222a6cdc8e2840040f93c9e59))
- Add `sampling_metadatas` field to `ResponseMetaData` ([commit a5715d6](https://github.com/googleapis/google-cloud-dotnet/commit/a5715d6a230fc24222a6cdc8e2840040f93c9e59))
- Add `SamplingMetadata`, `AudienceExport`, `AudienceExportMetadata`, `AudienceDimensionValue` types ([commit a5715d6](https://github.com/googleapis/google-cloud-dotnet/commit/a5715d6a230fc24222a6cdc8e2840040f93c9e59))

### Documentation improvements

- Updated comments ([commit a5715d6](https://github.com/googleapis/google-cloud-dotnet/commit/a5715d6a230fc24222a6cdc8e2840040f93c9e59))
- Minor formatting ([commit 8c49dd7](https://github.com/googleapis/google-cloud-dotnet/commit/8c49dd73c4e337e7e67db23a8726b5d01d073317))
- Add clarifications ([commit 8c49dd7](https://github.com/googleapis/google-cloud-dotnet/commit/8c49dd73c4e337e7e67db23a8726b5d01d073317))
