### PR TITLE
Release Google.Cloud.AIPlatform.V1 version 2.22.0

### DIFF
--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.21.0</Version>
+    <Version>2.22.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AI Platform API, which allows you to train high-quality custom machine learning models with minimal machine learning expertise and effort.</Description>

--- a/apis/Google.Cloud.AIPlatform.V1/docs/history.md
+++ b/apis/Google.Cloud.AIPlatform.V1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 2.22.0, released 2024-02-08
+
+### New features
+
+- Add SearchNearestEntities rpc to FeatureOnlineStoreService in aiplatform v1 ([commit 2572a76](https://github.com/googleapis/google-cloud-dotnet/commit/2572a7605aaf4d4270ef12d900e4580c6ad08ff8))
+- Add generateContent Unary API for aiplatform_v1 ([commit d0ece95](https://github.com/googleapis/google-cloud-dotnet/commit/d0ece9564685912690966b80fb05b533ca2ae3b8))
+
+### Documentation improvements
+
+- Update comment for DirectPredict and DirectRawPredict ([commit d0ece95](https://github.com/googleapis/google-cloud-dotnet/commit/d0ece9564685912690966b80fb05b533ca2ae3b8))
+
 ## Version 2.21.0, released 2024-01-31
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -280,7 +280,7 @@
     },
     {
       "id": "Google.Cloud.AIPlatform.V1",
-      "version": "2.21.0",
+      "version": "2.22.0",
       "type": "grpc",
       "productName": "Cloud AI Platform",
       "productUrl": "https://cloud.google.com/ai-platform/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add SearchNearestEntities rpc to FeatureOnlineStoreService in aiplatform v1 ([commit 2572a76](https://github.com/googleapis/google-cloud-dotnet/commit/2572a7605aaf4d4270ef12d900e4580c6ad08ff8))
- Add generateContent Unary API for aiplatform_v1 ([commit d0ece95](https://github.com/googleapis/google-cloud-dotnet/commit/d0ece9564685912690966b80fb05b533ca2ae3b8))

### Documentation improvements

- Update comment for DirectPredict and DirectRawPredict ([commit d0ece95](https://github.com/googleapis/google-cloud-dotnet/commit/d0ece9564685912690966b80fb05b533ca2ae3b8))
