### PR TITLE
tools: Add a "release anything with a last release date older than X" criterion

### DIFF
--- a/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/BatchReleaseConfig.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/BatchReleaseConfig.cs
@@ -83,6 +83,12 @@ namespace Google.Cloud.Tools.ReleaseManager.BatchRelease
         /// </summary>
         public bool CollectProposalsEagerly { get; set; }
 
+        /// <summary>
+        /// When specified, all APIs whose last release was before the specified date (yyyy-MM-dd format)
+        /// are released. APIs which haven't been released at all not released.
+        /// </summary>
+        public string LastReleaseBefore { get; set; }
+
         internal IEnumerable<IBatchCriterion> GetCriteria()
         {
             if (KnownCommits is object)
@@ -96,6 +102,10 @@ namespace Google.Cloud.Tools.ReleaseManager.BatchRelease
             if (ReleaseAll is object)
             {
                 yield return ReleaseAll;
+            }
+            if (LastReleaseBefore != null)
+            {
+                yield return new LastReleaseBeforeCriterion(LastReleaseBefore);
             }
         }
     }

--- a/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/LastReleaseBeforeCriterion.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/LastReleaseBeforeCriterion.cs
@@ -1,0 +1,68 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+using Google.Cloud.Tools.Common;
+using LibGit2Sharp;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace Google.Cloud.Tools.ReleaseManager.BatchRelease;
+
+public sealed class LastReleaseBeforeCriterion : IBatchCriterion
+{
+    private readonly DateTimeOffset _cutoff;
+
+    public LastReleaseBeforeCriterion(string isoCutoff)
+    {
+        _cutoff = DateTimeOffset.ParseExact(isoCutoff, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
+    }
+
+    IEnumerable<ReleaseProposal> IBatchCriterion.GetProposals(
+        ApiCatalog catalog,
+        Func<string, StructuredVersion, StructuredVersion> versionIncrementer,
+        string defaultMessage,
+        Action<int, int> progressCallback)
+    {
+        var root = DirectoryLayout.DetermineRootDirectory();
+        using var repo = new Repository(root);
+
+        var allTags = repo.Tags.OrderByDescending(GitHelpers.GetDate).ToList();
+
+        int progress = 0;
+        foreach (var api in catalog.Apis)
+        {
+            progressCallback?.Invoke(++progress, catalog.Apis.Count);
+            string expectedTagPrefix = $"{api.Id}-";
+            var latestRelease = allTags.FirstOrDefault(tag => tag.FriendlyName.StartsWith(expectedTagPrefix, StringComparison.Ordinal));
+
+            // If we've never released, or the last release was on/after the cut-off date, skip.
+            if (latestRelease is null || GitHelpers.GetDate(latestRelease) >= _cutoff)
+            {
+                continue;
+            }
+
+            if (api.BlockRelease is string blockReason)
+            {
+                Console.WriteLine($"Skipping {api.Id} due to block: {blockReason}");
+                continue;
+            }
+
+            var newVersion = versionIncrementer(api.Id, api.StructuredVersion);
+            yield return ReleaseProposal.CreateFromHistory(repo, api.Id, newVersion, defaultMessage);
+        }
+        yield break;
+    }
+}


### PR DESCRIPTION
Our recent "release everything" only released APIs which had had at least one commit (even if it was a chore or docs) since the last release. That missed a bunch of APIs. (There are some others I still don't understand right now, but not many.)