### PR TITLE
Release Google.Cloud.Language.V2 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2/Google.Cloud.Language.V2.csproj
+++ b/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2/Google.Cloud.Language.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Natural Language API (v2), which provides natural language understanding technologies, such as sentiment analysis, entity recognition, entity sentiment analysis, and other text annotations, to developers.</Description>

--- a/apis/Google.Cloud.Language.V2/docs/history.md
+++ b/apis/Google.Cloud.Language.V2/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2024-02-28
+
+No API surface changes; just dependency updates.
+
 ## Version 1.0.0-beta01, released 2023-08-15
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2926,7 +2926,7 @@
     },
     {
       "id": "Google.Cloud.Language.V2",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Cloud Natural Language",
       "productUrl": "https://cloud.google.com/natural-language/docs",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
