### PR TITLE
Release Google.Cloud.PolicyTroubleshooter.Iam.V3 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.PolicyTroubleshooter.Iam.V3/.repo-metadata.json
+++ b/apis/Google.Cloud.PolicyTroubleshooter.Iam.V3/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.PolicyTroubleshooter.Iam.V3",
-  "release_level": "preview",
+  "release_level": "stable",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.PolicyTroubleshooter.Iam.V3/latest",
   "library_type": "GAPIC_AUTO",
   "language": "dotnet",

--- a/apis/Google.Cloud.PolicyTroubleshooter.Iam.V3/Google.Cloud.PolicyTroubleshooter.Iam.V3/Google.Cloud.PolicyTroubleshooter.Iam.V3.csproj
+++ b/apis/Google.Cloud.PolicyTroubleshooter.Iam.V3/Google.Cloud.PolicyTroubleshooter.Iam.V3/Google.Cloud.PolicyTroubleshooter.Iam.V3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Policy Troubleshooter for IAM API, which helps you understand why a user has access to a resource or doesn't have permission to call an API.</Description>

--- a/apis/Google.Cloud.PolicyTroubleshooter.Iam.V3/docs/history.md
+++ b/apis/Google.Cloud.PolicyTroubleshooter.Iam.V3/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0, released 2024-03-12
+
+No API surface changes; just promotion to GA.
+
 ## Version 1.0.0-beta02, released 2024-02-29
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3826,7 +3826,7 @@
     },
     {
       "id": "Google.Cloud.PolicyTroubleshooter.Iam.V3",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Policy Troubleshooter",
       "productUrl": "https://cloud.google.com/policy-intelligence/docs/troubleshoot-access",
@@ -3836,8 +3836,10 @@
         "authentication"
       ],
       "dependencies": {
+        "Google.Api.Gax.Grpc": "4.6.0",
         "Google.Cloud.Iam.V1": "3.1.0",
-        "Google.Cloud.Iam.V2": "1.1.0"
+        "Google.Cloud.Iam.V2": "1.1.0",
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/policytroubleshooter/iam/v3",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just promotion to GA.
