### PR TITLE
feat: All BatchGetDocuments RPCs to have customized retry settiings (per-FirestoreDb)

### DIFF
--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/FirestoreDbBuilder.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/FirestoreDbBuilder.cs
@@ -45,6 +45,12 @@ namespace Google.Cloud.Firestore
         public FirestoreSettings Settings { get; set; }
 
         /// <summary>
+        /// The settings to use for BatchGetDocuments RPCs (used by all methods that get document snapshots),
+        /// or null for the default settings.
+        /// </summary>
+        public RetrySettings BatchGetDocumentsRetrySettings { get; set; }
+
+        /// <summary>
         /// The ID of the Google Cloud project that contains the database. May be null, in which case
         /// the project will be automatically detected if possible.
         /// </summary>
@@ -137,7 +143,7 @@ namespace Google.Cloud.Firestore
             throw new InvalidOperationException($"This method should never execute in {nameof(FirestoreDbBuilder)}");
 
         private FirestoreDb BuildFromClient(string projectId, FirestoreClient client) =>
-            FirestoreDb.Create(projectId, DatabaseId, client, WarningLogger, ConverterRegistry);
+            FirestoreDb.Create(projectId, DatabaseId, client, WarningLogger, ConverterRegistry, BatchGetDocumentsRetrySettings);
 
         /// <summary>
         /// Returns the effective settings for a new client, including the "gccl" version header.

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/RetryHelper.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/RetryHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2019, Google LLC
+// Copyright 2019, Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,10 +28,10 @@ namespace Google.Cloud.Firestore
     internal static class RetryHelper
     {
         internal static async Task<TResponse> Retry<TRequest, TResponse>(
+            RetrySettings retrySettings,
             Func<TRequest, CallSettings, Task<TResponse>> fn,
             TRequest request, CallSettings callSettings, IClock clock, IScheduler scheduler)
         {
-            RetrySettings retrySettings = callSettings.Retry;
             if (retrySettings == null)
             {
                 return await fn(request, callSettings).ConfigureAwait(false);


### PR DESCRIPTION
fix: Use FirestoreSettings.BatchGetDocuments for batch timing

This will change the default timeout from 10 minutes to 5 minutes, but that will bring us in line with other clients. Any customer observing problems after this change can manually set the timeout in FirestoreSettings. I regard this as a "sufficiently safe" (but still *potentially* breaking) change to not merit a new major version.

Fixes #11322.

(While it would be nice to have per-RPC settings, that's probably too niche a requirement to be worth the API surface upheaval, at least for now.)