### PR TITLE
Release Google.Cloud.DevTools.Common version 3.1.0

### DIFF
--- a/apis/Google.Cloud.DevTools.Common/docs/history.md
+++ b/apis/Google.Cloud.DevTools.Common/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 3.1.0, released 2024-02-28
+
+No API surface changes; just dependency updates.
+
 ## Version 3.0.0, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1895,7 +1895,7 @@
     },
     {
       "id": "Google.Cloud.DevTools.Common",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "type": "other",
       "targetFrameworks": "netstandard2.1;net462",
       "testTargetFrameworks": "net6.0;net462",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
