### PR TITLE
Release Google.Cloud.Commerce.Consumer.Procurement.V1 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.csproj
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Commerce Consumer Procurement API, which enables consumers to procure products served by Cloud Marketplace platform.</Description>

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/docs/history.md
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.1.0, released 2024-02-28
+
+No API surface changes; just dependency updates.
+
 ## Version 1.0.0, released 2023-11-01
 
 No API surface changes; just dependency updates and promotion to GA.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1371,7 +1371,7 @@
     },
     {
       "id": "Google.Cloud.Commerce.Consumer.Procurement.V1",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "grpc",
       "productName": "Cloud Commerce Consumer Procurement",
       "productUrl": "https://cloud.google.com/marketplace/docs/",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
