### PR TITLE
Release Google.Cloud.Workflows.Common.V1Beta version 2.0.0-beta03

### DIFF
--- a/apis/Google.Cloud.Workflows.Common.V1Beta/Google.Cloud.Workflows.Common.V1Beta/Google.Cloud.Workflows.Common.V1Beta.csproj
+++ b/apis/Google.Cloud.Workflows.Common.V1Beta/Google.Cloud.Workflows.Common.V1Beta/Google.Cloud.Workflows.Common.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta02</Version>
+    <Version>2.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Common resource names used by all Workflows V1Beta APIs</Description>

--- a/apis/Google.Cloud.Workflows.Common.V1Beta/docs/history.md
+++ b/apis/Google.Cloud.Workflows.Common.V1Beta/docs/history.md
@@ -1,0 +1,2 @@
+# Version history
+

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5572,7 +5572,7 @@
       "id": "Google.Cloud.Workflows.Common.V1Beta",
       "type": "other",
       "targetFrameworks": "netstandard2.1;net462",
-      "version": "2.0.0-beta02",
+      "version": "2.0.0-beta03",
       "description": "Common resource names used by all Workflows V1Beta APIs",
       "tags": [
         "Spanner"


### PR DESCRIPTION

This library has no dedicated release history. Changes are typically recorded in other libraries, or are just dependency updates.
