### PR TITLE
Release Google.Shopping.Css.V1 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1/Google.Shopping.Css.V1.csproj
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1/Google.Shopping.Css.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Shopping CSS API, which allows you to programmatically manage your Comparison Shopping Service (CSS) account data at scale.</Description>

--- a/apis/Google.Shopping.Css.V1/docs/history.md
+++ b/apis/Google.Shopping.Css.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2024-02-29
+
+No API surface changes; just dependency updates.
+
 ## Version 1.0.0-beta01, released 2023-12-12
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5828,7 +5828,7 @@
     },
     {
       "id": "Google.Shopping.Css.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "CSS",
       "productUrl": "https://developers.google.com/comparison-shopping-services/api",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
