### PR TITLE
Release Google.Cloud.Video.Stitcher.V1 version 3.0.0-beta03

### DIFF
--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.csproj
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0-beta02</Version>
+    <Version>3.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Video Stitcher API, which helps you generate dynamic content for delivery to client devices. </Description>

--- a/apis/Google.Cloud.Video.Stitcher.V1/docs/history.md
+++ b/apis/Google.Cloud.Video.Stitcher.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 3.0.0-beta03, released 2024-02-29
+
+No API surface changes; just dependency updates.
+
 ## Version 3.0.0-beta02, released 2023-08-22
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5224,7 +5224,7 @@
     },
     {
       "id": "Google.Cloud.Video.Stitcher.V1",
-      "version": "3.0.0-beta02",
+      "version": "3.0.0-beta03",
       "type": "grpc",
       "productName": "Video Stitcher",
       "productUrl": "https://cloud.google.com/video-stitcher/docs",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
