### PR TITLE
Release Google.Cloud.BigQuery.DataTransfer.V1 version 4.5.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.4.0</Version>
+    <Version>4.5.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery Data Transfer API, which transfers data from partner SaaS applications to Google BigQuery on a scheduled, managed basis.</Description>

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 4.5.0, released 2024-02-20
+
+### New features
+
+- Add UnenrollDataSources API which gives users a programmatic way to unenroll data sources ([commit 174b0bc](https://github.com/googleapis/google-cloud-dotnet/commit/174b0bc552a3438b586c999a5a4f8f1e57dcbc48))
+
+### Documentation improvements
+
+- Update transferConfig.name description to indicate that it supports both formats ([commit e821bb9](https://github.com/googleapis/google-cloud-dotnet/commit/e821bb96b2abb6b7473ada5169283e27a2e267dd))
+
 ## Version 4.4.0, released 2023-08-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -897,7 +897,7 @@
       "protoPath": "google/cloud/bigquery/datatransfer/v1",
       "productName": "Google BigQuery Data Transfer",
       "productUrl": "https://cloud.google.com/bigquery/transfer/",
-      "version": "4.4.0",
+      "version": "4.5.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the BigQuery Data Transfer API, which transfers data from partner SaaS applications to Google BigQuery on a scheduled, managed basis.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Add UnenrollDataSources API which gives users a programmatic way to unenroll data sources ([commit 174b0bc](https://github.com/googleapis/google-cloud-dotnet/commit/174b0bc552a3438b586c999a5a4f8f1e57dcbc48))

### Documentation improvements

- Update transferConfig.name description to indicate that it supports both formats ([commit e821bb9](https://github.com/googleapis/google-cloud-dotnet/commit/e821bb96b2abb6b7473ada5169283e27a2e267dd))
