### PR TITLE
Release Google.Cloud.RecaptchaEnterprise.V1 version 2.8.0

### DIFF
--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.csproj
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.7.0</Version>
+    <Version>2.8.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud reCAPTCHA for Enterprise API v1.</Description>

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/docs/history.md
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 2.8.0, released 2023-12-11
+
+### New features
+
+- Added stable account identifier to related group membership resources, and deprecated hashed identifier field ([commit 45bfaad](https://github.com/googleapis/google-cloud-dotnet/commit/45bfaad51e9d0a9564872844963f9398caffc8cc))
+
+### Documentation improvements
+
+- Noted applicable fields as resource identifiers ([commit 45bfaad](https://github.com/googleapis/google-cloud-dotnet/commit/45bfaad51e9d0a9564872844963f9398caffc8cc))
+
 ## Version 2.7.0, released 2023-12-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3711,7 +3711,7 @@
       "protoPath": "google/cloud/recaptchaenterprise/v1",
       "productName": "Google Cloud reCAPTCHA Enterprise",
       "productUrl": "https://cloud.google.com/recaptcha-enterprise/",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud reCAPTCHA for Enterprise API v1.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- Added stable account identifier to related group membership resources, and deprecated hashed identifier field ([commit 45bfaad](https://github.com/googleapis/google-cloud-dotnet/commit/45bfaad51e9d0a9564872844963f9398caffc8cc))

### Documentation improvements

- Noted applicable fields as resource identifiers ([commit 45bfaad](https://github.com/googleapis/google-cloud-dotnet/commit/45bfaad51e9d0a9564872844963f9398caffc8cc))
