### PR TITLE
Release Google.Cloud.ApigeeConnect.V1 version 2.2.0

### DIFF
--- a/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1.csproj
+++ b/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Apigee Connect API which allows the Apigee hybrid management plane to connect securely to the MART service in the runtime plane.</Description>

--- a/apis/Google.Cloud.ApigeeConnect.V1/docs/history.md
+++ b/apis/Google.Cloud.ApigeeConnect.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 2.2.0, released 2024-02-28
+
+No API surface changes; just dependency updates.
+
 ## Version 2.1.0, released 2023-01-19
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -350,7 +350,7 @@
     },
     {
       "id": "Google.Cloud.ApigeeConnect.V1",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "type": "grpc",
       "productName": "Apigee Connect",
       "productUrl": "https://cloud.google.com/apigee/docs/hybrid/v1.4/apigee-connect",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
