### PR TITLE
Release Google.Cloud.NetApp.V1 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.NetApp.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.NetApp.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.NetApp.V1",
-  "release_level": "preview",
+  "release_level": "stable",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.NetApp.V1/latest",
   "library_type": "GAPIC_AUTO",
   "language": "dotnet",

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.csproj
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta03</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud NetApp Volumes API, which is a fully-managed, cloud-based data storage service that provides advanced data management capabilities and highly scalable performance with global availability.</Description>
@@ -10,8 +10,8 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.6.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Location" Version="[2.1.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[3.1.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.NetApp.V1/docs/history.md
+++ b/apis/Google.Cloud.NetApp.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 1.0.0, released 2024-03-12
+
+This is the first GA release of the library.
+
+### Documentation improvements
+
+- Mark optional fields explicitly in Storage Pool ([commit 41065fe](https://github.com/googleapis/google-cloud-dotnet/commit/41065fe41d33abf18e9055cb6c079f80eaec571f))
+- Change comments of the psa_range field to note it is currently not implemented ([commit 41065fe](https://github.com/googleapis/google-cloud-dotnet/commit/41065fe41d33abf18e9055cb6c079f80eaec571f))
+- Update comments of ServiceLevel and EncryptionType ([commit 41065fe](https://github.com/googleapis/google-cloud-dotnet/commit/41065fe41d33abf18e9055cb6c079f80eaec571f))
+
 ## Version 1.0.0-beta03, released 2024-02-28
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3354,7 +3354,7 @@
     },
     {
       "id": "Google.Cloud.NetApp.V1",
-      "version": "1.0.0-beta03",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "NetApp",
       "productUrl": "https://cloud.google.com/netapp/volumes/docs/discover/overview",
@@ -3365,8 +3365,10 @@
         "availability"
       ],
       "dependencies": {
-        "Google.Cloud.Location": "2.0.0",
-        "Google.LongRunning": "3.0.0"
+        "Google.Api.Gax.Grpc": "4.6.0",
+        "Google.Cloud.Location": "2.1.0",
+        "Google.LongRunning": "3.1.0",
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/netapp/v1",


### PR DESCRIPTION

Changes in this release:

This is the first GA release of the library.

### Documentation improvements

- Mark optional fields explicitly in Storage Pool ([commit 41065fe](https://github.com/googleapis/google-cloud-dotnet/commit/41065fe41d33abf18e9055cb6c079f80eaec571f))
- Change comments of the psa_range field to note it is currently not implemented ([commit 41065fe](https://github.com/googleapis/google-cloud-dotnet/commit/41065fe41d33abf18e9055cb6c079f80eaec571f))
- Update comments of ServiceLevel and EncryptionType ([commit 41065fe](https://github.com/googleapis/google-cloud-dotnet/commit/41065fe41d33abf18e9055cb6c079f80eaec571f))
