### PR TITLE
Release Google.Cloud.CloudBuild.V2 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.csproj
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Build API v2, which creates and manages builds on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.CloudBuild.V2/docs/history.md
+++ b/apis/Google.Cloud.CloudBuild.V2/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.1.0, released 2024-02-28
+
+No API surface changes; just dependency updates.
+
 ## Version 1.0.0, released 2023-11-01
 
 No API surface changes; just dependency updates and promotion to GA.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1281,7 +1281,7 @@
     },
     {
       "id": "Google.Cloud.CloudBuild.V2",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "grpc",
       "productName": "Cloud Build",
       "description": "Recommended Google client library to access the Google Cloud Build API v2, which creates and manages builds on Google Cloud Platform.",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
