### PR TITLE
Release Google.Cloud.DataQnA.V1Alpha version 2.0.0-alpha02

### DIFF
--- a/apis/Google.Cloud.DataQnA.V1Alpha/Google.Cloud.DataQnA.V1Alpha/Google.Cloud.DataQnA.V1Alpha.csproj
+++ b/apis/Google.Cloud.DataQnA.V1Alpha/Google.Cloud.DataQnA.V1Alpha/Google.Cloud.DataQnA.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha01</Version>
+    <Version>2.0.0-alpha02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Data QnA API (v1alpha) which is a natural language question and answer service for BigQuery data.</Description>

--- a/apis/Google.Cloud.DataQnA.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.DataQnA.V1Alpha/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+## Version 2.0.0-alpha02, released 2024-01-24
+
+This release is being used to publish a new front-page of
+documentation, to indicate package deprecation.
+
 ## Version 2.0.0-alpha01, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/Google.Cloud.DataQnA.V1Alpha/docs/index.md
+++ b/apis/Google.Cloud.DataQnA.V1Alpha/docs/index.md
@@ -2,14 +2,10 @@
 
 {{description}}
 
-{{version}}
+The DataQnA API is officially deprecated.
 
-{{installation}}
-
-{{auth}}
-
-## Getting started
-
-{{client-classes}}
-
-{{client-construction}}
+The Google.Cloud.DataQnA.V1Alpha package is delisted from NuGet,
+and the source code removed from the google-cloud-dotnet repository.
+Any projects that depend on the package will still be
+able to restore that dependency, but the package won't be shown in
+search results on [nuget.org](https://www.nuget.org/).

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1607,7 +1607,7 @@
     },
     {
       "id": "Google.Cloud.DataQnA.V1Alpha",
-      "version": "2.0.0-alpha01",
+      "version": "2.0.0-alpha02",
       "type": "grpc",
       "productName": "Data QnA",
       "productUrl": "https://cloud.google.com/bigquery/docs/dataqna",


### PR DESCRIPTION

Changes in this release:

This release is being used to publish a new front-page of documentation, to indicate package deprecation.
