### PR TITLE
Release Google.Cloud.AppEngine.Logging.V1 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.AppEngine.Logging.V1/Google.Cloud.AppEngine.Logging.V1/Google.Cloud.AppEngine.Logging.V1.csproj
+++ b/apis/Google.Cloud.AppEngine.Logging.V1/Google.Cloud.AppEngine.Logging.V1/Google.Cloud.AppEngine.Logging.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Protobuf messages for Google Cloud App Engine logs.</Description>

--- a/apis/Google.Cloud.AppEngine.Logging.V1/docs/history.md
+++ b/apis/Google.Cloud.AppEngine.Logging.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.1.0, released 2024-02-28
+
+No API surface changes; just dependency updates.
+
 ## Version 1.0.0, released 2022-09-14
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -398,7 +398,7 @@
     },
     {
       "id": "Google.Cloud.AppEngine.Logging.V1",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "targetFrameworks": "netstandard2.1;net462",
       "productName": "App Engine Logging Data",
       "productUrl": "https://cloud.google.com/appengine",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
