### PR TITLE
Release Google.Cloud.SecretManager.V1Beta1 version 3.0.0-beta03

### DIFF
--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.csproj
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0-beta02</Version>
+    <Version>3.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Secret Manager API version v1beta1.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.6.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.1.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.SecretManager.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 3.0.0-beta03, released 2024-02-29
+
+No API surface changes; just dependency updates.
+
 ## Version 3.0.0-beta02, released 2023-01-17
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4229,12 +4229,12 @@
       "protoPath": "google/cloud/secrets/v1beta1",
       "productName": "Secret Manager",
       "productUrl": "https://cloud.google.com/secret-manager",
-      "version": "3.0.0-beta02",
+      "version": "3.0.0-beta03",
       "releaseLevelOverride": "preview",
       "type": "grpc",
       "description": "Recommended Google client library to access the Secret Manager API version v1beta1.",
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.0.0"
+        "Google.Cloud.Iam.V1": "3.1.0"
       },
       "tags": [
         "secret",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
