### PR TITLE
Release Google.Cloud.Dialogflow.V2 version 4.17.0

### DIFF
--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.csproj
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.16.0</Version>
+    <Version>4.17.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Dialogflow API (v2).</Description>

--- a/apis/Google.Cloud.Dialogflow.V2/docs/history.md
+++ b/apis/Google.Cloud.Dialogflow.V2/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 4.17.0, released 2024-03-21
+
+### New features
+
+- Added text sections to the submitted summary ([commit 720a6ad](https://github.com/googleapis/google-cloud-dotnet/commit/720a6ad8a0c11a7a7d386208b22f04c1afa48769))
+- Added conformer model migration opt out flag ([commit 720a6ad](https://github.com/googleapis/google-cloud-dotnet/commit/720a6ad8a0c11a7a7d386208b22f04c1afa48769))
+
+### Documentation improvements
+
+- Clarified wording around END_OF_SINGLE_UTTERANCE ([commit 720a6ad](https://github.com/googleapis/google-cloud-dotnet/commit/720a6ad8a0c11a7a7d386208b22f04c1afa48769))
+
 ## Version 4.16.0, released 2024-02-28
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1951,7 +1951,7 @@
       "protoPath": "google/cloud/dialogflow/v2",
       "productName": "Google Cloud Dialogflow",
       "productUrl": "https://cloud.google.com/dialogflow-enterprise/",
-      "version": "4.16.0",
+      "version": "4.17.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Dialogflow API (v2).",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- Added text sections to the submitted summary ([commit 720a6ad](https://github.com/googleapis/google-cloud-dotnet/commit/720a6ad8a0c11a7a7d386208b22f04c1afa48769))
- Added conformer model migration opt out flag ([commit 720a6ad](https://github.com/googleapis/google-cloud-dotnet/commit/720a6ad8a0c11a7a7d386208b22f04c1afa48769))

### Documentation improvements

- Clarified wording around END_OF_SINGLE_UTTERANCE ([commit 720a6ad](https://github.com/googleapis/google-cloud-dotnet/commit/720a6ad8a0c11a7a7d386208b22f04c1afa48769))
