### PR TITLE
Release Google.Cloud.DataCatalog.V1 version 2.8.0

### DIFF
--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.csproj
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.7.0</Version>
+    <Version>2.8.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Data Catalog API. Data Catalog is a fully managed and highly scalable data discovery and metadata management service.</Description>

--- a/apis/Google.Cloud.DataCatalog.V1/docs/history.md
+++ b/apis/Google.Cloud.DataCatalog.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.8.0, released 2024-01-16
+
+### Bug fixes
+
+- Change field behavior of the property "name" to IDENTIFIER ([commit 093f27c](https://github.com/googleapis/google-cloud-dotnet/commit/093f27c1285516f85ebb81be4c10753deefd42d4))
+
 ## Version 2.7.0, released 2023-10-02
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1543,7 +1543,7 @@
       "protoPath": "google/cloud/datacatalog/v1",
       "productName": "Data Catalog",
       "productUrl": "https://cloud.google.com/data-catalog/docs",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Data Catalog API. Data Catalog is a fully managed and highly scalable data discovery and metadata management service.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Change field behavior of the property "name" to IDENTIFIER ([commit 093f27c](https://github.com/googleapis/google-cloud-dotnet/commit/093f27c1285516f85ebb81be4c10753deefd42d4))
