### PR TITLE
Release Google.Cloud.AlloyDb.V1Alpha version 1.0.0-alpha05

### DIFF
--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.csproj
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha04</Version>
+    <Version>1.0.0-alpha05</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AlloyDB API (v1alpha). AlloyDB for PostgreSQL is an open source-compatible database service that provides a powerful option for migrating, modernizing, or building commercial-grade applications.</Description>

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/docs/history.md
@@ -1,5 +1,19 @@
 # Version history
 
+## Version 1.0.0-alpha05, released 2024-01-08
+
+### New features
+
+- Added PSC config, PSC interface config, PSC instance config ([commit 838504a](https://github.com/googleapis/google-cloud-dotnet/commit/838504a48905157e2ae8acfd328ed948b3f974b8))
+- Added two boolean fields satisfies_pzi and satisfies_pzs ([commit 838504a](https://github.com/googleapis/google-cloud-dotnet/commit/838504a48905157e2ae8acfd328ed948b3f974b8))
+- Added instance network config ([commit 838504a](https://github.com/googleapis/google-cloud-dotnet/commit/838504a48905157e2ae8acfd328ed948b3f974b8))
+- Added ListDatabases API and Database object ([commit 838504a](https://github.com/googleapis/google-cloud-dotnet/commit/838504a48905157e2ae8acfd328ed948b3f974b8))
+- Changed field network in NetworkConfig from required to optional ([commit 838504a](https://github.com/googleapis/google-cloud-dotnet/commit/838504a48905157e2ae8acfd328ed948b3f974b8))
+
+### Documentation improvements
+
+- Clarified read pool config is for read pool type instances ([commit 838504a](https://github.com/googleapis/google-cloud-dotnet/commit/838504a48905157e2ae8acfd328ed948b3f974b8))
+
 ## Version 1.0.0-alpha04, released 2023-09-25
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -188,7 +188,7 @@
     },
     {
       "id": "Google.Cloud.AlloyDb.V1Alpha",
-      "version": "1.0.0-alpha04",
+      "version": "1.0.0-alpha05",
       "type": "grpc",
       "productName": "AlloyDB",
       "productUrl": "https://cloud.google.com/alloydb/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Added PSC config, PSC interface config, PSC instance config ([commit 838504a](https://github.com/googleapis/google-cloud-dotnet/commit/838504a48905157e2ae8acfd328ed948b3f974b8))
- Added two boolean fields satisfies_pzi and satisfies_pzs ([commit 838504a](https://github.com/googleapis/google-cloud-dotnet/commit/838504a48905157e2ae8acfd328ed948b3f974b8))
- Added instance network config ([commit 838504a](https://github.com/googleapis/google-cloud-dotnet/commit/838504a48905157e2ae8acfd328ed948b3f974b8))
- Added ListDatabases API and Database object ([commit 838504a](https://github.com/googleapis/google-cloud-dotnet/commit/838504a48905157e2ae8acfd328ed948b3f974b8))
- Changed field network in NetworkConfig from required to optional ([commit 838504a](https://github.com/googleapis/google-cloud-dotnet/commit/838504a48905157e2ae8acfd328ed948b3f974b8))

### Documentation improvements

- Clarified read pool config is for read pool type instances ([commit 838504a](https://github.com/googleapis/google-cloud-dotnet/commit/838504a48905157e2ae8acfd328ed948b3f974b8))
