### PR TITLE
Release Google.Cloud.Billing.V1 version 3.5.0

### DIFF
--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.csproj
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.4.0</Version>
+    <Version>3.5.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Billing API, which allows you to define a budget plan and the rules to execute as spend is tracked against that plan.</Description>

--- a/apis/Google.Cloud.Billing.V1/docs/history.md
+++ b/apis/Google.Cloud.Billing.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 3.5.0, released 2023-12-11
+
+### New features
+
+- Added the MoveBillingAccount method, which allows changing which organization a billing account belongs to ([commit d8674a8](https://github.com/googleapis/google-cloud-dotnet/commit/d8674a8ec8fed0314c4a0c557f05f47eb5139381))
+- Added field BillingAccount.parent ([commit d8674a8](https://github.com/googleapis/google-cloud-dotnet/commit/d8674a8ec8fed0314c4a0c557f05f47eb5139381))
+
+### Documentation improvements
+
+- Update service documentation ([commit e6e28ae](https://github.com/googleapis/google-cloud-dotnet/commit/e6e28aea18f1fbd8d70e62eae8bbdc698e321565))
 ## Version 3.4.0, released 2023-09-08
 
 ### Breaking change

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1053,7 +1053,7 @@
       "protoPath": "google/cloud/billing/v1",
       "productName": "Google Cloud Billing",
       "productUrl": "https://cloud.google.com/billing/docs/",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Billing API, which allows you to define a budget plan and the rules to execute as spend is tracked against that plan.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Added the MoveBillingAccount method, which allows changing which organization a billing account belongs to ([commit d8674a8](https://github.com/googleapis/google-cloud-dotnet/commit/d8674a8ec8fed0314c4a0c557f05f47eb5139381))
- Added field BillingAccount.parent ([commit d8674a8](https://github.com/googleapis/google-cloud-dotnet/commit/d8674a8ec8fed0314c4a0c557f05f47eb5139381))

### Documentation improvements

- Update service documentation ([commit e6e28ae](https://github.com/googleapis/google-cloud-dotnet/commit/e6e28aea18f1fbd8d70e62eae8bbdc698e321565))
