### PR TITLE
Release Google.Cloud.BigQuery.Logging.V1 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.Logging.V1/Google.Cloud.BigQuery.Logging.V1/Google.Cloud.BigQuery.Logging.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.Logging.V1/Google.Cloud.BigQuery.Logging.V1/Google.Cloud.BigQuery.Logging.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Protobuf messages for Google Cloud BigQuery audit data logs.</Description>

--- a/apis/Google.Cloud.BigQuery.Logging.V1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.Logging.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.1.0, released 2024-01-08
+
+### New features
+
+- Add the name of the reservation the job was submitted to as a field ([commit 2ed5211](https://github.com/googleapis/google-cloud-dotnet/commit/2ed521141cce32eef0b56e6b20f705ba444409d5))
+
 ## Version 1.0.0, released 2022-09-14
 
 First release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -876,7 +876,7 @@
     },
     {
       "id": "Google.Cloud.BigQuery.Logging.V1",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "targetFrameworks": "netstandard2.1;net462",
       "productName": "BigQuery Audit Data Logging",
       "productUrl": "https://cloud.google.com/bigquery",


### PR DESCRIPTION

Changes in this release:

### New features

- Add the name of the reservation the job was submitted to as a field ([commit 2ed5211](https://github.com/googleapis/google-cloud-dotnet/commit/2ed521141cce32eef0b56e6b20f705ba444409d5))
