### PR TITLE
feat(spanner): add PG.OID support

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/PgTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/PgTests.cs
@@ -57,6 +57,20 @@ public class PgTests
     public async Task BindPgJsonbArray() =>
         await TestBindNonNull(SpannerDbType.ArrayOf(SpannerDbType.PgJsonb), new string[] { "{\"key\": \"value\"}", null, "{\"other-key\": \"other-value\"}" });
 
+    [Fact]
+    public async Task BindPgOid() =>
+        await TestBindNonNull(SpannerDbType.PgOid, 1234, r => r.GetInt64(0));
+
+    [Fact]
+    public Task BindPgOidArray() => TestBindNonNull(
+        SpannerDbType.ArrayOf(SpannerDbType.PgOid),
+        new long?[] { 1, null, 0 });
+
+    [Fact]
+    public Task BindPgOidEmptyArray() => TestBindNonNull(
+        SpannerDbType.ArrayOf(SpannerDbType.PgOid),
+        new long[] { });
+
     private async Task TestBindNonNull<T>(SpannerDbType parameterType, T value, Func<SpannerDataReader, T> typeSpecificReader = null)
     {
         using var connection = GetConnection();
@@ -70,8 +84,10 @@ public class PgTests
     {
         SpannerDbType.PgNumeric,
         SpannerDbType.PgJsonb,
+        SpannerDbType.PgOid,
         SpannerDbType.ArrayOf(SpannerDbType.PgNumeric),
-        SpannerDbType.ArrayOf(SpannerDbType.PgJsonb)
+        SpannerDbType.ArrayOf(SpannerDbType.PgJsonb),
+        SpannerDbType.ArrayOf(SpannerDbType.PgOid)
     };
 
     [Theory]
@@ -81,6 +97,24 @@ public class PgTests
         using var connection = GetConnection();
         using var cmd = connection.CreateSelectCommand("SELECT $1");
         cmd.Parameters.Add("p1", parameterType, null);
+        using var reader = await cmd.ExecuteReaderAsync();
+        await BindingTests.AssertNull(reader);
+    }
+
+    [Fact]
+    public async Task ReadCastAsOid()
+    {
+        using var connection = GetConnection();
+        using var cmd = connection.CreateSelectCommand("SELECT 123::oid");
+        using var reader = await cmd.ExecuteReaderAsync();
+        await BindingTests.AssertNotNull<long>(reader, 123, r => r.GetInt64(0));
+    }
+
+    [Fact]
+    public async Task ReadCastAsNullOid()
+    {
+        using var connection = GetConnection();
+        using var cmd = connection.CreateSelectCommand("SELECT null::oid");
         using var reader = await cmd.ExecuteReaderAsync();
         await BindingTests.AssertNull(reader);
     }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/KeysTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/KeysTests.cs
@@ -36,6 +36,7 @@ namespace Google.Cloud.Spanner.Data.Tests
                     { "", SpannerDbType.PgJsonb, "{\"key1\": \"value1\"}" },
                     { "", SpannerDbType.Numeric, SpannerNumeric.Parse("10.1") },
                     { "", SpannerDbType.PgNumeric, PgNumeric.Parse("20.1") },
+                    { "", SpannerDbType.PgOid, 2 },
                     { "", SpannerDbType.String, "test" },
                     { "", SpannerDbType.Timestamp, new DateTime(2021, 9, 10, 9, 37, 10, DateTimeKind.Utc) }
                 });
@@ -54,6 +55,7 @@ namespace Google.Cloud.Spanner.Data.Tests
                     Value.ForString("{\"key1\": \"value1\"}"),
                     Value.ForString("10.1"),
                     Value.ForString("20.1"),
+                    Value.ForString("2"),
                     Value.ForString("test"),
                     Value.ForString("2021-09-10T09:37:10Z")
                 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerDbTypeTests.ValueConversions.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerDbTypeTests.ValueConversions.cs
@@ -58,13 +58,14 @@ namespace Google.Cloud.Spanner.Data.Tests
             { "NumericField", SpannerDbType.Numeric, SpannerNumeric.MaxValue },
             { "PgNumericField", SpannerDbType.PgNumeric, PgNumeric.NaN },
             { "JsonField", SpannerDbType.Json, "{\"field\": \"value\"}" },
-            { "PgJsonbField", SpannerDbType.PgJsonb, "{\"field1\": \"value1\"}" }
+            { "PgJsonbField", SpannerDbType.PgJsonb, "{\"field1\": \"value1\"}" },
+            { "PgOidField", SpannerDbType.PgOid, 3L }
         };
 
         // Structs are serialized as lists of their values. The field names aren't present, as they're
         // specified in the type.
         private static readonly string s_sampleStructSerialized =
-            "[ \"stringValue\", \"2\", \"NaN\", true, \"2017-01-31\", \"2017-01-31T03:15:30Z\", \"99999999999999999999999999999.999999999\", \"NaN\", \"{\\\"field\\\": \\\"value\\\"}\", \"{\\\"field1\\\": \\\"value1\\\"}\" ]";
+            "[ \"stringValue\", \"2\", \"NaN\", true, \"2017-01-31\", \"2017-01-31T03:15:30Z\", \"99999999999999999999999999999.999999999\", \"NaN\", \"{\\\"field\\\": \\\"value\\\"}\", \"{\\\"field1\\\": \\\"value1\\\"}\", \"3\" ]";
 
         private static string Quote(string s) => $"\"{s}\"";
 
@@ -334,6 +335,11 @@ namespace Google.Cloud.Spanner.Data.Tests
             yield return new object[]
             {
                 new List<int>(GetIntsForArray()), SpannerDbType.ArrayOf(SpannerDbType.Int64),
+                "[ \"4\", \"5\", \"6\" ]"
+            };
+            yield return new object[]
+            {
+                new List<int>(GetIntsForArray()), SpannerDbType.ArrayOf(SpannerDbType.PgOid),
                 "[ \"4\", \"5\", \"6\" ]"
             };
             yield return new object[]

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerDbTypeTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerDbTypeTests.cs
@@ -71,6 +71,7 @@ namespace Google.Cloud.Spanner.Data.Tests
             yield return new object[] { "DATE", SpannerDbType.Date };
             yield return new object[] { "FLOAT64", SpannerDbType.Float64 };
             yield return new object[] { "INT64", SpannerDbType.Int64 };
+            yield return new object[] { "OID{PG}", SpannerDbType.PgOid };
             yield return new object[] { "TIMESTAMP", SpannerDbType.Timestamp };
             yield return new object[] { "NUMERIC", SpannerDbType.Numeric };
             yield return new object[] { "NUMERIC{PG}", SpannerDbType.PgNumeric };
@@ -83,6 +84,7 @@ namespace Google.Cloud.Spanner.Data.Tests
             yield return new object[] { "  DATE  ", SpannerDbType.Date };
             yield return new object[] { "  FLOAT64  ", SpannerDbType.Float64 };
             yield return new object[] { "  INT64  ", SpannerDbType.Int64 };
+            yield return new object[] { "  OID{PG}", SpannerDbType.PgOid };
             yield return new object[] { "  TIMESTAMP  ", SpannerDbType.Timestamp };
             yield return new object[] { "  NUMERIC  ", SpannerDbType.Numeric };
             yield return new object[] { "  NUMERIC{PG}  ", SpannerDbType.PgNumeric };
@@ -109,6 +111,7 @@ namespace Google.Cloud.Spanner.Data.Tests
             yield return new object[] { "ARRAY<DATE>", SpannerDbType.ArrayOf(SpannerDbType.Date) };
             yield return new object[] { "ARRAY<FLOAT64>", SpannerDbType.ArrayOf(SpannerDbType.Float64) };
             yield return new object[] { "ARRAY<INT64>", SpannerDbType.ArrayOf(SpannerDbType.Int64) };
+            yield return new object[] { "ARRAY<OID{PG}>", SpannerDbType.ArrayOf(SpannerDbType.PgOid) };
             yield return new object[] { "ARRAY<TIMESTAMP>", SpannerDbType.ArrayOf(SpannerDbType.Timestamp) };
 
             yield return new object[] { "ARRAY<STRING(5)>", SpannerDbType.ArrayOf(SpannerDbType.String), false };
@@ -161,9 +164,10 @@ namespace Google.Cloud.Spanner.Data.Tests
                 { "F8", SpannerDbType.Numeric, null },
                 { "F9", SpannerDbType.Json, null },
                 { "F10", SpannerDbType.PgNumeric, null },
-                { "F11", SpannerDbType.PgJsonb, null }
+                { "F11", SpannerDbType.PgJsonb, null },
+                { "F12", SpannerDbType.PgOid, null }
             };
-            yield return new object[] { "STRUCT<F1:STRING,F2:INT64,F3:BOOL,F4:BYTES,F5:DATE,F6:FLOAT64,F7:TIMESTAMP,F8:NUMERIC,F9:JSON,F10:NUMERIC{PG},F11:JSONB{PG}>", sampleStruct.GetSpannerDbType() };
+            yield return new object[] { "STRUCT<F1:STRING,F2:INT64,F3:BOOL,F4:BYTES,F5:DATE,F6:FLOAT64,F7:TIMESTAMP,F8:NUMERIC,F9:JSON,F10:NUMERIC{PG},F11:JSONB{PG},F12:OID{PG}>", sampleStruct.GetSpannerDbType() };
 
             sampleStruct = new SpannerStruct
             {

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerParameterTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerParameterTests.cs
@@ -34,9 +34,11 @@ namespace Google.Cloud.Spanner.Data.Tests
             yield return new object[] { SpannerDbType.Numeric, DbType.VarNumeric, true };
             yield return new object[] { SpannerDbType.Unspecified, DbType.Object, true };
             yield return new object[] { SpannerDbType.String, DbType.String, true };
-            // There is no DbType that will map automatically to SpannerDbType.Json or SpannerDbType.PgJsonb.
+            // There is no DbType that will map automatically to SpannerDbType.Json, SpannerDbType.PgJsonb
+            // or SpannerDbType.PgOid.
             yield return new object[] { SpannerDbType.Json, DbType.String, false };
             yield return new object[] { SpannerDbType.PgJsonb, DbType.String, false };
+            yield return new object[] { SpannerDbType.PgOid, DbType.Int64, false };
         }
 
         [Theory]
@@ -126,6 +128,7 @@ namespace Google.Cloud.Spanner.Data.Tests
             yield return new object[] { SpannerDbType.Date, 0 };
             yield return new object[] { SpannerDbType.Float64, 0 };
             yield return new object[] { SpannerDbType.Int64, 0 };
+            yield return new object[] { SpannerDbType.PgOid, 0 };
             yield return new object[] { SpannerDbType.Timestamp, 0 };
             yield return new object[] { SpannerDbType.Json, 0 };
             yield return new object[] { SpannerDbType.PgJsonb, 0 };
@@ -155,6 +158,7 @@ namespace Google.Cloud.Spanner.Data.Tests
             yield return new object[] { SpannerDbType.Date };
             yield return new object[] { SpannerDbType.Float64 };
             yield return new object[] { SpannerDbType.Int64 };
+            yield return new object[] { SpannerDbType.PgOid };
             yield return new object[] { SpannerDbType.Numeric };
             yield return new object[] { SpannerDbType.PgNumeric };
             yield return new object[] { SpannerDbType.Timestamp };
@@ -166,6 +170,7 @@ namespace Google.Cloud.Spanner.Data.Tests
             yield return new object[] { SpannerDbType.ArrayOf(SpannerDbType.Date) };
             yield return new object[] { SpannerDbType.ArrayOf(SpannerDbType.Float64) };
             yield return new object[] { SpannerDbType.ArrayOf(SpannerDbType.Int64) };
+            yield return new object[] { SpannerDbType.ArrayOf(SpannerDbType.PgOid) };
             yield return new object[] { SpannerDbType.ArrayOf(SpannerDbType.Numeric) };
             yield return new object[] { SpannerDbType.ArrayOf(SpannerDbType.PgNumeric) };
             yield return new object[] { SpannerDbType.ArrayOf(SpannerDbType.Timestamp) };

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDbType.StringParsing.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDbType.StringParsing.cs
@@ -143,7 +143,8 @@ namespace Google.Cloud.Spanner.Data
             }
 
             var trimmedComplexName = complexName.Trim();
-            // Special handling for NUMERIC{PG} and JSONB{PG}, as other types are just based on TypeCode and we need to keep the code backward compatible.
+            // Special handling for NUMERIC{PG}, JSONB{PG} and OID{PG}, as other types are just based on
+            // TypeCode and we need to keep the code backward compatible.
             if (string.Equals(trimmedComplexName, "NUMERIC{PG}", StringComparison.OrdinalIgnoreCase))
             {
                 type.Code = TypeCode.Numeric;
@@ -154,6 +155,12 @@ namespace Google.Cloud.Spanner.Data
             {
                 type.Code = TypeCode.Json;
                 type.TypeAnnotation = TypeAnnotationCode.PgJsonb;
+                return true;
+            }
+            else if (string.Equals(trimmedComplexName, "OID{PG}", StringComparison.OrdinalIgnoreCase))
+            {
+                type.Code = TypeCode.Int64;
+                type.TypeAnnotation = TypeAnnotationCode.PgOid;
                 return true;
             }
 
@@ -221,6 +228,10 @@ namespace Google.Cloud.Spanner.Data
             else if (TypeAnnotationCode == TypeAnnotationCode.PgJsonb)
             {
                 return "JSONB{PG}";
+            }
+            else if (TypeAnnotationCode == TypeAnnotationCode.PgOid)
+            {
+                return "OID{PG}";
             }
 
             return Size.HasValue ? $"{TypeCode.GetOriginalName()}({Size})" : TypeCode.GetOriginalName();

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDbType.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDbType.cs
@@ -91,6 +91,11 @@ namespace Google.Cloud.Spanner.Data
         /// </summary>
         public static SpannerDbType PgNumeric { get; } = new SpannerDbType(TypeCode.Numeric, TypeAnnotationCode.PgNumeric);
 
+        /// <summary>
+        /// Representation of PostgreSQL OID type.
+        /// </summary>
+        public static SpannerDbType PgOid { get; } = new SpannerDbType(TypeCode.Int64, TypeAnnotationCode.PgOid);
+
         private static readonly Dictionary<V1.Type, SpannerDbType> s_simpleTypes
             = new Dictionary<V1.Type, SpannerDbType>
             {
@@ -105,7 +110,8 @@ namespace Google.Cloud.Spanner.Data
                 { new V1.Type { Code = TypeCode.Json }, Json },
                 { new V1.Type { Code = TypeCode.Json, TypeAnnotation = TypeAnnotationCode.PgJsonb }, PgJsonb },
                 { new V1.Type { Code = TypeCode.Numeric }, Numeric },
-                { new V1.Type { Code = TypeCode.Numeric, TypeAnnotation = TypeAnnotationCode.PgNumeric }, PgNumeric }
+                { new V1.Type { Code = TypeCode.Numeric, TypeAnnotation = TypeAnnotationCode.PgNumeric }, PgNumeric },
+                { new V1.Type { Code = TypeCode.Int64, TypeAnnotation = TypeAnnotationCode.PgOid }, PgOid }
             };
 
         internal static SpannerDbType FromType(V1.Type type) =>
@@ -161,6 +167,7 @@ namespace Google.Cloud.Spanner.Data
                     case TypeCode.Bool:
                         return DbType.Boolean;
                     case TypeCode.Int64:
+                        // This handles PG.OID as well.
                         return DbType.Int64;
                     case TypeCode.Float64:
                         return DbType.Double;

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerParameter.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerParameter.cs
@@ -150,7 +150,7 @@ namespace Google.Cloud.Spanner.Data
                     + $"({nameof(SpannerDbType.Bool)}, {nameof(SpannerDbType.Int64)}, {nameof(SpannerDbType.Float64)},"
                     + $" {nameof(SpannerDbType.Timestamp)}, {nameof(SpannerDbType.Date)}, {nameof(SpannerDbType.String)},"
                     + $" {nameof(SpannerDbType.Bytes)}, {nameof(SpannerDbType.Json)}, {nameof(SpannerDbType.PgJsonb)}, {nameof(SpannerDbType.Numeric)},"
-                    + $" {nameof(SpannerDbType.PgNumeric)})");
+                    + $" {nameof(SpannerDbType.PgNumeric)}, {nameof(SpannerDbType.PgOid)})");
             }
             return Value;
         }


### PR DESCRIPTION
The PG.OID type is an int64 value with a PG_OID type annotation, mostly used by pg_catalog tables. This PR adds support for representing PG.OID values in the C# client.

Tests are added for being able to query a PG.OID value.

User tables can't be created with PG.OID as a column type so no tests were added for DML or mutations. Since the currently available set of pg_catalog tables don't have PG.OID columns, we also don't test being able to read a PG.OID from a table.