### PR TITLE
Release Google.Cloud.DocumentAI.V1 version 3.11.0

### DIFF
--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.csproj
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.10.0</Version>
+    <Version>3.11.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Document AI API (v1), which is a service to parse structured information from unstructured or semi-structured documents using state-of-the-art Google AI such as natural language, computer vision, translation, and AutoML.</Description>

--- a/apis/Google.Cloud.DocumentAI.V1/docs/history.md
+++ b/apis/Google.Cloud.DocumentAI.V1/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 3.11.0, released 2024-02-09
+
+### New features
+
+- Expose model_type in v1 processor, so that user can see the model_type after get or list processor version ([commit 307fadd](https://github.com/googleapis/google-cloud-dotnet/commit/307fadd18a9a0e4c8ae7184061b6d6fd4a90f295))
+
+### Documentation improvements
+
+- Clarify Properties documentation ([commit 89e17b5](https://github.com/googleapis/google-cloud-dotnet/commit/89e17b50c34e72c421ac3eebb0b2078f009ea066))
+- Updated comments ([commit 86a7453](https://github.com/googleapis/google-cloud-dotnet/commit/86a745358ae56aac9b878ad0e68560210b1e3bc7))
+- Minor comment update ([commit 4c3b325](https://github.com/googleapis/google-cloud-dotnet/commit/4c3b3257925feb320332f19764bf4a6c75a5cbc8))
+
 ## Version 3.10.0, released 2023-09-26
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2093,7 +2093,7 @@
     },
     {
       "id": "Google.Cloud.DocumentAI.V1",
-      "version": "3.10.0",
+      "version": "3.11.0",
       "type": "grpc",
       "productName": "Cloud Document AI",
       "productUrl": "https://cloud.google.com/solutions/document-ai",


### PR DESCRIPTION

Changes in this release:

### New features

- Expose model_type in v1 processor, so that user can see the model_type after get or list processor version ([commit 307fadd](https://github.com/googleapis/google-cloud-dotnet/commit/307fadd18a9a0e4c8ae7184061b6d6fd4a90f295))

### Documentation improvements

- Clarify Properties documentation ([commit 89e17b5](https://github.com/googleapis/google-cloud-dotnet/commit/89e17b50c34e72c421ac3eebb0b2078f009ea066))
- Updated comments ([commit 86a7453](https://github.com/googleapis/google-cloud-dotnet/commit/86a745358ae56aac9b878ad0e68560210b1e3bc7))
- Minor comment update ([commit 4c3b325](https://github.com/googleapis/google-cloud-dotnet/commit/4c3b3257925feb320332f19764bf4a6c75a5cbc8))
