### PR TITLE
Release Google.Cloud.Datastore.V1 version 4.9.0

### DIFF
--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.8.0</Version>
+    <Version>4.9.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Datastore API, which accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.</Description>

--- a/apis/Google.Cloud.Datastore.V1/docs/history.md
+++ b/apis/Google.Cloud.Datastore.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 4.9.0, released 2024-03-21
+
+### New features
+
+- Add new types ExplainOptions, ExplainMetrics, PlanSummary, ExecutionStats ([commit 6049921](https://github.com/googleapis/google-cloud-dotnet/commit/60499218b493f600c9920abd0bc9471191200d3c))
+- Add ExplainOptions field to RunQueryRequest ([commit 6049921](https://github.com/googleapis/google-cloud-dotnet/commit/60499218b493f600c9920abd0bc9471191200d3c))
+- Add ExplainMetrics field to RunQueryResponse ([commit 6049921](https://github.com/googleapis/google-cloud-dotnet/commit/60499218b493f600c9920abd0bc9471191200d3c))
+- Add ExplainOptions field to RunAggregationQueryRequest ([commit 6049921](https://github.com/googleapis/google-cloud-dotnet/commit/60499218b493f600c9920abd0bc9471191200d3c))
+- Add ExplainMetrics field to RunAggregationQueryResponse ([commit 6049921](https://github.com/googleapis/google-cloud-dotnet/commit/60499218b493f600c9920abd0bc9471191200d3c))
+
 ## Version 4.8.0, released 2024-02-28
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1734,7 +1734,7 @@
       "protoPath": "google/datastore/v1",
       "productName": "Google Cloud Datastore",
       "productUrl": "https://cloud.google.com/datastore/docs/concepts/overview",
-      "version": "4.8.0",
+      "version": "4.9.0",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Datastore API, which accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.",


### PR DESCRIPTION

Changes in this release:

### New features

- Add new types ExplainOptions, ExplainMetrics, PlanSummary, ExecutionStats ([commit 6049921](https://github.com/googleapis/google-cloud-dotnet/commit/60499218b493f600c9920abd0bc9471191200d3c))
- Add ExplainOptions field to RunQueryRequest ([commit 6049921](https://github.com/googleapis/google-cloud-dotnet/commit/60499218b493f600c9920abd0bc9471191200d3c))
- Add ExplainMetrics field to RunQueryResponse ([commit 6049921](https://github.com/googleapis/google-cloud-dotnet/commit/60499218b493f600c9920abd0bc9471191200d3c))
- Add ExplainOptions field to RunAggregationQueryRequest ([commit 6049921](https://github.com/googleapis/google-cloud-dotnet/commit/60499218b493f600c9920abd0bc9471191200d3c))
- Add ExplainMetrics field to RunAggregationQueryResponse ([commit 6049921](https://github.com/googleapis/google-cloud-dotnet/commit/60499218b493f600c9920abd0bc9471191200d3c))
