### PR TITLE
tests: Unskip previously failing test.

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/ListRowsTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.IntegrationTests/ListRowsTest.cs
@@ -81,7 +81,7 @@ namespace Google.Cloud.BigQuery.V2.IntegrationTests
             Assert.Empty(rows);
         }
 
-        [Fact(Skip = "https://github.com/googleapis/google-cloud-dotnet/issues/11403")]
+        [Fact]
         public void ImplicitPagingWithStartIndex()
         {
             var client = BigQueryClient.Create(_fixture.ProjectId);


### PR DESCRIPTION
This was because of a regression service side, which has been fixed. Closes #11403