### PR TITLE
Release Google.Cloud.AppEngine.V1 version 2.2.0

### DIFF
--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.csproj
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the App Engine API, which provisions and manages developers' App Engine applications.</Description>

--- a/apis/Google.Cloud.AppEngine.V1/docs/history.md
+++ b/apis/Google.Cloud.AppEngine.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.2.0, released 2024-02-28
+
+### Documentation improvements
+
+- Point to Search Console for domain ownership verification ([commit e79e82e](https://github.com/googleapis/google-cloud-dotnet/commit/e79e82e92a5cccdfa8f6bc7e16c1805e2632afb8))
+
 ## Version 2.1.0, released 2023-01-17
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -417,7 +417,7 @@
     },
     {
       "id": "Google.Cloud.AppEngine.V1",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "type": "grpc",
       "productName": "App Engine",
       "productUrl": "https://cloud.google.com/appengine",


### PR DESCRIPTION

Changes in this release:

### Documentation improvements

- Point to Search Console for domain ownership verification ([commit e79e82e](https://github.com/googleapis/google-cloud-dotnet/commit/e79e82e92a5cccdfa8f6bc7e16c1805e2632afb8))
