### PR TITLE
Release Google.Cloud.Deploy.V1 version 2.12.0

### DIFF
--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.csproj
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.11.0</Version>
+    <Version>2.12.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Deploy API, which automates delivery of your applications to a series of target environments in a defined sequence.</Description>

--- a/apis/Google.Cloud.Deploy.V1/docs/history.md
+++ b/apis/Google.Cloud.Deploy.V1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 2.12.0, released 2024-01-16
+
+### New features
+
+- Add stable cutback duration configuration to the k8s gateway service mesh deployment strategy. This allows configuring the amount of time to migrate traffic back to the original Service in the stable phase ([commit 86ff329](https://github.com/googleapis/google-cloud-dotnet/commit/86ff329170bcede92ce7e5e9c9eb29b802e13e0f))
+- Updated logging protos with new fields ([commit 86ff329](https://github.com/googleapis/google-cloud-dotnet/commit/86ff329170bcede92ce7e5e9c9eb29b802e13e0f))
+
+### Documentation improvements
+
+- Fixed a number of comments ([commit 86ff329](https://github.com/googleapis/google-cloud-dotnet/commit/86ff329170bcede92ce7e5e9c9eb29b802e13e0f))
+
 ## Version 2.11.0, released 2023-12-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1822,7 +1822,7 @@
     },
     {
       "id": "Google.Cloud.Deploy.V1",
-      "version": "2.11.0",
+      "version": "2.12.0",
       "type": "grpc",
       "productName": "Google Cloud Deploy",
       "productUrl": "https://cloud.google.com/deploy/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add stable cutback duration configuration to the k8s gateway service mesh deployment strategy. This allows configuring the amount of time to migrate traffic back to the original Service in the stable phase ([commit 86ff329](https://github.com/googleapis/google-cloud-dotnet/commit/86ff329170bcede92ce7e5e9c9eb29b802e13e0f))
- Updated logging protos with new fields ([commit 86ff329](https://github.com/googleapis/google-cloud-dotnet/commit/86ff329170bcede92ce7e5e9c9eb29b802e13e0f))

### Documentation improvements

- Fixed a number of comments ([commit 86ff329](https://github.com/googleapis/google-cloud-dotnet/commit/86ff329170bcede92ce7e5e9c9eb29b802e13e0f))
