### PR TITLE
Release Google.Cloud.Datastore.V1 version 4.7.0

### DIFF
--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.7.0-beta03</Version>
+    <Version>4.7.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Datastore API, which accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.</Description>

--- a/apis/Google.Cloud.Datastore.V1/docs/history.md
+++ b/apis/Google.Cloud.Datastore.V1/docs/history.md
@@ -1,5 +1,18 @@
 # Version history
 
+## Version 4.7.0, released 2024-01-30
+
+### New features
+
+Multiple database support is now GA.
+
+### Bug fixes (from beta)
+
+- The new features released in 4.7.0-beta03 have been removed. This
+  is a breaking change, but the features were never available to
+  customers in terms of server interactions (only protos) and were
+  not published in a stable release.
+
 ## Version 4.7.0-beta03, released 2024-01-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1729,7 +1729,7 @@
       "protoPath": "google/datastore/v1",
       "productName": "Google Cloud Datastore",
       "productUrl": "https://cloud.google.com/datastore/docs/concepts/overview",
-      "version": "4.7.0-beta03",
+      "version": "4.7.0",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Datastore API, which accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.",


### PR DESCRIPTION

Changes in this release:

### New features

Multiple database support is now GA.

### Bug fixes (from beta)

- The new features released in 4.7.0-beta03 have been removed. This
  is a breaking change, but the features were never available to
  customers in terms of server interactions (only protos) and were
  not published in a stable release.
