### PR TITLE
Release Google.Cloud.DocumentAI.V1 version 3.13.0

### DIFF
--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.csproj
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.12.0</Version>
+    <Version>3.13.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Document AI API (v1), which is a service to parse structured information from unstructured or semi-structured documents using state-of-the-art Google AI such as natural language, computer vision, translation, and AutoML.</Description>
@@ -10,8 +10,8 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.6.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Location" Version="[2.1.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[3.1.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.DocumentAI.V1/docs/history.md
+++ b/apis/Google.Cloud.DocumentAI.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 3.13.0, released 2024-03-13
+
+No API surface changes; just dependency updates.
+
 ## Version 3.12.0, released 2024-02-20
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2181,7 +2181,7 @@
     },
     {
       "id": "Google.Cloud.DocumentAI.V1",
-      "version": "3.12.0",
+      "version": "3.13.0",
       "type": "grpc",
       "productName": "Cloud Document AI",
       "productUrl": "https://cloud.google.com/solutions/document-ai",
@@ -2196,8 +2196,8 @@
       ],
       "dependencies": {
         "Google.Api.Gax.Grpc": "4.6.0",
-        "Google.Cloud.Location": "2.0.0",
-        "Google.LongRunning": "3.0.0",
+        "Google.Cloud.Location": "2.1.0",
+        "Google.LongRunning": "3.1.0",
         "Grpc.Core": "2.46.6"
       },
       "generator": "micro",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
