### PR TITLE
Release Google.Identity.AccessContextManager.Type version 2.1.0

### DIFF
--- a/apis/Google.Identity.AccessContextManager.Type/Google.Identity.AccessContextManager.Type/Google.Identity.AccessContextManager.Type.csproj
+++ b/apis/Google.Identity.AccessContextManager.Type/Google.Identity.AccessContextManager.Type/Google.Identity.AccessContextManager.Type.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Version-agnostic types for the Google Identity Access Context Manager API.</Description>

--- a/apis/Google.Identity.AccessContextManager.Type/docs/history.md
+++ b/apis/Google.Identity.AccessContextManager.Type/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 2.1.0, released 2024-03-13
+
+No API surface changes; just dependency updates.
+
 ## Version 2.0.0, released 2022-06-08
 
 This is the first version of this package to depend on GAX v4.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5718,7 +5718,7 @@
       "packageOwner": "google-cloud",
       "generator": "proto",
       "protoPath": "google/identity/accesscontextmanager/type",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "type": "other",
       "targetFrameworks": "netstandard2.1;net462",
       "description": "Version-agnostic types for the Google Identity Access Context Manager API.",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
