### PR TITLE
Release Google.Cloud.Profiler.V2 version 2.4.0

### DIFF
--- a/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.csproj
+++ b/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Profiler API, which manages continuous profiling information.</Description>

--- a/apis/Google.Cloud.Profiler.V2/docs/history.md
+++ b/apis/Google.Cloud.Profiler.V2/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 2.4.0, released 2024-02-27
+
+### New features
+
+- Add `start_time` to Profile proto ([commit 4e7680a](https://github.com/googleapis/google-cloud-dotnet/commit/4e7680a120658891eddb812e47e739e239eb524d))
+
+### Documentation improvements
+
+- Update documentation to add guidance around use of ProfilerService API methods ([commit 4e7680a](https://github.com/googleapis/google-cloud-dotnet/commit/4e7680a120658891eddb812e47e739e239eb524d))
+
 ## Version 2.3.0, released 2024-01-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3849,7 +3849,7 @@
     },
     {
       "id": "Google.Cloud.Profiler.V2",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "type": "grpc",
       "productName": "Cloud Profiler",
       "productUrl": "https://cloud.google.com/profiler/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add `start_time` to Profile proto ([commit 4e7680a](https://github.com/googleapis/google-cloud-dotnet/commit/4e7680a120658891eddb812e47e739e239eb524d))

### Documentation improvements

- Update documentation to add guidance around use of ProfilerService API methods ([commit 4e7680a](https://github.com/googleapis/google-cloud-dotnet/commit/4e7680a120658891eddb812e47e739e239eb524d))
