### PR TITLE
Release Google.Cloud.Billing.Budgets.V1Beta1 version 2.0.0-beta04

### DIFF
--- a/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1.csproj
+++ b/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta03</Version>
+    <Version>2.0.0-beta04</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Cloud Billing Budget API v1beta1. This API stores Cloud Billing budgets, which define a budget plan and the rules to execute as spend is tracked against that plan.</Description>

--- a/apis/Google.Cloud.Billing.Budgets.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.Billing.Budgets.V1Beta1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 2.0.0-beta04, released 2024-02-28
+
+No API surface changes; just dependency updates.
+
 ## Version 2.0.0-beta03, released 2023-08-23
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1114,7 +1114,7 @@
     },
     {
       "id": "Google.Cloud.Billing.Budgets.V1Beta1",
-      "version": "2.0.0-beta03",
+      "version": "2.0.0-beta04",
       "type": "grpc",
       "productName": "Cloud Billing Budget",
       "productUrl": "https://cloud.google.com/billing/docs/how-to/budget-api-overview",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
