### PR TITLE
Release Google.Cloud.Dataplex.V1 version 2.14.0

### DIFF
--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.csproj
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.13.0</Version>
+    <Version>2.14.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Dataplex API, which is used to manage the lifecycle of data lakes.</Description>

--- a/apis/Google.Cloud.Dataplex.V1/docs/history.md
+++ b/apis/Google.Cloud.Dataplex.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.14.0, released 2024-03-21
+
+### New features
+
+- Added Unified Metastore APIs and CRUD Metastore APIs ([commit 547bc55](https://github.com/googleapis/google-cloud-dotnet/commit/547bc5514bdda3379e506f5ea121edf55895800a))
+
 ## Version 2.13.0, released 2024-03-13
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1662,7 +1662,7 @@
     },
     {
       "id": "Google.Cloud.Dataplex.V1",
-      "version": "2.13.0",
+      "version": "2.14.0",
       "type": "grpc",
       "productName": "Cloud Dataplex",
       "productUrl": "https://cloud.google.com/dataplex/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Added Unified Metastore APIs and CRUD Metastore APIs ([commit 547bc55](https://github.com/googleapis/google-cloud-dotnet/commit/547bc5514bdda3379e506f5ea121edf55895800a))
