### PR TITLE
Release Google.Cloud.Batch.V1Alpha version 1.0.0-alpha22

### DIFF
--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.csproj
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha21</Version>
+    <Version>1.0.0-alpha22</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Batch API (v1alpha), which allows you to manage the running of batch jobs on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Batch.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.Batch.V1Alpha/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 1.0.0-alpha22, released 2024-02-28
+
+### Documentation improvements
+
+- Remove UUID specification in comment ([commit 8951fe6](https://github.com/googleapis/google-cloud-dotnet/commit/8951fe6cfcb94b62017cb970a95df258ffe4a000))
+- Add caution messages for container runnable username and password fields ([commit 7377638](https://github.com/googleapis/google-cloud-dotnet/commit/73776380d25ca177f91f65b7ed2496030e25e884))
+- Refine proto comment for run_as_non_root ([commit 7377638](https://github.com/googleapis/google-cloud-dotnet/commit/73776380d25ca177f91f65b7ed2496030e25e884))
+
 ## Version 1.0.0-alpha21, released 2024-02-08
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -662,7 +662,7 @@
     },
     {
       "id": "Google.Cloud.Batch.V1Alpha",
-      "version": "1.0.0-alpha21",
+      "version": "1.0.0-alpha22",
       "type": "grpc",
       "productName": "Batch",
       "productUrl": "https://cloud.google.com/batch/docs/",


### PR DESCRIPTION

Changes in this release:

### Documentation improvements

- Remove UUID specification in comment ([commit 8951fe6](https://github.com/googleapis/google-cloud-dotnet/commit/8951fe6cfcb94b62017cb970a95df258ffe4a000))
- Add caution messages for container runnable username and password fields ([commit 7377638](https://github.com/googleapis/google-cloud-dotnet/commit/73776380d25ca177f91f65b7ed2496030e25e884))
- Refine proto comment for run_as_non_root ([commit 7377638](https://github.com/googleapis/google-cloud-dotnet/commit/73776380d25ca177f91f65b7ed2496030e25e884))
