### PR TITLE
Release Google.Cloud.PubSub.V1 version 3.9.1

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.9.0</Version>
+    <Version>3.9.1</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.</Description>

--- a/apis/Google.Cloud.PubSub.V1/docs/history.md
+++ b/apis/Google.Cloud.PubSub.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.9.1, released 2024-01-03
+
+### Bug fixes
+
+- Use message ordering enabled property that comes with streaming pull responses so that messages are only delivered to the callback one at a time in order when ordering is actually enabled ([commit 3f8f8a2](https://github.com/googleapis/google-cloud-dotnet/commit/3f8f8a26587dd329cf2a90c6b9952a8ce5fff7f4))
+
 ## Version 3.9.0, released 2023-12-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3661,7 +3661,7 @@
       "protoPath": "google/pubsub/v1",
       "productName": "Cloud Pub/Sub",
       "productUrl": "https://cloud.google.com/pubsub/",
-      "version": "3.9.0",
+      "version": "3.9.1",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Use message ordering enabled property that comes with streaming pull responses so that messages are only delivered to the callback one at a time in order when ordering is actually enabled ([commit 3f8f8a2](https://github.com/googleapis/google-cloud-dotnet/commit/3f8f8a26587dd329cf2a90c6b9952a8ce5fff7f4))
