### PR TITLE
Release Google.Cloud.Storage.V1 version 4.8.0

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.7.0</Version>
+    <Version>4.8.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Storage API. It wraps the Google.Apis.Storage.v1 client library, making common operations simpler in client code. Google Cloud Storage stores and retrieves potentially large, immutable data objects.</Description>

--- a/apis/Google.Cloud.Storage.V1/docs/history.md
+++ b/apis/Google.Cloud.Storage.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 4.8.0, released 2024-02-09
+
+### New features
+
+- Support the include folders option for listing objects. ([commit 28b9cb6](https://github.com/googleapis/google-cloud-dotnet/commit/28b9cb6c01105763b1564811e4d41d412f82fdac))
+- Add support for the Firebase Storage emulator ([commit a454073](https://github.com/googleapis/google-cloud-dotnet/commit/a454073e1264092ab5c8ae7c8f1420e14216c7c4))
+
 ## Version 4.7.0, released 2023-10-31
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4713,7 +4713,7 @@
       "id": "Google.Cloud.Storage.V1",
       "productName": "Google Cloud Storage",
       "productUrl": "https://cloud.google.com/storage/",
-      "version": "4.7.0",
+      "version": "4.8.0",
       "type": "rest",
       "description": "Recommended Google client library to access the Google Cloud Storage API. It wraps the Google.Apis.Storage.v1 client library, making common operations simpler in client code. Google Cloud Storage stores and retrieves potentially large, immutable data objects.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Support the include folders option for listing objects. ([commit 28b9cb6](https://github.com/googleapis/google-cloud-dotnet/commit/28b9cb6c01105763b1564811e4d41d412f82fdac))
- Add support for the Firebase Storage emulator ([commit a454073](https://github.com/googleapis/google-cloud-dotnet/commit/a454073e1264092ab5c8ae7c8f1420e14216c7c4))
