### PR TITLE
Release Google.Cloud.Speech.V1 version 3.6.0

### DIFF
--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.csproj
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.5.0</Version>
+    <Version>3.6.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Speech API (v1), which performs speech recognition.</Description>

--- a/apis/Google.Cloud.Speech.V1/docs/history.md
+++ b/apis/Google.Cloud.Speech.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 3.6.0, released 2024-02-29
+
+No API surface changes; just dependency updates.
+
 ## Version 3.5.0, released 2023-11-07
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4711,7 +4711,7 @@
       "protoPath": "google/cloud/speech/v1",
       "productName": "Google Cloud Speech",
       "productUrl": "https://cloud.google.com/speech",
-      "version": "3.5.0",
+      "version": "3.6.0",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Speech API (v1), which performs speech recognition.",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
