### PR TITLE
Release Google.Cloud.Datastore.Admin.V1 version 2.2.0

### DIFF
--- a/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.csproj
+++ b/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Datastore Admin API. This accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.</Description>

--- a/apis/Google.Cloud.Datastore.Admin.V1/docs/history.md
+++ b/apis/Google.Cloud.Datastore.Admin.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 2.2.0, released 2024-02-28
+
+### Documentation improvements
+
+- Specify limit for `properties` in `Index` message in Datastore Admin API ([commit 2e2e21b](https://github.com/googleapis/google-cloud-dotnet/commit/2e2e21bc8c6e01672dc17e966f8d824c37ec60de))
+- Minor formatting in Datastore Admin API ([commit 2e2e21b](https://github.com/googleapis/google-cloud-dotnet/commit/2e2e21bc8c6e01672dc17e966f8d824c37ec60de))
+
 ## Version 2.1.0, released 2023-01-16
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1765,7 +1765,7 @@
     },
     {
       "id": "Google.Cloud.Datastore.Admin.V1",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "type": "grpc",
       "productName": "Cloud Datastore",
       "description": "Recommended Google client library to access the Google Cloud Datastore Admin API. This accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.",


### PR DESCRIPTION

Changes in this release:

### Documentation improvements

- Specify limit for `properties` in `Index` message in Datastore Admin API ([commit 2e2e21b](https://github.com/googleapis/google-cloud-dotnet/commit/2e2e21bc8c6e01672dc17e966f8d824c37ec60de))
- Minor formatting in Datastore Admin API ([commit 2e2e21b](https://github.com/googleapis/google-cloud-dotnet/commit/2e2e21bc8c6e01672dc17e966f8d824c37ec60de))
