### PR TITLE
Release Google.Geo.Type version 1.1.0

### DIFF
--- a/apis/Google.Geo.Type/Google.Geo.Type/Google.Geo.Type.csproj
+++ b/apis/Google.Geo.Type/Google.Geo.Type/Google.Geo.Type.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Version-agnostic types for Geo APIs.</Description>

--- a/apis/Google.Geo.Type/docs/history.md
+++ b/apis/Google.Geo.Type/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.1.0, released 2024-02-29
+
+No API surface changes; just dependency updates.
+
 ## Version 1.0.0, released 2023-06-12
 
 No API surface changes; just dependency updates and promotion to 1.0.0.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5588,7 +5588,7 @@
     },
     {
       "id": "Google.Geo.Type",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "targetFrameworks": "netstandard2.1;net462",
       "type": "other",
       "description": "Version-agnostic types for Geo APIs.",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
