### PR TITLE
Release Google.Cloud.GkeMultiCloud.V1 version 2.3.0

### DIFF
--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.csproj
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.2.0</Version>
+    <Version>2.3.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Anthos Multi-Cloud API, which provides a way to manage Kubernetes clusters that run on AWS and Azure infrastructure using the Anthos Multi-Cloud API. Combined with Connect, you can manage Kubernetes clusters on Google Cloud, AWS, and Azure from the Google Cloud Console.  When you create a cluster with Anthos Multi-Cloud, Google creates the resources needed and brings up a cluster on your behalf. You can deploy workloads with the Anthos Multi-Cloud API or the gcloud and kubectl command-line tools.</Description>

--- a/apis/Google.Cloud.GkeMultiCloud.V1/docs/history.md
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/docs/history.md
@@ -1,5 +1,22 @@
 # Version history
 
+## Version 2.3.0, released 2024-01-08
+
+### New features
+
+- Added proxy support for Attached Clusters ([commit 39eb8f0](https://github.com/googleapis/google-cloud-dotnet/commit/39eb8f0e301aa1be2a771c3301689079bae230ba))
+- Added Binary Authorization support which is a deploy-time security control that ensures only trusted container images are deployed ([commit 39eb8f0](https://github.com/googleapis/google-cloud-dotnet/commit/39eb8f0e301aa1be2a771c3301689079bae230ba))
+- Added support for a new admin-groups flag in the create and update APIs ([commit 39eb8f0](https://github.com/googleapis/google-cloud-dotnet/commit/39eb8f0e301aa1be2a771c3301689079bae230ba))
+- Added Surge Update and Rollback support for AWS Node Pools ([commit 39eb8f0](https://github.com/googleapis/google-cloud-dotnet/commit/39eb8f0e301aa1be2a771c3301689079bae230ba))
+- Added support for per-node-pool subnet security group rules for AWS Node Pools ([commit 39eb8f0](https://github.com/googleapis/google-cloud-dotnet/commit/39eb8f0e301aa1be2a771c3301689079bae230ba))
+- Added support for EC2 Spot instance types for AWS Node Pools ([commit 39eb8f0](https://github.com/googleapis/google-cloud-dotnet/commit/39eb8f0e301aa1be2a771c3301689079bae230ba))
+- Added force-deletion support for AWS Clusters & Node Pools ([commit 39eb8f0](https://github.com/googleapis/google-cloud-dotnet/commit/39eb8f0e301aa1be2a771c3301689079bae230ba))
+- Expanded Kubernetes version info ([commit 39eb8f0](https://github.com/googleapis/google-cloud-dotnet/commit/39eb8f0e301aa1be2a771c3301689079bae230ba))
+
+### Documentation improvements
+
+- Updated comments of existing fields ([commit 39eb8f0](https://github.com/googleapis/google-cloud-dotnet/commit/39eb8f0e301aa1be2a771c3301689079bae230ba))
+
 ## Version 2.2.0, released 2023-02-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2631,7 +2631,7 @@
     },
     {
       "id": "Google.Cloud.GkeMultiCloud.V1",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "type": "grpc",
       "productName": "Anthos Multi-Cloud",
       "productUrl": "https://cloud.google.com/anthos/clusters/docs/multi-cloud",


### PR DESCRIPTION

Changes in this release:

### New features

- Added proxy support for Attached Clusters ([commit 39eb8f0](https://github.com/googleapis/google-cloud-dotnet/commit/39eb8f0e301aa1be2a771c3301689079bae230ba))
- Added Binary Authorization support which is a deploy-time security control that ensures only trusted container images are deployed ([commit 39eb8f0](https://github.com/googleapis/google-cloud-dotnet/commit/39eb8f0e301aa1be2a771c3301689079bae230ba))
- Added support for a new admin-groups flag in the create and update APIs ([commit 39eb8f0](https://github.com/googleapis/google-cloud-dotnet/commit/39eb8f0e301aa1be2a771c3301689079bae230ba))
- Added Surge Update and Rollback support for AWS Node Pools ([commit 39eb8f0](https://github.com/googleapis/google-cloud-dotnet/commit/39eb8f0e301aa1be2a771c3301689079bae230ba))
- Added support for per-node-pool subnet security group rules for AWS Node Pools ([commit 39eb8f0](https://github.com/googleapis/google-cloud-dotnet/commit/39eb8f0e301aa1be2a771c3301689079bae230ba))
- Added support for EC2 Spot instance types for AWS Node Pools ([commit 39eb8f0](https://github.com/googleapis/google-cloud-dotnet/commit/39eb8f0e301aa1be2a771c3301689079bae230ba))
- Added force-deletion support for AWS Clusters & Node Pools ([commit 39eb8f0](https://github.com/googleapis/google-cloud-dotnet/commit/39eb8f0e301aa1be2a771c3301689079bae230ba))
- Expanded Kubernetes version info ([commit 39eb8f0](https://github.com/googleapis/google-cloud-dotnet/commit/39eb8f0e301aa1be2a771c3301689079bae230ba))

### Documentation improvements

- Updated comments of existing fields ([commit 39eb8f0](https://github.com/googleapis/google-cloud-dotnet/commit/39eb8f0e301aa1be2a771c3301689079bae230ba))
