### PR TITLE
Release Google.Cloud.Logging.NLog version 5.0.0-beta01

### DIFF
--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.csproj
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>5.0.0-beta00</Version>
+    <Version>5.0.0-beta01</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>NLog target for the Google Cloud Logging API.</Description>
@@ -11,7 +11,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.4.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.DevTools.Common" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Logging.V2" Version="[4.0.0, 5.0.0)" />
+    <PackageReference Include="Google.Cloud.Logging.V2" Version="[4.1.0, 5.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
     <PackageReference Include="NLog" Version="5.2.8" />
   </ItemGroup>

--- a/apis/Google.Cloud.Logging.NLog/docs/history.md
+++ b/apis/Google.Cloud.Logging.NLog/docs/history.md
@@ -1,5 +1,14 @@
 # Version history
 
+## Version 5.0.0-beta01, released 2024-01-04
+
+### New features
+
+- Update NLog to 5.x ([commit 25820cf](https://github.com/googleapis/google-cloud-dotnet/commit/25820cf824e01ad1c3ac98a001db7c83d89f0ce2))
+
+This is a major version bump due to taking a new dependency major
+version. The API within the Google-owned code has no changes.
+
 ## Version 4.0.0, released 2022-06-09
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2985,7 +2985,7 @@
     },
     {
       "id": "Google.Cloud.Logging.NLog",
-      "version": "5.0.0-beta00",
+      "version": "5.0.0-beta01",
       "type": "other",
       "metadataType": "INTEGRATION",
       "targetFrameworks": "netstandard2.1;net462",
@@ -2999,7 +2999,7 @@
       "dependencies": {
         "Google.Api.Gax.Grpc": "4.4.0",
         "Google.Cloud.DevTools.Common": "3.0.0",
-        "Google.Cloud.Logging.V2": "4.0.0",
+        "Google.Cloud.Logging.V2": "4.1.0",
         "Grpc.Core": "2.46.6",
         "NLog": "5.2.8"
       },


### PR DESCRIPTION

Changes in this release:

### New features

- Update NLog to 5.x ([commit 25820cf](https://github.com/googleapis/google-cloud-dotnet/commit/25820cf824e01ad1c3ac98a001db7c83d89f0ce2))

This is a major version bump due to taking a new dependency major version. The API within the Google-owned code has no changes.
