### PR TITLE
tests: Smoketest only on gRPC because there's not default scope

### DIFF
--- a/apis/Google.Maps.Routing.V2/smoketests.json
+++ b/apis/Google.Maps.Routing.V2/smoketests.json
@@ -3,7 +3,7 @@
     "method": "ComputeRoutes",
     "client": "RoutesClient",
     "fieldMask": "*",
-    "transports": [ "Grpc", "Rest" ],
+    "transports": [ "Grpc" ],
     "arguments": {
       "request": {
         "origin": {


### PR DESCRIPTION
See b/308895602