### PR TITLE
Release Google.Cloud.Security.PublicCA.V1Beta1 version 1.0.0-beta03

### DIFF
--- a/apis/Google.Cloud.Security.PublicCA.V1Beta1/Google.Cloud.Security.PublicCA.V1Beta1/Google.Cloud.Security.PublicCA.V1Beta1.csproj
+++ b/apis/Google.Cloud.Security.PublicCA.V1Beta1/Google.Cloud.Security.PublicCA.V1Beta1/Google.Cloud.Security.PublicCA.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Public Certificate Authority API, which may be used to create and manage ACME external account binding keys associated with Google Trust Services' publicly trusted certificate authority.</Description>

--- a/apis/Google.Cloud.Security.PublicCA.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.Security.PublicCA.V1Beta1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0-beta03, released 2024-02-29
+
+No API surface changes; just dependency updates.
+
 ## Version 1.0.0-beta02, released 2023-01-19
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4300,7 +4300,7 @@
     },
     {
       "id": "Google.Cloud.Security.PublicCA.V1Beta1",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0-beta03",
       "type": "grpc",
       "productName": "Public Certificate Authority",
       "productUrl": "cloud.google.com/certificate-manager/docs/public-ca/",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
