### PR TITLE
Release Google.Cloud.Logging.Type version 4.1.0

### DIFF
--- a/apis/Google.Cloud.Logging.Type/Google.Cloud.Logging.Type/Google.Cloud.Logging.Type.csproj
+++ b/apis/Google.Cloud.Logging.Type/Google.Cloud.Logging.Type/Google.Cloud.Logging.Type.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.0.0</Version>
+    <Version>4.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Version-agnostic types for the Google Cloud Logging API.</Description>

--- a/apis/Google.Cloud.Logging.Type/docs/history.md
+++ b/apis/Google.Cloud.Logging.Type/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 4.1.0, released 2024-02-28
+
+### Documentation improvements
+
+- Fix link to RFC 2616 ([commit 5868d25](https://github.com/googleapis/google-cloud-dotnet/commit/5868d2595a028cca59aa9bd5882e0389ead7eed5))
+
 ## Version 4.0.0, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3056,7 +3056,7 @@
       "id": "Google.Cloud.Logging.Type",
       "generator": "proto",
       "protoPath": "google/logging/type",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "type": "other",
       "targetFrameworks": "netstandard2.1;net462",
       "description": "Version-agnostic types for the Google Cloud Logging API.",


### PR DESCRIPTION

Changes in this release:

### Documentation improvements

- Fix link to RFC 2616 ([commit 5868d25](https://github.com/googleapis/google-cloud-dotnet/commit/5868d2595a028cca59aa9bd5882e0389ead7eed5))
