### PR TITLE
Release Google.Cloud.AccessApproval.V1 version 2.3.0

### DIFF
--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.csproj
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.2.0</Version>
+    <Version>2.3.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>An API for controlling access to data by Google personnel.</Description>

--- a/apis/Google.Cloud.AccessApproval.V1/docs/history.md
+++ b/apis/Google.Cloud.AccessApproval.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 2.3.0, released 2024-02-28
+
+No API surface changes; just dependency updates.
+
 ## Version 2.2.0, released 2023-01-11
 
 This is primarily a promotion of the previous beta, which includes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -156,7 +156,7 @@
     },
     {
       "id": "Google.Cloud.AccessApproval.V1",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "type": "grpc",
       "productName": "Access Approval",
       "productUrl": "https://cloud.google.com/access-approval/docs/",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
