### PR TITLE
chore: Update link for Google.Cloud.CloudControlsPartner.V1Beta

### DIFF
--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1308,7 +1308,7 @@
       "version": "1.0.0-beta00",
       "type": "grpc",
       "productName": "Cloud Controls Partner",
-      "productUrl": "https://cloud.google.com/cloud-controls-partner/docs",
+      "productUrl": "https://cloud.google.com/sovereign-controls-by-partners/docs/sovereign-partners/reference/rest",
       "description": "Recommended Google client library to access the Google Cloud Controls Partner API (v1beta) which provides insights about your customers and their Assured Workloads based on your Sovereign Controls by Partners offering.",
       "tags": [
         "partner",


### PR DESCRIPTION
(We may not actually release this library, as we're about to generate the v1 library, but let's at least make sure it's ready.)