### PR TITLE
Release Google.Cloud.Video.Stitcher.V1 version 3.0.0

### DIFF
--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.csproj
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0-beta03</Version>
+    <Version>3.0.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Video Stitcher API, which helps you generate dynamic content for delivery to client devices. </Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.6.0, 5.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[3.1.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Video.Stitcher.V1/docs/history.md
+++ b/apis/Google.Cloud.Video.Stitcher.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 3.0.0, released 2024-03-12
+
+No API surface changes; just promotion to GA.
+
 ## Version 3.0.0-beta03, released 2024-02-29
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5330,7 +5330,7 @@
     },
     {
       "id": "Google.Cloud.Video.Stitcher.V1",
-      "version": "3.0.0-beta03",
+      "version": "3.0.0",
       "type": "grpc",
       "productName": "Video Stitcher",
       "productUrl": "https://cloud.google.com/video-stitcher/docs",
@@ -5342,7 +5342,7 @@
       ],
       "dependencies": {
         "Google.Api.Gax.Grpc": "4.6.0",
-        "Google.LongRunning": "3.0.0",
+        "Google.LongRunning": "3.1.0",
         "Grpc.Core": "2.46.6"
       },
       "generator": "micro",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just promotion to GA.
