### PR TITLE
Release Google.Cloud.RapidMigrationAssessment.V1 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.RapidMigrationAssessment.V1",
-  "release_level": "preview",
+  "release_level": "stable",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.RapidMigrationAssessment.V1/latest",
   "library_type": "GAPIC_AUTO",
   "language": "dotnet",

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.csproj
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Rapid Migration Assessment API.</Description>
@@ -11,7 +11,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.6.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.1.0, 3.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[3.1.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/docs/history.md
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0, released 2024-03-12
+
+No API surface changes; just promotion to GA.
+
 ## Version 1.0.0-beta02, released 2024-02-29
 
 ### Documentation improvements

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3951,7 +3951,7 @@
     },
     {
       "id": "Google.Cloud.RapidMigrationAssessment.V1",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Rapid Migration Assessment",
       "productUrl": "https://cloud.google.com/migration-center/docs",
@@ -3960,8 +3960,10 @@
         "migration"
       ],
       "dependencies": {
+        "Google.Api.Gax.Grpc": "4.6.0",
         "Google.Cloud.Location": "2.1.0",
-        "Google.LongRunning": "3.0.0"
+        "Google.LongRunning": "3.1.0",
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/rapidmigrationassessment/v1",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just promotion to GA.
