### PR TITLE
Release Google.Cloud.BigQuery.DataTransfer.V1 version 4.6.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.5.0</Version>
+    <Version>4.6.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery Data Transfer API, which transfers data from partner SaaS applications to Google BigQuery on a scheduled, managed basis.</Description>

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 4.6.0, released 2024-02-28
+
+### Documentation improvements
+
+- Update unenrollDataSources API documentation ([commit 4139f3c](https://github.com/googleapis/google-cloud-dotnet/commit/4139f3c037ac0723446f602a5e167cf695857222))
+
 ## Version 4.5.0, released 2024-02-20
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -897,7 +897,7 @@
       "protoPath": "google/cloud/bigquery/datatransfer/v1",
       "productName": "Google BigQuery Data Transfer",
       "productUrl": "https://cloud.google.com/bigquery/transfer/",
-      "version": "4.5.0",
+      "version": "4.6.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the BigQuery Data Transfer API, which transfers data from partner SaaS applications to Google BigQuery on a scheduled, managed basis.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### Documentation improvements

- Update unenrollDataSources API documentation ([commit 4139f3c](https://github.com/googleapis/google-cloud-dotnet/commit/4139f3c037ac0723446f602a5e167cf695857222))
