### PR TITLE
Release Google.Cloud.Workstations.V1 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.csproj
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Allows administrators to create managed developer environments in the cloud.</Description>
@@ -10,8 +10,8 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.6.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.1.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Location" Version="[2.1.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>

--- a/apis/Google.Cloud.Workstations.V1/docs/history.md
+++ b/apis/Google.Cloud.Workstations.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.1.0, released 2024-02-29
+
+No API surface changes; just dependency updates.
+
 ## Version 1.0.0, released 2023-11-01
 
 No API surface changes; just dependency updates and promotion to GA.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5563,7 +5563,7 @@
     },
     {
       "id": "Google.Cloud.Workstations.V1",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "grpc",
       "productName": "Cloud Workstations",
       "productUrl": "https://cloud.google.com/workstations/docs",
@@ -5574,8 +5574,8 @@
       ],
       "dependencies": {
         "Google.Api.Gax.Grpc": "4.6.0",
-        "Google.Cloud.Iam.V1": "3.0.0",
-        "Google.Cloud.Location": "2.0.0",
+        "Google.Cloud.Iam.V1": "3.1.0",
+        "Google.Cloud.Location": "2.1.0",
         "Google.LongRunning": "3.0.0",
         "Grpc.Core": "2.46.6"
       },


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
