### PR TITLE
Release Google.Cloud.Location version 2.1.0

### DIFF
--- a/apis/Google.Cloud.Location/Google.Cloud.Location/Google.Cloud.Location.csproj
+++ b/apis/Google.Cloud.Location/Google.Cloud.Location/Google.Cloud.Location.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>gRPC services for the Google Cloud Locations API. This library is typically used as a dependency for other API client libraries.</Description>

--- a/apis/Google.Cloud.Location/docs/history.md
+++ b/apis/Google.Cloud.Location/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 2.1.0, released 2024-02-28
+
+No API surface changes; just dependency updates.
+
 ## Version 2.0.0, released 2022-06-07
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2967,7 +2967,7 @@
     },
     {
       "id": "Google.Cloud.Location",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "type": "grpc",
       "listingDescription": "Support for the Google Cloud Locations mix-in API pattern",
       "metadataType": "CORE",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
