### PR TITLE
Release Google.Cloud.Asset.V1 version 3.9.0

### DIFF
--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.csproj
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.8.0</Version>
+    <Version>3.9.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Asset Inventory API (v1).</Description>

--- a/apis/Google.Cloud.Asset.V1/docs/history.md
+++ b/apis/Google.Cloud.Asset.V1/docs/history.md
@@ -1,5 +1,20 @@
 # Version history
 
+## Version 3.9.0, released 2024-03-21
+
+### New features
+
+- Add `asset_type` field to `GovernedIamPolicy` and `GovernedResource` ([commit eaf3b84](https://github.com/googleapis/google-cloud-dotnet/commit/eaf3b84414ef1545d66884c3398c161bdd79e5ad))
+- Add `effective_tags` field to `GovernedResource` ([commit eaf3b84](https://github.com/googleapis/google-cloud-dotnet/commit/eaf3b84414ef1545d66884c3398c161bdd79e5ad))
+- Add fields `project`, `folders`, `organization` and `effective_tags` to `GovernedContainer` ([commit eaf3b84](https://github.com/googleapis/google-cloud-dotnet/commit/eaf3b84414ef1545d66884c3398c161bdd79e5ad))
+- Add fields `project`, `folders` and `organization` to `OrgPolicyResult` ([commit eaf3b84](https://github.com/googleapis/google-cloud-dotnet/commit/eaf3b84414ef1545d66884c3398c161bdd79e5ad))
+- Add field `condition_evaluation` to `AnalyzerOrgPolicy.Rule` ([commit eaf3b84](https://github.com/googleapis/google-cloud-dotnet/commit/eaf3b84414ef1545d66884c3398c161bdd79e5ad))
+
+### Documentation improvements
+
+- Minor comment updates ([commit ddb9f51](https://github.com/googleapis/google-cloud-dotnet/commit/ddb9f5135966f10b5a3a76b4778b37019cef5346))
+- Update comment for rpc `AnalyzeOrgPolicyGovernedAssets` to include additional canned constraints ([commit eaf3b84](https://github.com/googleapis/google-cloud-dotnet/commit/eaf3b84414ef1545d66884c3398c161bdd79e5ad))
+
 ## Version 3.8.0, released 2024-02-28
 
 ### Documentation improvements

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -501,7 +501,7 @@
       "protoPath": "google/cloud/asset/v1",
       "productName": "Google Cloud Asset Inventory",
       "productUrl": "https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview",
-      "version": "3.8.0",
+      "version": "3.9.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Asset Inventory API (v1).",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Add `asset_type` field to `GovernedIamPolicy` and `GovernedResource` ([commit eaf3b84](https://github.com/googleapis/google-cloud-dotnet/commit/eaf3b84414ef1545d66884c3398c161bdd79e5ad))
- Add `effective_tags` field to `GovernedResource` ([commit eaf3b84](https://github.com/googleapis/google-cloud-dotnet/commit/eaf3b84414ef1545d66884c3398c161bdd79e5ad))
- Add fields `project`, `folders`, `organization` and `effective_tags` to `GovernedContainer` ([commit eaf3b84](https://github.com/googleapis/google-cloud-dotnet/commit/eaf3b84414ef1545d66884c3398c161bdd79e5ad))
- Add fields `project`, `folders` and `organization` to `OrgPolicyResult` ([commit eaf3b84](https://github.com/googleapis/google-cloud-dotnet/commit/eaf3b84414ef1545d66884c3398c161bdd79e5ad))
- Add field `condition_evaluation` to `AnalyzerOrgPolicy.Rule` ([commit eaf3b84](https://github.com/googleapis/google-cloud-dotnet/commit/eaf3b84414ef1545d66884c3398c161bdd79e5ad))

### Documentation improvements

- Minor comment updates ([commit ddb9f51](https://github.com/googleapis/google-cloud-dotnet/commit/ddb9f5135966f10b5a3a76b4778b37019cef5346))
- Update comment for rpc `AnalyzeOrgPolicyGovernedAssets` to include additional canned constraints ([commit eaf3b84](https://github.com/googleapis/google-cloud-dotnet/commit/eaf3b84414ef1545d66884c3398c161bdd79e5ad))
