### PR TITLE
Release Google.Cloud.Language.V1 version 3.4.0

### DIFF
--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.Snippets/LanguageServiceClientSnippets.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.Snippets/LanguageServiceClientSnippets.cs
@@ -138,21 +138,11 @@ namespace Google.Cloud.Language.V1.Snippets
             Skip.If(string.IsNullOrEmpty(apiKey));
 
             // Sample: ApiKey
-            // Create a LanguageServiceSettings that applies the X-Goog-Api-Key
-            // header on every request
-            LanguageServiceSettings settings = new LanguageServiceSettings
-            {
-                CallSettings = CallSettings.FromHeader("X-Goog-Api-Key", apiKey)
-            };
-
-            // Create a LanguageServiceClient which uses the settings to apply
-            // the API key to every request. The ChannelCredentials are set to
-            // just SSL; we don't authenticate at the channel level when
-            // applying API keys.
+            // Create a LanguageServiceClient which uses the given API key
+            // instead of regular credentials.
             LanguageServiceClient client = new LanguageServiceClientBuilder
             {
-                ChannelCredentials = ChannelCredentials.SecureSsl,
-                Settings = settings
+                ApiKey = apiKey
             }.Build();
 
             // After creating the client with an API key configured, we can use it

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/Google.Cloud.Language.V1.csproj
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/Google.Cloud.Language.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.3.0</Version>
+    <Version>3.4.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Natural Language API (v1), which provides natural language understanding technologies to developers. Examples include sentiment analysis, entity recognition, and text annotations.</Description>

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/LanguageServiceClientBuilderPartial.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/LanguageServiceClientBuilderPartial.cs
@@ -1,0 +1,34 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Google.Cloud.Language.V1;
+
+// Support for API keys
+
+public partial class LanguageServiceClientBuilder
+{
+    /// <summary>
+    /// An API key to use instead of an authenticated credential.
+    /// When this is set, no other credential-related properties should be set.
+    /// </summary>
+    public new string ApiKey
+    {
+        get => base.ApiKey;
+        set => base.ApiKey = value;
+    }
+}

--- a/apis/Google.Cloud.Language.V1/docs/history.md
+++ b/apis/Google.Cloud.Language.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.4.0, released 2024-01-30
+
+### New features
+
+- Support API keys directly in the Language library ([commit 33aad2c](https://github.com/googleapis/google-cloud-dotnet/commit/33aad2ce86593aedf4ee4073952227bb82d35d38))
+
 ## Version 3.3.0, released 2023-05-26
 
 ### New features

--- a/apis/Google.Cloud.Language.V1/docs/index.md
+++ b/apis/Google.Cloud.Language.V1/docs/index.md
@@ -47,9 +47,8 @@ you can specify a Google Cloud Storage URI.
 The Cloud Language API supports [API
 keys](https://cloud.google.com/docs/authentication/api-keys) as an
 alternative to regular authentication. The Google.Cloud.Language.V1
-library can be configured to supply the API key in the
-`X-Goog-Api-Key` header. Note that when specifying an API key, the
-gRPC channel should use plain SSL without including any Cloud
-authentication information, as demonstrated in the sample below.
+library can be configured to use an API key instead of any other
+credentials, by setting the `ApiKey` property in the client builder,
+as shown below.
 
 {{sample:LanguageServiceClient.ApiKey}}

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2844,7 +2844,7 @@
       "protoPath": "google/cloud/language/v1",
       "productName": "Google Cloud Natural Language",
       "productUrl": "https://cloud.google.com/natural-language",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Natural Language API (v1), which provides natural language understanding technologies to developers. Examples include sentiment analysis, entity recognition, and text annotations.",
       "dependencies": {

--- a/docs/devsite-help/client-configuration.md
+++ b/docs/devsite-help/client-configuration.md
@@ -55,12 +55,25 @@ properties, and are rarely as useful as the ones above.
 ### API Keys
 
 Most Cloud APIs do not support API keys, instead requiring full credentials as described above. For this
-reason, the client libraries do not have *direct* support for API keys, but API keys can still be used
-for those APIs which support them. The API key should be specified in the `X-Goog-Api-Key` header on
-every request, and the gRPC channel should be built using `ChannelCredentials.SecureSsl`. For example,
-to create a client for the Language API using an API key, you could use the following code:
+reason, most client libraries do not have *direct* support for API keys, but API keys can still be used
+for those APIs which support them.
 
-[!code-cs[](../examples/help.Configuration.txt#ApiKey)]
+Where we are aware that API keys are supported, the client builder
+exposes an `ApiKey` property which can be set, leaving all other
+credential-related properties unset. For example, you can create a
+client for the Language API using an API key like this:
+
+[!code-cs[](../examples/help.Configuration.txt#ApiKey_Simple)]
+
+If you're using a library which doesn't expose an `ApiKey` property
+in the builder, but you wish to set one anyway, you can specify the
+API key in the `X-Goog-Api-Key` header on every request.
+Additionally, the gRPC channel should be built using
+`ChannelCredentials.SecureSsl`. For example, to manually specify the
+API key in a Language client (instead of using the built-in support)
+you could write code like this:
+
+[!code-cs[](../examples/help.Configuration.txt#ApiKey_Manual)]
 
 After building the client, it can be used like any other client.
 

--- a/tools/Google.Cloud.Docs.Snippets/ConfigurationSnippets.cs
+++ b/tools/Google.Cloud.Docs.Snippets/ConfigurationSnippets.cs
@@ -24,7 +24,24 @@ public class ConfigurationSnippets
     // Note: If you change this sample, please also change the sample
     // in Google.Cloud.Language.V1.Snippets.
     [Fact]
-    public void LanguageApiKey()
+    public void LanguageApiKey_Simple()
+    {
+        string apiKey = "some-api-key";
+
+        // Sample: ApiKey
+        // Create a LanguageServiceClient which uses the given API key
+        // instead of regular credentials.
+        LanguageServiceClient client = new LanguageServiceClientBuilder
+        {
+            ApiKey = apiKey
+        }.Build();
+        // End sample
+
+        Assert.NotNull(client);
+    }
+
+    [Fact]
+    public void LanguageApiKey_Manual()
     {
         string apiKey = "some-api-key";
 


### PR DESCRIPTION

Changes in this release:

### New features

- Support API keys directly in the Language library ([commit 33aad2c](https://github.com/googleapis/google-cloud-dotnet/commit/33aad2ce86593aedf4ee4073952227bb82d35d38))
