### PR TITLE
Release Google.Cloud.BigQuery.DataExchange.V1Beta1 version 2.0.0-beta03

### DIFF
--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.csproj
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta02</Version>
+    <Version>2.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery DataExchange API, which allows users to exchange data and analytics assets securely and efficiently.</Description>

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 2.0.0-beta03, released 2024-02-28
+
+No API surface changes; just dependency updates.
+
 ## Version 2.0.0-beta02, released 2022-09-02
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -828,7 +828,7 @@
     },
     {
       "id": "Google.Cloud.BigQuery.DataExchange.V1Beta1",
-      "version": "2.0.0-beta02",
+      "version": "2.0.0-beta03",
       "type": "grpc",
       "productName": "Analytics Hub",
       "productUrl": "https://cloud.google.com/analytics-hub",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
