### PR TITLE
Release Google.Cloud.AlloyDb.V1Beta version 1.0.0-beta04

### DIFF
--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.csproj
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta03</Version>
+    <Version>1.0.0-beta04</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AlloyDB API (v1beta). AlloyDB for PostgreSQL is an open source-compatible database service that provides a powerful option for migrating, modernizing, or building commercial-grade applications.</Description>

--- a/apis/Google.Cloud.AlloyDb.V1Beta/docs/history.md
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/docs/history.md
@@ -1,5 +1,18 @@
 # Version history
 
+## Version 1.0.0-beta04, released 2024-02-27
+
+### New features
+
+- Support for obtaining the public IP address of an Instance ([commit 28c0d9d](https://github.com/googleapis/google-cloud-dotnet/commit/28c0d9d23d02ec425e360ebc5b1d53814fc6dffd))
+- Support for getting PSC DNS name from the GetConnectionInfo API ([commit 28c0d9d](https://github.com/googleapis/google-cloud-dotnet/commit/28c0d9d23d02ec425e360ebc5b1d53814fc6dffd))
+- Add PSC cluster and instance configuration settings to enable/disable PSC and obtain the PSC endpoint name ([commit 28c0d9d](https://github.com/googleapis/google-cloud-dotnet/commit/28c0d9d23d02ec425e360ebc5b1d53814fc6dffd))
+- Add new API to list the databases in a project and location ([commit 28c0d9d](https://github.com/googleapis/google-cloud-dotnet/commit/28c0d9d23d02ec425e360ebc5b1d53814fc6dffd))
+
+### Documentation improvements
+
+- Clarified read pool config is for read pool type instances ([commit 28c0d9d](https://github.com/googleapis/google-cloud-dotnet/commit/28c0d9d23d02ec425e360ebc5b1d53814fc6dffd))
+
 ## Version 1.0.0-beta03, released 2023-09-25
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -254,7 +254,7 @@
     },
     {
       "id": "Google.Cloud.AlloyDb.V1Beta",
-      "version": "1.0.0-beta03",
+      "version": "1.0.0-beta04",
       "type": "grpc",
       "productName": "AlloyDB",
       "productUrl": "https://cloud.google.com/alloydb/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Support for obtaining the public IP address of an Instance ([commit 28c0d9d](https://github.com/googleapis/google-cloud-dotnet/commit/28c0d9d23d02ec425e360ebc5b1d53814fc6dffd))
- Support for getting PSC DNS name from the GetConnectionInfo API ([commit 28c0d9d](https://github.com/googleapis/google-cloud-dotnet/commit/28c0d9d23d02ec425e360ebc5b1d53814fc6dffd))
- Add PSC cluster and instance configuration settings to enable/disable PSC and obtain the PSC endpoint name ([commit 28c0d9d](https://github.com/googleapis/google-cloud-dotnet/commit/28c0d9d23d02ec425e360ebc5b1d53814fc6dffd))
- Add new API to list the databases in a project and location ([commit 28c0d9d](https://github.com/googleapis/google-cloud-dotnet/commit/28c0d9d23d02ec425e360ebc5b1d53814fc6dffd))

### Documentation improvements

- Clarified read pool config is for read pool type instances ([commit 28c0d9d](https://github.com/googleapis/google-cloud-dotnet/commit/28c0d9d23d02ec425e360ebc5b1d53814fc6dffd))
