### PR TITLE
Release Google.Cloud.OsLogin.V1Beta version 3.0.0-beta07

### DIFF
--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.csproj
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0-beta06</Version>
+    <Version>3.0.0-beta07</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to manages OS login configuration for Google account users.</Description>

--- a/apis/Google.Cloud.OsLogin.V1Beta/docs/history.md
+++ b/apis/Google.Cloud.OsLogin.V1Beta/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 3.0.0-beta07, released 2024-02-29
+
+No API surface changes; just dependency updates.
+
 ## Version 3.0.0-beta06, released 2024-01-16
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3695,7 +3695,7 @@
       "protoPath": "google/cloud/oslogin/v1beta",
       "productName": "Google Cloud OS Login",
       "productUrl": "https://cloud.google.com/compute/docs/instances/managing-instance-access",
-      "version": "3.0.0-beta06",
+      "version": "3.0.0-beta07",
       "releaseLevelOverride": "preview",
       "type": "grpc",
       "description": "Recommended Google client library to manages OS login configuration for Google account users.",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
