### PR TITLE
Release Google.Cloud.Compute.V1 version 2.13.0

### DIFF
--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.12.0</Version>
+    <Version>2.13.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Compute Engine API.</Description>

--- a/apis/Google.Cloud.Compute.V1/docs/history.md
+++ b/apis/Google.Cloud.Compute.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.13.0, released 2024-02-08
+
+### New features
+
+- Update Compute Engine API to revision 20240130 ([issue 881](https://github.com/googleapis/google-cloud-dotnet/issues/881)) ([commit f265ab6](https://github.com/googleapis/google-cloud-dotnet/commit/f265ab6a4e138a1285a4730288fbbf62f0938730))
+
 ## Version 2.12.0, released 2023-12-11
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1363,7 +1363,7 @@
     },
     {
       "id": "Google.Cloud.Compute.V1",
-      "version": "2.12.0",
+      "version": "2.13.0",
       "type": "regapic",
       "productName": "Compute Engine",
       "productUrl": "https://cloud.google.com/compute",


### PR DESCRIPTION

Changes in this release:

### New features

- Update Compute Engine API to revision 20240130 ([issue 881](https://github.com/googleapis/google-cloud-dotnet/issues/881)) ([commit f265ab6](https://github.com/googleapis/google-cloud-dotnet/commit/f265ab6a4e138a1285a4730288fbbf62f0938730))
