### PR TITLE
Release Google.Cloud.OsConfig.V1Alpha version 2.0.0-alpha03

### DIFF
--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.csproj
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha02</Version>
+    <Version>2.0.0-alpha03</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library for the Cloud OS Config API (v1 alpha). These are OS management tools that can be used for patch management, patch compliance, and configuration management on VM instances.</Description>

--- a/apis/Google.Cloud.OsConfig.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 2.0.0-alpha03, released 2024-02-28
+
+No API surface changes; just dependency updates.
+
 ## Version 2.0.0-alpha02, released 2023-01-19
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3620,7 +3620,7 @@
     },
     {
       "id": "Google.Cloud.OsConfig.V1Alpha",
-      "version": "2.0.0-alpha02",
+      "version": "2.0.0-alpha03",
       "type": "grpc",
       "productName": "Google Cloud OS Config",
       "productUrl": "https://cloud.google.com/compute/docs/osconfig/rest",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
