### PR TITLE
fix: Fix Firestore build, which still depends on ResourcePrefixHeader

### DIFF
--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/FirestoreClientPartial.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/FirestoreClientPartial.cs
@@ -37,6 +37,25 @@ namespace Google.Cloud.Firestore.V1
         }
     }
 
+    // Partial class to set up resource-based routing.
+    public partial class FirestoreClientImpl
+    {
+        /// <summary>
+        /// The name of the header used for efficiently routing requests.
+        /// </summary>
+        /// <remarks>
+        /// This should be set to the database resource name ("projects/{projectId}/databases/{databaseId}") for any RPC.
+        /// For non-streaming calls, <see cref="FirestoreClientImpl"/> performs this automatically. This cannot be performed
+        /// automatically for streaming calls due to the separation between initializing the stream and sending requests, so
+        /// client code should set the value in a <see cref="CallSettings"/>. Typically this is performed with either the
+        /// <see cref="CallSettings.FromHeader(string, string)"/> factory method or the
+        /// <see cref="CallSettingsExtensions.WithHeader(CallSettings, string, string)"/> extension method.
+        /// </remarks>
+        [Obsolete("This header is obsolete; x-goog-request-params should now be used instead. " +
+            "This constant will be removed in a future version")]
+        public const string ResourcePrefixHeader = "google-cloud-resource-prefix";
+    }
+
     // Support for FirestoreDbBuilder.
     public sealed partial class FirestoreClientBuilder : ClientBuilderBase<FirestoreClient>
     {

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/WatchStreamTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/WatchStreamTest.cs
@@ -478,7 +478,9 @@ namespace Google.Cloud.Firestore.Tests
             {
                 var metadata = new Metadata();
                 callSettings.HeaderMutation?.Invoke(metadata);
+#pragma warning disable CS0618 // Type or member is obsolete
                 var resourcePrefixHeader = metadata.FirstOrDefault(entry => entry.Key == FirestoreClientImpl.ResourcePrefixHeader);
+#pragma warning restore CS0618 // Type or member is obsolete
                 Assert.NotNull(resourcePrefixHeader);
                 Assert.Equal(_expectedResourceName, resourcePrefixHeader.Value);
                 return _streams[_index++];

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/WatchStream.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/WatchStream.cs
@@ -73,7 +73,11 @@ namespace Google.Cloud.Firestore
             _db = db;
             _callbackCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             _networkCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(_callbackCancellationTokenSource.Token);
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            // TODO(b/320595510): Use x-goog-request-params (which will be easier after a new GAX release)
             _listenCallSettings = CallSettings.FromHeader(FirestoreClientImpl.ResourcePrefixHeader, db.RootPath);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             // TODO: Make these configurable?
             _backoffSettings = RetrySettings.FromExponentialBackoff(


### PR DESCRIPTION
This makes the constant obsolete, but continues to use it in WatchStream for now. When we've had the next GAX release and consulted with the Firestore team, we should remove its use from WatchStream (but keep it in FirestoreClientImpl until the next major release).