### PR TITLE
Release Google.Cloud.Dialogflow.V2Beta1 version 1.0.0-beta14

### DIFF
--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.csproj
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta13</Version>
+    <Version>1.0.0-beta14</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Dialogflow API (v2beta1).</Description>

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/docs/history.md
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 1.0.0-beta14, released 2024-03-21
+
+### New features
+
+- Added text sections to the submitted summary ([commit b036872](https://github.com/googleapis/google-cloud-dotnet/commit/b0368725f22b282abd78dcc39c1c8205d6be7594))
+- Added conformer model migration opt out flag ([commit b036872](https://github.com/googleapis/google-cloud-dotnet/commit/b0368725f22b282abd78dcc39c1c8205d6be7594))
+- Added intent input to StreamingAnalyzeContentRequest ([commit b036872](https://github.com/googleapis/google-cloud-dotnet/commit/b0368725f22b282abd78dcc39c1c8205d6be7594))
+
+### Documentation improvements
+
+- Clarified wording around END_OF_SINGLE_UTTERANCE ([commit b036872](https://github.com/googleapis/google-cloud-dotnet/commit/b0368725f22b282abd78dcc39c1c8205d6be7594))
+
 ## Version 1.0.0-beta13, released 2024-02-28
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1973,7 +1973,7 @@
     },
     {
       "id": "Google.Cloud.Dialogflow.V2Beta1",
-      "version": "1.0.0-beta13",
+      "version": "1.0.0-beta14",
       "type": "grpc",
       "productName": "Google Cloud Dialogflow",
       "productUrl": "https://cloud.google.com/dialogflow-enterprise/",


### PR DESCRIPTION

Changes in this release:

### New features

- Added text sections to the submitted summary ([commit b036872](https://github.com/googleapis/google-cloud-dotnet/commit/b0368725f22b282abd78dcc39c1c8205d6be7594))
- Added conformer model migration opt out flag ([commit b036872](https://github.com/googleapis/google-cloud-dotnet/commit/b0368725f22b282abd78dcc39c1c8205d6be7594))
- Added intent input to StreamingAnalyzeContentRequest ([commit b036872](https://github.com/googleapis/google-cloud-dotnet/commit/b0368725f22b282abd78dcc39c1c8205d6be7594))

### Documentation improvements

- Clarified wording around END_OF_SINGLE_UTTERANCE ([commit b036872](https://github.com/googleapis/google-cloud-dotnet/commit/b0368725f22b282abd78dcc39c1c8205d6be7594))
