### PR TITLE
Release Google.Cloud.NetworkConnectivity.V1Alpha1 version 2.0.0-alpha02

### DIFF
--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.csproj
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha01</Version>
+    <Version>2.0.0-alpha02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Network Connectivity API (v1alpha1), which provides information pertaining to network connectivity.</Description>

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/docs/history.md
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 2.0.0-alpha02, released 2024-02-28
+
+No API surface changes; just dependency updates.
+
 ## Version 2.0.0-alpha01, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3358,7 +3358,7 @@
     },
     {
       "id": "Google.Cloud.NetworkConnectivity.V1Alpha1",
-      "version": "2.0.0-alpha01",
+      "version": "2.0.0-alpha02",
       "type": "grpc",
       "productName": "Network Connectivity",
       "productUrl": "https://cloud.google.com/network-connectivity/docs/apis",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
