### PR TITLE
Release Google.Cloud.TextToSpeech.V1 version 3.3.0

### DIFF
--- a/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.csproj
+++ b/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.2.0</Version>
+    <Version>3.3.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Text-to-Speech API v1, synthesizes natural-sounding speech by applying powerful neural network models.</Description>

--- a/apis/Google.Cloud.TextToSpeech.V1/docs/history.md
+++ b/apis/Google.Cloud.TextToSpeech.V1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 3.3.0, released 2024-01-08
+
+### Bug fixes
+
+- Correct long audio synthesis HTTP binding ([commit ce90310](https://github.com/googleapis/google-cloud-dotnet/commit/ce90310499ec80b42ec5412a0cb538a3bbe71561))
+
+### Documentation improvements
+
+- Deprecate the custom voice usage field ([commit ce90310](https://github.com/googleapis/google-cloud-dotnet/commit/ce90310499ec80b42ec5412a0cb538a3bbe71561))
+- Update documentation to require certain fields ([commit 43382af](https://github.com/googleapis/google-cloud-dotnet/commit/43382afe88bd439072507a6c4566a54f67c5f21a))
+
 ## Version 3.2.0, released 2023-01-11
 
 This is primarily a promotion of the previous beta, which includes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4928,7 +4928,7 @@
       "protoPath": "google/cloud/texttospeech/v1",
       "productName": "Google Cloud Text-to-Speech",
       "productUrl": "https://cloud.google.com/text-to-speech",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Text-to-Speech API v1, synthesizes natural-sounding speech by applying powerful neural network models.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Correct long audio synthesis HTTP binding ([commit ce90310](https://github.com/googleapis/google-cloud-dotnet/commit/ce90310499ec80b42ec5412a0cb538a3bbe71561))

### Documentation improvements

- Deprecate the custom voice usage field ([commit ce90310](https://github.com/googleapis/google-cloud-dotnet/commit/ce90310499ec80b42ec5412a0cb538a3bbe71561))
- Update documentation to require certain fields ([commit 43382af](https://github.com/googleapis/google-cloud-dotnet/commit/43382afe88bd439072507a6c4566a54f67c5f21a))
