### PR TITLE
Release Google.Cloud.BareMetalSolution.V2 version 1.4.0

### DIFF
--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.csproj
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Bare Metal Solution API (v2), which provides ways to manage Bare Metal Solution hardware installed in a regional extension located near a Google Cloud data center.</Description>

--- a/apis/Google.Cloud.BareMetalSolution.V2/docs/history.md
+++ b/apis/Google.Cloud.BareMetalSolution.V2/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.4.0, released 2024-02-28
+
+No API surface changes; just dependency updates.
+
 ## Version 1.3.0, released 2023-08-22
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -611,7 +611,7 @@
     },
     {
       "id": "Google.Cloud.BareMetalSolution.V2",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "type": "grpc",
       "productName": "Bare Metal Solution",
       "productUrl": "https://cloud.google.com/bare-metal/",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
