### PR TITLE
Release Google.Cloud.Notebooks.V1Beta1 version 2.0.0-beta03

### DIFF
--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.csproj
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta02</Version>
+    <Version>2.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AI Platform Notebooks API (v1 beta), which is used to manage notebook resources in Google Cloud.</Description>

--- a/apis/Google.Cloud.Notebooks.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.0.0-beta03, released 2024-02-28
+
+### Documentation improvements
+
+- Minor formatting fixes to reference documentation ([commit cbe3cad](https://github.com/googleapis/google-cloud-dotnet/commit/cbe3cad6997d3563e7084f51ff9138aa215b0141))
+
 ## Version 2.0.0-beta02, released 2022-12-01
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3463,7 +3463,7 @@
     },
     {
       "id": "Google.Cloud.Notebooks.V1Beta1",
-      "version": "2.0.0-beta02",
+      "version": "2.0.0-beta03",
       "type": "grpc",
       "productName": "AI Platform Notebooks",
       "productUrl": "https://cloud.google.com/ai-platform-notebooks",


### PR DESCRIPTION

Changes in this release:

### Documentation improvements

- Minor formatting fixes to reference documentation ([commit cbe3cad](https://github.com/googleapis/google-cloud-dotnet/commit/cbe3cad6997d3563e7084f51ff9138aa215b0141))
