### PR TITLE
Release Google.Cloud.Container.V1 version 3.21.0

### DIFF
--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.20.0</Version>
+    <Version>3.21.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.</Description>

--- a/apis/Google.Cloud.Container.V1/docs/history.md
+++ b/apis/Google.Cloud.Container.V1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 3.21.0, released 2024-02-08
+
+### New features
+
+- Added configuration for the StatefulHA addon to the AddonsConfig ([commit 8372d78](https://github.com/googleapis/google-cloud-dotnet/commit/8372d78ce1752529bcb1e98a6a9f801f20f18929))
+- Add fields desired_in_transit_encryption_config and in_transit_encryption_config ([commit 3995d17](https://github.com/googleapis/google-cloud-dotnet/commit/3995d1733e2d50c0a72826988b3f102e8b9c41ba))
+
+### Documentation improvements
+
+- Remove Not GA comments for GetOpenIDConfig and GetJSONWebKeys in v1alpha1/v1beta1/v1 ([commit 3995d17](https://github.com/googleapis/google-cloud-dotnet/commit/3995d1733e2d50c0a72826988b3f102e8b9c41ba))
+
 ## Version 3.20.0, released 2023-12-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1515,7 +1515,7 @@
       "protoPath": "google/container/v1",
       "productName": "Google Kubernetes Engine",
       "productUrl": "https://cloud.google.com/kubernetes-engine/docs/reference/rest/",
-      "version": "3.20.0",
+      "version": "3.21.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Added configuration for the StatefulHA addon to the AddonsConfig ([commit 8372d78](https://github.com/googleapis/google-cloud-dotnet/commit/8372d78ce1752529bcb1e98a6a9f801f20f18929))
- Add fields desired_in_transit_encryption_config and in_transit_encryption_config ([commit 3995d17](https://github.com/googleapis/google-cloud-dotnet/commit/3995d1733e2d50c0a72826988b3f102e8b9c41ba))

### Documentation improvements

- Remove Not GA comments for GetOpenIDConfig and GetJSONWebKeys in v1alpha1/v1beta1/v1 ([commit 3995d17](https://github.com/googleapis/google-cloud-dotnet/commit/3995d1733e2d50c0a72826988b3f102e8b9c41ba))
