### PR TITLE
feat: Allow a new upload session to be initiated as a single method call

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Snippets/StorageClientSnippets.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Snippets/StorageClientSnippets.cs
@@ -355,9 +355,7 @@ namespace Google.Cloud.Storage.V1.Snippets
             // var acl = PredefinedAcl.PublicRead // public
             var acl = PredefinedObjectAcl.AuthenticatedRead; // private
             var options = new UploadObjectOptions { PredefinedAcl = acl };
-            // Create a temporary uploader so the upload session can be manually initiated without actually uploading.
-            var tempUploader = client.CreateObjectUploader(bucketName, destination, contentType, new MemoryStream(), options);
-            var uploadUri = await tempUploader.InitiateSessionAsync();
+            var uploadUri = await client.InitiateUploadSessionAsync(bucketName, destination, contentType, contentLength: null, options);
 
             // Send uploadUri to (unauthenticated) client application, so it can perform the upload:
             using (var stream = File.OpenRead(source))

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClient.UploadObject.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClient.UploadObject.cs
@@ -49,8 +49,8 @@ namespace Google.Cloud.Storage.V1
         /// <summary>
         /// Creates an instance which is capable of starting a resumable upload for an object.
         /// </summary>
-        /// <param name="destination">Object to create or update. Must not be null, and must have the name,
-        /// bucket and content type populated.</param>
+        /// <param name="destination">Object to create or update. Must not be null, and must have the name
+        /// and bucket populated.</param>
         /// <param name="source">The stream to read the data from. Must not be null.</param>
         /// <param name="options">Additional options for the upload. May be null, in which case appropriate
         /// defaults will be used.</param>
@@ -116,8 +116,8 @@ namespace Google.Cloud.Storage.V1
         /// <summary>
         /// Uploads the data for an object in storage synchronously, from a specified stream.
         /// </summary>
-        /// <param name="destination">Object to create or update. Must not be null, and must have the name,
-        /// bucket and content type populated.</param>
+        /// <param name="destination">Object to create or update. Must not be null, and must have the name
+        /// and bucket populated.</param>
         /// <param name="source">The stream to read the data from. Must not be null.</param>
         /// <param name="options">Additional options for the upload. May be null, in which case appropriate
         /// defaults will be used.</param>
@@ -135,8 +135,8 @@ namespace Google.Cloud.Storage.V1
         /// <summary>
         /// Uploads the data for an object in storage asynchronously, from a specified stream.
         /// </summary>
-        /// <param name="destination">Object to create or update. Must not be null, and must have the name,
-        /// bucket and content type populated.</param>
+        /// <param name="destination">Object to create or update. Must not be null, and must have the name
+        /// and bucket populated.</param>
         /// <param name="source">The stream to read the data from. Must not be null.</param>
         /// <param name="options">Additional options for the upload. May be null, in which case appropriate
         /// defaults will be used.</param>
@@ -153,5 +153,51 @@ namespace Google.Cloud.Storage.V1
         {
             throw new NotImplementedException();
         }
+
+        /// <summary>
+        /// Initiates an upload session, optionally specifying the length of the content to be uploaded.
+        /// The resulting URI can be used with <see cref="ResumableUpload.CreateFromUploadUri"/>.
+        /// </summary>
+        /// <param name="destination">Object to create or update. Must not be null, and must have the name
+        /// and bucket populated.</param>
+        /// <param name="contentLength">The length of the content to upload later. This may be null, in which
+        /// case any length of content may be uploaded. If the value is non-null, it must be strictly positive
+        /// (not zero), and the content uploaded later must be exactly this length.</param>
+        /// <param name="options">Additional options for the upload. May be null, in which case appropriate
+        /// defaults will be used.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task representing the asynchronous operation, with a result returning the
+        /// <see cref="Uri"/> to use in order to upload the content.</returns>
+        public virtual Task<Uri> InitiateUploadSessionAsync(
+            Object destination,
+            long? contentLength,
+            UploadObjectOptions options = null,
+            CancellationToken cancellationToken = default) =>
+            throw new NotImplementedException();
+
+        /// <summary>
+        /// Initiates an upload session, optionally specifying the length of the content to be uploaded.
+        /// The resulting URI can be used with <see cref="ResumableUpload.CreateFromUploadUri"/>.
+        /// </summary>
+        /// <param name="bucket">The name of the bucket containing the object. Must not be null.</param>
+        /// <param name="objectName">The name of the object within the bucket. Must not be null.</param>
+        /// <param name="contentType">The content type of the object. This should be a MIME type
+        /// such as "text/html" or "application/octet-stream". May be null.</param>
+        /// <param name="contentLength">The length of the content to upload later. This may be null, in which
+        /// case any length of content may be uploaded. If the value is non-null, it must be strictly positive
+        /// (not zero), and the content uploaded later must be exactly this length.</param>
+        /// <param name="options">Additional options for the upload. May be null, in which case appropriate
+        /// defaults will be used.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task representing the asynchronous operation, with a result returning the
+        /// <see cref="Uri"/> to use in order to upload the content.</returns>
+        public virtual Task<Uri> InitiateUploadSessionAsync(
+            string bucket,
+            string objectName,
+            string contentType,
+            long? contentLength,
+            UploadObjectOptions options = null,
+            CancellationToken cancellationToken = default) =>
+            throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
This allows the content length to be (optionally) specified, which is then propagated via X-Upload-Content-Length.

This is currently just a prototype for comment - I'd want to add integration tests, some unit tests, and obviously XML docs.

See #12034 for background.