### PR TITLE
Release Google.Cloud.Run.V2 version 2.6.0

### DIFF
--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/Google.Cloud.Run.V2.csproj
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/Google.Cloud.Run.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.5.0</Version>
+    <Version>2.6.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Run Admin API (v2)</Description>
@@ -12,7 +12,7 @@
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.6.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.1.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[3.1.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Run.V2/docs/history.md
+++ b/apis/Google.Cloud.Run.V2/docs/history.md
@@ -1,5 +1,18 @@
 # Version history
 
+## Version 2.6.0, released 2024-03-05
+
+### New features
+
+- Support mounting NFS and GCS volumes in Cloud Run Jobs and Services ([commit e85fcd7](https://github.com/googleapis/google-cloud-dotnet/commit/e85fcd750c48d20b360e2cb8a4cd9bbc2eb821b8))
+- Support specifying a per-Service min-instance-count ([commit e85fcd7](https://github.com/googleapis/google-cloud-dotnet/commit/e85fcd750c48d20b360e2cb8a4cd9bbc2eb821b8))
+- Support disabling waiting for health checks during Service deployment. ([commit e85fcd7](https://github.com/googleapis/google-cloud-dotnet/commit/e85fcd750c48d20b360e2cb8a4cd9bbc2eb821b8))
+- Allow disabling the default URL (run.app) for Cloud Run Services ([commit e85fcd7](https://github.com/googleapis/google-cloud-dotnet/commit/e85fcd750c48d20b360e2cb8a4cd9bbc2eb821b8))
+
+### Documentation improvements
+
+- Clarify some defaults and required or optional values ([commit e85fcd7](https://github.com/googleapis/google-cloud-dotnet/commit/e85fcd750c48d20b360e2cb8a4cd9bbc2eb821b8))
+
 ## Version 2.5.0, released 2024-02-29
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4150,7 +4150,7 @@
     },
     {
       "id": "Google.Cloud.Run.V2",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "type": "grpc",
       "productName": "Cloud Run Admin",
       "productUrl": "https://cloud.google.com/run/docs",
@@ -4163,7 +4163,7 @@
         "Google.Api.Gax.Grpc": "4.6.0",
         "Google.Cloud.Iam.V1": "3.1.0",
         "Google.Cloud.Location": "2.1.0",
-        "Google.LongRunning": "3.0.0",
+        "Google.LongRunning": "3.1.0",
         "Grpc.Core": "2.46.6"
       },
       "generator": "micro",


### PR DESCRIPTION

Changes in this release:

### New features

- Support mounting NFS and GCS volumes in Cloud Run Jobs and Services ([commit e85fcd7](https://github.com/googleapis/google-cloud-dotnet/commit/e85fcd750c48d20b360e2cb8a4cd9bbc2eb821b8))
- Support specifying a per-Service min-instance-count ([commit e85fcd7](https://github.com/googleapis/google-cloud-dotnet/commit/e85fcd750c48d20b360e2cb8a4cd9bbc2eb821b8))
- Support disabling waiting for health checks during Service deployment. ([commit e85fcd7](https://github.com/googleapis/google-cloud-dotnet/commit/e85fcd750c48d20b360e2cb8a4cd9bbc2eb821b8))
- Allow disabling the default URL (run.app) for Cloud Run Services ([commit e85fcd7](https://github.com/googleapis/google-cloud-dotnet/commit/e85fcd750c48d20b360e2cb8a4cd9bbc2eb821b8))

### Documentation improvements

- Clarify some defaults and required or optional values ([commit e85fcd7](https://github.com/googleapis/google-cloud-dotnet/commit/e85fcd750c48d20b360e2cb8a4cd9bbc2eb821b8))
