### PR TITLE
Release Google.Cloud.Video.Transcoder.V1 version 2.7.0

### DIFF
--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.csproj
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Transcoder API version v1, which converts video files into formats suitable for consumer distribution.</Description>

--- a/apis/Google.Cloud.Video.Transcoder.V1/docs/history.md
+++ b/apis/Google.Cloud.Video.Transcoder.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 2.7.0, released 2024-02-29
+
+No API surface changes; just dependency updates.
+
 ## Version 2.6.0, released 2023-07-13
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5248,7 +5248,7 @@
     },
     {
       "id": "Google.Cloud.Video.Transcoder.V1",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "type": "grpc",
       "productName": "Transcoder",
       "productUrl": "https://cloud.google.com/transcoder/docs",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
