### PR TITLE
Release Google.Cloud.DocumentAI.V1Beta3 version 2.0.0-beta14

### DIFF
--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.csproj
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta13</Version>
+    <Version>2.0.0-beta14</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Document AI API (v1beta3), which is a service to parse structured information from unstructured or semi-structured documents using state-of-the-art Google AI such as natural language, computer vision, translation, and AutoML.</Description>

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/docs/history.md
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.0.0-beta14, released 2024-02-09
+
+### New features
+
+- Add model_type in v1beta3 processor proto ([commit ec4dfb3](https://github.com/googleapis/google-cloud-dotnet/commit/ec4dfb38e20d9892acbdd5b3965b3846e18392a6))
+
 ## Version 2.0.0-beta13, released 2023-09-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2122,7 +2122,7 @@
     },
     {
       "id": "Google.Cloud.DocumentAI.V1Beta3",
-      "version": "2.0.0-beta13",
+      "version": "2.0.0-beta14",
       "type": "grpc",
       "productName": "Cloud Document AI",
       "productUrl": "https://cloud.google.com/solutions/document-ai",


### PR DESCRIPTION

Changes in this release:

### New features

- Add model_type in v1beta3 processor proto ([commit ec4dfb3](https://github.com/googleapis/google-cloud-dotnet/commit/ec4dfb38e20d9892acbdd5b3965b3846e18392a6))
