### PR TITLE
Release Google.Cloud.Bigtable.Common.V2 version 3.1.0

### DIFF
--- a/apis/Google.Cloud.Bigtable.Common.V2/Google.Cloud.Bigtable.Common.V2/Google.Cloud.Bigtable.Common.V2.csproj
+++ b/apis/Google.Cloud.Bigtable.Common.V2/Google.Cloud.Bigtable.Common.V2/Google.Cloud.Bigtable.Common.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0</Version>
+    <Version>3.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Common code used by Bigtable V2 APIs</Description>

--- a/apis/Google.Cloud.Bigtable.Common.V2/docs/history.md
+++ b/apis/Google.Cloud.Bigtable.Common.V2/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 3.1.0, released 2024-03-13
+
+No API surface changes; just dependency updates.
+
 ## Version 3.0.0, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1074,7 +1074,7 @@
       "id": "Google.Cloud.Bigtable.Common.V2",
       "type": "other",
       "targetFrameworks": "netstandard2.1;net462",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "description": "Common code used by Bigtable V2 APIs",
       "tags": [
         "Bigtable"


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
