### PR TITLE
Release diagnostics libraries version 5.2.0

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>5.1.0</Version>
+    <Version>5.2.0</Version>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core 3.</Description>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore3/docs/history.md
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore3/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 5.2.0, released 2024-03-05
+
+No API surface changes; just dependency updates.
+
 ## Version 5.1.0, released 2023-02-08
 
 No API surface changes; just dependency updates.

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Google.Cloud.Diagnostics.Common.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Google.Cloud.Diagnostics.Common.IntegrationTests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Google.Api.Gax.Testing" Version="[4.6.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.csproj" />
-    <PackageReference Include="Google.Cloud.ErrorReporting.V1Beta1" Version="[3.0.0-beta02, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.ErrorReporting.V1Beta1" Version="[3.0.0-beta03, 4.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Snippets/Google.Cloud.Diagnostics.Common.Snippets.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Snippets/Google.Cloud.Diagnostics.Common.Snippets.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Google.Api.Gax.Testing" Version="[4.6.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.csproj" />
-    <PackageReference Include="Google.Cloud.ErrorReporting.V1Beta1" Version="[3.0.0-beta02, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.ErrorReporting.V1Beta1" Version="[3.0.0-beta03, 4.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Google.Cloud.Diagnostics.Common.Tests.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.Tests/Google.Cloud.Diagnostics.Common.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Google.Api.Gax.Testing" Version="[4.6.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.csproj" />
-    <PackageReference Include="Google.Cloud.ErrorReporting.V1Beta1" Version="[3.0.0-beta02, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.ErrorReporting.V1Beta1" Version="[3.0.0-beta03, 4.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>5.1.0</Version>
+    <Version>5.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries Common Components.</Description>
@@ -10,8 +10,8 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.6.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Logging.V2" Version="[4.1.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Trace.V1" Version="[3.1.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Logging.V2" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="Google.Cloud.Trace.V1" Version="[3.2.0, 4.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
   </ItemGroup>

--- a/apis/Google.Cloud.Diagnostics.Common/docs/history.md
+++ b/apis/Google.Cloud.Diagnostics.Common/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 5.2.0, released 2024-03-05
+
+No API surface changes; just dependency updates.
+
 ## Version 5.1.0, released 2023-02-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1936,7 +1936,7 @@
     },
     {
       "id": "Google.Cloud.Diagnostics.AspNetCore3",
-      "version": "5.1.0",
+      "version": "5.2.0",
       "type": "other",
       "metadataType": "INTEGRATION",
       "targetFrameworks": "netcoreapp3.1",
@@ -1961,7 +1961,7 @@
     },
     {
       "id": "Google.Cloud.Diagnostics.Common",
-      "version": "5.1.0",
+      "version": "5.2.0",
       "type": "other",
       "targetFrameworks": "netstandard2.1;net462",
       "testTargetFrameworks": "net6.0;net462",
@@ -1976,14 +1976,14 @@
       ],
       "dependencies": {
         "Google.Api.Gax.Grpc": "4.6.0",
-        "Google.Cloud.Logging.V2": "4.1.0",
-        "Google.Cloud.Trace.V1": "3.1.0",
+        "Google.Cloud.Logging.V2": "4.2.0",
+        "Google.Cloud.Trace.V1": "3.2.0",
         "Microsoft.Extensions.Http": "6.0.0",
         "System.Diagnostics.StackTrace": "4.3.0"
       },
       "testDependencies": {
         "Google.Api.Gax.Testing": "4.6.0",
-        "Google.Cloud.ErrorReporting.V1Beta1": "3.0.0-beta02",
+        "Google.Cloud.ErrorReporting.V1Beta1": "3.0.0-beta03",
         "Microsoft.Extensions.Hosting": "6.0.1"
       }
     },


### PR DESCRIPTION

Changes in Google.Cloud.Diagnostics.AspNetCore3 version 5.2.0:

No API surface changes; just dependency updates.

Changes in Google.Cloud.Diagnostics.Common version 5.2.0:

No API surface changes; just dependency updates.

Packages in this release:
- Release Google.Cloud.Diagnostics.AspNetCore3 version 5.2.0
- Release Google.Cloud.Diagnostics.Common version 5.2.0
