### PR TITLE
Release Google.Cloud.Common version 2.1.0

### DIFF
--- a/apis/Google.Cloud.Common/Google.Cloud.Common/Google.Cloud.Common.csproj
+++ b/apis/Google.Cloud.Common/Google.Cloud.Common/Google.Cloud.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Common protos for Cloud APIs.</Description>

--- a/apis/Google.Cloud.Common/docs/history.md
+++ b/apis/Google.Cloud.Common/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 2.1.0, released 2024-02-28
+
+No API surface changes; just dependency updates.
+
 ## Version 2.0.0, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1393,7 +1393,7 @@
     },
     {
       "id": "Google.Cloud.Common",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "targetFrameworks": "netstandard2.1;net462",
       "type": "other",
       "description": "Common protos for Cloud APIs.",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
