### PR TITLE
Release Google.Cloud.BigQuery.AnalyticsHub.V1 version 1.2.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery Analytics Hub, which allows users to exchange data and analytics assets securely and efficiently.</Description>

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.2.0, released 2024-02-28
+
+No API surface changes; just dependency updates.
+
 ## Version 1.1.0, released 2023-09-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -781,7 +781,7 @@
     },
     {
       "id": "Google.Cloud.BigQuery.AnalyticsHub.V1",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "type": "grpc",
       "productName": "Analytics Hub",
       "productUrl": "https://cloud.google.com/analytics-hub",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
