### PR TITLE
Release Google.Cloud.ContactCenterInsights.V1 version 2.13.0

### DIFF
--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.csproj
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.12.0</Version>
+    <Version>2.13.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Contact Center AI Insights API, which helps users detect and visualize patterns in their contact center data. Understanding conversational data drives business value, improves operational efficiency, and provides a voice for customer feedback.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.6.0, 5.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[3.1.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ContactCenterInsights.V1/docs/history.md
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 2.13.0, released 2024-03-13
+
+No API surface changes; just dependency updates.
+
 ## Version 2.12.0, released 2024-02-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1574,7 +1574,7 @@
     },
     {
       "id": "Google.Cloud.ContactCenterInsights.V1",
-      "version": "2.12.0",
+      "version": "2.13.0",
       "type": "grpc",
       "productName": "Contact Center AI Insights",
       "productUrl": "https://cloud.google.com/contact-center/insights/docs",
@@ -1586,7 +1586,7 @@
       ],
       "dependencies": {
         "Google.Api.Gax.Grpc": "4.6.0",
-        "Google.LongRunning": "3.0.0",
+        "Google.LongRunning": "3.1.0",
         "Grpc.Core": "2.46.6"
       },
       "generator": "micro",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
