### PR TITLE
feat: Add configurable retry timing for RunTransactionAsync

### DIFF
--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/TransactionTestingClient.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/TransactionTestingClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2017, Google Inc. All rights reserved.
+// Copyright 2017, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -57,9 +57,9 @@ namespace Google.Cloud.Firestore.Tests
         /// <summary>
         /// Creates a client which will respond to the first <paramref name="failures"/> commit calls with <paramref name="exception"/>.
         /// </summary>
-        public TransactionTestingClient(int failures, Exception exception)
+        public TransactionTestingClient(int failures, Exception exception, FirestoreSettings settings = null)
         {
-            Settings = FirestoreSettings.GetDefault();
+            Settings = settings ?? FirestoreSettings.GetDefault();
             _failures = failures;
             _exception = exception;
         }


### PR DESCRIPTION
There are further changes to come in terms of transaction retry, but this is at least a start. Note that this changes the default backoff from "none at all" to "100ms initial, with a multiplier of 1.3". That's a more reasonable default, and it seems unlikely that customers would actually *depend* on there being no backoff.

Fixes #10513