### PR TITLE
Release Google.Cloud.OsLogin.V1 version 3.3.0

### DIFF
--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.csproj
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.2.0</Version>
+    <Version>3.3.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to manage OS login configuration for Google account users.</Description>

--- a/apis/Google.Cloud.OsLogin.V1/docs/history.md
+++ b/apis/Google.Cloud.OsLogin.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 3.3.0, released 2024-02-29
+
+No API surface changes; just dependency updates.
+
 ## Version 3.2.0, released 2024-01-16
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3670,7 +3670,7 @@
       "protoPath": "google/cloud/oslogin/v1",
       "productName": "Google Cloud OS Login",
       "productUrl": "https://cloud.google.com/compute/docs/instances/managing-instance-access",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "type": "grpc",
       "description": "Recommended Google client library to manage OS login configuration for Google account users.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
