### PR TITLE
Release Google.Apps.Meet.V2 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2/Google.Apps.Meet.V2.csproj
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2/Google.Apps.Meet.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to create and manage meetings in Google Meet.</Description>

--- a/apis/Google.Apps.Meet.V2/docs/history.md
+++ b/apis/Google.Apps.Meet.V2/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2024-03-13
+
+No API surface changes; just dependency updates.
+
 ## Version 1.0.0-beta01, released 2024-02-20
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -83,7 +83,7 @@
     },
     {
       "id": "Google.Apps.Meet.V2",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Google Meet",
       "productUrl": "https://developers.google.com/meet/api/guides/overview",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
