### PR TITLE
Release Google.Cloud.StorageInsights.V1 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.csproj
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Storage Insights API, which helps you manage your object storage at scale.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.6.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
+    <PackageReference Include="Google.Cloud.Location" Version="[2.1.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>

--- a/apis/Google.Cloud.StorageInsights.V1/docs/history.md
+++ b/apis/Google.Cloud.StorageInsights.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.1.0, released 2024-02-29
+
+### Documentation improvements
+
+- Add link to documentation for ReportConfig proto fields ([commit 9ece40a](https://github.com/googleapis/google-cloud-dotnet/commit/9ece40a4379f510096117fe7c656ce6112e7540f))
+
 ## Version 1.0.0, released 2023-06-12
 
 Primary purpose of release is to update dependencies and promote to 1.0.0.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4824,7 +4824,7 @@
     },
     {
       "id": "Google.Cloud.StorageInsights.V1",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "grpc",
       "productName": "Google Cloud Storage Insights",
       "productUrl": "https://cloud.google.com/storage/docs/insights/inventory-reports",
@@ -4836,7 +4836,7 @@
       ],
       "dependencies": {
         "Google.Api.Gax.Grpc": "4.6.0",
-        "Google.Cloud.Location": "2.0.0",
+        "Google.Cloud.Location": "2.1.0",
         "Google.LongRunning": "3.0.0",
         "Grpc.Core": "2.46.6"
       },


### PR DESCRIPTION

Changes in this release:

### Documentation improvements

- Add link to documentation for ReportConfig proto fields ([commit 9ece40a](https://github.com/googleapis/google-cloud-dotnet/commit/9ece40a4379f510096117fe7c656ce6112e7540f))
