### PR TITLE
Release Google.Cloud.Datastore.V1 version 4.7.0-beta03

### DIFF
--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/Google.Cloud.Datastore.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/Google.Cloud.Datastore.V1.GeneratedSnippets.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Datastore.V1\Google.Cloud.Datastore.V1.csproj" />
-    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.4.0, 4.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />
     <PackageReference Include="System.Linq.Async" Version="$(SystemLinqAsyncVersion)" />

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/Google.Cloud.Datastore.V1.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/Google.Cloud.Datastore.V1.IntegrationTests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Datastore.V1\Google.Cloud.Datastore.V1.csproj" />
-    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.4.0, 4.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />
     <PackageReference Include="System.Linq.Async" Version="$(SystemLinqAsyncVersion)" />

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/Google.Cloud.Datastore.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/Google.Cloud.Datastore.V1.Snippets.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Datastore.V1\Google.Cloud.Datastore.V1.csproj" />
-    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.4.0, 4.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />
     <PackageReference Include="System.Linq.Async" Version="$(SystemLinqAsyncVersion)" />

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Tests/Google.Cloud.Datastore.V1.Tests.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Tests/Google.Cloud.Datastore.V1.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Datastore.V1\Google.Cloud.Datastore.V1.csproj" />
-    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.4.0, 4.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />
     <PackageReference Include="System.Linq.Async" Version="$(SystemLinqAsyncVersion)" />

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.7.0-beta02</Version>
+    <Version>4.7.0-beta03</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Datastore API, which accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.</Description>

--- a/apis/Google.Cloud.Datastore.V1/docs/history.md
+++ b/apis/Google.Cloud.Datastore.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 4.7.0-beta03, released 2024-01-08
+
+### New features
+
+- Add new types QueryMode, QueryPlan, ResultSetStats ([commit 44bca87](https://github.com/googleapis/google-cloud-dotnet/commit/44bca8714317d24b5db5acb28ba62a95a0bd0c39))
+- Add QueryMode field to RunQueryRequest ([commit 44bca87](https://github.com/googleapis/google-cloud-dotnet/commit/44bca8714317d24b5db5acb28ba62a95a0bd0c39))
+- Add ResultSetStats field to RunQueryResponse ([commit 44bca87](https://github.com/googleapis/google-cloud-dotnet/commit/44bca8714317d24b5db5acb28ba62a95a0bd0c39))
+- Add QueryMode field to RunAggregationQueryRequest ([commit 44bca87](https://github.com/googleapis/google-cloud-dotnet/commit/44bca8714317d24b5db5acb28ba62a95a0bd0c39))
+- Add ResultSetStats field to RunAggregationQueryResponse ([commit 44bca87](https://github.com/googleapis/google-cloud-dotnet/commit/44bca8714317d24b5db5acb28ba62a95a0bd0c39))
+
 ## Version 4.7.0-beta02, released 2023-12-05
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1748,7 +1748,7 @@
       "protoPath": "google/datastore/v1",
       "productName": "Google Cloud Datastore",
       "productUrl": "https://cloud.google.com/datastore/docs/concepts/overview",
-      "version": "4.7.0-beta02",
+      "version": "4.7.0-beta03",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Datastore API, which accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.",
@@ -1763,7 +1763,7 @@
       },
       "testDependencies": {
         "Google.Api.Gax.Grpc.Testing": "4.4.0",
-        "Google.Cloud.Firestore.Admin.V1": "3.3.0"
+        "Google.Cloud.Firestore.Admin.V1": "3.4.0"
       },
       "shortName": "datastore",
       "serviceConfigFile": "datastore_v1.yaml",


### PR DESCRIPTION

Changes in this release:

### New features

- Add new types QueryMode, QueryPlan, ResultSetStats ([commit 44bca87](https://github.com/googleapis/google-cloud-dotnet/commit/44bca8714317d24b5db5acb28ba62a95a0bd0c39))
- Add QueryMode field to RunQueryRequest ([commit 44bca87](https://github.com/googleapis/google-cloud-dotnet/commit/44bca8714317d24b5db5acb28ba62a95a0bd0c39))
- Add ResultSetStats field to RunQueryResponse ([commit 44bca87](https://github.com/googleapis/google-cloud-dotnet/commit/44bca8714317d24b5db5acb28ba62a95a0bd0c39))
- Add QueryMode field to RunAggregationQueryRequest ([commit 44bca87](https://github.com/googleapis/google-cloud-dotnet/commit/44bca8714317d24b5db5acb28ba62a95a0bd0c39))
- Add ResultSetStats field to RunAggregationQueryResponse ([commit 44bca87](https://github.com/googleapis/google-cloud-dotnet/commit/44bca8714317d24b5db5acb28ba62a95a0bd0c39))
