### PR TITLE
Release Google.Cloud.SecurityCenter.V1 version 3.15.0

### DIFF
--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.csproj
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.14.0</Version>
+    <Version>3.15.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Security Command Center API, which helps security teams gather data, identify threats, and act on them before they result in business damage or loss.</Description>

--- a/apis/Google.Cloud.SecurityCenter.V1/docs/history.md
+++ b/apis/Google.Cloud.SecurityCenter.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 3.15.0, released 2024-02-27
+
+### New features
+
+- Add load balancer, log entry, org policy, database.version, exfiltration.total_exfiltrated_bytes, file.disk_path, indicator.signature_type, and kubernetes.objects to finding's list of attributes ([commit 2e2659b](https://github.com/googleapis/google-cloud-dotnet/commit/2e2659b8b970ba3e0cf2937f91016f1835fb4c0c))
+- Add Backup DR field to finding's list of attributes ([commit 3a79f3f](https://github.com/googleapis/google-cloud-dotnet/commit/3a79f3f15ddb7445c0da61db768e33ab2c28fc1c))
+
 ## Version 3.14.0, released 2024-02-20
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4349,7 +4349,7 @@
       "protoPath": "google/cloud/securitycenter/v1",
       "productName": "Google Cloud Security Command Center",
       "productUrl": "https://cloud.google.com/security-command-center/",
-      "version": "3.14.0",
+      "version": "3.15.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Security Command Center API, which helps security teams gather data, identify threats, and act on them before they result in business damage or loss.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Add load balancer, log entry, org policy, database.version, exfiltration.total_exfiltrated_bytes, file.disk_path, indicator.signature_type, and kubernetes.objects to finding's list of attributes ([commit 2e2659b](https://github.com/googleapis/google-cloud-dotnet/commit/2e2659b8b970ba3e0cf2937f91016f1835fb4c0c))
- Add Backup DR field to finding's list of attributes ([commit 3a79f3f](https://github.com/googleapis/google-cloud-dotnet/commit/3a79f3f15ddb7445c0da61db768e33ab2c28fc1c))
