### PR TITLE
Release Google.Cloud.Logging.Console version 1.2.0

### DIFF
--- a/apis/Google.Cloud.Logging.Console/Google.Cloud.Logging.Console/Google.Cloud.Logging.Console.csproj
+++ b/apis/Google.Cloud.Logging.Console/Google.Cloud.Logging.Console/Google.Cloud.Logging.Console.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>ConsoleFormatter for Google Cloud Logging.</Description>

--- a/apis/Google.Cloud.Logging.Console/docs/history.md
+++ b/apis/Google.Cloud.Logging.Console/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.2.0, released 2024-02-28
+
+No API surface changes; just dependency updates.
+
 ## Version 1.1.0, released 2023-05-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3012,7 +3012,7 @@
     },
     {
       "id": "Google.Cloud.Logging.Console",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "type": "other",
       "metadataType": "INTEGRATION",
       "targetFrameworks": "netstandard2.1",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
