### PR TITLE
feat: UrlSigner supports custom endpoints

### DIFF
--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/Conformance/Tests.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Tests/Conformance/Tests.g.cs
@@ -51,6 +51,7 @@ namespace Google.Cloud.Bigtable.V2.Tests.Conformance {
 
   }
   #region Messages
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class TestFile : pb::IMessage<TestFile>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -229,6 +230,7 @@ namespace Google.Cloud.Bigtable.V2.Tests.Conformance {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ReadRowsTest : pb::IMessage<ReadRowsTest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -477,6 +479,7 @@ namespace Google.Cloud.Bigtable.V2.Tests.Conformance {
       /// Expected results of reading the row.
       /// Only the last result can be an error.
       /// </summary>
+      [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
       public sealed partial class Result : pb::IMessage<Result>
       #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
           , pb::IBufferMessage

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Proto/Tests.g.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Proto/Tests.g.cs
@@ -145,6 +145,7 @@ namespace Google.Cloud.Firestore.Tests.Proto {
   /// <summary>
   /// A collection of tests.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class TestFile : pb::IMessage<TestFile>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -326,6 +327,7 @@ namespace Google.Cloud.Firestore.Tests.Proto {
   /// <summary>
   /// A Test describes a single client method call and its expected result.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Test : pb::IMessage<Test>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -1012,6 +1014,7 @@ namespace Google.Cloud.Firestore.Tests.Proto {
   /// <summary>
   /// Call to the DocumentRef.Get method.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class GetTest : pb::IMessage<GetTest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -1256,6 +1259,7 @@ namespace Google.Cloud.Firestore.Tests.Proto {
   /// <summary>
   /// Call to DocumentRef.Create.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class CreateTest : pb::IMessage<CreateTest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -1583,6 +1587,7 @@ namespace Google.Cloud.Firestore.Tests.Proto {
   /// <summary>
   /// A call to DocumentRef.Set.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class SetTest : pb::IMessage<SetTest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -1957,6 +1962,7 @@ namespace Google.Cloud.Firestore.Tests.Proto {
   /// A call to the form of DocumentRef.Update that represents the data as a map
   /// or dictionary.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class UpdateTest : pb::IMessage<UpdateTest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -2331,6 +2337,7 @@ namespace Google.Cloud.Firestore.Tests.Proto {
   /// A call to the form of DocumentRef.Update that represents the data as a list
   /// of field paths and their values.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class UpdatePathsTest : pb::IMessage<UpdatePathsTest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -2722,6 +2729,7 @@ namespace Google.Cloud.Firestore.Tests.Proto {
   /// <summary>
   /// A call to DocmentRef.Delete
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class DeleteTest : pb::IMessage<DeleteTest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -3052,6 +3060,7 @@ namespace Google.Cloud.Firestore.Tests.Proto {
   /// <summary>
   /// An option to the DocumentRef.Set call.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class SetOption : pb::IMessage<SetOption>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -3273,6 +3282,7 @@ namespace Google.Cloud.Firestore.Tests.Proto {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class QueryTest : pb::IMessage<QueryTest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -3574,6 +3584,7 @@ namespace Google.Cloud.Firestore.Tests.Proto {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Clause : pb::IMessage<Clause>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -4232,6 +4243,7 @@ namespace Google.Cloud.Firestore.Tests.Proto {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Select : pb::IMessage<Select>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -4410,6 +4422,7 @@ namespace Google.Cloud.Firestore.Tests.Proto {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Where : pb::IMessage<Where>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -4682,6 +4695,7 @@ namespace Google.Cloud.Firestore.Tests.Proto {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class OrderBy : pb::IMessage<OrderBy>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -4920,6 +4934,7 @@ namespace Google.Cloud.Firestore.Tests.Proto {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Cursor : pb::IMessage<Cursor>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -5147,6 +5162,7 @@ namespace Google.Cloud.Firestore.Tests.Proto {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class DocSnapshot : pb::IMessage<DocSnapshot>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -5373,6 +5389,7 @@ namespace Google.Cloud.Firestore.Tests.Proto {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class FieldPath : pb::IMessage<FieldPath>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -5564,6 +5581,7 @@ namespace Google.Cloud.Firestore.Tests.Proto {
   /// should either change their client's ID for testing,
   /// or change the ID in the tests before running them.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ListenTest : pb::IMessage<ListenTest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -5805,6 +5823,7 @@ namespace Google.Cloud.Firestore.Tests.Proto {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Snapshot : pb::IMessage<Snapshot>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -6055,6 +6074,7 @@ namespace Google.Cloud.Firestore.Tests.Proto {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class DocChange : pb::IMessage<DocChange>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/WriteBatch.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/WriteBatch.cs
@@ -121,6 +121,7 @@ namespace Google.Cloud.Firestore
             GaxPreconditions.CheckNotNull(documentReference, nameof(documentReference));
             GaxPreconditions.CheckNotNull(updates, nameof(updates));
             GaxPreconditions.CheckArgument(updates.Count != 0, nameof(updates), "Empty set of updates specified");
+            GaxPreconditions.CheckArgument(precondition?.Exists != false, nameof(precondition), "Cannot specify an explicit exists=false precondition.");
 
             var serializedUpdates = updates.ToDictionary(pair => pair.Key, pair => ValueSerializer.Serialize(documentReference.Database.SerializationContext, pair.Value));
             var expanded = ExpandObject(serializedUpdates);

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/Conformance/Tests.g.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/Conformance/Tests.g.cs
@@ -32,7 +32,7 @@ namespace Google.Cloud.Storage.V1.Tests.Conformance {
             "c3QSUwoUcG9zdF9wb2xpY3lfdjRfdGVzdHMYAiADKAsyNS5nb29nbGUuY2xv",
             "dWQuY29uZm9ybWFuY2Uuc3RvcmFnZS52MS5Qb3N0UG9saWN5VjRUZXN0EkMK",
             "C3JldHJ5X3Rlc3RzGAMgAygLMi4uZ29vZ2xlLmNsb3VkLmNvbmZvcm1hbmNl",
-            "LnN0b3JhZ2UudjEuUmV0cnlUZXN0IokFCg1TaWduaW5nVjRUZXN0EhAKCGZp",
+            "LnN0b3JhZ2UudjEuUmV0cnlUZXN0IuUFCg1TaWduaW5nVjRUZXN0EhAKCGZp",
             "bGVOYW1lGAEgASgJEhMKC2Rlc2NyaXB0aW9uGAIgASgJEg4KBmJ1Y2tldBgD",
             "IAEoCRIOCgZvYmplY3QYBCABKAkSDgoGbWV0aG9kGAUgASgJEhIKCmV4cGly",
             "YXRpb24YBiABKAMSLQoJdGltZXN0YW1wGAcgASgLMhouZ29vZ2xlLnByb3Rv",
@@ -44,51 +44,53 @@ namespace Google.Cloud.Storage.V1.Tests.Conformance {
             "GAsgASgJEj8KCHVybFN0eWxlGAwgASgOMi0uZ29vZ2xlLmNsb3VkLmNvbmZv",
             "cm1hbmNlLnN0b3JhZ2UudjEuVXJsU3R5bGUSGwoTYnVja2V0Qm91bmRIb3N0",
             "bmFtZRgNIAEoCRIgChhleHBlY3RlZENhbm9uaWNhbFJlcXVlc3QYDiABKAkS",
-            "HAoUZXhwZWN0ZWRTdHJpbmdUb1NpZ24YDyABKAkaLgoMSGVhZGVyc0VudHJ5",
-            "EgsKA2tleRgBIAEoCRINCgV2YWx1ZRgCIAEoCToCOAEaNgoUUXVlcnlQYXJh",
-            "bWV0ZXJzRW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4ASIo",
-            "ChJDb25kaXRpb25hbE1hdGNoZXMSEgoKZXhwcmVzc2lvbhgBIAMoCSJCChBQ",
-            "b2xpY3lDb25kaXRpb25zEhoKEmNvbnRlbnRMZW5ndGhSYW5nZRgBIAMoBRIS",
-            "CgpzdGFydHNXaXRoGAIgAygJIqYDCgtQb2xpY3lJbnB1dBIOCgZzY2hlbWUY",
-            "ASABKAkSPwoIdXJsU3R5bGUYAiABKA4yLS5nb29nbGUuY2xvdWQuY29uZm9y",
-            "bWFuY2Uuc3RvcmFnZS52MS5VcmxTdHlsZRIbChNidWNrZXRCb3VuZEhvc3Ru",
-            "YW1lGAMgASgJEg4KBmJ1Y2tldBgEIAEoCRIOCgZvYmplY3QYBSABKAkSEgoK",
-            "ZXhwaXJhdGlvbhgGIAEoBRItCgl0aW1lc3RhbXAYByABKAsyGi5nb29nbGUu",
-            "cHJvdG9idWYuVGltZXN0YW1wEkwKBmZpZWxkcxgIIAMoCzI8Lmdvb2dsZS5j",
-            "bG91ZC5jb25mb3JtYW5jZS5zdG9yYWdlLnYxLlBvbGljeUlucHV0LkZpZWxk",
-            "c0VudHJ5EkkKCmNvbmRpdGlvbnMYCSABKAsyNS5nb29nbGUuY2xvdWQuY29u",
-            "Zm9ybWFuY2Uuc3RvcmFnZS52MS5Qb2xpY3lDb25kaXRpb25zGi0KC0ZpZWxk",
-            "c0VudHJ5EgsKA2tleRgBIAEoCRINCgV2YWx1ZRgCIAEoCToCOAEiuAEKDFBv",
-            "bGljeU91dHB1dBILCgN1cmwYASABKAkSTQoGZmllbGRzGAIgAygLMj0uZ29v",
-            "Z2xlLmNsb3VkLmNvbmZvcm1hbmNlLnN0b3JhZ2UudjEuUG9saWN5T3V0cHV0",
-            "LkZpZWxkc0VudHJ5Eh0KFWV4cGVjdGVkRGVjb2RlZFBvbGljeRgDIAEoCRot",
-            "CgtGaWVsZHNFbnRyeRILCgNrZXkYASABKAkSDQoFdmFsdWUYAiABKAk6AjgB",
-            "IrcBChBQb3N0UG9saWN5VjRUZXN0EhMKC2Rlc2NyaXB0aW9uGAEgASgJEkUK",
-            "C3BvbGljeUlucHV0GAIgASgLMjAuZ29vZ2xlLmNsb3VkLmNvbmZvcm1hbmNl",
-            "LnN0b3JhZ2UudjEuUG9saWN5SW5wdXQSRwoMcG9saWN5T3V0cHV0GAMgASgL",
-            "MjEuZ29vZ2xlLmNsb3VkLmNvbmZvcm1hbmNlLnN0b3JhZ2UudjEuUG9saWN5",
-            "T3V0cHV0IlAKClJldHJ5VGVzdHMSQgoKcmV0cnlUZXN0cxgBIAMoCzIuLmdv",
-            "b2dsZS5jbG91ZC5jb25mb3JtYW5jZS5zdG9yYWdlLnYxLlJldHJ5VGVzdCIn",
-            "Cg9JbnN0cnVjdGlvbkxpc3QSFAoMaW5zdHJ1Y3Rpb25zGAEgAygJImcKBk1l",
-            "dGhvZBIMCgRuYW1lGAEgASgJEkAKCXJlc291cmNlcxgCIAMoDjItLmdvb2ds",
-            "ZS5jbG91ZC5jb25mb3JtYW5jZS5zdG9yYWdlLnYxLlJlc291cmNlEg0KBWdy",
-            "b3VwGAMgASgJIuQBCglSZXRyeVRlc3QSCgoCaWQYASABKAUSEwoLZGVzY3Jp",
-            "cHRpb24YAiABKAkSQwoFY2FzZXMYAyADKAsyNC5nb29nbGUuY2xvdWQuY29u",
-            "Zm9ybWFuY2Uuc3RvcmFnZS52MS5JbnN0cnVjdGlvbkxpc3QSPAoHbWV0aG9k",
-            "cxgEIAMoCzIrLmdvb2dsZS5jbG91ZC5jb25mb3JtYW5jZS5zdG9yYWdlLnYx",
-            "Lk1ldGhvZBIcChRwcmVjb25kaXRpb25Qcm92aWRlZBgFIAEoCBIVCg1leHBl",
-            "Y3RTdWNjZXNzGAYgASgIKk8KCFVybFN0eWxlEg4KClBBVEhfU1RZTEUQABIY",
-            "ChRWSVJUVUFMX0hPU1RFRF9TVFlMRRABEhkKFUJVQ0tFVF9CT1VORF9IT1NU",
-            "TkFNRRACKkIKCFJlc291cmNlEgoKBkJVQ0tFVBAAEgoKBk9CSkVDVBABEhAK",
-            "DE5PVElGSUNBVElPThACEgwKCEhNQUNfS0VZEANCfAonY29tLmdvb2dsZS5j",
-            "bG91ZC5jb25mb3JtYW5jZS5zdG9yYWdlLnYxUAFaI2dvb2dsZS9jbG91ZC9j",
-            "b25mb3JtYW5jZS9zdG9yYWdlL3YxqgIpR29vZ2xlLkNsb3VkLlN0b3JhZ2Uu",
-            "VjEuVGVzdHMuQ29uZm9ybWFuY2ViBnByb3RvMw=="));
+            "HAoUZXhwZWN0ZWRTdHJpbmdUb1NpZ24YDyABKAkSEAoIaG9zdG5hbWUYECAB",
+            "KAkSFgoOY2xpZW50RW5kcG9pbnQYESABKAkSGAoQZW11bGF0b3JIb3N0bmFt",
+            "ZRgSIAEoCRIWCg51bml2ZXJzZURvbWFpbhgTIAEoCRouCgxIZWFkZXJzRW50",
+            "cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4ARo2ChRRdWVyeVBh",
+            "cmFtZXRlcnNFbnRyeRILCgNrZXkYASABKAkSDQoFdmFsdWUYAiABKAk6AjgB",
+            "IigKEkNvbmRpdGlvbmFsTWF0Y2hlcxISCgpleHByZXNzaW9uGAEgAygJIkIK",
+            "EFBvbGljeUNvbmRpdGlvbnMSGgoSY29udGVudExlbmd0aFJhbmdlGAEgAygF",
+            "EhIKCnN0YXJ0c1dpdGgYAiADKAkipgMKC1BvbGljeUlucHV0Eg4KBnNjaGVt",
+            "ZRgBIAEoCRI/Cgh1cmxTdHlsZRgCIAEoDjItLmdvb2dsZS5jbG91ZC5jb25m",
+            "b3JtYW5jZS5zdG9yYWdlLnYxLlVybFN0eWxlEhsKE2J1Y2tldEJvdW5kSG9z",
+            "dG5hbWUYAyABKAkSDgoGYnVja2V0GAQgASgJEg4KBm9iamVjdBgFIAEoCRIS",
+            "CgpleHBpcmF0aW9uGAYgASgFEi0KCXRpbWVzdGFtcBgHIAEoCzIaLmdvb2ds",
+            "ZS5wcm90b2J1Zi5UaW1lc3RhbXASTAoGZmllbGRzGAggAygLMjwuZ29vZ2xl",
+            "LmNsb3VkLmNvbmZvcm1hbmNlLnN0b3JhZ2UudjEuUG9saWN5SW5wdXQuRmll",
+            "bGRzRW50cnkSSQoKY29uZGl0aW9ucxgJIAEoCzI1Lmdvb2dsZS5jbG91ZC5j",
+            "b25mb3JtYW5jZS5zdG9yYWdlLnYxLlBvbGljeUNvbmRpdGlvbnMaLQoLRmll",
+            "bGRzRW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4ASK4AQoM",
+            "UG9saWN5T3V0cHV0EgsKA3VybBgBIAEoCRJNCgZmaWVsZHMYAiADKAsyPS5n",
+            "b29nbGUuY2xvdWQuY29uZm9ybWFuY2Uuc3RvcmFnZS52MS5Qb2xpY3lPdXRw",
+            "dXQuRmllbGRzRW50cnkSHQoVZXhwZWN0ZWREZWNvZGVkUG9saWN5GAMgASgJ",
+            "Gi0KC0ZpZWxkc0VudHJ5EgsKA2tleRgBIAEoCRINCgV2YWx1ZRgCIAEoCToC",
+            "OAEitwEKEFBvc3RQb2xpY3lWNFRlc3QSEwoLZGVzY3JpcHRpb24YASABKAkS",
+            "RQoLcG9saWN5SW5wdXQYAiABKAsyMC5nb29nbGUuY2xvdWQuY29uZm9ybWFu",
+            "Y2Uuc3RvcmFnZS52MS5Qb2xpY3lJbnB1dBJHCgxwb2xpY3lPdXRwdXQYAyAB",
+            "KAsyMS5nb29nbGUuY2xvdWQuY29uZm9ybWFuY2Uuc3RvcmFnZS52MS5Qb2xp",
+            "Y3lPdXRwdXQiUAoKUmV0cnlUZXN0cxJCCgpyZXRyeVRlc3RzGAEgAygLMi4u",
+            "Z29vZ2xlLmNsb3VkLmNvbmZvcm1hbmNlLnN0b3JhZ2UudjEuUmV0cnlUZXN0",
+            "IicKD0luc3RydWN0aW9uTGlzdBIUCgxpbnN0cnVjdGlvbnMYASADKAkiZwoG",
+            "TWV0aG9kEgwKBG5hbWUYASABKAkSQAoJcmVzb3VyY2VzGAIgAygOMi0uZ29v",
+            "Z2xlLmNsb3VkLmNvbmZvcm1hbmNlLnN0b3JhZ2UudjEuUmVzb3VyY2USDQoF",
+            "Z3JvdXAYAyABKAki5AEKCVJldHJ5VGVzdBIKCgJpZBgBIAEoBRITCgtkZXNj",
+            "cmlwdGlvbhgCIAEoCRJDCgVjYXNlcxgDIAMoCzI0Lmdvb2dsZS5jbG91ZC5j",
+            "b25mb3JtYW5jZS5zdG9yYWdlLnYxLkluc3RydWN0aW9uTGlzdBI8CgdtZXRo",
+            "b2RzGAQgAygLMisuZ29vZ2xlLmNsb3VkLmNvbmZvcm1hbmNlLnN0b3JhZ2Uu",
+            "djEuTWV0aG9kEhwKFHByZWNvbmRpdGlvblByb3ZpZGVkGAUgASgIEhUKDWV4",
+            "cGVjdFN1Y2Nlc3MYBiABKAgqTwoIVXJsU3R5bGUSDgoKUEFUSF9TVFlMRRAA",
+            "EhgKFFZJUlRVQUxfSE9TVEVEX1NUWUxFEAESGQoVQlVDS0VUX0JPVU5EX0hP",
+            "U1ROQU1FEAIqQgoIUmVzb3VyY2USCgoGQlVDS0VUEAASCgoGT0JKRUNUEAES",
+            "EAoMTk9USUZJQ0FUSU9OEAISDAoISE1BQ19LRVkQA0J8Cidjb20uZ29vZ2xl",
+            "LmNsb3VkLmNvbmZvcm1hbmNlLnN0b3JhZ2UudjFQAVojZ29vZ2xlL2Nsb3Vk",
+            "L2NvbmZvcm1hbmNlL3N0b3JhZ2UvdjGqAilHb29nbGUuQ2xvdWQuU3RvcmFn",
+            "ZS5WMS5UZXN0cy5Db25mb3JtYW5jZWIGcHJvdG8z"));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Google.Protobuf.WellKnownTypes.TimestampReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(new[] {typeof(global::Google.Cloud.Storage.V1.Tests.Conformance.UrlStyle), typeof(global::Google.Cloud.Storage.V1.Tests.Conformance.Resource), }, null, new pbr::GeneratedClrTypeInfo[] {
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.Storage.V1.Tests.Conformance.TestFile), global::Google.Cloud.Storage.V1.Tests.Conformance.TestFile.Parser, new[]{ "SigningV4Tests", "PostPolicyV4Tests", "RetryTests" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.Storage.V1.Tests.Conformance.SigningV4Test), global::Google.Cloud.Storage.V1.Tests.Conformance.SigningV4Test.Parser, new[]{ "FileName", "Description", "Bucket", "Object", "Method", "Expiration", "Timestamp", "ExpectedUrl", "Headers", "QueryParameters", "Scheme", "UrlStyle", "BucketBoundHostname", "ExpectedCanonicalRequest", "ExpectedStringToSign" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { null, null, }),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.Storage.V1.Tests.Conformance.SigningV4Test), global::Google.Cloud.Storage.V1.Tests.Conformance.SigningV4Test.Parser, new[]{ "FileName", "Description", "Bucket", "Object", "Method", "Expiration", "Timestamp", "ExpectedUrl", "Headers", "QueryParameters", "Scheme", "UrlStyle", "BucketBoundHostname", "ExpectedCanonicalRequest", "ExpectedStringToSign", "Hostname", "ClientEndpoint", "EmulatorHostname", "UniverseDomain" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { null, null, }),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.Storage.V1.Tests.Conformance.ConditionalMatches), global::Google.Cloud.Storage.V1.Tests.Conformance.ConditionalMatches.Parser, new[]{ "Expression" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.Storage.V1.Tests.Conformance.PolicyConditions), global::Google.Cloud.Storage.V1.Tests.Conformance.PolicyConditions.Parser, new[]{ "ContentLengthRange", "StartsWith" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Cloud.Storage.V1.Tests.Conformance.PolicyInput), global::Google.Cloud.Storage.V1.Tests.Conformance.PolicyInput.Parser, new[]{ "Scheme", "UrlStyle", "BucketBoundHostname", "Bucket", "Object", "Expiration", "Timestamp", "Fields", "Conditions" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { null, }),
@@ -124,6 +126,7 @@ namespace Google.Cloud.Storage.V1.Tests.Conformance {
   #endregion
 
   #region Messages
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class TestFile : pb::IMessage<TestFile>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -359,6 +362,7 @@ namespace Google.Cloud.Storage.V1.Tests.Conformance {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class SigningV4Test : pb::IMessage<SigningV4Test>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -408,6 +412,10 @@ namespace Google.Cloud.Storage.V1.Tests.Conformance {
       bucketBoundHostname_ = other.bucketBoundHostname_;
       expectedCanonicalRequest_ = other.expectedCanonicalRequest_;
       expectedStringToSign_ = other.expectedStringToSign_;
+      hostname_ = other.hostname_;
+      clientEndpoint_ = other.clientEndpoint_;
+      emulatorHostname_ = other.emulatorHostname_;
+      universeDomain_ = other.universeDomain_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -595,6 +603,54 @@ namespace Google.Cloud.Storage.V1.Tests.Conformance {
       }
     }
 
+    /// <summary>Field number for the "hostname" field.</summary>
+    public const int HostnameFieldNumber = 16;
+    private string hostname_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string Hostname {
+      get { return hostname_; }
+      set {
+        hostname_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "clientEndpoint" field.</summary>
+    public const int ClientEndpointFieldNumber = 17;
+    private string clientEndpoint_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string ClientEndpoint {
+      get { return clientEndpoint_; }
+      set {
+        clientEndpoint_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "emulatorHostname" field.</summary>
+    public const int EmulatorHostnameFieldNumber = 18;
+    private string emulatorHostname_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string EmulatorHostname {
+      get { return emulatorHostname_; }
+      set {
+        emulatorHostname_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "universeDomain" field.</summary>
+    public const int UniverseDomainFieldNumber = 19;
+    private string universeDomain_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string UniverseDomain {
+      get { return universeDomain_; }
+      set {
+        universeDomain_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
@@ -625,6 +681,10 @@ namespace Google.Cloud.Storage.V1.Tests.Conformance {
       if (BucketBoundHostname != other.BucketBoundHostname) return false;
       if (ExpectedCanonicalRequest != other.ExpectedCanonicalRequest) return false;
       if (ExpectedStringToSign != other.ExpectedStringToSign) return false;
+      if (Hostname != other.Hostname) return false;
+      if (ClientEndpoint != other.ClientEndpoint) return false;
+      if (EmulatorHostname != other.EmulatorHostname) return false;
+      if (UniverseDomain != other.UniverseDomain) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
@@ -647,6 +707,10 @@ namespace Google.Cloud.Storage.V1.Tests.Conformance {
       if (BucketBoundHostname.Length != 0) hash ^= BucketBoundHostname.GetHashCode();
       if (ExpectedCanonicalRequest.Length != 0) hash ^= ExpectedCanonicalRequest.GetHashCode();
       if (ExpectedStringToSign.Length != 0) hash ^= ExpectedStringToSign.GetHashCode();
+      if (Hostname.Length != 0) hash ^= Hostname.GetHashCode();
+      if (ClientEndpoint.Length != 0) hash ^= ClientEndpoint.GetHashCode();
+      if (EmulatorHostname.Length != 0) hash ^= EmulatorHostname.GetHashCode();
+      if (UniverseDomain.Length != 0) hash ^= UniverseDomain.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -719,6 +783,22 @@ namespace Google.Cloud.Storage.V1.Tests.Conformance {
         output.WriteRawTag(122);
         output.WriteString(ExpectedStringToSign);
       }
+      if (Hostname.Length != 0) {
+        output.WriteRawTag(130, 1);
+        output.WriteString(Hostname);
+      }
+      if (ClientEndpoint.Length != 0) {
+        output.WriteRawTag(138, 1);
+        output.WriteString(ClientEndpoint);
+      }
+      if (EmulatorHostname.Length != 0) {
+        output.WriteRawTag(146, 1);
+        output.WriteString(EmulatorHostname);
+      }
+      if (UniverseDomain.Length != 0) {
+        output.WriteRawTag(154, 1);
+        output.WriteString(UniverseDomain);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -783,6 +863,22 @@ namespace Google.Cloud.Storage.V1.Tests.Conformance {
         output.WriteRawTag(122);
         output.WriteString(ExpectedStringToSign);
       }
+      if (Hostname.Length != 0) {
+        output.WriteRawTag(130, 1);
+        output.WriteString(Hostname);
+      }
+      if (ClientEndpoint.Length != 0) {
+        output.WriteRawTag(138, 1);
+        output.WriteString(ClientEndpoint);
+      }
+      if (EmulatorHostname.Length != 0) {
+        output.WriteRawTag(146, 1);
+        output.WriteString(EmulatorHostname);
+      }
+      if (UniverseDomain.Length != 0) {
+        output.WriteRawTag(154, 1);
+        output.WriteString(UniverseDomain);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
       }
@@ -833,6 +929,18 @@ namespace Google.Cloud.Storage.V1.Tests.Conformance {
       }
       if (ExpectedStringToSign.Length != 0) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(ExpectedStringToSign);
+      }
+      if (Hostname.Length != 0) {
+        size += 2 + pb::CodedOutputStream.ComputeStringSize(Hostname);
+      }
+      if (ClientEndpoint.Length != 0) {
+        size += 2 + pb::CodedOutputStream.ComputeStringSize(ClientEndpoint);
+      }
+      if (EmulatorHostname.Length != 0) {
+        size += 2 + pb::CodedOutputStream.ComputeStringSize(EmulatorHostname);
+      }
+      if (UniverseDomain.Length != 0) {
+        size += 2 + pb::CodedOutputStream.ComputeStringSize(UniverseDomain);
       }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
@@ -889,6 +997,18 @@ namespace Google.Cloud.Storage.V1.Tests.Conformance {
       }
       if (other.ExpectedStringToSign.Length != 0) {
         ExpectedStringToSign = other.ExpectedStringToSign;
+      }
+      if (other.Hostname.Length != 0) {
+        Hostname = other.Hostname;
+      }
+      if (other.ClientEndpoint.Length != 0) {
+        ClientEndpoint = other.ClientEndpoint;
+      }
+      if (other.EmulatorHostname.Length != 0) {
+        EmulatorHostname = other.EmulatorHostname;
+      }
+      if (other.UniverseDomain.Length != 0) {
+        UniverseDomain = other.UniverseDomain;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
@@ -966,6 +1086,22 @@ namespace Google.Cloud.Storage.V1.Tests.Conformance {
           }
           case 122: {
             ExpectedStringToSign = input.ReadString();
+            break;
+          }
+          case 130: {
+            Hostname = input.ReadString();
+            break;
+          }
+          case 138: {
+            ClientEndpoint = input.ReadString();
+            break;
+          }
+          case 146: {
+            EmulatorHostname = input.ReadString();
+            break;
+          }
+          case 154: {
+            UniverseDomain = input.ReadString();
             break;
           }
         }
@@ -1046,6 +1182,22 @@ namespace Google.Cloud.Storage.V1.Tests.Conformance {
             ExpectedStringToSign = input.ReadString();
             break;
           }
+          case 130: {
+            Hostname = input.ReadString();
+            break;
+          }
+          case 138: {
+            ClientEndpoint = input.ReadString();
+            break;
+          }
+          case 146: {
+            EmulatorHostname = input.ReadString();
+            break;
+          }
+          case 154: {
+            UniverseDomain = input.ReadString();
+            break;
+          }
         }
       }
     }
@@ -1053,6 +1205,7 @@ namespace Google.Cloud.Storage.V1.Tests.Conformance {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ConditionalMatches : pb::IMessage<ConditionalMatches>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -1231,6 +1384,7 @@ namespace Google.Cloud.Storage.V1.Tests.Conformance {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class PolicyConditions : pb::IMessage<PolicyConditions>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -1437,6 +1591,7 @@ namespace Google.Cloud.Storage.V1.Tests.Conformance {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class PolicyInput : pb::IMessage<PolicyInput>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -1944,6 +2099,7 @@ namespace Google.Cloud.Storage.V1.Tests.Conformance {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class PolicyOutput : pb::IMessage<PolicyOutput>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -2254,6 +2410,7 @@ namespace Google.Cloud.Storage.V1.Tests.Conformance {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class PostPolicyV4Test : pb::IMessage<PostPolicyV4Test>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -2535,6 +2692,7 @@ namespace Google.Cloud.Storage.V1.Tests.Conformance {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class RetryTests : pb::IMessage<RetryTests>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -2717,6 +2875,7 @@ namespace Google.Cloud.Storage.V1.Tests.Conformance {
   /// A list of instructions to send as headers to the GCS emulator. Each
   /// instruction will force a specified failure for that request.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class InstructionList : pb::IMessage<InstructionList>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -2899,6 +3058,7 @@ namespace Google.Cloud.Storage.V1.Tests.Conformance {
   /// A particular storage API method and required resources in order to test it.
   /// Methods must be implemented in tests for each language.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Method : pb::IMessage<Method>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -3163,6 +3323,7 @@ namespace Google.Cloud.Storage.V1.Tests.Conformance {
   /// Schema for a retry test, corresponding to a single scenario from the design
   /// doc.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class RetryTest : pb::IMessage<RetryTest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/Conformance/V4SignerConformanceTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/Conformance/V4SignerConformanceTest.cs
@@ -27,15 +27,17 @@ namespace Google.Cloud.Storage.V1.Tests.Conformance
 {
     public class V4SignerConformanceTest
     {
-        public static TheoryData<SigningV4Test> V4SigningTestData { get; } = StorageConformanceTestData.TestData.GetTheoryData(f => f.SigningV4Tests);
+        public static TheoryData<SigningV4Test> V4SigningTestData { get; } = StorageConformanceTestData.TestData.GetTheoryData(f =>
+            // We skip test data with features that we don't support.
+            f.SigningV4Tests.Where(data => data.Hostname == "" && data.EmulatorHostname == "" && data.ClientEndpoint == "" && data.UniverseDomain == ""));
         public static TheoryData<PostPolicyV4Test> V4PostPolicyTestData { get; } = StorageConformanceTestData.TestData.GetTheoryData(f => f.PostPolicyV4Tests);
 
         private static readonly Dictionary<string, HttpMethod> s_methods = new Dictionary<string, HttpMethod>
-            {
-                { "GET", HttpMethod.Get },
-                { "POST", HttpMethod.Post },
-                { "PUT", HttpMethod.Put }
-            };
+        {
+            { "GET", HttpMethod.Get },
+            { "POST", HttpMethod.Post },
+            { "PUT", HttpMethod.Put }
+        };
 
         [Theory, MemberData(nameof(V4SigningTestData))]
         public void SigningTest(SigningV4Test test)

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/UrlSignerTest.OptionsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/UrlSignerTest.OptionsTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Google Inc. All Rights Reserved.
+// Copyright 2020 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -175,6 +175,70 @@ namespace Google.Cloud.Storage.V1.Tests
                 var options = Options.FromDuration(TimeSpan.FromMinutes(1));
 
                 Assert.Throws<ArgumentException>(() => options.WithScheme("ftp"));
+            }
+
+            [Fact]
+            public void Host_Defaults()
+            {
+                var options = Options.FromDuration(TimeSpan.FromMinutes(1));
+
+                Assert.Equal("storage.googleapis.com", options.Host);
+            }
+
+            [Fact]
+            public void WithHost()
+            {
+                var options = Options.FromDuration(TimeSpan.FromMinutes(1));
+
+                var newHost = options.WithHost("another.custom.host");
+
+                Assert.NotSame(options, newHost);
+                Assert.Equal("another.custom.host", newHost.Host);
+            }
+
+            [Fact]
+            public void WithHost_Null()
+            {
+                var options = Options.FromDuration(TimeSpan.FromMinutes(1));
+
+                options = options.WithHost("another.custom.host");
+
+                var newOptions = options.WithHost(null);
+
+                Assert.NotSame(options, newOptions);
+                Assert.Equal("storage.googleapis.com", newOptions.Host);
+            }
+
+            [Fact]
+            public void Port_Defaults()
+            {
+                var options = Options.FromDuration(TimeSpan.FromMinutes(1));
+
+                Assert.Null(options.Port);
+            }
+
+            [Fact]
+            public void WithPort()
+            {
+                var options = Options.FromDuration(TimeSpan.FromMinutes(1));
+
+                var newPort = options.WithPort(443);
+
+                Assert.NotSame(options, newPort);
+                Assert.Equal(443, newPort.Port);
+            }
+
+            [Fact]
+            public void WithPort_Null()
+            {
+                var options = Options.FromDuration(TimeSpan.FromMinutes(1));
+
+                options = options.WithPort(443);
+
+                var newOptions = options.WithPort(null);
+
+                Assert.NotSame(options, newOptions);
+                Assert.Null(newOptions.Port);
             }
         }
     }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/UrlSignerTest.OptionsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/UrlSignerTest.OptionsTest.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
 using Xunit;
 using static Google.Cloud.Storage.V1.UrlSigner;
 
@@ -239,6 +240,45 @@ namespace Google.Cloud.Storage.V1.Tests
 
                 Assert.NotSame(options, newOptions);
                 Assert.Null(newOptions.Port);
+            }
+
+            [Fact]
+            public void WithDefaultOverrides_NullOverrideValues()
+            {
+                var options = Options.FromDuration(TimeSpan.FromMinutes(1));
+
+                var newOptions = options.WithDefaultOptionsOverrides(new DefaultOptionsOverrides(null, null, null));
+
+                Assert.NotSame(options, newOptions);
+                Assert.Equal(Options.DefaultScheme, newOptions.Scheme);
+                Assert.Equal(Options.DefaultStorageHost, newOptions.Host);
+                Assert.Null(newOptions.Port);
+            }
+
+            [Fact]
+            public void WithDefaultOverrides()
+            {
+                var options = Options.FromDuration(TimeSpan.FromMinutes(1));
+
+                var newOptions = options.WithDefaultOptionsOverrides(new DefaultOptionsOverrides("http", "overrideHost", 1234));
+
+                Assert.NotSame(options, newOptions);
+                Assert.Equal("http", newOptions.Scheme);
+                Assert.Equal("overrideHost", newOptions.Host);
+                Assert.Equal(1234, newOptions.Port);
+            }
+
+            [Fact]
+            public void WithDefaultOverrides_DoesNotOverrideExplicit()
+            {
+                var options = Options.FromDuration(TimeSpan.FromMinutes(1)).WithScheme("https").WithHost("explicitHost").WithPort(5678);
+
+                var newOptions = options.WithDefaultOptionsOverrides(new DefaultOptionsOverrides("http", "overrideHost", 1234));
+
+                Assert.NotSame(options, newOptions);
+                Assert.Equal("https", newOptions.Scheme);
+                Assert.Equal("explicitHost", newOptions.Host);
+                Assert.Equal(5678, newOptions.Port);
             }
         }
     }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/UrlSignerTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/UrlSignerTest.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Google.Apis.Auth.OAuth2;
+using Google.Apis.Http;
 using System;
 using System.IO;
 using System.Security.Cryptography;
@@ -48,6 +49,7 @@ namespace Google.Cloud.Storage.V1.Tests
             Assert.Throws<ArgumentNullException>(() => UrlSigner.FromCredential((ComputeCredential) null));
             Assert.Throws<ArgumentNullException>(() => UrlSigner.FromCredential((ServiceAccountCredential) null));
             Assert.Throws<ArgumentNullException>(() => UrlSigner.FromCredential((ImpersonatedCredential) null));
+            Assert.Throws<ArgumentNullException>(() => UrlSigner.FromCredential((IHttpExecuteInterceptor) null));
         }
 
         [Fact]

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/UrlSignerTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/UrlSignerTest.cs
@@ -21,12 +21,6 @@ using System.Threading.Tasks;
 using Xunit;
 using static Google.Cloud.Storage.V1.UrlSigner;
 
-#if NET461
-using RsaKey = System.Security.Cryptography.RSACryptoServiceProvider;
-#else
-using RsaKey = System.Security.Cryptography.RSA;
-#endif
-
 namespace Google.Cloud.Storage.V1.Tests
 {
     /// <summary>
@@ -104,7 +98,7 @@ namespace Google.Cloud.Storage.V1.Tests
         private static ServiceAccountCredential CreateFakeServiceAccountCredential(string id = "test") =>
             new ServiceAccountCredential(new ServiceAccountCredential.Initializer(id)
             {
-                Key = (RsaKey) RSA.Create()
+                Key = RSA.Create()
             });
     }
 }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClient.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClient.cs
@@ -133,6 +133,26 @@ namespace Google.Cloud.Storage.V1
             }.Build();
 
         /// <summary>
+        /// Creates a URL signer based on this client, that uses the same credential as this client, as well
+        /// as defaulting to this client's URI scheme, host and port. 
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// If the credential used by this client is not compatible with <see cref="UrlSigner"/>.
+        /// See <see cref="UrlSigner"/>'s documentation for more information on compatible credentials.
+        /// </exception>
+        public UrlSigner CreateUrlSigner()
+        {
+            UrlSigner signer = UrlSigner.FromCredential(Service.HttpClient.MessageHandler.Credential);
+
+            var baseUri = new Uri(Service.BaseUri);
+            // If the original URI didn't specify a port, we want signed URLs to not have a port either;
+            // but Uri.Port returns the default port for the URI scheme when the port was not specified on the
+            // original URI.
+            int? port = baseUri.IsDefaultPort && !Service.BaseUri.Contains(baseUri.Port.ToString()) ? null : baseUri.Port;
+            return signer.WithDefaultOptionsOverride(new UrlSigner.DefaultOptionsOverrides(baseUri.Scheme, baseUri.Host, port));
+        }
+
+        /// <summary>
         /// Dispose of this instance. See the <see cref="StorageClient"/> remarks on when this should be called.
         /// </summary>
         public virtual void Dispose() { }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/UrlSigner.DefaultOptionsOverrides.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/UrlSigner.DefaultOptionsOverrides.cs
@@ -1,0 +1,54 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+namespace Google.Cloud.Storage.V1;
+public sealed partial class UrlSigner
+{
+    /// <summary>
+    /// Overrides for default values for some of the options in <see cref="Options"/>.
+    /// Useful for creating signers where signing options default to specific values, for instance
+    /// for creating signers from a <see cref="StorageClient"/> where the scheme, host and port should
+    /// default to that of the client.
+    /// </summary>
+    internal sealed class DefaultOptionsOverrides
+    {
+        internal DefaultOptionsOverrides(string scheme, string host, int? port)
+        {
+            Scheme = scheme;
+            Host = host;
+            Port = port;
+        }
+
+        /// <summary>
+        /// A scheme to be used by the <see cref="UrlSigner"/> signing operations if
+        /// <see cref="Options.ExplicitScheme"/> is null. May be null in which case
+        /// <see cref="Options.DefaultScheme"/> will be used.
+        /// </summary>
+        internal string Scheme { get; }
+
+        /// <summary>
+        /// A host to be used by the <see cref="UrlSigner"/> signing operations if
+        /// <see cref="Options.ExplicitHost"/> is null. May be null in which case
+        /// <see cref="Options.DefaultStorageHost"/> will be used.
+        /// </summary>
+        internal string Host { get; }
+
+        /// <summary>
+        /// A port to be used by the <see cref="UrlSigner"/> signing operations if
+        /// <see cref="Options.ExplicitPort"/> is null. May be null in which case
+        /// no port will be used.
+        /// </summary>
+        internal int? Port { get; }
+    }
+}

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/UrlSigner.V2Signer.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/UrlSigner.V2Signer.cs
@@ -146,8 +146,8 @@ namespace Google.Cloud.Storage.V1
 
                     (_host, _urlResourcePath) = options.UrlStyle switch
                     {
-                        UrlStyle.PathStyle => (StorageHost, $"/{template.Bucket}"),
-                        UrlStyle.VirtualHostedStyle => ($"{template.Bucket}.{StorageHost}", string.Empty),
+                        UrlStyle.PathStyle => (options.HostAndPort, $"/{template.Bucket}"),
+                        UrlStyle.VirtualHostedStyle => ($"{template.Bucket}.{options.HostAndPort}", string.Empty),
                         _ => throw new ArgumentOutOfRangeException(
                             nameof(options.UrlStyle),
                             $"When using {nameof(SigningVersion.V2)} only {nameof(UrlStyle.PathStyle)} or {nameof(UrlStyle.VirtualHostedStyle)} can be specified.")

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/UrlSigner.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/UrlSigner.cs
@@ -14,6 +14,7 @@
 
 using Google.Api.Gax;
 using Google.Apis.Auth.OAuth2;
+using Google.Apis.Http;
 using System;
 using System.IO;
 using System.Net.Http;
@@ -133,6 +134,24 @@ namespace Google.Cloud.Storage.V1
                 ImpersonatedCredential imp => FromCredential(imp),
                 ComputeCredential comp => FromCredential(comp),
                 _ => throw new InvalidOperationException($"The credential type {credential.UnderlyingCredential.GetType()} is not supported for signing.")
+            };
+
+        /// <summary>
+        /// Creates a new <see cref="UrlSigner"/> instace for a <see cref="IHttpExecuteInterceptor"/> if
+        /// the <paramref name="credential"/> is of a type supported for signing.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// The type of <paramref name="credential"/> is not supported for signing.
+        /// </exception>
+        internal static UrlSigner FromCredential(IHttpExecuteInterceptor credential) =>
+            GaxPreconditions.CheckNotNull(credential, nameof(credential)) switch
+            {
+                GoogleCredential gc => FromCredential(gc),
+                ServiceAccountCredential sa => FromCredential(sa),
+                ImpersonatedCredential imp => FromCredential(imp),
+                ComputeCredential comp => FromCredential(comp),
+                IBlobSigner blobSigner => FromBlobSigner(blobSigner),
+                _ => throw new InvalidOperationException($"The type {credential.GetType()} is not supported for signing.")
             };
 
         /// <summary>

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/UrlSigner.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/UrlSigner.cs
@@ -32,7 +32,6 @@ namespace Google.Cloud.Storage.V1
     /// </remarks>
     public sealed partial class UrlSigner
     {
-        private const string StorageHost = "storage.googleapis.com";
         private static readonly ISigner s_v2Signer = new V2Signer();
         private static readonly ISigner s_v4Signer = new V4Signer();
 


### PR DESCRIPTION
And can be built from StorageClient

Closes #11313 

@jskeet as always, one commit at a time. And a couple of notes:

- The second commit is a Firestore commit implementing /googleapis/conformance-tests#84 because Firestore tests started failing after I updated the conformance tests module.
- The Storage conformance tests should be fine now, so this PR is ready for full review.