### PR TITLE
Release Google.Cloud.ServiceHealth.V1 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.csproj
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Service Health API, which helps you gain visibility into disruptive events impacting Google Cloud products.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.6.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
+    <PackageReference Include="Google.Cloud.Location" Version="[2.1.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ServiceHealth.V1/docs/history.md
+++ b/apis/Google.Cloud.ServiceHealth.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2024-02-29
+
+### Documentation improvements
+
+- Update proto comments ([commit bef44ef](https://github.com/googleapis/google-cloud-dotnet/commit/bef44ef4047ac2b9e179a49cbe87398fe0c61746))
+
 ## Version 1.0.0-beta01, released 2024-01-12
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4488,7 +4488,7 @@
     },
     {
       "id": "Google.Cloud.ServiceHealth.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Service Health",
       "productUrl": "https://cloud.google.com/service-health/docs/overview",
@@ -4497,7 +4497,7 @@
         "monitoring"
       ],
       "dependencies": {
-        "Google.Cloud.Location": "2.0.0"
+        "Google.Cloud.Location": "2.1.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/servicehealth/v1",


### PR DESCRIPTION

Changes in this release:

### Documentation improvements

- Update proto comments ([commit bef44ef](https://github.com/googleapis/google-cloud-dotnet/commit/bef44ef4047ac2b9e179a49cbe87398fe0c61746))
