### PR TITLE
chore: Fix transport definitions in the API catalog

### DIFF
--- a/apis/apis.json
+++ b/apis/apis.json
@@ -783,7 +783,8 @@
       "protoPath": "google/cloud/bigquery/analyticshub/v1",
       "shortName": "analyticshub",
       "serviceConfigFile": "analyticshub_v1.yaml",
-      "includeCommonResourcesProto": true
+      "includeCommonResourcesProto": true,
+      "transport": "grpc+rest"
     },
     {
       "id": "Google.Cloud.BigQuery.Connection.V1",


### PR DESCRIPTION
(These were updated using update-from-bazel.)