### PR TITLE
Release Google.Cloud.Iap.V1 version 2.5.0

### DIFF
--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.csproj
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.4.0</Version>
+    <Version>2.5.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud IAP API, which controls access to cloud applications running on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Iap.V1/docs/history.md
+++ b/apis/Google.Cloud.Iap.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.5.0, released 2024-02-28
+
+### Documentation improvements
+
+- Fixing Oauth typo ([commit 50dce7e](https://github.com/googleapis/google-cloud-dotnet/commit/50dce7e87a926b0773a3f3a13117f17976b7202f))
+
 ## Version 2.4.0, released 2023-09-18
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2800,7 +2800,7 @@
     },
     {
       "id": "Google.Cloud.Iap.V1",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "type": "grpc",
       "productName": "Cloud Identity-Aware Proxy",
       "productUrl": "https://cloud.google.com/iap/docs/",


### PR DESCRIPTION

Changes in this release:

### Documentation improvements

- Fixing Oauth typo ([commit 50dce7e](https://github.com/googleapis/google-cloud-dotnet/commit/50dce7e87a926b0773a3f3a13117f17976b7202f))
