### PR TITLE
Release Google.Cloud.AlloyDb.V1Alpha version 1.0.0-alpha06

### DIFF
--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.csproj
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha05</Version>
+    <Version>1.0.0-alpha06</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AlloyDB API (v1alpha). AlloyDB for PostgreSQL is an open source-compatible database service that provides a powerful option for migrating, modernizing, or building commercial-grade applications.</Description>

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 1.0.0-alpha06, released 2024-02-27
+
+### New features
+
+- Support for obtaining the public IP address of an Instance ([commit 984260f](https://github.com/googleapis/google-cloud-dotnet/commit/984260f6f5ae6810095e86938cf65a0a780a1a20))
+- Support for getting PSC DNS name from the GetConnectionInfo API ([commit 984260f](https://github.com/googleapis/google-cloud-dotnet/commit/984260f6f5ae6810095e86938cf65a0a780a1a20))
+
 ## Version 1.0.0-alpha05, released 2024-01-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -230,7 +230,7 @@
     },
     {
       "id": "Google.Cloud.AlloyDb.V1Alpha",
-      "version": "1.0.0-alpha05",
+      "version": "1.0.0-alpha06",
       "type": "grpc",
       "productName": "AlloyDB",
       "productUrl": "https://cloud.google.com/alloydb/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Support for obtaining the public IP address of an Instance ([commit 984260f](https://github.com/googleapis/google-cloud-dotnet/commit/984260f6f5ae6810095e86938cf65a0a780a1a20))
- Support for getting PSC DNS name from the GetConnectionInfo API ([commit 984260f](https://github.com/googleapis/google-cloud-dotnet/commit/984260f6f5ae6810095e86938cf65a0a780a1a20))
