### PR TITLE
Release Google.Cloud.PolicySimulator.V1 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.PolicySimulator.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.PolicySimulator.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.PolicySimulator.V1",
-  "release_level": "preview",
+  "release_level": "stable",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.PolicySimulator.V1/latest",
   "library_type": "GAPIC_AUTO",
   "language": "dotnet",

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.csproj
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Policy Simulator API, which is a collection of endpoints for creating, running, and viewing simulations of IAM policy changes.</Description>
@@ -11,7 +11,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.6.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.1.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[3.1.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.PolicySimulator.V1/docs/history.md
+++ b/apis/Google.Cloud.PolicySimulator.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0, released 2024-03-12
+
+No API surface changes; just promotion to GA.
+
 ## Version 1.0.0-beta02, released 2024-02-29
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3803,7 +3803,7 @@
     },
     {
       "id": "Google.Cloud.PolicySimulator.V1",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Policy Simulator",
       "productUrl": "https://cloud.google.com/policy-intelligence/docs/iam-simulator-overview",
@@ -3814,8 +3814,10 @@
         "policy"
       ],
       "dependencies": {
+        "Google.Api.Gax.Grpc": "4.6.0",
         "Google.Cloud.Iam.V1": "3.1.0",
-        "Google.LongRunning": "3.0.0"
+        "Google.LongRunning": "3.1.0",
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/policysimulator/v1",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just promotion to GA.
