### PR TITLE
Release Google.LongRunning version 3.1.0

### DIFF
--- a/apis/Google.LongRunning/Google.LongRunning/Google.LongRunning.csproj
+++ b/apis/Google.LongRunning/Google.LongRunning/Google.LongRunning.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0</Version>
+    <Version>3.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>gRPC services for the Google Long Running Operations API. This library is typically used as a dependency for other API client libraries.</Description>

--- a/apis/Google.LongRunning/docs/history.md
+++ b/apis/Google.LongRunning/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 3.1.0, released 2024-02-29
+
+No API surface changes; just dependency updates.
+
 ## Version 3.0.0, released 2022-06-07
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5649,7 +5649,7 @@
       "generator": "micro",
       "protoPath": "google/longrunning",
       "listingDescription": "Support for the Long-Running Operations API pattern",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "type": "grpc",
       "metadataType": "CORE",
       "description": "gRPC services for the Google Long Running Operations API. This library is typically used as a dependency for other API client libraries.",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
