### PR TITLE
Release Google.Cloud.ConfidentialComputing.V1Alpha1 version 1.0.0-alpha02

### DIFF
--- a/apis/Google.Cloud.ConfidentialComputing.V1Alpha1/Google.Cloud.ConfidentialComputing.V1Alpha1/Google.Cloud.ConfidentialComputing.V1Alpha1.csproj
+++ b/apis/Google.Cloud.ConfidentialComputing.V1Alpha1/Google.Cloud.ConfidentialComputing.V1Alpha1/Google.Cloud.ConfidentialComputing.V1Alpha1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha01</Version>
+    <Version>1.0.0-alpha02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Confidential Computing API (v1alpha1)</Description>

--- a/apis/Google.Cloud.ConfidentialComputing.V1Alpha1/docs/history.md
+++ b/apis/Google.Cloud.ConfidentialComputing.V1Alpha1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0-alpha02, released 2024-02-28
+
+No API surface changes; just dependency updates.
+
 ## Version 1.0.0-alpha01, released 2023-04-12
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1452,7 +1452,7 @@
     },
     {
       "id": "Google.Cloud.ConfidentialComputing.V1Alpha1",
-      "version": "1.0.0-alpha01",
+      "version": "1.0.0-alpha02",
       "type": "grpc",
       "productName": "Confidential Computing",
       "productUrl": "https://cloud.google.com/confidential-computing",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
