### PR TITLE
Release Google.Cloud.NetApp.V1 version 1.0.0-beta03

### DIFF
--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.csproj
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud NetApp Volumes API, which is a fully-managed, cloud-based data storage service that provides advanced data management capabilities and highly scalable performance with global availability.</Description>

--- a/apis/Google.Cloud.NetApp.V1/docs/history.md
+++ b/apis/Google.Cloud.NetApp.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0-beta03, released 2024-02-28
+
+No API surface changes; just dependency updates.
+
 ## Version 1.0.0-beta02, released 2024-01-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3309,7 +3309,7 @@
     },
     {
       "id": "Google.Cloud.NetApp.V1",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0-beta03",
       "type": "grpc",
       "productName": "NetApp",
       "productUrl": "https://cloud.google.com/netapp/volumes/docs/discover/overview",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
