### PR TITLE
Release Google.Cloud.Domains.V1 version 2.2.0

### DIFF
--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.csproj
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Domains API v1, which enables management and configuration of domain names.</Description>

--- a/apis/Google.Cloud.Domains.V1/docs/history.md
+++ b/apis/Google.Cloud.Domains.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 2.2.0, released 2024-02-28
+
+No API surface changes; just dependency updates.
+
 ## Version 2.1.0, released 2023-01-11
 
 This is primarily a promotion of the previous beta, which includes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2192,7 +2192,7 @@
     },
     {
       "id": "Google.Cloud.Domains.V1",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "type": "grpc",
       "productName": "Cloud Domains",
       "productUrl": "https://cloud.google.com/domains/",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
