### PR TITLE
Release Google.Cloud.MigrationCenter.V1 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.csproj
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Migration Center API, which is a unified platform that helps you accelerate your end-to-end cloud journey from your current on-premises or cloud environments to Google Cloud.</Description>

--- a/apis/Google.Cloud.MigrationCenter.V1/docs/history.md
+++ b/apis/Google.Cloud.MigrationCenter.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.1.0, released 2024-02-28
+
+No API surface changes; just dependency updates.
+
 ## Version 1.0.0, released 2023-11-01
 
 No API surface changes; just dependency updates and promotion to GA.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3263,7 +3263,7 @@
     },
     {
       "id": "Google.Cloud.MigrationCenter.V1",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "grpc",
       "productName": "Migration Center",
       "productUrl": "https://cloud.google.com/migration-center/docs/migration-center-overview",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
