### PR TITLE
Release Google.Cloud.SecretManager.V1 version 2.2.0

### DIFF
--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.csproj
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Secret Manager API.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.6.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.1.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.SecretManager.V1/docs/history.md
+++ b/apis/Google.Cloud.SecretManager.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 2.2.0, released 2024-02-29
+
+No API surface changes; just dependency updates.
+
 ## Version 2.1.0, released 2023-01-11
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4204,12 +4204,12 @@
       "protoPath": "google/cloud/secretmanager/v1",
       "productName": "Secret Manager",
       "productUrl": "https://cloud.google.com/secret-manager",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Secret Manager API.",
       "dependencies": {
         "Google.Api.Gax.Grpc": "4.6.0",
-        "Google.Cloud.Iam.V1": "3.0.0",
+        "Google.Cloud.Iam.V1": "3.1.0",
         "Grpc.Core": "2.46.6"
       },
       "tags": [


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
