### PR TITLE
Release Google.Cloud.Batch.V1 version 2.8.0

### DIFF
--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.csproj
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.7.0</Version>
+    <Version>2.8.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Batch API (v1), which allows you to manage the running of batch jobs on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Batch.V1/docs/history.md
+++ b/apis/Google.Cloud.Batch.V1/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 2.8.0, released 2024-02-28
+
+### Documentation improvements
+
+- Update description of Job uid field ([commit eaaff5e](https://github.com/googleapis/google-cloud-dotnet/commit/eaaff5e430e478452b5463f33b590209e944b7a7))
+- Refine proto comment for run_as_non_root ([commit 354560a](https://github.com/googleapis/google-cloud-dotnet/commit/354560a797a3038d45cab928a5d4e8b0bd0cac91))
+- Add caution messages for container runnable username and password fields ([commit 354560a](https://github.com/googleapis/google-cloud-dotnet/commit/354560a797a3038d45cab928a5d4e8b0bd0cac91))
+
 ## Version 2.7.0, released 2024-02-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -637,7 +637,7 @@
     },
     {
       "id": "Google.Cloud.Batch.V1",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "type": "grpc",
       "productName": "Batch",
       "productUrl": "https://cloud.google.com/batch/docs/",


### PR DESCRIPTION

Changes in this release:

### Documentation improvements

- Update description of Job uid field ([commit eaaff5e](https://github.com/googleapis/google-cloud-dotnet/commit/eaaff5e430e478452b5463f33b590209e944b7a7))
- Refine proto comment for run_as_non_root ([commit 354560a](https://github.com/googleapis/google-cloud-dotnet/commit/354560a797a3038d45cab928a5d4e8b0bd0cac91))
- Add caution messages for container runnable username and password fields ([commit 354560a](https://github.com/googleapis/google-cloud-dotnet/commit/354560a797a3038d45cab928a5d4e8b0bd0cac91))
