### PR TITLE
Release Google.Cloud.BigQuery.DataPolicies.V1Beta1 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.csproj
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery DataPolicies API (v1beta1), which allows users to manage BigQuery data policies.</Description>

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2024-02-28
+
+No API surface changes; just dependency updates.
+
 ## Version 1.0.0-beta01, released 2022-10-03
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -873,7 +873,7 @@
     },
     {
       "id": "Google.Cloud.BigQuery.DataPolicies.V1Beta1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "BigQuery Data Policy",
       "productUrl": "https://cloud.google.com/bigquery/docs/data-governance",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
