### PR TITLE
Release Google.Cloud.Container.V1 version 3.23.0

### DIFF
--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.22.0</Version>
+    <Version>3.23.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.</Description>

--- a/apis/Google.Cloud.Container.V1/docs/history.md
+++ b/apis/Google.Cloud.Container.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 3.23.0, released 2024-03-21
+
+### New features
+
+- Add API to enable/disable secret manager csi component on GKE clusters ([commit caeb6be](https://github.com/googleapis/google-cloud-dotnet/commit/caeb6be38fa69608c26e48a91bc9e0884a21b4a6))
+- Add secondary boot disks field to NodePool API ([commit a48dfdc](https://github.com/googleapis/google-cloud-dotnet/commit/a48dfdcfbe195846f236a3f562551180ad708cd5))
+
 ## Version 3.22.0, released 2024-02-27
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1515,7 +1515,7 @@
       "protoPath": "google/container/v1",
       "productName": "Google Kubernetes Engine",
       "productUrl": "https://cloud.google.com/kubernetes-engine/docs/reference/rest/",
-      "version": "3.22.0",
+      "version": "3.23.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.",
       "dependencies": {},


### PR DESCRIPTION

Changes in this release:

### New features

- Add API to enable/disable secret manager csi component on GKE clusters ([commit caeb6be](https://github.com/googleapis/google-cloud-dotnet/commit/caeb6be38fa69608c26e48a91bc9e0884a21b4a6))
- Add secondary boot disks field to NodePool API ([commit a48dfdc](https://github.com/googleapis/google-cloud-dotnet/commit/a48dfdcfbe195846f236a3f562551180ad708cd5))
