### PR TITLE
Release Google.Analytics.Admin.V1Alpha version 2.0.0-alpha16

### DIFF
--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha15</Version>
+    <Version>2.0.0-alpha16</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Analytics Admin API (v1alpha)</Description>

--- a/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
+++ b/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
@@ -1,5 +1,14 @@
 # Version history
 
+## Version 2.0.0-alpha16, released 2024-02-08
+
+### New features
+
+- Add `GetCalculatedMetric`, `CreateCalculatedMetric`, `ListCalculatedMetrics`, `UpdateCalculatedMetric`, `DeleteCalculatedMetric` methods to the Admin API v1alpha ([commit 7e182b3](https://github.com/googleapis/google-cloud-dotnet/commit/7e182b31f53fef45ab151247c672a4a70a825138))
+- Add the `CALCULATED_METRIC` option to the `ChangeHistoryResourceType` enum ([commit 7e182b3](https://github.com/googleapis/google-cloud-dotnet/commit/7e182b31f53fef45ab151247c672a4a70a825138))
+- Add the `calculated_metric` field to the `ChangeHistoryResource.resource` oneof field ([commit 7e182b3](https://github.com/googleapis/google-cloud-dotnet/commit/7e182b31f53fef45ab151247c672a4a70a825138))
+- Add the `CalculatedMetric` resource ([commit 7e182b3](https://github.com/googleapis/google-cloud-dotnet/commit/7e182b31f53fef45ab151247c672a4a70a825138))
+
 ## Version 2.0.0-alpha15, released 2024-01-08
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2,7 +2,7 @@
   "apis": [
     {
       "id": "Google.Analytics.Admin.V1Alpha",
-      "version": "2.0.0-alpha15",
+      "version": "2.0.0-alpha16",
       "type": "grpc",
       "productName": "Analytics Admin",
       "productUrl": "https://developers.google.com/analytics",


### PR DESCRIPTION

Changes in this release:

### New features

- Add `GetCalculatedMetric`, `CreateCalculatedMetric`, `ListCalculatedMetrics`, `UpdateCalculatedMetric`, `DeleteCalculatedMetric` methods to the Admin API v1alpha ([commit 7e182b3](https://github.com/googleapis/google-cloud-dotnet/commit/7e182b31f53fef45ab151247c672a4a70a825138))
- Add the `CALCULATED_METRIC` option to the `ChangeHistoryResourceType` enum ([commit 7e182b3](https://github.com/googleapis/google-cloud-dotnet/commit/7e182b31f53fef45ab151247c672a4a70a825138))
- Add the `calculated_metric` field to the `ChangeHistoryResource.resource` oneof field ([commit 7e182b3](https://github.com/googleapis/google-cloud-dotnet/commit/7e182b31f53fef45ab151247c672a4a70a825138))
- Add the `CalculatedMetric` resource ([commit 7e182b3](https://github.com/googleapis/google-cloud-dotnet/commit/7e182b31f53fef45ab151247c672a4a70a825138))
