### PR TITLE
Release Google.Cloud.RecaptchaEnterprise.V1Beta1 version 2.0.0-beta05

### DIFF
--- a/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.csproj
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta04</Version>
+    <Version>2.0.0-beta05</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud reCAPTCHA for Enterprise API v1beta1.</Description>

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.0.0-beta05, released 2024-02-29
+
+### Documentation improvements
+
+- Minor comments updates ([commit 418f496](https://github.com/googleapis/google-cloud-dotnet/commit/418f496915ce5047c5044f0a6ecd43b61316ba6f))
+
 ## Version 2.0.0-beta04, released 2023-10-30
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3950,7 +3950,7 @@
       "protoPath": "google/cloud/recaptchaenterprise/v1beta1",
       "productName": "Google Cloud reCAPTCHA Enterprise",
       "productUrl": "https://cloud.google.com/recaptcha-enterprise/",
-      "version": "2.0.0-beta04",
+      "version": "2.0.0-beta05",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud reCAPTCHA for Enterprise API v1beta1.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### Documentation improvements

- Minor comments updates ([commit 418f496](https://github.com/googleapis/google-cloud-dotnet/commit/418f496915ce5047c5044f0a6ecd43b61316ba6f))
