### PR TITLE
Release Google.Cloud.Scheduler.V1 version 3.3.0

### DIFF
--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.csproj
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.2.0</Version>
+    <Version>3.3.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Scheduler API (v1), which creates and manages jobs run on a regular recurring schedule.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.6.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
+    <PackageReference Include="Google.Cloud.Location" Version="[2.1.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Scheduler.V1/docs/history.md
+++ b/apis/Google.Cloud.Scheduler.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.3.0, released 2024-02-29
+
+### Documentation improvements
+
+- Correct timezone/offset information for Cloud Scheduler headers ([commit 986fc6f](https://github.com/googleapis/google-cloud-dotnet/commit/986fc6fed12f179c14ab7c61a0de00e89396394f))
+
 ## Version 3.2.0, released 2023-03-06
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4180,7 +4180,7 @@
       "protoPath": "google/cloud/scheduler/v1",
       "productName": "Google Cloud Scheduler",
       "productUrl": "https://cloud.google.com/scheduler/",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Scheduler API (v1), which creates and manages jobs run on a regular recurring schedule.",
       "tags": [
@@ -4189,7 +4189,7 @@
       ],
       "dependencies": {
         "Google.Api.Gax.Grpc": "4.6.0",
-        "Google.Cloud.Location": "2.0.0",
+        "Google.Cloud.Location": "2.1.0",
         "Grpc.Core": "2.46.6"
       },
       "shortName": "cloudscheduler",


### PR DESCRIPTION

Changes in this release:

### Documentation improvements

- Correct timezone/offset information for Cloud Scheduler headers ([commit 986fc6f](https://github.com/googleapis/google-cloud-dotnet/commit/986fc6fed12f179c14ab7c61a0de00e89396394f))
