### PR TITLE
Release Google.Cloud.TelcoAutomation.V1 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.csproj
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Telco Automation API, which automates 5G deployment and management of cloud infrastructure and network functions.</Description>

--- a/apis/Google.Cloud.TelcoAutomation.V1/docs/history.md
+++ b/apis/Google.Cloud.TelcoAutomation.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2024-02-09
+
+### New features
+
+- Support for the STATUS_NOT_APPLICABLE entity status ([commit 3ed0d6e](https://github.com/googleapis/google-cloud-dotnet/commit/3ed0d6e2ca08efaccda007c0b7de3cdf0cf7cde0))
+- Support for the WORKLOAD_CLUSTER_DEPLOYMENT blueprint deployment level ([commit 3ed0d6e](https://github.com/googleapis/google-cloud-dotnet/commit/3ed0d6e2ca08efaccda007c0b7de3cdf0cf7cde0))
+
+### Documentation improvements
+
+- Clarified Deployment.workload_cluster field description ([commit 3ed0d6e](https://github.com/googleapis/google-cloud-dotnet/commit/3ed0d6e2ca08efaccda007c0b7de3cdf0cf7cde0))
 ## Version 1.0.0-beta01, released 2023-11-29
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4926,7 +4926,7 @@
     },
     {
       "id": "Google.Cloud.TelcoAutomation.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Telco Automation",
       "productUrl": "https://cloud.google.com/telecom-network-automation",


### PR DESCRIPTION

Changes in this release:

### New features

- Support for the STATUS_NOT_APPLICABLE entity status ([commit 3ed0d6e](https://github.com/googleapis/google-cloud-dotnet/commit/3ed0d6e2ca08efaccda007c0b7de3cdf0cf7cde0))
- Support for the WORKLOAD_CLUSTER_DEPLOYMENT blueprint deployment level ([commit 3ed0d6e](https://github.com/googleapis/google-cloud-dotnet/commit/3ed0d6e2ca08efaccda007c0b7de3cdf0cf7cde0))

### Documentation improvements

- Clarified Deployment.workload_cluster field description ([commit 3ed0d6e](https://github.com/googleapis/google-cloud-dotnet/commit/3ed0d6e2ca08efaccda007c0b7de3cdf0cf7cde0))
