### PR TITLE
Release Google.Cloud.Workflows.Executions.V1 version 2.4.0

### DIFF
--- a/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.csproj
+++ b/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Workflow Executions API v1, used to manage user-provided workflows.</Description>

--- a/apis/Google.Cloud.Workflows.Executions.V1/docs/history.md
+++ b/apis/Google.Cloud.Workflows.Executions.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 2.4.0, released 2024-02-29
+
+No API surface changes; just dependency updates.
+
 ## Version 2.3.0, released 2023-09-06
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5472,7 +5472,7 @@
     },
     {
       "id": "Google.Cloud.Workflows.Executions.V1",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "commonResourcesConfig": "apis/Google.Cloud.Workflows.Common.V1/CommonResourcesConfig.json",
       "type": "grpc",
       "productName": "Workflow Executions",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
