### PR TITLE
chore: Update generator, protoc and gRPC versions

### DIFF
--- a/apis/Google.Cloud.Channel.V1/postgeneration.sh
+++ b/apis/Google.Cloud.Channel.V1/postgeneration.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -e
-
-# Suppress deprecation warnings in generated gRPC code.
-# We should be able to remove this after upgrading to gRPC generator
-# 2.56.0 or higher.
-
-sed -i 's/^#pragma warning disable 0414, 1591, 8981$/#pragma warning disable 0414, 1591, 8981, 0612/g' Google.Cloud.Channel.V1/ReportsServiceGrpc.g.cs

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/postgeneration.sh
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/postgeneration.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -e
-
-# Ignore deprecation in the generated gRPC code
-sed -i 's/#pragma warning disable/#pragma warning disable 0612,/g' Google.Cloud.Dialogflow.V2Beta1/ParticipantGrpc.g.cs

--- a/apis/Google.Cloud.OsConfig.V1Alpha/postgeneration.sh
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/postgeneration.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -e
-
-# Suppress deprecation warnings in generated gRPC code.
-# (If this becomes a common problem, we'll want a more robust fix.
-# It'll do for now.)
-
-sed -i 's/^#pragma warning disable 0414, 1591, 8981$/#pragma warning disable 0414, 1591, 8981, 0612/g' Google.Cloud.OsConfig.V1Alpha/OsconfigZonalServiceGrpc.g.cs

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/postgeneration.sh
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/postgeneration.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -e
-
-# Suppress deprecation warnings in generated gRPC code.
-# (If this becomes a common problem, we'll want a more robust fix.
-# It'll do for now.)
-
-sed -i 's/^#pragma warning disable 0414, 1591, 8981$/#pragma warning disable 0414, 1591, 8981, 0612/g' Google.Maps.FleetEngine.Delivery.V1/DeliveryApiGrpc.g.cs

--- a/apis/Google.Maps.FleetEngine.V1/postgeneration.sh
+++ b/apis/Google.Maps.FleetEngine.V1/postgeneration.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -e
-
-# Suppress deprecation warnings in generated gRPC code.
-# (If this becomes a common problem, we'll want a more robust fix.
-# It'll do for now.)
-
-sed -i 's/^#pragma warning disable 0414, 1591, 8981$/#pragma warning disable 0414, 1591, 8981, 0612/g' Google.Maps.FleetEngine.V1/VehicleApiGrpc.g.cs

--- a/toolversions.sh
+++ b/toolversions.sh
@@ -11,9 +11,9 @@ declare -r TOOL_PACKAGES=$REPO_ROOT/packages
 
 declare -r DOTCOVER_VERSION=2019.3.4
 declare -r REPORTGENERATOR_VERSION=2.4.5.0
-declare -r PROTOC_VERSION=3.23.1
-declare -r GRPC_VERSION=2.54.0
-declare -r GAPIC_GENERATOR_VERSION=1.4.20
+declare -r PROTOC_VERSION=3.25.2
+declare -r GRPC_VERSION=2.60.0
+declare -r GAPIC_GENERATOR_VERSION=1.4.24
 
 # Tools that only run under Windows (at the moment)
 declare -r DOTCOVER=$TOOL_PACKAGES/JetBrains.dotCover.CommandLineTools.$DOTCOVER_VERSION/tools/dotCover.exe


### PR DESCRIPTION
This change renders five of our postgeneration scripts redundant.

Fixes #10768

(This anticipates a generator version of 1.4.24; that doesn't exist quite yet.)

Once the generator is released and this is merged, we can regenerate everything, revert AI Platform changes (it still needs fixes) and then just not merge OwlBot PRs until we update versions there too.