### PR TITLE
Release Google.Cloud.Video.LiveStream.V1 version 1.4.0

### DIFF
--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.csproj
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Live Stream API, which transcodes mezzanine live signals into direct-to-consumer streaming formats.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.6.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
+    <PackageReference Include="Google.Cloud.Location" Version="[2.1.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>

--- a/apis/Google.Cloud.Video.LiveStream.V1/docs/history.md
+++ b/apis/Google.Cloud.Video.LiveStream.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.4.0, released 2024-02-29
+
+No API surface changes; just dependency updates.
+
 ## Version 1.3.0, released 2023-08-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5198,7 +5198,7 @@
     },
     {
       "id": "Google.Cloud.Video.LiveStream.V1",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "type": "grpc",
       "productName": "Live Stream",
       "productUrl": "https://cloud.google.com/livestream/docs/",
@@ -5210,7 +5210,7 @@
       ],
       "dependencies": {
         "Google.Api.Gax.Grpc": "4.6.0",
-        "Google.Cloud.Location": "2.0.0",
+        "Google.Cloud.Location": "2.1.0",
         "Google.LongRunning": "3.0.0",
         "Grpc.Core": "2.46.6"
       },


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
