### PR TITLE
chore: Use GAPIC client to delete Firestore/Datastore databases

### DIFF
--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/Google.Cloud.Datastore.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/Google.Cloud.Datastore.V1.GeneratedSnippets.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Datastore.V1\Google.Cloud.Datastore.V1.csproj" />
-    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />
     <PackageReference Include="System.Linq.Async" Version="$(SystemLinqAsyncVersion)" />

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/Google.Cloud.Datastore.V1.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/Google.Cloud.Datastore.V1.IntegrationTests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Datastore.V1\Google.Cloud.Datastore.V1.csproj" />
-    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />
     <PackageReference Include="System.Linq.Async" Version="$(SystemLinqAsyncVersion)" />

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/Google.Cloud.Datastore.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/Google.Cloud.Datastore.V1.Snippets.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Datastore.V1\Google.Cloud.Datastore.V1.csproj" />
-    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />
     <PackageReference Include="System.Linq.Async" Version="$(SystemLinqAsyncVersion)" />

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Tests/Google.Cloud.Datastore.V1.Tests.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Tests/Google.Cloud.Datastore.V1.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Datastore.V1\Google.Cloud.Datastore.V1.csproj" />
-    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />
     <PackageReference Include="System.Linq.Async" Version="$(SystemLinqAsyncVersion)" />

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/Google.Cloud.Firestore.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/Google.Cloud.Firestore.IntegrationTests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Google.Api.Gax.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Firestore\Google.Cloud.Firestore.csproj" />
-    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core.Testing" Version="[2.46.6, 3.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/Google.Cloud.Firestore.Snippets.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/Google.Cloud.Firestore.Snippets.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Google.Api.Gax.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Firestore\Google.Cloud.Firestore.csproj" />
-    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core.Testing" Version="[2.46.6, 3.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Google.Cloud.Firestore.Tests.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Google.Cloud.Firestore.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Google.Api.Gax.Testing" Version="[4.4.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Firestore\Google.Cloud.Firestore.csproj" />
-    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.5.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core.Testing" Version="[2.46.6, 3.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1763,7 +1763,7 @@
       },
       "testDependencies": {
         "Google.Api.Gax.Grpc.Testing": "4.4.0",
-        "Google.Cloud.Firestore.Admin.V1": "3.4.0"
+        "Google.Cloud.Firestore.Admin.V1": "3.5.0"
       },
       "shortName": "datastore",
       "serviceConfigFile": "datastore_v1.yaml",
@@ -2398,7 +2398,7 @@
       "testDependencies": {
         "Google.Api.Gax.Grpc.Testing": "4.4.0",
         "Google.Api.Gax.Testing": "4.4.0",
-        "Google.Cloud.Firestore.Admin.V1": "3.3.0",
+        "Google.Cloud.Firestore.Admin.V1": "3.5.0",
         "Grpc.Core.Testing": "2.46.6",
         "System.ValueTuple": "4.5.0",
         "Xunit.Combinatorial": "1.6.24"


### PR DESCRIPTION
(The functionality was released in Google.Cloud.Firestore.Admin.V1 version 3.5.0.)