### PR TITLE
Release Google.Cloud.Bigtable.Admin.V2 version 3.11.0

### DIFF
--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.csproj
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.10.0</Version>
+    <Version>3.11.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Bigtable Instance and Table Admin APIs.</Description>

--- a/apis/Google.Cloud.Bigtable.Admin.V2/docs/history.md
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.11.0, released 2024-03-21
+
+### New features
+
+- Publish new bigtable APIs for types and aggregates ([commit 485f4e8](https://github.com/googleapis/google-cloud-dotnet/commit/485f4e88c7f2e2f153e79f76b04e5a3eb1eba15d))
+
 ## Version 3.10.0, released 2024-03-05
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -992,7 +992,7 @@
       "protoPath": "google/bigtable/admin/v2",
       "productName": "Google Cloud Bigtable Administration",
       "productUrl": "https://cloud.google.com/bigtable/",
-      "version": "3.10.0",
+      "version": "3.11.0",
       "commonResourcesConfig": "apis/Google.Cloud.Bigtable.Common.V2/CommonResourcesConfig.json",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Bigtable Instance and Table Admin APIs.",


### PR DESCRIPTION

Changes in this release:

### New features

- Publish new bigtable APIs for types and aggregates ([commit 485f4e8](https://github.com/googleapis/google-cloud-dotnet/commit/485f4e88c7f2e2f153e79f76b04e5a3eb1eba15d))
