### PR TITLE
Release Google.Maps.FleetEngine.V1 version 1.1.0

### DIFF
--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.csproj
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Maps Fleet Engine API (v1), which enables access to On Demand Rides and Deliveries and Last Mile Fleet Solutions.</Description>

--- a/apis/Google.Maps.FleetEngine.V1/docs/history.md
+++ b/apis/Google.Maps.FleetEngine.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.1.0, released 2024-01-08
+
+### New features
+
+- Add trace_id to Fleet Engine headers ([commit 1b83ab1](https://github.com/googleapis/google-cloud-dotnet/commit/1b83ab168426c889cffffd951744576042c91601))
+
 ## Version 1.0.0, released 2023-12-04
 
 No API surface changes; just dependency updates and promotion to GA.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5626,7 +5626,7 @@
     },
     {
       "id": "Google.Maps.FleetEngine.V1",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "grpc",
       "productName": "Local Rides and Deliveries",
       "productUrl": "https://developers.google.com/maps/documentation/transportation-logistics/mobility",


### PR DESCRIPTION

Changes in this release:

### New features

- Add trace_id to Fleet Engine headers ([commit 1b83ab1](https://github.com/googleapis/google-cloud-dotnet/commit/1b83ab168426c889cffffd951744576042c91601))
