### PR TITLE
Release Google.Cloud.PubSub.V1 version 3.10.0-beta01

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.10.0-beta00</Version>
+    <Version>3.10.0-beta01</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.</Description>

--- a/apis/Google.Cloud.PubSub.V1/docs/history.md
+++ b/apis/Google.Cloud.PubSub.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 3.10.0-beta01, released 2024-02-09
+
+### New features
+
+- Add enforce_in_transit fields and optional annotations ([commit 43c6cd3](https://github.com/googleapis/google-cloud-dotnet/commit/43c6cd3d59c575deed21a1b9de81de66ed6eeee1))
+- Add `ingestion_data_source_settings` field to `Topic` ([commit 06f6c30](https://github.com/googleapis/google-cloud-dotnet/commit/06f6c303967d7c433041f7f8c659fe85285eaded))
+
 ## Version 3.9.1, released 2024-01-03
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3811,7 +3811,7 @@
       "protoPath": "google/pubsub/v1",
       "productName": "Cloud Pub/Sub",
       "productUrl": "https://cloud.google.com/pubsub/",
-      "version": "3.10.0-beta00",
+      "version": "3.10.0-beta01",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.",


### PR DESCRIPTION

Changes in this release:

### New features

- Add enforce_in_transit fields and optional annotations ([commit 43c6cd3](https://github.com/googleapis/google-cloud-dotnet/commit/43c6cd3d59c575deed21a1b9de81de66ed6eeee1))
- Add `ingestion_data_source_settings` field to `Topic` ([commit 06f6c30](https://github.com/googleapis/google-cloud-dotnet/commit/06f6c303967d7c433041f7f8c659fe85285eaded))
