### PR TITLE
Release Google.Cloud.RecaptchaEnterprise.V1 version 2.9.0

### DIFF
--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.csproj
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.8.0</Version>
+    <Version>2.9.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud reCAPTCHA for Enterprise API v1.</Description>

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/docs/history.md
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 2.9.0, released 2024-02-20
+
+### New features
+
+- Add an API method for reordering firewall policies ([commit 3a8650e](https://github.com/googleapis/google-cloud-dotnet/commit/3a8650eeeec900cc533908c62cb610336425b517))
+
+### Documentation improvements
+
+- Update comment for `AccountVerificationInfo.username` ([commit 7560af8](https://github.com/googleapis/google-cloud-dotnet/commit/7560af85aa6f677214b9a19d5eeeef15f30c7f64))
+
 ## Version 2.8.0, released 2023-12-11
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3908,7 +3908,7 @@
       "protoPath": "google/cloud/recaptchaenterprise/v1",
       "productName": "Google Cloud reCAPTCHA Enterprise",
       "productUrl": "https://cloud.google.com/recaptcha-enterprise/",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud reCAPTCHA for Enterprise API v1.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- Add an API method for reordering firewall policies ([commit 3a8650e](https://github.com/googleapis/google-cloud-dotnet/commit/3a8650eeeec900cc533908c62cb610336425b517))

### Documentation improvements

- Update comment for `AccountVerificationInfo.username` ([commit 7560af8](https://github.com/googleapis/google-cloud-dotnet/commit/7560af85aa6f677214b9a19d5eeeef15f30c7f64))
