### PR TITLE
Release Google.Cloud.Bigtable.V2 version 3.9.0

### DIFF
--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.8.0</Version>
+    <Version>3.9.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Bigtable API.</Description>

--- a/apis/Google.Cloud.Bigtable.V2/docs/history.md
+++ b/apis/Google.Cloud.Bigtable.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.9.0, released 2024-01-08
+
+### New features
+
+- Adding feature flags for routing cookie and retry info ([commit af7aca5](https://github.com/googleapis/google-cloud-dotnet/commit/af7aca508568fba8e04d3d037ed6485f1dba1b12))
+
 ## Version 3.8.0, released 2023-09-18
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1025,7 +1025,7 @@
       "protoPath": "google/bigtable/v2",
       "productName": "Google Bigtable",
       "productUrl": "https://cloud.google.com/bigtable/",
-      "version": "3.8.0",
+      "version": "3.9.0",
       "commonResourcesConfig": "apis/Google.Cloud.Bigtable.Common.V2/CommonResourcesConfig.json",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",


### PR DESCRIPTION

Changes in this release:

### New features

- Adding feature flags for routing cookie and retry info ([commit af7aca5](https://github.com/googleapis/google-cloud-dotnet/commit/af7aca508568fba8e04d3d037ed6485f1dba1b12))
