### PR TITLE
Release Google.Cloud.Tpu.V1 version 2.1.0

### DIFF
--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.csproj
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud TPU API, which provides customers with access to Google TPU technology.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.6.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
+    <PackageReference Include="Google.Cloud.Location" Version="[2.1.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>

--- a/apis/Google.Cloud.Tpu.V1/docs/history.md
+++ b/apis/Google.Cloud.Tpu.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.1.0, released 2024-02-29
+
+### Documentation improvements
+
+- Minor updates in comments ([commit 4386e68](https://github.com/googleapis/google-cloud-dotnet/commit/4386e6852ffac109d2e464d3e1f2bf41c6239c3b))
+
 ## Version 2.0.0, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5061,7 +5061,7 @@
     },
     {
       "id": "Google.Cloud.Tpu.V1",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "type": "grpc",
       "productName": "Cloud TPU",
       "productUrl": "https://cloud.google.com/tpu/",
@@ -5071,7 +5071,7 @@
       ],
       "dependencies": {
         "Google.Api.Gax.Grpc": "4.6.0",
-        "Google.Cloud.Location": "2.0.0",
+        "Google.Cloud.Location": "2.1.0",
         "Google.LongRunning": "3.0.0",
         "Grpc.Core": "2.46.6"
       },


### PR DESCRIPTION

Changes in this release:

### Documentation improvements

- Minor updates in comments ([commit 4386e68](https://github.com/googleapis/google-cloud-dotnet/commit/4386e6852ffac109d2e464d3e1f2bf41c6239c3b))
