### PR TITLE
Release Google.Cloud.VmwareEngine.V1 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.csproj
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google VMware Engine API, which lets you programmatically manage VMware environments.</Description>

--- a/apis/Google.Cloud.VmwareEngine.V1/docs/history.md
+++ b/apis/Google.Cloud.VmwareEngine.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 1.1.0, released 2024-02-07
+
+### New features
+
+- Adding ManagementDnsZoneBinding, DnsBindPermission, DnsForwarding, ExternalAccessRule, ExternalAddress, LoggingServer, NetworkPeering, Node and stretched PC features ([commit 11e1be8](https://github.com/googleapis/google-cloud-dotnet/commit/11e1be85ad44b9ba4ef2178c50bd8a6b7a424cf1))
+
+### Documentation improvements
+
+- Clarified wording around private cloud and update cluster ([commit 11e1be8](https://github.com/googleapis/google-cloud-dotnet/commit/11e1be85ad44b9ba4ef2178c50bd8a6b7a424cf1))
+
 ## Version 1.0.0, released 2023-11-01
 
 No API surface changes; just dependency updates and promotion to GA.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5235,7 +5235,7 @@
     },
     {
       "id": "Google.Cloud.VmwareEngine.V1",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "grpc",
       "productName": "VMware Engine",
       "productUrl": "https://cloud.google.com/vmware-engine/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Adding ManagementDnsZoneBinding, DnsBindPermission, DnsForwarding, ExternalAccessRule, ExternalAddress, LoggingServer, NetworkPeering, Node and stretched PC features ([commit 11e1be8](https://github.com/googleapis/google-cloud-dotnet/commit/11e1be85ad44b9ba4ef2178c50bd8a6b7a424cf1))

### Documentation improvements

- Clarified wording around private cloud and update cluster ([commit 11e1be8](https://github.com/googleapis/google-cloud-dotnet/commit/11e1be85ad44b9ba4ef2178c50bd8a6b7a424cf1))
