### PR TITLE
Release Google.Cloud.Language.V1 version 3.6.0-alpha01

### DIFF
--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/Google.Cloud.Language.V1.csproj
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/Google.Cloud.Language.V1.csproj
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.5.0</Version>
-    <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
+    <Version>3.6.0-alpha01</Version>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Natural Language API (v1), which provides natural language understanding technologies to developers. Examples include sentiment analysis, entity recognition, and text annotations.</Description>
     <PackageTags>Language;Google;Cloud</PackageTags>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.7.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.8.0-alpha01, 5.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Language.V1/docs/history.md
+++ b/apis/Google.Cloud.Language.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 3.6.0-alpha01, released 2024-03-20
+
+Experimental release targeting netstandard2.0 instead of netstandard2.1.
+
 ## Version 3.5.0, released 2024-02-28
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2791,10 +2791,14 @@
       "protoPath": "google/cloud/language/v1",
       "productName": "Google Cloud Natural Language",
       "productUrl": "https://cloud.google.com/natural-language",
-      "version": "3.5.0",
+      "version": "3.6.0-alpha01",
+      "targetFrameworks": "netstandard2.0;net462",
+      "testTargetFrameworks": "net6.0;net462",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Natural Language API (v1), which provides natural language understanding technologies to developers. Examples include sentiment analysis, entity recognition, and text annotations.",
-      "dependencies": {},
+      "dependencies": {
+        "Google.Api.Gax.Grpc": "4.8.0-alpha01"
+      },
       "tags": [
         "Language"
       ],

--- a/tools/Google.Cloud.Tools.ReleaseManager/GenerateProjectsCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/GenerateProjectsCommand.cs
@@ -65,11 +65,13 @@ namespace Google.Cloud.Tools.ReleaseManager
             { "Google.Cloud.Diagnostics.Common.IntegrationTests", @"..\..\Google.Cloud.Diagnostics.Common\Google.Cloud.Diagnostics.Common.IntegrationTests\Google.Cloud.Diagnostics.Common.IntegrationTests.csproj" }
         };
 
+        internal const string DefaultNetstandardTarget = "netstandard2.1";
+
         private static readonly Dictionary<ApiType, string> PackageTypeToDefaultTargetFrameworks = new Dictionary<ApiType, string>
         {
-            { ApiType.Rest, "netstandard2.1;net462" },
-            { ApiType.Grpc, "netstandard2.1;net462" },
-            { ApiType.Regapic, "netstandard2.1;net462" }
+            { ApiType.Rest, $"{DefaultNetstandardTarget};net462" },
+            { ApiType.Grpc, $"{DefaultNetstandardTarget};net462" },
+            { ApiType.Regapic, $"{DefaultNetstandardTarget};net462" }
         };
 
         private const string DefaultTestTargetFrameworks = "net6.0;net462";

--- a/tools/Google.Cloud.Tools.ReleaseManager/Google.Cloud.Tools.ReleaseManager.csproj
+++ b/tools/Google.Cloud.Tools.ReleaseManager/Google.Cloud.Tools.ReleaseManager.csproj
@@ -14,6 +14,13 @@
     <ProjectReference Include="..\Google.Cloud.Tools.Common\Google.Cloud.Tools.Common.csproj" />
     <ProjectReference Include="..\Google.Cloud.Tools.VersionCompat\Google.Cloud.Tools.VersionCompat.csproj" />
     <EmbeddedResource Include="History/*.json" />
+
+    <!--
+     - Refer to Grpc.Net.Client explicitly, so that smoke tests load the same TFM as
+     - this binary refers to. Without this, we end up loading the netstandard2.0 TFM
+     - for libraries which target that, and that then fails to use the channel.
+     -->
+    <PackageReference Include="Grpc.Net.Client" Version="2.61.0" />
   </ItemGroup>
 
 </Project>

--- a/tools/Google.Cloud.Tools.ReleaseManager/SmokeTestCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/SmokeTestCommand.cs
@@ -30,8 +30,6 @@ namespace Google.Cloud.Tools.ReleaseManager
     /// </summary>
     public class SmokeTestCommand : CommandBase
     {
-        private const string PublishTargetFramework = "netstandard2.1";
-
         public SmokeTestCommand()
             : base("smoke-test", "Runs smoke tests for a package", "id")
         {
@@ -63,10 +61,20 @@ namespace Google.Cloud.Tools.ReleaseManager
         private Assembly PublishAndLoadAssembly(string id)
         {
             Console.WriteLine($"Publishing release version of library");
-            var sourceRoot = DirectoryLayout.ForApi(id).SourceDirectory;
-            Processes.RunDotnet(sourceRoot, "publish", "-nologo", "-clp:NoSummary", "-v", "quiet", "-c", "Release", id, "-f", PublishTargetFramework);
 
-            var assemblyFile = Path.Combine(sourceRoot, id, "bin", "Release", PublishTargetFramework, "publish", $"{id}.dll");
+            // Work out the TFM to publish, based on specified target frameworks.
+            var api = ApiCatalog.Load()[id];
+            var tfm = api.TargetFrameworks?
+                .Split(';')
+                .FirstOrDefault(candidate => candidate.StartsWith("netstandard"))
+                ?? GenerateProjectsCommand.DefaultNetstandardTarget;
+
+            // Publish the assembly.
+            var sourceRoot = DirectoryLayout.ForApi(id).SourceDirectory;            
+            Processes.RunDotnet(sourceRoot, "publish", "-nologo", "-clp:NoSummary", "-v", "quiet", "-c", "Release", id, "-f", tfm);
+
+            // Load it with reflection.
+            var assemblyFile = Path.Combine(sourceRoot, id, "bin", "Release", tfm, "publish", $"{id}.dll");
             return Assembly.LoadFrom(assemblyFile);
         }
 
@@ -98,7 +106,7 @@ namespace Google.Cloud.Tools.ReleaseManager
                         e = e.InnerException;
                     }
                     failed.Add($"{test.Client}.{test.Method}");
-                    Console.WriteLine($"{test.Client}.{test.Method} failed: {e.GetType().Name} {e.Message}");
+                    Console.WriteLine($"{test.Client}.{test.Method} failed: {e.GetType().Name} {e.Message} {e}");
                 }
             }
             Console.WriteLine($"Passed: {tests.Count - skipped.Count - failed.Count}");


### PR DESCRIPTION

Changes in this release:

Experimental release targeting netstandard2.0 instead of netstandard2.1.
