### PR TITLE
Release Google.Cloud.Logging.Log4Net version 4.2.0

### DIFF
--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.csproj
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.1.0</Version>
+    <Version>4.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Log4Net client library for the Google Cloud Logging API.</Description>
@@ -10,8 +10,8 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.6.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.DevTools.Common" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Logging.V2" Version="[4.1.0, 5.0.0)" />
+    <PackageReference Include="Google.Cloud.DevTools.Common" Version="[3.1.1, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Logging.V2" Version="[4.2.0, 5.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
     <PackageReference Include="log4net" Version="2.0.14" />
   </ItemGroup>

--- a/apis/Google.Cloud.Logging.Log4Net/docs/history.md
+++ b/apis/Google.Cloud.Logging.Log4Net/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 4.2.0, released 2024-03-13
+
+No API surface changes; just dependency updates.
+
 ## Version 4.1.0, released 2023-09-25
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3035,7 +3035,7 @@
     },
     {
       "id": "Google.Cloud.Logging.Log4Net",
-      "version": "4.1.0",
+      "version": "4.2.0",
       "type": "other",
       "metadataType": "INTEGRATION",
       "targetFrameworks": "netstandard2.1;net462",
@@ -3048,8 +3048,8 @@
       ],
       "dependencies": {
         "Google.Api.Gax.Grpc": "4.6.0",
-        "Google.Cloud.DevTools.Common": "3.0.0",
-        "Google.Cloud.Logging.V2": "4.1.0",
+        "Google.Cloud.DevTools.Common": "3.1.1",
+        "Google.Cloud.Logging.V2": "4.2.0",
         "Grpc.Core": "2.46.6",
         "log4net": "2.0.14"
       },


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
