### PR TITLE
Release Google.Cloud.Dataplex.V1 version 2.11.0

### DIFF
--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.csproj
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.10.0</Version>
+    <Version>2.11.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Dataplex API, which is used to manage the lifecycle of data lakes.</Description>

--- a/apis/Google.Cloud.Dataplex.V1/docs/history.md
+++ b/apis/Google.Cloud.Dataplex.V1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 2.11.0, released 2024-01-08
+
+### New features
+
+- Added enum value EventType.GOVERNANCE_RULE_PROCESSING ([commit d69b53d](https://github.com/googleapis/google-cloud-dotnet/commit/d69b53d698d7473699414f3686aa8f9e08ebf927))
+
+### Documentation improvements
+
+- Fix the comment for `ignore_null` field to clarify its applicability on data quality rules ([commit df58fbb](https://github.com/googleapis/google-cloud-dotnet/commit/df58fbbfc3c5912724d0253ef3fd959ddf47d811))
+- Added documentation of page_size default and maximum value for ListEntries and RetrieveAspects ([commit df58fbb](https://github.com/googleapis/google-cloud-dotnet/commit/df58fbbfc3c5912724d0253ef3fd959ddf47d811))
+
 ## Version 2.10.0, released 2023-12-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1670,7 +1670,7 @@
     },
     {
       "id": "Google.Cloud.Dataplex.V1",
-      "version": "2.10.0",
+      "version": "2.11.0",
       "type": "grpc",
       "productName": "Cloud Dataplex",
       "productUrl": "https://cloud.google.com/dataplex/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Added enum value EventType.GOVERNANCE_RULE_PROCESSING ([commit d69b53d](https://github.com/googleapis/google-cloud-dotnet/commit/d69b53d698d7473699414f3686aa8f9e08ebf927))

### Documentation improvements

- Fix the comment for `ignore_null` field to clarify its applicability on data quality rules ([commit df58fbb](https://github.com/googleapis/google-cloud-dotnet/commit/df58fbbfc3c5912724d0253ef3fd959ddf47d811))
- Added documentation of page_size default and maximum value for ListEntries and RetrieveAspects ([commit df58fbb](https://github.com/googleapis/google-cloud-dotnet/commit/df58fbbfc3c5912724d0253ef3fd959ddf47d811))
