### PR TITLE
Release Google.Cloud.Speech.V2 version 1.0.0-beta08

### DIFF
--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.csproj
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta07</Version>
+    <Version>1.0.0-beta08</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Speech-to-Text API (v2) which converts audio to text by applying powerful neural network models.</Description>

--- a/apis/Google.Cloud.Speech.V2/docs/history.md
+++ b/apis/Google.Cloud.Speech.V2/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 1.0.0-beta08, released 2024-02-27
+
+### New features
+
+- Add API for writing BatchRecognize transcripts in SRT and VTT formats ([commit 75f14ec](https://github.com/googleapis/google-cloud-dotnet/commit/75f14ec9ae233ff89a3649e501a0c84abb0b867b))
+
+### Documentation improvements
+
+- Update field documentation based on field behavior updates ([commit 75f14ec](https://github.com/googleapis/google-cloud-dotnet/commit/75f14ec9ae233ff89a3649e501a0c84abb0b867b))
+
 ## Version 1.0.0-beta07, released 2023-11-07
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4754,7 +4754,7 @@
     },
     {
       "id": "Google.Cloud.Speech.V2",
-      "version": "1.0.0-beta07",
+      "version": "1.0.0-beta08",
       "type": "grpc",
       "productName": "Cloud Speech-to-Text",
       "productUrl": "https://cloud.google.com/speech",


### PR DESCRIPTION

Changes in this release:

### New features

- Add API for writing BatchRecognize transcripts in SRT and VTT formats ([commit 75f14ec](https://github.com/googleapis/google-cloud-dotnet/commit/75f14ec9ae233ff89a3649e501a0c84abb0b867b))

### Documentation improvements

- Update field documentation based on field behavior updates ([commit 75f14ec](https://github.com/googleapis/google-cloud-dotnet/commit/75f14ec9ae233ff89a3649e501a0c84abb0b867b))
