### PR TITLE
Release Google.Cloud.BinaryAuthorization.V1Beta1 version 2.0.0-beta06

### DIFF
--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.csproj
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta05</Version>
+    <Version>2.0.0-beta06</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Binary Authorization API v1beta1, providing policy control for images deployed to Kubernetes Engine clusters.</Description>

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 2.0.0-beta06, released 2024-02-28
+
+No API surface changes; just dependency updates.
+
 ## Version 2.0.0-beta05, released 2023-12-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1184,7 +1184,7 @@
     },
     {
       "id": "Google.Cloud.BinaryAuthorization.V1Beta1",
-      "version": "2.0.0-beta05",
+      "version": "2.0.0-beta06",
       "type": "grpc",
       "productName": "Binary Authorization",
       "productUrl": "https://cloud.google.com/binary-authorization/docs/reference/rpc",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
