### PR TITLE
Release Google.Cloud.BigQuery.AnalyticsHub.V1 version 1.3.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery Analytics Hub, which allows users to exchange data and analytics assets securely and efficiently.</Description>

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 1.3.0, released 2024-03-21
+
+### New features
+
+- Support selective sharing on data clean room Listings ([commit 6aa0d67](https://github.com/googleapis/google-cloud-dotnet/commit/6aa0d67da6e11bb3d621d4b9756b52b0c28a2588))
+- Support output fields on DcrExchangeConfig specifying selective sharing behavior on a data clean room ([commit 6aa0d67](https://github.com/googleapis/google-cloud-dotnet/commit/6aa0d67da6e11bb3d621d4b9756b52b0c28a2588))
+
 ## Version 1.2.0, released 2024-02-28
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -766,7 +766,7 @@
     },
     {
       "id": "Google.Cloud.BigQuery.AnalyticsHub.V1",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "type": "grpc",
       "productName": "Analytics Hub",
       "productUrl": "https://cloud.google.com/analytics-hub",


### PR DESCRIPTION

Changes in this release:

### New features

- Support selective sharing on data clean room Listings ([commit 6aa0d67](https://github.com/googleapis/google-cloud-dotnet/commit/6aa0d67da6e11bb3d621d4b9756b52b0c28a2588))
- Support output fields on DcrExchangeConfig specifying selective sharing behavior on a data clean room ([commit 6aa0d67](https://github.com/googleapis/google-cloud-dotnet/commit/6aa0d67da6e11bb3d621d4b9756b52b0c28a2588))
