### PR TITLE
Release Google.Shopping.Type version 1.0.0-beta03

### DIFF
--- a/apis/Google.Shopping.Type/Google.Shopping.Type/Google.Shopping.Type.csproj
+++ b/apis/Google.Shopping.Type/Google.Shopping.Type/Google.Shopping.Type.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Version-agnostic types for Shopping APIs.</Description>

--- a/apis/Google.Shopping.Type/docs/history.md
+++ b/apis/Google.Shopping.Type/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0-beta03, released 2024-02-29
+
+No API surface changes; just dependency updates.
+
 ## Version 1.0.0-beta02, released 2023-10-13
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5871,7 +5871,7 @@
     },
     {
       "id": "Google.Shopping.Type",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0-beta03",
       "targetFrameworks": "netstandard2.1;net462",
       "type": "other",
       "description": "Version-agnostic types for Shopping APIs.",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
