### PR TITLE
Release Google.Cloud.Container.V1 version 3.22.0

### DIFF
--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.21.0</Version>
+    <Version>3.22.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.</Description>

--- a/apis/Google.Cloud.Container.V1/docs/history.md
+++ b/apis/Google.Cloud.Container.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 3.22.0, released 2024-02-27
+
+### New features
+
+- Add API to enable Provisioning Request API on existing nodepools ([commit 01d881e](https://github.com/googleapis/google-cloud-dotnet/commit/01d881eabb489af5bdb0f0fa88da1b11827000ea))
+- Promoted enable_confidential_storage to GA (behind allowlist) ([commit 01d881e](https://github.com/googleapis/google-cloud-dotnet/commit/01d881eabb489af5bdb0f0fa88da1b11827000ea))
+
 ## Version 3.21.0, released 2024-02-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1558,7 +1558,7 @@
       "protoPath": "google/container/v1",
       "productName": "Google Kubernetes Engine",
       "productUrl": "https://cloud.google.com/kubernetes-engine/docs/reference/rest/",
-      "version": "3.21.0",
+      "version": "3.22.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Add API to enable Provisioning Request API on existing nodepools ([commit 01d881e](https://github.com/googleapis/google-cloud-dotnet/commit/01d881eabb489af5bdb0f0fa88da1b11827000ea))
- Promoted enable_confidential_storage to GA (behind allowlist) ([commit 01d881e](https://github.com/googleapis/google-cloud-dotnet/commit/01d881eabb489af5bdb0f0fa88da1b11827000ea))
