### PR TITLE
Release Google.Cloud.Compute.V1 version 2.12.0

### DIFF
--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.11.0</Version>
+    <Version>2.12.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Compute Engine API.</Description>

--- a/apis/Google.Cloud.Compute.V1/docs/history.md
+++ b/apis/Google.Cloud.Compute.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.12.0, released 2023-12-11
+
+### New features
+
+- Update Compute Engine API to revision 20231110 ([issue 868](https://github.com/googleapis/google-cloud-dotnet/issues/868)) ([commit 8e8bab2](https://github.com/googleapis/google-cloud-dotnet/commit/8e8bab2c81fa30e3a176fc6a71f2abe9acae3646))
+
 ## Version 2.11.0, released 2023-08-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1290,7 +1290,7 @@
     },
     {
       "id": "Google.Cloud.Compute.V1",
-      "version": "2.11.0",
+      "version": "2.12.0",
       "type": "regapic",
       "productName": "Compute Engine",
       "productUrl": "https://cloud.google.com/compute",


### PR DESCRIPTION

Changes in this release:

### New features

- Update Compute Engine API to revision 20231110 ([issue 868](https://github.com/googleapis/google-cloud-dotnet/issues/868)) ([commit 8e8bab2](https://github.com/googleapis/google-cloud-dotnet/commit/8e8bab2c81fa30e3a176fc6a71f2abe9acae3646))
