### PR TITLE
Release Google.Cloud.Bigtable.V2 version 3.10.0

### DIFF
--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.10.0-beta01</Version>
+    <Version>3.10.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Bigtable API.</Description>

--- a/apis/Google.Cloud.Bigtable.V2/docs/history.md
+++ b/apis/Google.Cloud.Bigtable.V2/docs/history.md
@@ -1,5 +1,22 @@
 # Version history
 
+## Version 3.10.0, released 2024-03-12
+
+### New features
+
+- Publish new bigtable APIs for types and aggregates ([commit 47a6ffd](https://github.com/googleapis/google-cloud-dotnet/commit/47a6ffdfeb169ed5c08eb0243b7810bb42e9bf29))
+- Add authorized view bindings to Cloud Bigtable data APIs and messages ([commit f09ba5c](https://github.com/googleapis/google-cloud-dotnet/commit/f09ba5cdffa0cd059141ed921e12440ac32e8002))
+- (From 3.10.0-beta01) Bigtable supports universe domain ([commit c3610f9](https://github.com/googleapis/google-cloud-dotnet/commit/c3610f97235f1582376e3a124b9531dc01a43a77))
+
+### Documentation improvements
+
+- The field `table_name` in message `.google.bigtable.v2.ReadRowsRequest` is changed from required to optional ([commit f09ba5c](https://github.com/googleapis/google-cloud-dotnet/commit/f09ba5cdffa0cd059141ed921e12440ac32e8002))
+- The field `table_name` in message `.google.bigtable.v2.SampleRowKeysRequest` is changed from required to optional ([commit f09ba5c](https://github.com/googleapis/google-cloud-dotnet/commit/f09ba5cdffa0cd059141ed921e12440ac32e8002))
+- The field `table_name` in message `.google.bigtable.v2.MutateRowRequest` is changed from required to optional ([commit f09ba5c](https://github.com/googleapis/google-cloud-dotnet/commit/f09ba5cdffa0cd059141ed921e12440ac32e8002))
+- The field `table_name` in message `.google.bigtable.v2.MutateRowsRequest` is changed from required to optional ([commit f09ba5c](https://github.com/googleapis/google-cloud-dotnet/commit/f09ba5cdffa0cd059141ed921e12440ac32e8002))
+- The field `table_name` in message `.google.bigtable.v2.CheckAndMutateRowRequest` is changed from required to optional ([commit f09ba5c](https://github.com/googleapis/google-cloud-dotnet/commit/f09ba5cdffa0cd059141ed921e12440ac32e8002))
+- The field `table_name` in message `.google.bigtable.v2.ReadModifyWriteRowRequest` is changed from required to optional ([commit f09ba5c](https://github.com/googleapis/google-cloud-dotnet/commit/f09ba5cdffa0cd059141ed921e12440ac32e8002))
+
 ## Version 3.10.0-beta01, released 2024-02-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1090,7 +1090,7 @@
       "protoPath": "google/bigtable/v2",
       "productName": "Google Bigtable",
       "productUrl": "https://cloud.google.com/bigtable/",
-      "version": "3.10.0-beta01",
+      "version": "3.10.0",
       "commonResourcesConfig": "apis/Google.Cloud.Bigtable.Common.V2/CommonResourcesConfig.json",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",


### PR DESCRIPTION

Changes in this release:

### New features

- Publish new bigtable APIs for types and aggregates ([commit 47a6ffd](https://github.com/googleapis/google-cloud-dotnet/commit/47a6ffdfeb169ed5c08eb0243b7810bb42e9bf29))
- Add authorized view bindings to Cloud Bigtable data APIs and messages ([commit f09ba5c](https://github.com/googleapis/google-cloud-dotnet/commit/f09ba5cdffa0cd059141ed921e12440ac32e8002))
- (From 3.10.0-beta01) Bigtable supports universe domain ([commit c3610f9](https://github.com/googleapis/google-cloud-dotnet/commit/c3610f97235f1582376e3a124b9531dc01a43a77))

### Documentation improvements

- The field `table_name` in message `.google.bigtable.v2.ReadRowsRequest` is changed from required to optional ([commit f09ba5c](https://github.com/googleapis/google-cloud-dotnet/commit/f09ba5cdffa0cd059141ed921e12440ac32e8002))
- The field `table_name` in message `.google.bigtable.v2.SampleRowKeysRequest` is changed from required to optional ([commit f09ba5c](https://github.com/googleapis/google-cloud-dotnet/commit/f09ba5cdffa0cd059141ed921e12440ac32e8002))
- The field `table_name` in message `.google.bigtable.v2.MutateRowRequest` is changed from required to optional ([commit f09ba5c](https://github.com/googleapis/google-cloud-dotnet/commit/f09ba5cdffa0cd059141ed921e12440ac32e8002))
- The field `table_name` in message `.google.bigtable.v2.MutateRowsRequest` is changed from required to optional ([commit f09ba5c](https://github.com/googleapis/google-cloud-dotnet/commit/f09ba5cdffa0cd059141ed921e12440ac32e8002))
- The field `table_name` in message `.google.bigtable.v2.CheckAndMutateRowRequest` is changed from required to optional ([commit f09ba5c](https://github.com/googleapis/google-cloud-dotnet/commit/f09ba5cdffa0cd059141ed921e12440ac32e8002))
- The field `table_name` in message `.google.bigtable.v2.ReadModifyWriteRowRequest` is changed from required to optional ([commit f09ba5c](https://github.com/googleapis/google-cloud-dotnet/commit/f09ba5cdffa0cd059141ed921e12440ac32e8002))
