### PR TITLE
Release Google.Cloud.Functions.V1 version 2.3.0

### DIFF
--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.csproj
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.2.0</Version>
+    <Version>2.3.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Functions API (v1), which manages lightweight user-provided functions executed in response to events.</Description>

--- a/apis/Google.Cloud.Functions.V1/docs/history.md
+++ b/apis/Google.Cloud.Functions.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 2.3.0, released 2024-02-09
+
+### New features
+
+- Updated description for `docker_registry` to reflect transition to Artifact Registry ([commit 9a4683f](https://github.com/googleapis/google-cloud-dotnet/commit/9a4683f9311e6e7357f63a204cd7dbef08494f24))
+- Fields for automatic runtime updates ([commit 9a4683f](https://github.com/googleapis/google-cloud-dotnet/commit/9a4683f9311e6e7357f63a204cd7dbef08494f24))
+- Additional optional parameter `version_id` added to `GetFunctionRequest` ([commit 9a4683f](https://github.com/googleapis/google-cloud-dotnet/commit/9a4683f9311e6e7357f63a204cd7dbef08494f24))
+- Reflects deprecation of `network` field ([commit 9a4683f](https://github.com/googleapis/google-cloud-dotnet/commit/9a4683f9311e6e7357f63a204cd7dbef08494f24))
+- Minor updates in comments throughout ([commit 9a4683f](https://github.com/googleapis/google-cloud-dotnet/commit/9a4683f9311e6e7357f63a204cd7dbef08494f24))
+
 ## Version 2.2.0, released 2023-05-11
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2435,7 +2435,7 @@
     },
     {
       "id": "Google.Cloud.Functions.V1",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "type": "grpc",
       "productName": "Cloud Functions",
       "productUrl": "https://cloud.google.com/functions",


### PR DESCRIPTION

Changes in this release:

### New features

- Updated description for `docker_registry` to reflect transition to Artifact Registry ([commit 9a4683f](https://github.com/googleapis/google-cloud-dotnet/commit/9a4683f9311e6e7357f63a204cd7dbef08494f24))
- Fields for automatic runtime updates ([commit 9a4683f](https://github.com/googleapis/google-cloud-dotnet/commit/9a4683f9311e6e7357f63a204cd7dbef08494f24))
- Additional optional parameter `version_id` added to `GetFunctionRequest` ([commit 9a4683f](https://github.com/googleapis/google-cloud-dotnet/commit/9a4683f9311e6e7357f63a204cd7dbef08494f24))
- Reflects deprecation of `network` field ([commit 9a4683f](https://github.com/googleapis/google-cloud-dotnet/commit/9a4683f9311e6e7357f63a204cd7dbef08494f24))
- Minor updates in comments throughout ([commit 9a4683f](https://github.com/googleapis/google-cloud-dotnet/commit/9a4683f9311e6e7357f63a204cd7dbef08494f24))
