### PR TITLE
Release Google.Cloud.Compute.V1 version 2.14.0

### DIFF
--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.13.0</Version>
+    <Version>2.14.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Compute Engine API.</Description>
@@ -10,6 +10,6 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.6.0, 5.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[3.1.0, 4.0.0)" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Compute.V1/docs/history.md
+++ b/apis/Google.Cloud.Compute.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.14.0, released 2024-03-04
+
+### New features
+
+- Update Compute Engine API to revision 20240220 ([issue 886](https://github.com/googleapis/google-cloud-dotnet/issues/886)) ([commit eca3b4f](https://github.com/googleapis/google-cloud-dotnet/commit/eca3b4f258bac8d1b67e9b5178d0daf25efa2cef))
+
 ## Version 2.13.0, released 2024-02-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1406,7 +1406,7 @@
     },
     {
       "id": "Google.Cloud.Compute.V1",
-      "version": "2.13.0",
+      "version": "2.14.0",
       "type": "regapic",
       "productName": "Compute Engine",
       "productUrl": "https://cloud.google.com/compute",
@@ -1416,7 +1416,7 @@
       ],
       "dependencies": {
         "Google.Api.Gax.Grpc": "4.6.0",
-        "Google.LongRunning": "3.0.0"
+        "Google.LongRunning": "3.1.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/compute/v1",


### PR DESCRIPTION

Changes in this release:

### New features

- Update Compute Engine API to revision 20240220 ([issue 886](https://github.com/googleapis/google-cloud-dotnet/issues/886)) ([commit eca3b4f](https://github.com/googleapis/google-cloud-dotnet/commit/eca3b4f258bac8d1b67e9b5178d0daf25efa2cef))
