### PR TITLE
Release Google.Maps.FleetEngine.V1 version 1.2.0

### DIFF
--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.csproj
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Maps Fleet Engine API (v1), which enables access to On Demand Rides and Deliveries and Last Mile Fleet Solutions.</Description>

--- a/apis/Google.Maps.FleetEngine.V1/docs/history.md
+++ b/apis/Google.Maps.FleetEngine.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 1.2.0, released 2024-02-29
+
+### Documentation improvements
+
+- Update comment on Waypoint ([commit 68706c9](https://github.com/googleapis/google-cloud-dotnet/commit/68706c97df4cfa38cee0b78ca00b947ac1572294))
+- Better comments on SearchVehicle fields ([commit 8876dfb](https://github.com/googleapis/google-cloud-dotnet/commit/8876dfbfd4a7e14a29f58780eaee071758fa6607))
+
 ## Version 1.1.0, released 2024-01-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5717,7 +5717,7 @@
     },
     {
       "id": "Google.Maps.FleetEngine.V1",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "type": "grpc",
       "productName": "Local Rides and Deliveries",
       "productUrl": "https://developers.google.com/maps/documentation/transportation-logistics/mobility",


### PR DESCRIPTION

Changes in this release:

### Documentation improvements

- Update comment on Waypoint ([commit 68706c9](https://github.com/googleapis/google-cloud-dotnet/commit/68706c97df4cfa38cee0b78ca00b947ac1572294))
- Better comments on SearchVehicle fields ([commit 8876dfb](https://github.com/googleapis/google-cloud-dotnet/commit/8876dfbfd4a7e14a29f58780eaee071758fa6607))
