### PR TITLE
Release Google.Cloud.DocumentAI.V1Beta3 version 2.0.0-beta15

### DIFF
--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.csproj
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta14</Version>
+    <Version>2.0.0-beta15</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Document AI API (v1beta3), which is a service to parse structured information from unstructured or semi-structured documents using state-of-the-art Google AI such as natural language, computer vision, translation, and AutoML.</Description>

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/docs/history.md
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/docs/history.md
@@ -1,5 +1,22 @@
 # Version history
 
+## Version 2.0.0-beta15, released 2024-02-20
+
+### Bug fixes
+
+- Deprecate `Dataset.document_warehouse_config` ([commit 9161ec3](https://github.com/googleapis/google-cloud-dotnet/commit/9161ec3cbc47939c6e0e0a5ca8640a34f80b6a0c))
+
+### New features
+
+- A new message FoundationModelTuningOptions is added ([commit 9161ec3](https://github.com/googleapis/google-cloud-dotnet/commit/9161ec3cbc47939c6e0e0a5ca8640a34f80b6a0c))
+- A new field foundation_model_tuning_options is added to message TrainProcessorVersionRequest ([commit 9161ec3](https://github.com/googleapis/google-cloud-dotnet/commit/9161ec3cbc47939c6e0e0a5ca8640a34f80b6a0c))
+- A new field `labels` is added to messages `ProcessRequest` and `BatchProcessRequest` ([commit 9161ec3](https://github.com/googleapis/google-cloud-dotnet/commit/9161ec3cbc47939c6e0e0a5ca8640a34f80b6a0c))
+- A new field `display_name` is added to message `DocumentSchema` ([commit 9161ec3](https://github.com/googleapis/google-cloud-dotnet/commit/9161ec3cbc47939c6e0e0a5ca8640a34f80b6a0c))
+
+### Documentation improvements
+
+- Updated comments ([commit 9161ec3](https://github.com/googleapis/google-cloud-dotnet/commit/9161ec3cbc47939c6e0e0a5ca8640a34f80b6a0c))
+
 ## Version 2.0.0-beta14, released 2024-02-09
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2144,7 +2144,7 @@
     },
     {
       "id": "Google.Cloud.DocumentAI.V1Beta3",
-      "version": "2.0.0-beta14",
+      "version": "2.0.0-beta15",
       "type": "grpc",
       "productName": "Cloud Document AI",
       "productUrl": "https://cloud.google.com/solutions/document-ai",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Deprecate `Dataset.document_warehouse_config` ([commit 9161ec3](https://github.com/googleapis/google-cloud-dotnet/commit/9161ec3cbc47939c6e0e0a5ca8640a34f80b6a0c))

### New features

- A new message FoundationModelTuningOptions is added ([commit 9161ec3](https://github.com/googleapis/google-cloud-dotnet/commit/9161ec3cbc47939c6e0e0a5ca8640a34f80b6a0c))
- A new field foundation_model_tuning_options is added to message TrainProcessorVersionRequest ([commit 9161ec3](https://github.com/googleapis/google-cloud-dotnet/commit/9161ec3cbc47939c6e0e0a5ca8640a34f80b6a0c))
- A new field `labels` is added to messages `ProcessRequest` and `BatchProcessRequest` ([commit 9161ec3](https://github.com/googleapis/google-cloud-dotnet/commit/9161ec3cbc47939c6e0e0a5ca8640a34f80b6a0c))
- A new field `display_name` is added to message `DocumentSchema` ([commit 9161ec3](https://github.com/googleapis/google-cloud-dotnet/commit/9161ec3cbc47939c6e0e0a5ca8640a34f80b6a0c))

### Documentation improvements

- Updated comments ([commit 9161ec3](https://github.com/googleapis/google-cloud-dotnet/commit/9161ec3cbc47939c6e0e0a5ca8640a34f80b6a0c))
