### PR TITLE
Release Google.Cloud.BigQuery.Storage.V1 version 3.12.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.11.0</Version>
+    <Version>3.12.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery Storage API.</Description>

--- a/apis/Google.Cloud.BigQuery.Storage.V1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.12.0, released 2024-02-20
+
+### New features
+
+- Add the RANGE type to the google.cloud.bigquery.storage.v1.TableFieldSchema ([commit 7867a64](https://github.com/googleapis/google-cloud-dotnet/commit/7867a6402a3216bc1387a9e5c44a99f0379c350b))
+
 ## Version 3.11.0, released 2024-01-16
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1004,7 +1004,7 @@
       "protoPath": "google/cloud/bigquery/storage/v1",
       "productName": "Google BigQuery Storage",
       "productUrl": "https://cloud.google.com/bigquery/docs/reference/storage/",
-      "version": "3.11.0",
+      "version": "3.12.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the BigQuery Storage API.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Add the RANGE type to the google.cloud.bigquery.storage.v1.TableFieldSchema ([commit 7867a64](https://github.com/googleapis/google-cloud-dotnet/commit/7867a6402a3216bc1387a9e5c44a99f0379c350b))
