### PR TITLE
Release Google.Cloud.PhishingProtection.V1Beta1 version 2.0.0-beta03

### DIFF
--- a/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1.csproj
+++ b/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta02</Version>
+    <Version>2.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Phishing Protection API.</Description>

--- a/apis/Google.Cloud.PhishingProtection.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.PhishingProtection.V1Beta1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 2.0.0-beta03, released 2024-02-29
+
+No API surface changes; just dependency updates.
+
 ## Version 2.0.0-beta02, released 2023-01-18
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3743,7 +3743,7 @@
       "protoPath": "google/cloud/phishingprotection/v1beta1",
       "productName": "Cloud Phishing Protection",
       "productUrl": "https://cloud.google.com/phishing-protection/",
-      "version": "2.0.0-beta02",
+      "version": "2.0.0-beta03",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Phishing Protection API.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
