### PR TITLE
Release Google.Cloud.Speech.V1P1Beta1 version 3.0.0-beta06

### DIFF
--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.csproj
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0-beta05</Version>
+    <Version>3.0.0-beta06</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google client library to access the Google Cloud Speech API version v1p1beta1 with upcoming features.</Description>

--- a/apis/Google.Cloud.Speech.V1P1Beta1/docs/history.md
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.0.0-beta06, released 2024-02-29
+
+### Documentation improvements
+
+- Fix the resource name format in comment for CreatePhraseSetRequest ([commit c2e3fcf](https://github.com/googleapis/google-cloud-dotnet/commit/c2e3fcffb4dfaecd7b2d0b160a0b68ded3df80e4))
+
 ## Version 3.0.0-beta05, released 2023-03-06
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4735,7 +4735,7 @@
       "protoPath": "google/cloud/speech/v1p1beta1",
       "productName": "Google Cloud Speech",
       "productUrl": "https://cloud.google.com/speech",
-      "version": "3.0.0-beta05",
+      "version": "3.0.0-beta06",
       "releaseLevelOverride": "preview",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",


### PR DESCRIPTION

Changes in this release:

### Documentation improvements

- Fix the resource name format in comment for CreatePhraseSetRequest ([commit c2e3fcf](https://github.com/googleapis/google-cloud-dotnet/commit/c2e3fcffb4dfaecd7b2d0b160a0b68ded3df80e4))
