### PR TITLE
Release Google.Cloud.NetworkManagement.V1 version 2.6.0

### DIFF
--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.csproj
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.5.0</Version>
+    <Version>2.6.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Network Management API, which provides a collection of network performance monitoring and diagnostic capabilities.</Description>

--- a/apis/Google.Cloud.NetworkManagement.V1/docs/history.md
+++ b/apis/Google.Cloud.NetworkManagement.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 2.6.0, released 2024-02-28
+
+No API surface changes; just dependency updates.
+
 ## Version 2.5.0, released 2023-08-16
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3379,7 +3379,7 @@
     },
     {
       "id": "Google.Cloud.NetworkManagement.V1",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "type": "grpc",
       "productName": "Network Management",
       "productUrl": "https://cloud.google.com/network-intelligence-center/docs/",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
