### PR TITLE
Release Google.Cloud.Language.V1 version 3.6.0-alpha01

### DIFF
--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/Google.Cloud.Language.V1.csproj
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/Google.Cloud.Language.V1.csproj
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.5.0</Version>
-    <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
+    <Version>3.6.0-alpha01</Version>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Natural Language API (v1), which provides natural language understanding technologies to developers. Examples include sentiment analysis, entity recognition, and text annotations.</Description>
     <PackageTags>Language;Google;Cloud</PackageTags>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.7.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.8.0-alpha01, 5.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Language.V1/docs/history.md
+++ b/apis/Google.Cloud.Language.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 3.6.0-alpha01, released 2024-03-20
+
+Experimental release targeting netstandard2.0 instead of netstandard2.1.
+
 ## Version 3.5.0, released 2024-02-28
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2791,10 +2791,14 @@
       "protoPath": "google/cloud/language/v1",
       "productName": "Google Cloud Natural Language",
       "productUrl": "https://cloud.google.com/natural-language",
-      "version": "3.5.0",
+      "version": "3.6.0-alpha01",
+      "targetFrameworks": "netstandard2.0;net462",
+      "testTargetFrameworks": "net6.0;net462",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Natural Language API (v1), which provides natural language understanding technologies to developers. Examples include sentiment analysis, entity recognition, and text annotations.",
-      "dependencies": {},
+      "dependencies": {
+        "Google.Api.Gax.Grpc": "4.8.0-alpha01"
+      },
       "tags": [
         "Language"
       ],


### PR DESCRIPTION

Changes in this release:

Experimental release targeting netstandard2.0 instead of netstandard2.1.
