### PR TITLE
Release Google.Maps.AddressValidation.V1 version 1.1.0

### DIFF
--- a/apis/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1.csproj
+++ b/apis/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Maps Address Validation API, which allows developers to verify the accuracy of addresses. Given an address, it returns information about the correctness of the components of the parsed address, a geocode, and a verdict on the deliverability of the parsed address.</Description>

--- a/apis/Google.Maps.AddressValidation.V1/docs/history.md
+++ b/apis/Google.Maps.AddressValidation.V1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 1.1.0, released 2024-02-20
+
+### New features
+
+- Add session token support for Autocomplete (New) sessions that end with a call to Address Validation ([commit 289fa6e](https://github.com/googleapis/google-cloud-dotnet/commit/289fa6e1f785e4da53676b952eefe2f7182ef4c2))
+- Add new fields to USPS data ([commit 289fa6e](https://github.com/googleapis/google-cloud-dotnet/commit/289fa6e1f785e4da53676b952eefe2f7182ef4c2))
+
+### Documentation improvements
+
+- Update proto field descriptions ([commit 289fa6e](https://github.com/googleapis/google-cloud-dotnet/commit/289fa6e1f785e4da53676b952eefe2f7182ef4c2))
+
 ## Version 1.0.0, released 2023-11-01
 
 In addition to the documentation changes listed below, this library

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5648,7 +5648,7 @@
     },
     {
       "id": "Google.Maps.AddressValidation.V1",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "grpc",
       "productName": "Address Validation",
       "productUrl": "https://developers.google.com/maps/documentation/address-validation/requests-validate-address",


### PR DESCRIPTION

Changes in this release:

### New features

- Add session token support for Autocomplete (New) sessions that end with a call to Address Validation ([commit 289fa6e](https://github.com/googleapis/google-cloud-dotnet/commit/289fa6e1f785e4da53676b952eefe2f7182ef4c2))
- Add new fields to USPS data ([commit 289fa6e](https://github.com/googleapis/google-cloud-dotnet/commit/289fa6e1f785e4da53676b952eefe2f7182ef4c2))

### Documentation improvements

- Update proto field descriptions ([commit 289fa6e](https://github.com/googleapis/google-cloud-dotnet/commit/289fa6e1f785e4da53676b952eefe2f7182ef4c2))
