### PR TITLE
Release Google.Maps.AddressValidation.V1 version 1.2.0

### DIFF
--- a/apis/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1.csproj
+++ b/apis/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Maps Address Validation API, which allows developers to verify the accuracy of addresses. Given an address, it returns information about the correctness of the components of the parsed address, a geocode, and a verdict on the deliverability of the parsed address.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.6.0, 5.0.0)" />
-    <PackageReference Include="Google.Geo.Type" Version="[1.0.0, 2.0.0)" />
+    <PackageReference Include="Google.Geo.Type" Version="[1.1.0, 2.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Maps.AddressValidation.V1/docs/history.md
+++ b/apis/Google.Maps.AddressValidation.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.2.0, released 2024-03-13
+
+No API surface changes; just dependency updates.
+
 ## Version 1.1.0, released 2024-02-20
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5781,7 +5781,7 @@
     },
     {
       "id": "Google.Maps.AddressValidation.V1",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "type": "grpc",
       "productName": "Address Validation",
       "productUrl": "https://developers.google.com/maps/documentation/address-validation/requests-validate-address",
@@ -5793,7 +5793,7 @@
       ],
       "dependencies": {
         "Google.Api.Gax.Grpc": "4.6.0",
-        "Google.Geo.Type": "1.0.0",
+        "Google.Geo.Type": "1.1.0",
         "Grpc.Core": "2.46.6"
       },
       "generator": "micro",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
