### PR TITLE
Release Google.Cloud.GkeBackup.V1 version 2.3.0

### DIFF
--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.csproj
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.2.0</Version>
+    <Version>2.3.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Backup for GKE API, which is a managed Kubernetes workload backup and restore service for GKE clusters.</Description>

--- a/apis/Google.Cloud.GkeBackup.V1/docs/history.md
+++ b/apis/Google.Cloud.GkeBackup.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.3.0, released 2024-02-28
+
+### Documentation improvements
+
+- Minor formatting ([commit 9498ba9](https://github.com/googleapis/google-cloud-dotnet/commit/9498ba98ecac1ebc1aa1fa0174aadd089d9f853c))
+
 ## Version 2.2.0, released 2023-06-27
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2576,7 +2576,7 @@
     },
     {
       "id": "Google.Cloud.GkeBackup.V1",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "type": "grpc",
       "productName": "Backup for GKE",
       "productUrl": "https://cloud.google.com/kubernetes-engine/docs/add-on/backup-for-gke",


### PR DESCRIPTION

Changes in this release:

### Documentation improvements

- Minor formatting ([commit 9498ba9](https://github.com/googleapis/google-cloud-dotnet/commit/9498ba98ecac1ebc1aa1fa0174aadd089d9f853c))
