### PR TITLE
Release Google.Cloud.Recommender.V1 version 3.4.0

### DIFF
--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.csproj
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.3.0</Version>
+    <Version>3.4.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library for the Recommender API, which provides usage recommendations for Cloud products and services.</Description>

--- a/apis/Google.Cloud.Recommender.V1/docs/history.md
+++ b/apis/Google.Cloud.Recommender.V1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 3.4.0, released 2024-01-08
+
+### New features
+
+- Support cost_in_local_currency field in the cost projection ([commit 0c726a4](https://github.com/googleapis/google-cloud-dotnet/commit/0c726a49180253efe4447dea6e07611962569fba))
+
+### Documentation improvements
+
+- Fix typo for the comment of reliability_projection ([commit 0c726a4](https://github.com/googleapis/google-cloud-dotnet/commit/0c726a49180253efe4447dea6e07611962569fba))
+- Add comment for targetResources ([commit 0c726a4](https://github.com/googleapis/google-cloud-dotnet/commit/0c726a49180253efe4447dea6e07611962569fba))
+
 ## Version 3.3.0, released 2023-09-06
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3923,7 +3923,7 @@
       "protoPath": "google/cloud/recommender/v1",
       "productName": "Google Cloud Recommender",
       "productUrl": "https://cloud.google.com/recommender/",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "type": "grpc",
       "description": "Recommended Google client library for the Recommender API, which provides usage recommendations for Cloud products and services.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Support cost_in_local_currency field in the cost projection ([commit 0c726a4](https://github.com/googleapis/google-cloud-dotnet/commit/0c726a49180253efe4447dea6e07611962569fba))

### Documentation improvements

- Fix typo for the comment of reliability_projection ([commit 0c726a4](https://github.com/googleapis/google-cloud-dotnet/commit/0c726a49180253efe4447dea6e07611962569fba))
- Add comment for targetResources ([commit 0c726a4](https://github.com/googleapis/google-cloud-dotnet/commit/0c726a49180253efe4447dea6e07611962569fba))
