### PR TITLE
Release Google.Cloud.SecurityCenter.V1 version 3.14.0

### DIFF
--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.csproj
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.13.0</Version>
+    <Version>3.14.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Security Command Center API, which helps security teams gather data, identify threats, and act on them before they result in business damage or loss.</Description>

--- a/apis/Google.Cloud.SecurityCenter.V1/docs/history.md
+++ b/apis/Google.Cloud.SecurityCenter.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 3.14.0, released 2024-02-20
+
+### New features
+
+- Add application field to finding's list of attributes ([commit a359c07](https://github.com/googleapis/google-cloud-dotnet/commit/a359c076cf3ac7f795acf940d57eb408a94ffce4))
+
+### Documentation improvements
+
+- Modify documentation of SimulateSecurityHealthAnalyticsCustomModuleRequest ([commit fb09480](https://github.com/googleapis/google-cloud-dotnet/commit/fb094805f2a6b2d56ff3994603fa5d87148570c9))
+
 ## Version 3.13.0, released 2023-10-30
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4328,7 +4328,7 @@
       "protoPath": "google/cloud/securitycenter/v1",
       "productName": "Google Cloud Security Command Center",
       "productUrl": "https://cloud.google.com/security-command-center/",
-      "version": "3.13.0",
+      "version": "3.14.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Security Command Center API, which helps security teams gather data, identify threats, and act on them before they result in business damage or loss.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Add application field to finding's list of attributes ([commit a359c07](https://github.com/googleapis/google-cloud-dotnet/commit/a359c076cf3ac7f795acf940d57eb408a94ffce4))

### Documentation improvements

- Modify documentation of SimulateSecurityHealthAnalyticsCustomModuleRequest ([commit fb09480](https://github.com/googleapis/google-cloud-dotnet/commit/fb094805f2a6b2d56ff3994603fa5d87148570c9))
