### PR TITLE
Release Google.Cloud.ServiceHealth.V1 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.ServiceHealth.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.ServiceHealth.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.ServiceHealth.V1",
-  "release_level": "preview",
+  "release_level": "stable",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.ServiceHealth.V1/latest",
   "library_type": "GAPIC_AUTO",
   "language": "dotnet",

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.csproj
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Service Health API, which helps you gain visibility into disruptive events impacting Google Cloud products.</Description>

--- a/apis/Google.Cloud.ServiceHealth.V1/docs/history.md
+++ b/apis/Google.Cloud.ServiceHealth.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0, released 2024-03-12
+
+No API surface changes; just promotion to GA.
+
 ## Version 1.0.0-beta02, released 2024-02-29
 
 ### Documentation improvements

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4594,7 +4594,7 @@
     },
     {
       "id": "Google.Cloud.ServiceHealth.V1",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Service Health",
       "productUrl": "https://cloud.google.com/service-health/docs/overview",
@@ -4603,7 +4603,9 @@
         "monitoring"
       ],
       "dependencies": {
-        "Google.Cloud.Location": "2.1.0"
+        "Google.Api.Gax.Grpc": "4.6.0",
+        "Google.Cloud.Location": "2.1.0",
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/cloud/servicehealth/v1",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just promotion to GA.
