### PR TITLE
Release Google.Cloud.Datastream.V1 version 2.5.0

### DIFF
--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.csproj
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.4.0</Version>
+    <Version>2.5.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Datastream API (v1), which allows you to synchronize data across heterogeneous databases and applications reliably, and with minimal latency and downtime.</Description>

--- a/apis/Google.Cloud.Datastream.V1/docs/history.md
+++ b/apis/Google.Cloud.Datastream.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 2.5.0, released 2024-02-28
+
+No API surface changes; just dependency updates.
+
 ## Version 2.4.0, released 2023-08-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1817,7 +1817,7 @@
     },
     {
       "id": "Google.Cloud.Datastream.V1",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "type": "grpc",
       "productName": "DataStream",
       "productUrl": "https://cloud.google.com/datastream/docs",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
