### PR TITLE
Release Google.Shopping.Merchant.Inventories.V1Beta version 1.0.0-beta03

### DIFF
--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.csproj
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Merchant Inventories API (v1beta) which allows developers to programmatically showcase products with local (in-store) or regional availability for free on Google.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.6.0, 5.0.0)" />
-    <PackageReference Include="Google.Shopping.Type" Version="[1.0.0-beta02, 2.0.0)" />
+    <PackageReference Include="Google.Shopping.Type" Version="[1.0.0-beta03, 2.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/docs/history.md
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0-beta03, released 2024-03-13
+
+No API surface changes; just dependency updates.
+
 ## Version 1.0.0-beta02, released 2024-02-09
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5962,7 +5962,7 @@
     },
     {
       "id": "Google.Shopping.Merchant.Inventories.V1Beta",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0-beta03",
       "type": "grpc",
       "productName": "Merchant Inventories",
       "productUrl": "https://developers.google.com/merchant/api",
@@ -5972,7 +5972,7 @@
         "inventory"
       ],
       "dependencies": {
-        "Google.Shopping.Type": "1.0.0-beta02"
+        "Google.Shopping.Type": "1.0.0-beta03"
       },
       "generator": "micro",
       "protoPath": "google/shopping/merchant/inventories/v1beta",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates.
