### PR TITLE
Release Google.Cloud.Bigtable.V2 version 3.10.0-beta01

### DIFF
--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.10.0-beta00</Version>
+    <Version>3.10.0-beta01</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Bigtable API.</Description>

--- a/apis/Google.Cloud.Bigtable.V2/docs/history.md
+++ b/apis/Google.Cloud.Bigtable.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.10.0-beta01, released 2024-02-08
+
+### New features
+
+- Bigtable supports universe domain ([commit c3610f9](https://github.com/googleapis/google-cloud-dotnet/commit/c3610f97235f1582376e3a124b9531dc01a43a77))
+
 ## Version 3.9.0, released 2024-01-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1044,7 +1044,7 @@
       "protoPath": "google/bigtable/v2",
       "productName": "Google Bigtable",
       "productUrl": "https://cloud.google.com/bigtable/",
-      "version": "3.10.0-beta00",
+      "version": "3.10.0-beta01",
       "commonResourcesConfig": "apis/Google.Cloud.Bigtable.Common.V2/CommonResourcesConfig.json",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",


### PR DESCRIPTION

Changes in this release:

### New features

- Bigtable supports universe domain ([commit c3610f9](https://github.com/googleapis/google-cloud-dotnet/commit/c3610f97235f1582376e3a124b9531dc01a43a77))
