### PR TITLE
Release Google.Cloud.CertificateManager.V1 version 2.5.0

### DIFF
--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.csproj
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.4.0</Version>
+    <Version>2.5.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Certificate Manager API, which lets you acquire and manage TLS (SSL) certificates for use with Cloud Load Balancing</Description>

--- a/apis/Google.Cloud.CertificateManager.V1/docs/history.md
+++ b/apis/Google.Cloud.CertificateManager.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.5.0, released 2024-03-21
+
+### New features
+
+- Added Trust Configs and DnsAuthorization.Type to Certificate Manager ([commit ac4eb8a](https://github.com/googleapis/google-cloud-dotnet/commit/ac4eb8a1afb11a6885101a658e5b0094192c6e03))
+
 ## Version 2.4.0, released 2024-02-28
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1164,7 +1164,7 @@
     },
     {
       "id": "Google.Cloud.CertificateManager.V1",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "type": "grpc",
       "productName": "Certificate Manager",
       "productUrl": "https://cloud.google.com/certificate-manager/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Added Trust Configs and DnsAuthorization.Type to Certificate Manager ([commit ac4eb8a](https://github.com/googleapis/google-cloud-dotnet/commit/ac4eb8a1afb11a6885101a658e5b0094192c6e03))
