### PR TITLE
Release Google.Cloud.Dataplex.V1 version 2.12.0

### DIFF
--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.csproj
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.11.0</Version>
+    <Version>2.12.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Dataplex API, which is used to manage the lifecycle of data lakes.</Description>

--- a/apis/Google.Cloud.Dataplex.V1/docs/history.md
+++ b/apis/Google.Cloud.Dataplex.V1/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+## Version 2.12.0, released 2024-02-09
+
+### Documentation improvements
+
+- Fix typo in comment ([commit 84266b6](https://github.com/googleapis/google-cloud-dotnet/commit/84266b6099a52b845e28fae19300d1fa034309fc))
 ## Version 2.11.0, released 2024-01-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1671,7 +1671,7 @@
     },
     {
       "id": "Google.Cloud.Dataplex.V1",
-      "version": "2.11.0",
+      "version": "2.12.0",
       "type": "grpc",
       "productName": "Cloud Dataplex",
       "productUrl": "https://cloud.google.com/dataplex/docs",


### PR DESCRIPTION

Changes in this release:

### Documentation improvements

- Fix typo in comment ([commit 84266b6](https://github.com/googleapis/google-cloud-dotnet/commit/84266b6099a52b845e28fae19300d1fa034309fc))
