### PR TITLE
Release Google.Cloud.Batch.V1Alpha version 1.0.0-alpha20

### DIFF
--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.csproj
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha19</Version>
+    <Version>1.0.0-alpha20</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Batch API (v1alpha), which allows you to manage the running of batch jobs on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Batch.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.Batch.V1Alpha/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 1.0.0-alpha20, released 2024-01-16
+
+### New features
+
+- Add `tags` field in Job's AllocationPolicy field in v1alpha ([commit c6fb071](https://github.com/googleapis/google-cloud-dotnet/commit/c6fb07199c400c06c87fa10d4864a94df48523e5))
+- Add a run_as_non_root field and deprecate enable_oslogin for non-root execution ([commit c6fb071](https://github.com/googleapis/google-cloud-dotnet/commit/c6fb07199c400c06c87fa10d4864a94df48523e5))
+
+### Documentation improvements
+
+- Updated comments ([commit c6fb071](https://github.com/googleapis/google-cloud-dotnet/commit/c6fb07199c400c06c87fa10d4864a94df48523e5))
+
 ## Version 1.0.0-alpha19, released 2023-12-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -621,7 +621,7 @@
     },
     {
       "id": "Google.Cloud.Batch.V1Alpha",
-      "version": "1.0.0-alpha19",
+      "version": "1.0.0-alpha20",
       "type": "grpc",
       "productName": "Batch",
       "productUrl": "https://cloud.google.com/batch/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add `tags` field in Job's AllocationPolicy field in v1alpha ([commit c6fb071](https://github.com/googleapis/google-cloud-dotnet/commit/c6fb07199c400c06c87fa10d4864a94df48523e5))
- Add a run_as_non_root field and deprecate enable_oslogin for non-root execution ([commit c6fb071](https://github.com/googleapis/google-cloud-dotnet/commit/c6fb07199c400c06c87fa10d4864a94df48523e5))

### Documentation improvements

- Updated comments ([commit c6fb071](https://github.com/googleapis/google-cloud-dotnet/commit/c6fb07199c400c06c87fa10d4864a94df48523e5))
