### PR TITLE
feat: Update NLog to 5.x

### DIFF
--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.IntegrationTests/CredentialTest.cs
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.IntegrationTests/CredentialTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2018 Google Inc. All Rights Reserved.
+// Copyright 2018 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -46,13 +46,13 @@ namespace Google.Cloud.Logging.NLog.IntegrationTests
 
         private async Task AssertAsync<T>(GoogleStackdriverTarget target, bool shouldSucceed) where T : Exception
         {
-            // ConfigureForTargetLogging() and a write are both required to trigger target initialization.
-            SimpleConfigurator.ConfigureForTargetLogging(target);
+            // Configuration and a write are both required to trigger target initialization.
+            LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(target));
             var tcs = new TaskCompletionSource<int>();
             target.WriteAsyncLogEvent(new AsyncLogEventInfo(LogEventInfo.CreateNullEvent(), MakeContinuation(tcs)));
             if (shouldSucceed)
             {
-                // On "succees", a KeyNotFoundException is thrown, as we're using an empty LogEventInfo.
+                // On "success", a KeyNotFoundException is thrown, as we're using an empty LogEventInfo.
                 // This does depend on an NLog implementation detail, but provides a simple way to test
                 // the success case that doesn't actually log anything.
                 await Assert.ThrowsAsync<KeyNotFoundException>(() => tcs.Task);

--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.Snippets/GoogleStackdriverTargetSnippets.cs
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.Snippets/GoogleStackdriverTargetSnippets.cs
@@ -69,7 +69,7 @@ namespace Google.Cloud.Logging.NLog.Snippets
                 // Resource: nlog-template.xml nlog_template
                 // Sample: Overview
                 // Configure nlog to use Google Stackdriver logging from the XML configuration file.
-                LogManager.LoadConfiguration("nlog.xml");
+                LogManager.Setup().LoadConfigurationFromFile("nlog.xml", optional: false);
 
                 // Acquire a logger for this class
                 Logger logger = LogManager.GetCurrentClassLogger();

--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.Tests/GoogleStackdriverTargetTest.cs
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.Tests/GoogleStackdriverTargetTest.cs
@@ -90,7 +90,7 @@ namespace Google.Cloud.Logging.NLog.Tests
                     googleTarget.ContextProperties.Add(new TargetPropertyWithContext() { Name = metadata.Key, Layout = metadata.Value });
                 }
                 configFn?.Invoke(googleTarget);
-                SimpleConfigurator.ConfigureForTargetLogging(googleTarget);
+                LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(googleTarget));
                 await testFn(googleTarget);
             }
             finally
@@ -119,8 +119,8 @@ namespace Google.Cloud.Logging.NLog.Tests
 
         private Task ActivateTargetAsync(Target target)
         {
-            // ConfigureForTargetLogging() and a write are both required to trigger target initialization.
-            SimpleConfigurator.ConfigureForTargetLogging(target);
+            // Configuration and a write are both required to trigger target initialization.
+            LogManager.Setup().LoadConfiguration(c => c.ForLogger().WriteTo(target));
             var tcs = new TaskCompletionSource<int>();
             void Continuation(Exception ex)
             {

--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.csproj
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.0.0</Version>
+    <Version>5.0.0-beta00</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>NLog target for the Google Cloud Logging API.</Description>
@@ -13,6 +13,6 @@
     <PackageReference Include="Google.Cloud.DevTools.Common" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Logging.V2" Version="[4.0.0, 5.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
-    <PackageReference Include="NLog" Version="4.7.15" />
+    <PackageReference Include="NLog" Version="5.2.8" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/GoogleStackdriverTarget.cs
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/GoogleStackdriverTarget.cs
@@ -77,7 +77,6 @@ namespace Google.Cloud.Logging.NLog
         // For testing only.
         internal GoogleStackdriverTarget(LoggingServiceV2Client client, Platform platform)
         {
-            OptimizeBufferReuse = true;
             ResourceLabels = new List<TargetPropertyWithContext>();
             _contextProperties = new List<TargetPropertyWithContext>();
             _client = client;

--- a/apis/Google.Cloud.Logging.NLog/docs/index.md
+++ b/apis/Google.Cloud.Logging.NLog/docs/index.md
@@ -20,7 +20,14 @@ Create an `nlog` configuration file (`nlog.xml`):
 Edit the file replacing `PROJECT_ID` with your Google Cloud Project
 ID, and `LOG_ID` with an identifier for your application.
 
-Use this file to configure `nlog` and then log as normal:
+Ensure the file is copied to the output directory. For example, in
+your project file you might include:
+
+```xml
+<None Update="nlog.xml" CopyToOutputDirectory="Always" />
+```
+
+Use this file to configure NLog and then log as normal:
 
 {{sample:GoogleStackdriverTarget.Overview}}
 

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2869,7 +2869,7 @@
     },
     {
       "id": "Google.Cloud.Logging.NLog",
-      "version": "4.0.0",
+      "version": "5.0.0-beta00",
       "type": "other",
       "metadataType": "INTEGRATION",
       "targetFrameworks": "netstandard2.1;net462",
@@ -2885,7 +2885,7 @@
         "Google.Cloud.DevTools.Common": "3.0.0",
         "Google.Cloud.Logging.V2": "4.0.0",
         "Grpc.Core": "2.46.6",
-        "NLog": "4.7.15"
+        "NLog": "5.2.8"
       },
       "testDependencies": {
         "Google.Api.Gax.Testing": "4.4.0"


### PR DESCRIPTION
This requires a little work to remove uses of obsolete setup code (and the use of an obsolete property), but otherwise works fine.

The version of our provider is set to 5.0.0-beta00 in anticipation of a 5.0.0-beta01 release soon.

Fixes (barring the release) #11465.