### PR TITLE
Release Google.Cloud.Firestore.Admin.V1 version 3.5.0

### DIFF
--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.csproj
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.4.0</Version>
+    <Version>3.5.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Firestore Admin API.</Description>

--- a/apis/Google.Cloud.Firestore.Admin.V1/docs/history.md
+++ b/apis/Google.Cloud.Firestore.Admin.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 3.5.0, released 2024-01-08
+
+### New features
+
+- Add DeleteDatabase API and delete protection ([commit 045eb3b](https://github.com/googleapis/google-cloud-dotnet/commit/045eb3b54e169edab666bc0e3154683d402fde0e))
+
+### Documentation improvements
+
+- Update Database API description ([commit 045eb3b](https://github.com/googleapis/google-cloud-dotnet/commit/045eb3b54e169edab666bc0e3154683d402fde0e))
+
 ## Version 3.4.0, released 2023-12-05
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2354,7 +2354,7 @@
       "productUrl": "https://firebase.google.com",
       "targetFrameworks": "netstandard2.1;net462",
       "testTargetFrameworks": "net6.0;net462",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Firestore Admin API.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- Add DeleteDatabase API and delete protection ([commit 045eb3b](https://github.com/googleapis/google-cloud-dotnet/commit/045eb3b54e169edab666bc0e3154683d402fde0e))

### Documentation improvements

- Update Database API description ([commit 045eb3b](https://github.com/googleapis/google-cloud-dotnet/commit/045eb3b54e169edab666bc0e3154683d402fde0e))
