### PR TITLE
Release Google.Cloud.Monitoring.V3 version 3.5.0

### DIFF
--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.csproj
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.4.0</Version>
+    <Version>3.5.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Monitoring API, which manages your Google Cloud Monitoring data and configurations.</Description>

--- a/apis/Google.Cloud.Monitoring.V3/docs/history.md
+++ b/apis/Google.Cloud.Monitoring.V3/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 3.5.0, released 2024-01-08
+
+### New features
+
+- Added support for severity in AlertPolicy ([commit cbde75b](https://github.com/googleapis/google-cloud-dotnet/commit/cbde75b40a9be197dff4d39a9f7a1b6876936bc6))
+
+### Documentation improvements
+
+- Add value range to comment on field forecast_horizon ([commit cbde75b](https://github.com/googleapis/google-cloud-dotnet/commit/cbde75b40a9be197dff4d39a9f7a1b6876936bc6))
+
 ## Version 3.4.0, released 2023-09-18
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3245,7 +3245,7 @@
       "protoPath": "google/monitoring/v3",
       "productName": "Google Cloud Monitoring",
       "productUrl": "https://cloud.google.com/monitoring/api/v3/",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Monitoring API, which manages your Google Cloud Monitoring data and configurations.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- Added support for severity in AlertPolicy ([commit cbde75b](https://github.com/googleapis/google-cloud-dotnet/commit/cbde75b40a9be197dff4d39a9f7a1b6876936bc6))

### Documentation improvements

- Add value range to comment on field forecast_horizon ([commit cbde75b](https://github.com/googleapis/google-cloud-dotnet/commit/cbde75b40a9be197dff4d39a9f7a1b6876936bc6))
