### PR TITLE
Release Google.Cloud.Metastore.V1Alpha version 2.0.0-alpha08

### DIFF
--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.csproj
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha07</Version>
+    <Version>2.0.0-alpha08</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Dataproc Metastore API (v1alpha) which is used to manage the lifecycle and configuration of metastore services.</Description>

--- a/apis/Google.Cloud.Metastore.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.Metastore.V1Alpha/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 2.0.0-alpha08, released 2024-02-28
+
+No API surface changes; just dependency updates.
+
 ## Version 2.0.0-alpha07, released 2023-10-02
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3215,7 +3215,7 @@
     },
     {
       "id": "Google.Cloud.Metastore.V1Alpha",
-      "version": "2.0.0-alpha07",
+      "version": "2.0.0-alpha08",
       "type": "grpc",
       "productName": "Dataproc Metastore",
       "productUrl": "https://cloud.google.com/dataproc-metastore/docs",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
