### PR TITLE
Release Google.Cloud.ServiceControl.V1 version 2.2.0

### DIFF
--- a/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1.csproj
+++ b/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Service Control API, which provides control plane functionality to managed services, such as logging, monitoring, and status checks.</Description>

--- a/apis/Google.Cloud.ServiceControl.V1/docs/history.md
+++ b/apis/Google.Cloud.ServiceControl.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.2.0, released 2024-02-27
+
+### New features
+
+- Include api_key_uid in service control check response ([commit dffe35a](https://github.com/googleapis/google-cloud-dotnet/commit/dffe35a814210c672e29aa83bf8449acd5fdace3))
+
 ## Version 2.1.0, released 2023-01-19
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4418,7 +4418,7 @@
     },
     {
       "id": "Google.Cloud.ServiceControl.V1",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "type": "grpc",
       "productName": "Service Control",
       "productUrl": "https://cloud.google.com/service-infrastructure/docs/service-control/reference/rpc",


### PR DESCRIPTION

Changes in this release:

### New features

- Include api_key_uid in service control check response ([commit dffe35a](https://github.com/googleapis/google-cloud-dotnet/commit/dffe35a814210c672e29aa83bf8449acd5fdace3))
