### PR TITLE
Release Google.Maps.MapsPlatformDatasets.V1 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.csproj
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Maps Platform Datasets API (v1).</Description>

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/docs/history.md
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2024-02-29
+
+No API surface changes; just dependency updates.
+
 ## Version 1.0.0-beta01, released 2023-06-05
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5743,7 +5743,7 @@
     },
     {
       "id": "Google.Maps.MapsPlatformDatasets.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Maps Platform Datasets",
       "productUrl": "https://developers.google.com/maps/documentation",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
