### PR TITLE
Release Google.Cloud.Dataproc.V1 version 5.9.0

### DIFF
--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.csproj
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>5.8.0</Version>
+    <Version>5.9.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Dataproc API, which manages Hadoop-based clusters and jobs on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Dataproc.V1/docs/history.md
+++ b/apis/Google.Cloud.Dataproc.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 5.9.0, released 2024-02-28
+
+No API surface changes; just dependency updates.
+
 ## Version 5.8.0, released 2023-11-07
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1744,7 +1744,7 @@
       "protoPath": "google/cloud/dataproc/v1",
       "productName": "Google Cloud Dataproc",
       "productUrl": "https://cloud.google.com/dataproc/docs/concepts/overview",
-      "version": "5.8.0",
+      "version": "5.9.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Dataproc API, which manages Hadoop-based clusters and jobs on Google Cloud Platform.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
