### PR TITLE
Release Google.Cloud.BigQuery.Reservation.V1 version 2.3.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.2.0</Version>
+    <Version>2.3.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery Reservation API, which allows you to modify your BigQuery flat-rate reservations.</Description>

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 2.3.0, released 2024-02-28
+
+No API surface changes; just dependency updates.
+
 ## Version 2.2.0, released 2023-03-27
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -957,7 +957,7 @@
     },
     {
       "id": "Google.Cloud.BigQuery.Reservation.V1",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "type": "grpc",
       "productName": "BigQuery Reservation",
       "productUrl": "https://cloud.google.com/bigquery/docs/reference/reservations",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
