### PR TITLE
Release Google.Cloud.Logging.V2 version 4.2.0

### DIFF
--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.csproj
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.1.0</Version>
+    <Version>4.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Logging API, which writes log entries and manages your logs, log sinks, and logs-based metrics.</Description>

--- a/apis/Google.Cloud.Logging.V2/docs/history.md
+++ b/apis/Google.Cloud.Logging.V2/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 4.2.0, released 2024-02-28
+
+No API surface changes; just dependency updates.
+
 ## Version 4.1.0, released 2023-06-20
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3074,7 +3074,7 @@
       "protoPath": "google/logging/v2",
       "productName": "Google Cloud Logging",
       "productUrl": "https://cloud.google.com/logging/",
-      "version": "4.1.0",
+      "version": "4.2.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Logging API, which writes log entries and manages your logs, log sinks, and logs-based metrics.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
