### PR TITLE
Release Google.Cloud.Billing.V1 version 3.6.0

### DIFF
--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.csproj
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.5.0</Version>
+    <Version>3.6.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Billing API, which allows you to define a budget plan and the rules to execute as spend is tracked against that plan.</Description>

--- a/apis/Google.Cloud.Billing.V1/docs/history.md
+++ b/apis/Google.Cloud.Billing.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 3.6.0, released 2024-02-28
+
+### Documentation improvements
+
+- Clarify that the parent field in the CreateBillingAccountRequest must be a billing account ([commit 0c2c601](https://github.com/googleapis/google-cloud-dotnet/commit/0c2c6018b82fa49527b1b1108bc569cc4c9018c5))
+- Update comments ([commit fe663ba](https://github.com/googleapis/google-cloud-dotnet/commit/fe663ba9a85fd347c4fd3a4fd554466dede34a7f))
+
 ## Version 3.5.0, released 2023-12-11
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1138,7 +1138,7 @@
       "protoPath": "google/cloud/billing/v1",
       "productName": "Google Cloud Billing",
       "productUrl": "https://cloud.google.com/billing/docs/",
-      "version": "3.5.0",
+      "version": "3.6.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Billing API, which allows you to define a budget plan and the rules to execute as spend is tracked against that plan.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### Documentation improvements

- Clarify that the parent field in the CreateBillingAccountRequest must be a billing account ([commit 0c2c601](https://github.com/googleapis/google-cloud-dotnet/commit/0c2c6018b82fa49527b1b1108bc569cc4c9018c5))
- Update comments ([commit fe663ba](https://github.com/googleapis/google-cloud-dotnet/commit/fe663ba9a85fd347c4fd3a4fd554466dede34a7f))
