### PR TITLE
Release Google.Cloud.TextToSpeech.V1Beta1 version 2.0.0-beta05

### DIFF
--- a/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.csproj
+++ b/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta04</Version>
+    <Version>2.0.0-beta05</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Text-to-Speech API v1beta1, synthesizes natural-sounding speech by applying powerful neural network models.</Description>

--- a/apis/Google.Cloud.TextToSpeech.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.TextToSpeech.V1Beta1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 2.0.0-beta05, released 2024-02-29
+
+No API surface changes; just dependency updates.
+
 ## Version 2.0.0-beta04, released 2024-01-08
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5039,7 +5039,7 @@
     },
     {
       "id": "Google.Cloud.TextToSpeech.V1Beta1",
-      "version": "2.0.0-beta04",
+      "version": "2.0.0-beta05",
       "type": "grpc",
       "productName": "Google Cloud Text-to-Speech",
       "productUrl": "https://cloud.google.com/text-to-speech",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
