### PR TITLE
Release Google.Cloud.VmwareEngine.V1 version 1.2.0

### DIFF
--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.csproj
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google VMware Engine API, which lets you programmatically manage VMware environments.</Description>
@@ -10,9 +10,9 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.6.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Location" Version="[2.0.0, 3.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[3.0.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.1.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Location" Version="[2.1.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[3.1.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.VmwareEngine.V1/docs/history.md
+++ b/apis/Google.Cloud.VmwareEngine.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.2.0, released 2024-03-13
+
+No API surface changes; just dependency updates.
+
 ## Version 1.1.0, released 2024-02-07
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5432,7 +5432,7 @@
     },
     {
       "id": "Google.Cloud.VmwareEngine.V1",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "type": "grpc",
       "productName": "VMware Engine",
       "productUrl": "https://cloud.google.com/vmware-engine/docs",
@@ -5442,9 +5442,9 @@
       ],
       "dependencies": {
         "Google.Api.Gax.Grpc": "4.6.0",
-        "Google.Cloud.Iam.V1": "3.0.0",
-        "Google.Cloud.Location": "2.0.0",
-        "Google.LongRunning": "3.0.0",
+        "Google.Cloud.Iam.V1": "3.1.0",
+        "Google.Cloud.Location": "2.1.0",
+        "Google.LongRunning": "3.1.0",
         "Grpc.Core": "2.46.6"
       },
       "generator": "micro",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
