### PR TITLE
chore: Remove workaround for Google.Apps.Events.Subscriptions.V1 generation

### DIFF
--- a/apis/Google.Apps.Events.Subscriptions.V1/.OwlBot-ForceRegeneration.txt
+++ b/apis/Google.Apps.Events.Subscriptions.V1/.OwlBot-ForceRegeneration.txt
@@ -1,1 +1,0 @@
-API requires pre-generation tweaks.

--- a/apis/Google.Apps.Events.Subscriptions.V1/postgeneration.sh
+++ b/apis/Google.Apps.Events.Subscriptions.V1/postgeneration.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -e
-
-# Undo the changes made in pregeneration.sh
-git -C $GOOGLEAPIS checkout google/apps/events/subscriptions/v1/

--- a/apis/Google.Apps.Events.Subscriptions.V1/pregeneration.sh
+++ b/apis/Google.Apps.Events.Subscriptions.V1/pregeneration.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-# Temporary workaround for a method signature which redundantly includes pageToken and pageSize
-# See b/325289454
-sed -i 's/"page_size, page_token, filter"/"filter"/g' $GOOGLEAPIS/google/apps/events/subscriptions/v1/subscriptions_service.proto


### PR DESCRIPTION
The protos have now been fixed. Tested by regenerating: there are no changes to the generated code after the workaround has been removed.