### PR TITLE
chore: Update AllloyDB v1alpha to latest Google.Api.CommonProtos explicitly

### DIFF
--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.csproj
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
+    <PackageReference Include="Google.Api.CommonProtos" Version="[2.13.0, 3.0.0)" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -190,6 +190,7 @@
         "database"
       ],
       "dependencies": {
+        "Google.Api.CommonProtos": "2.13.0",
         "Google.Cloud.Iam.V1": "3.0.0",
         "Google.Cloud.Location": "2.0.0",
         "Google.LongRunning": "3.0.0"


### PR DESCRIPTION
This won't be necessary when we've done a new GAX release, but unblocks generation/release for now.