### PR TITLE
Release Google.Cloud.PolicyTroubleshooter.Iam.V3 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.PolicyTroubleshooter.Iam.V3/Google.Cloud.PolicyTroubleshooter.Iam.V3/Google.Cloud.PolicyTroubleshooter.Iam.V3.csproj
+++ b/apis/Google.Cloud.PolicyTroubleshooter.Iam.V3/Google.Cloud.PolicyTroubleshooter.Iam.V3/Google.Cloud.PolicyTroubleshooter.Iam.V3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Policy Troubleshooter for IAM API, which helps you understand why a user has access to a resource or doesn't have permission to call an API.</Description>
@@ -10,8 +10,8 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.6.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Iam.V2" Version="[1.0.0, 2.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.1.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V2" Version="[1.1.0, 2.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.PolicyTroubleshooter.Iam.V3/docs/history.md
+++ b/apis/Google.Cloud.PolicyTroubleshooter.Iam.V3/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2024-02-29
+
+No API surface changes; just dependency updates.
+
 ## Version 1.0.0-beta01, released 2023-08-16
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3781,7 +3781,7 @@
     },
     {
       "id": "Google.Cloud.PolicyTroubleshooter.Iam.V3",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Policy Troubleshooter",
       "productUrl": "https://cloud.google.com/policy-intelligence/docs/troubleshoot-access",
@@ -3791,8 +3791,8 @@
         "authentication"
       ],
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.0.0",
-        "Google.Cloud.Iam.V2": "1.0.0"
+        "Google.Cloud.Iam.V1": "3.1.0",
+        "Google.Cloud.Iam.V2": "1.1.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/policytroubleshooter/iam/v3",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
