### PR TITLE
Release Google.Cloud.Logging.NLog version 5.0.0

### DIFF
--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.csproj
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>5.0.0-beta01</Version>
+    <Version>5.0.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>NLog target for the Google Cloud Logging API.</Description>
@@ -10,8 +10,8 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.6.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.DevTools.Common" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Logging.V2" Version="[4.1.0, 5.0.0)" />
+    <PackageReference Include="Google.Cloud.DevTools.Common" Version="[3.1.1, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Logging.V2" Version="[4.2.0, 5.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
     <PackageReference Include="NLog" Version="5.2.8" />
   </ItemGroup>

--- a/apis/Google.Cloud.Logging.NLog/docs/history.md
+++ b/apis/Google.Cloud.Logging.NLog/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 5.0.0, released 2024-03-12
+
+No API surface changes; just dependency updates and promotion to GA.
+
 ## Version 5.0.0-beta01, released 2024-01-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3075,7 +3075,7 @@
     },
     {
       "id": "Google.Cloud.Logging.NLog",
-      "version": "5.0.0-beta01",
+      "version": "5.0.0",
       "type": "other",
       "metadataType": "INTEGRATION",
       "targetFrameworks": "netstandard2.1;net462",
@@ -3088,8 +3088,8 @@
       ],
       "dependencies": {
         "Google.Api.Gax.Grpc": "4.6.0",
-        "Google.Cloud.DevTools.Common": "3.0.0",
-        "Google.Cloud.Logging.V2": "4.1.0",
+        "Google.Cloud.DevTools.Common": "3.1.1",
+        "Google.Cloud.Logging.V2": "4.2.0",
         "Grpc.Core": "2.46.6",
         "NLog": "5.2.8"
       },


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates and promotion to GA.
