### PR TITLE
Release Google.Cloud.EdgeNetwork.V1 version 1.0.0-beta03

### DIFF
--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.csproj
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Distributed Cloud Edge Network API, which enables a management for Distributed Cloud Edge.</Description>

--- a/apis/Google.Cloud.EdgeNetwork.V1/docs/history.md
+++ b/apis/Google.Cloud.EdgeNetwork.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta03, released 2024-02-09
+
+### New features
+
+- Add MACsec status for internal links ([commit a8f398f](https://github.com/googleapis/google-cloud-dotnet/commit/a8f398f342d7d167cf4df6fea98c0d9ed89ba595))
+
 ## Version 1.0.0-beta02, released 2023-12-04
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2193,7 +2193,7 @@
     },
     {
       "id": "Google.Cloud.EdgeNetwork.V1",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0-beta03",
       "type": "grpc",
       "productName": "Distributed Cloud Edge Network",
       "productUrl": "https://cloud.google.com/distributed-cloud/edge/latest/docs/overview",


### PR DESCRIPTION

Changes in this release:

### New features

- Add MACsec status for internal links ([commit a8f398f](https://github.com/googleapis/google-cloud-dotnet/commit/a8f398f342d7d167cf4df6fea98c0d9ed89ba595))
