### PR TITLE
Release Google.Cloud.Memcache.V1 version 2.3.0

### DIFF
--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.csproj
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.2.0</Version>
+    <Version>2.3.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library at access the Google Cloud Memorystore for Memcached API (v1), which is used for creating and managing Memcached instances in GCP.</Description>

--- a/apis/Google.Cloud.Memcache.V1/docs/history.md
+++ b/apis/Google.Cloud.Memcache.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 2.3.0, released 2024-02-28
+
+No API surface changes; just dependency updates.
+
 ## Version 2.2.0, released 2023-01-19
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3139,7 +3139,7 @@
     },
     {
       "id": "Google.Cloud.Memcache.V1",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "type": "grpc",
       "productName": "Cloud Memorystore for Memcached",
       "productUrl": "https://cloud.google.com/memorystore/",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
