### PR TITLE
fix: Go back to sending the legacy resource header for Firestore

### DIFF
--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.Tests/FirestoreClientImplTest.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.Tests/FirestoreClientImplTest.cs
@@ -1,0 +1,48 @@
+﻿// Copyright 2019, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Xunit;
+
+namespace Google.Cloud.Firestore.V1.Tests
+{
+    public class FirestoreClientImplTest
+    {
+        [Theory]
+        [InlineData("projects/proj/databases/database", "projects/proj/databases/database")]
+        [InlineData("projects/proj/databases/database/", "projects/proj/databases/database")]
+        [InlineData("projects/proj/databases/database/documents", "projects/proj/databases/database")]
+        [InlineData("projects/proj/databases/database/documents/col1/doc", "projects/proj/databases/database")]
+        [InlineData("projects/proj_id/databases/(default)/foo", "projects/proj_id/databases/(default)")]
+        public void GetDatabaseResourceName_Valid(string resourceName, string expectedDatabaseName)
+        {
+            Assert.Equal(expectedDatabaseName, FirestoreClientImpl.GetDatabaseResourceName(resourceName));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("projects//databases/(default)/foo")]
+        [InlineData("not_projects/project/databases/(default)/foo")]
+        [InlineData("projects/proj/not_databases/database")]
+        [InlineData("projects/")]
+        [InlineData("projects/proj/")]
+        [InlineData("projects/proj/databases")]
+        [InlineData("projects/proj/databases/")]
+        [InlineData("projects/proj/databases//other")]
+        public void GetDatabaseResourceName_Invalid(string resourceName)
+        {
+            Assert.Throws<ArgumentException>(() => FirestoreClientImpl.GetDatabaseResourceName(resourceName));
+        }
+    }
+}

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.Tests/Google.Cloud.Firestore.V1.Tests.csproj
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.Tests/Google.Cloud.Firestore.V1.Tests.csproj
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;net462</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">net6.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <NoWarn>1701;1702;1705;xUnit2004;xUnit2013</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
+    <ProjectReference Include="..\Google.Cloud.Firestore.V1\Google.Cloud.Firestore.V1.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
+    <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />
+    <PackageReference Include="System.Linq.Async" Version="$(SystemLinqAsyncVersion)" />
+    <PackageReference Include="Xunit.SkippableFact" Version="$(XUnitSkippableFactVersion)" />
+    <PackageReference Include="xunit" Version="$(XUnitVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVersion)" />
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+</Project>

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.Tests/coverage.xml
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.Tests/coverage.xml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <TargetExecutable>C:/Program Files/dotnet/dotnet.exe</TargetExecutable>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
+  <Filters>
+    <IncludeFilters>
+      <FilterEntry>
+        <ModuleMask>Google.Cloud.Firestore.V1</ModuleMask>
+      </FilterEntry>
+    </IncludeFilters>
+  </Filters>
+  <AttributeFilters>
+    <AttributeFilterEntry>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</AttributeFilterEntry>
+    <AttributeFilterEntry>System.Diagnostics.DebuggerNonUserCodeAttribute</AttributeFilterEntry>
+  </AttributeFilters>
+  <TargetWorkingDir>.</TargetWorkingDir>
+  <Output>../../../coverage/Google.Cloud.Firestore.V1.Tests.dvcr</Output>
+</CoverageParams>

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.sln
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.sln
@@ -3,18 +3,23 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Firestore.V1", "Google.Cloud.Firestore.V1\Google.Cloud.Firestore.V1.csproj", "{F9CE8ABD-FB0E-437E-B03A-27F52D7A9F9A}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Firestore.V1", "Google.Cloud.Firestore.V1\Google.Cloud.Firestore.V1.csproj", "{F9CE8ABD-FB0E-437E-B03A-27F52D7A9F9A}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Firestore.V1.GeneratedSnippets", "Google.Cloud.Firestore.V1.GeneratedSnippets\Google.Cloud.Firestore.V1.GeneratedSnippets.csproj", "{F841636E-5304-4C09-B151-7B1DDB0618C8}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Firestore.V1.GeneratedSnippets", "Google.Cloud.Firestore.V1.GeneratedSnippets\Google.Cloud.Firestore.V1.GeneratedSnippets.csproj", "{F841636E-5304-4C09-B151-7B1DDB0618C8}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.ClientTesting", "..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj", "{99487E3D-9DFC-419B-95AC-F8D5BEE8A3A4}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.ClientTesting", "..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj", "{99487E3D-9DFC-419B-95AC-F8D5BEE8A3A4}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Firestore.V1.Snippets", "Google.Cloud.Firestore.V1.Snippets\Google.Cloud.Firestore.V1.Snippets.csproj", "{4357F6C5-8599-41D7-84EF-ED59E32B54DF}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Firestore.V1.Snippets", "Google.Cloud.Firestore.V1.Snippets\Google.Cloud.Firestore.V1.Snippets.csproj", "{4357F6C5-8599-41D7-84EF-ED59E32B54DF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Firestore.V1.Tests", "Google.Cloud.Firestore.V1.Tests\Google.Cloud.Firestore.V1.Tests.csproj", "{8C638D13-3585-4344-B597-DA0EA0266688}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{F9CE8ABD-FB0E-437E-B03A-27F52D7A9F9A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -33,11 +38,9 @@ Global
 		{4357F6C5-8599-41D7-84EF-ED59E32B54DF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4357F6C5-8599-41D7-84EF-ED59E32B54DF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4357F6C5-8599-41D7-84EF-ED59E32B54DF}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {A454C46B-D941-47B5-A3BD-218EC33797BE}
+		{8C638D13-3585-4344-B597-DA0EA0266688}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8C638D13-3585-4344-B597-DA0EA0266688}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8C638D13-3585-4344-B597-DA0EA0266688}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8C638D13-3585-4344-B597-DA0EA0266688}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/issues/Issue11653/Issue11653.csproj
+++ b/issues/Issue11653/Issue11653.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Firestore" Version="3.5.0" />
+    <ProjectReference Include="..\..\apis\Google.Cloud.Firestore\Google.Cloud.Firestore\Google.Cloud.Firestore.csproj" />
   </ItemGroup>
 
 </Project>

--- a/issues/Issue11653b/Issue11653b.csproj
+++ b/issues/Issue11653b/Issue11653b.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Google.Cloud.Datastore.V1" Version="4.7.0" />
+  </ItemGroup>
+
+</Project>

--- a/issues/Issue11653b/Issue11653b.sln
+++ b/issues/Issue11653b/Issue11653b.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34408.163
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Issue11653b", "Issue11653b.csproj", "{1B9AE535-B811-43D9-A56E-8B236B9E76B9}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{1B9AE535-B811-43D9-A56E-8B236B9E76B9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1B9AE535-B811-43D9-A56E-8B236B9E76B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1B9AE535-B811-43D9-A56E-8B236B9E76B9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1B9AE535-B811-43D9-A56E-8B236B9E76B9}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {4AB11F66-05AB-4096-B85A-35AA34842012}
+	EndGlobalSection
+EndGlobal

--- a/issues/Issue11653b/Program.cs
+++ b/issues/Issue11653b/Program.cs
@@ -1,0 +1,55 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+using Google.Api.Gax;
+using Google.Cloud.Datastore.V1;
+using Grpc.Core;
+
+if (args.Length != 2)
+{
+    Console.WriteLine("Arguments: <emulator-host> <project-id>");
+    Console.WriteLine("(The DATASTORE_EMULATOR_HOST environment variable is ignored.)");
+    return;
+}
+
+Environment.SetEnvironmentVariable("DATASTORE_EMULATOR_HOST", args[0]);
+
+var db = new DatastoreDbBuilder
+{
+    ProjectId = args[1],
+    EmulatorDetection = EmulatorDetection.EmulatorOnly
+}.Build();
+
+var keyFactory = db.CreateKeyFactory("test");
+var entityKey = keyFactory.CreateKey("testid");
+await Try("Allocate ID", () => db.AllocateIdAsync(keyFactory.CreateIncompleteKey()));
+await Try("Insert entity", () => db.InsertAsync(new Entity { Key = entityKey, Properties = { { "key", "value" } } }));
+await Try("Get entity", () => db.LookupAsync(entityKey));
+
+async Task Try(string description, Func<Task> taskProvider)
+{
+    try
+    {
+        await taskProvider();
+        Console.WriteLine($"'{description}' RPC succeeded");
+    }
+    catch (RpcException e)
+    {
+        Console.WriteLine($"'{description}' RPC failed: {e.Message}");
+    }
+    catch (Exception e)
+    {
+        Console.WriteLine($"'{description}' failed more dramatically: {e.GetType()}: {e.Message}");
+    }
+}


### PR DESCRIPTION
Integration tests still pass, and the emulator now works again.

Fixes #11653 (after a release, of course).

Datastore appears not to be affected by this: the code in the second commit works fine.

We should periodically re-evaluate this: when an emulator has been released that properly supports the new headers, we should drop the old ones again.