### PR TITLE
Release Google.Cloud.PubSub.V1 version 3.10.1

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.10.0</Version>
+    <Version>3.10.1</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.</Description>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.7.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.6.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.1.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>

--- a/apis/Google.Cloud.PubSub.V1/docs/history.md
+++ b/apis/Google.Cloud.PubSub.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.10.1, released 2024-03-19
+
+### New features
+
+- Add initial logging to PublisherClient and SubscriberClient ([commit 931bd76](https://github.com/googleapis/google-cloud-dotnet/commit/931bd762983688864b5f7fb22bdda6c563435d46))
+
 ## Version 3.10.0, released 2024-03-05
 
 ### Documentation improvements

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3717,12 +3717,14 @@
       "protoPath": "google/pubsub/v1",
       "productName": "Cloud Pub/Sub",
       "productUrl": "https://cloud.google.com/pubsub/",
-      "version": "3.10.0",
+      "version": "3.10.1",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.",
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.1.0"
+        "Google.Api.Gax.Grpc": "4.6.0",
+        "Google.Cloud.Iam.V1": "3.1.0",
+        "Grpc.Core": "2.46.6"
       },
       "testDependencies": {
         "Google.Api.Gax.Testing": "4.7.0",


### PR DESCRIPTION

Changes in this release:

### New features

- Add initial logging to PublisherClient and SubscriberClient ([commit 931bd76](https://github.com/googleapis/google-cloud-dotnet/commit/931bd762983688864b5f7fb22bdda6c563435d46))
