### PR TITLE
Release Google.Cloud.Orchestration.Airflow.Service.V1 version 2.5.0

### DIFF
--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.csproj
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.4.0</Version>
+    <Version>2.5.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Cloud Composer API, which manages Apache Airflow environments on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/docs/history.md
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/docs/history.md
@@ -1,5 +1,14 @@
 # Version history
 
+## Version 2.5.0, released 2024-02-20
+
+### New features
+
+- Added ListWorkloads RPC ([commit 2f0cfc6](https://github.com/googleapis/google-cloud-dotnet/commit/2f0cfc682d783c0629519bda7c3706ff1c271ea0))
+- Added field data_retention_config to EnvironmentConfig ([commit 2f0cfc6](https://github.com/googleapis/google-cloud-dotnet/commit/2f0cfc682d783c0629519bda7c3706ff1c271ea0))
+- Added field web_server_plugins_mode to SoftwareConfig ([commit 2f0cfc6](https://github.com/googleapis/google-cloud-dotnet/commit/2f0cfc682d783c0629519bda7c3706ff1c271ea0))
+- Added field storage_config to Environment ([commit 2f0cfc6](https://github.com/googleapis/google-cloud-dotnet/commit/2f0cfc682d783c0629519bda7c3706ff1c271ea0))
+
 ## Version 2.4.0, released 2023-06-20
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3510,7 +3510,7 @@
     },
     {
       "id": "Google.Cloud.Orchestration.Airflow.Service.V1",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "type": "grpc",
       "productName": "Cloud Composer",
       "productUrl": "https://cloud.google.com/composer/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Added ListWorkloads RPC ([commit 2f0cfc6](https://github.com/googleapis/google-cloud-dotnet/commit/2f0cfc682d783c0629519bda7c3706ff1c271ea0))
- Added field data_retention_config to EnvironmentConfig ([commit 2f0cfc6](https://github.com/googleapis/google-cloud-dotnet/commit/2f0cfc682d783c0629519bda7c3706ff1c271ea0))
- Added field web_server_plugins_mode to SoftwareConfig ([commit 2f0cfc6](https://github.com/googleapis/google-cloud-dotnet/commit/2f0cfc682d783c0629519bda7c3706ff1c271ea0))
- Added field storage_config to Environment ([commit 2f0cfc6](https://github.com/googleapis/google-cloud-dotnet/commit/2f0cfc682d783c0629519bda7c3706ff1c271ea0))
