### PR TITLE
Release Google.Cloud.Batch.V1Alpha version 1.0.0-alpha21

### DIFF
--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.csproj
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha20</Version>
+    <Version>1.0.0-alpha21</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Batch API (v1alpha), which allows you to manage the running of batch jobs on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Batch.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.Batch.V1Alpha/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 1.0.0-alpha21, released 2024-02-08
+
+### Bug fixes
+
+- **BREAKING CHANGE** Remove deprecated field enableOslogin ([commit 1531c7e](https://github.com/googleapis/google-cloud-dotnet/commit/1531c7e3583a7d79a410bc09269a457397300ea9))
+
+### Documentation improvements
+
+- Polish the field descriptions for enableImageStreaming and CloudLoggingOptions ([commit 5570490](https://github.com/googleapis/google-cloud-dotnet/commit/5570490e3463093b35864e64ff7b1187a50546f3))
+
 ## Version 1.0.0-alpha20, released 2024-01-16
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -640,7 +640,7 @@
     },
     {
       "id": "Google.Cloud.Batch.V1Alpha",
-      "version": "1.0.0-alpha20",
+      "version": "1.0.0-alpha21",
       "type": "grpc",
       "productName": "Batch",
       "productUrl": "https://cloud.google.com/batch/docs/",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- **BREAKING CHANGE** Remove deprecated field enableOslogin ([commit 1531c7e](https://github.com/googleapis/google-cloud-dotnet/commit/1531c7e3583a7d79a410bc09269a457397300ea9))

### Documentation improvements

- Polish the field descriptions for enableImageStreaming and CloudLoggingOptions ([commit 5570490](https://github.com/googleapis/google-cloud-dotnet/commit/5570490e3463093b35864e64ff7b1187a50546f3))
