### PR TITLE
Release Google.Area120.Tables.V1Alpha1 version 2.0.0-alpha03

### DIFF
--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.csproj
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha02</Version>
+    <Version>2.0.0-alpha03</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Area 120 Tables API</Description>

--- a/apis/Google.Area120.Tables.V1Alpha1/docs/history.md
+++ b/apis/Google.Area120.Tables.V1Alpha1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 2.0.0-alpha03, released 2024-02-28
+
+No API surface changes; just dependency updates.
+
 ## Version 2.0.0-alpha02, released 2023-01-17
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -138,7 +138,7 @@
     },
     {
       "id": "Google.Area120.Tables.V1Alpha1",
-      "version": "2.0.0-alpha02",
+      "version": "2.0.0-alpha03",
       "type": "grpc",
       "productName": "Google Area 120 Tables",
       "description": "Recommended Google client library to access the Area 120 Tables API",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
