### PR TITLE
Release Google.Cloud.Batch.V1 version 2.7.0

### DIFF
--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.csproj
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Batch API (v1), which allows you to manage the running of batch jobs on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Batch.V1/docs/history.md
+++ b/apis/Google.Cloud.Batch.V1/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 2.7.0, released 2024-02-08
+
+### New features
+
+- Add `run_as_non_root` field to allow user's runnable be executed as non root ([commit 7529915](https://github.com/googleapis/google-cloud-dotnet/commit/7529915e746cb6831a93ae0b6ca7a2a929dab233))
+- Add `tags` field in Job's AllocationPolicy field in v1 ([commit 7529915](https://github.com/googleapis/google-cloud-dotnet/commit/7529915e746cb6831a93ae0b6ca7a2a929dab233))
+- Add Batch Image Streaming support for v1 ([commit 7529915](https://github.com/googleapis/google-cloud-dotnet/commit/7529915e746cb6831a93ae0b6ca7a2a929dab233))
+
+### Documentation improvements
+
+- Polish the field descriptions for enableImageStreaming and CloudLoggingOptions ([commit 7529915](https://github.com/googleapis/google-cloud-dotnet/commit/7529915e746cb6831a93ae0b6ca7a2a929dab233))
+
 ## Version 2.6.0, released 2023-12-05
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -615,7 +615,7 @@
     },
     {
       "id": "Google.Cloud.Batch.V1",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "type": "grpc",
       "productName": "Batch",
       "productUrl": "https://cloud.google.com/batch/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add `run_as_non_root` field to allow user's runnable be executed as non root ([commit 7529915](https://github.com/googleapis/google-cloud-dotnet/commit/7529915e746cb6831a93ae0b6ca7a2a929dab233))
- Add `tags` field in Job's AllocationPolicy field in v1 ([commit 7529915](https://github.com/googleapis/google-cloud-dotnet/commit/7529915e746cb6831a93ae0b6ca7a2a929dab233))
- Add Batch Image Streaming support for v1 ([commit 7529915](https://github.com/googleapis/google-cloud-dotnet/commit/7529915e746cb6831a93ae0b6ca7a2a929dab233))

### Documentation improvements

- Polish the field descriptions for enableImageStreaming and CloudLoggingOptions ([commit 7529915](https://github.com/googleapis/google-cloud-dotnet/commit/7529915e746cb6831a93ae0b6ca7a2a929dab233))
