### PR TITLE
Release Google.Cloud.Translation.V2 version 3.3.0

### DIFF
--- a/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.csproj
+++ b/apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.2.0</Version>
+    <Version>3.3.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Translate v2 API. It wraps the Google.Apis.Translate.v2 client library, making common operations simpler in client code. The Translate API translates text from one language to another.</Description>

--- a/apis/Google.Cloud.Translation.V2/docs/history.md
+++ b/apis/Google.Cloud.Translation.V2/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 3.3.0, released 2024-03-06
+
+No API surface changes; just dependency updates.
+
 ## Version 3.2.0, released 2023-03-27
 
 No API surface changes; just dependency updates and a GA release for self-signed JWTs.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5177,7 +5177,7 @@
       "id": "Google.Cloud.Translation.V2",
       "productName": "Google Cloud Translation",
       "productUrl": "https://cloud.google.com/translate/",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "type": "rest",
       "description": "Recommended Google client library to access the Translate v2 API. It wraps the Google.Apis.Translate.v2 client library, making common operations simpler in client code. The Translate API translates text from one language to another.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
