### PR TITLE
Release Google.Cloud.VpcAccess.V1 version 2.3.0

### DIFF
--- a/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.csproj
+++ b/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.2.0</Version>
+    <Version>2.3.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>API for managing VPC access connectors.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.6.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
+    <PackageReference Include="Google.Cloud.Location" Version="[2.1.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>

--- a/apis/Google.Cloud.VpcAccess.V1/docs/history.md
+++ b/apis/Google.Cloud.VpcAccess.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 2.3.0, released 2024-02-29
+
+No API surface changes; just dependency updates.
+
 ## Version 2.2.0, released 2023-01-18
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5345,7 +5345,7 @@
     },
     {
       "id": "Google.Cloud.VpcAccess.V1",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "type": "grpc",
       "productName": "Serverless VPC Access",
       "productUrl": "https://cloud.google.com/vpc/docs/",
@@ -5355,7 +5355,7 @@
       ],
       "dependencies": {
         "Google.Api.Gax.Grpc": "4.6.0",
-        "Google.Cloud.Location": "2.0.0",
+        "Google.Cloud.Location": "2.1.0",
         "Google.LongRunning": "3.0.0",
         "Grpc.Core": "2.46.6"
       },


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
