### PR TITLE
Release Google.Maps.FleetEngine.Delivery.V1 version 1.2.0

### DIFF
--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.csproj
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Maps Fleet Engine Delivery API (v1), which enables access to Deliveries Solutions.</Description>

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/docs/history.md
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.2.0, released 2024-02-29
+
+### Documentation improvements
+
+- Updated incorrect reference to `Task.journeySharingInfo` ([commit 1c0c513](https://github.com/googleapis/google-cloud-dotnet/commit/1c0c513f3dfa371f21525365bd614fb13d522e93))
+
 ## Version 1.1.0, released 2024-01-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5694,7 +5694,7 @@
     },
     {
       "id": "Google.Maps.FleetEngine.Delivery.V1",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "type": "grpc",
       "productName": "Last Mile Fleet Solution Delivery",
       "productUrl": "https://developers.google.com/maps/documentation/transportation-logistics/mobility",


### PR DESCRIPTION

Changes in this release:

### Documentation improvements

- Updated incorrect reference to `Task.journeySharingInfo` ([commit 1c0c513](https://github.com/googleapis/google-cloud-dotnet/commit/1c0c513f3dfa371f21525365bd614fb13d522e93))
