### PR TITLE
Release Google.Cloud.Dlp.V2 version 4.8.0

### DIFF
--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.csproj
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.7.0</Version>
+    <Version>4.8.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Data Loss Prevention API, which provides methods for detection of privacy-sensitive fragments in text, images, and Google Cloud Platform storage repositories.</Description>

--- a/apis/Google.Cloud.Dlp.V2/docs/history.md
+++ b/apis/Google.Cloud.Dlp.V2/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 4.8.0, released 2024-03-21
+
+### New features
+
+- Add RPCs for getting and listing project, table, and column data profiles ([commit 5dd8bca](https://github.com/googleapis/google-cloud-dotnet/commit/5dd8bca0b4def432d3c7714d21947a2632208431))
+
+### Documentation improvements
+
+- Update urls to reflect branding change to Sensitive Data Protection ([commit 5dd8bca](https://github.com/googleapis/google-cloud-dotnet/commit/5dd8bca0b4def432d3c7714d21947a2632208431))
+
 ## Version 4.7.0, released 2024-02-28
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2042,7 +2042,7 @@
       "protoPath": "google/privacy/dlp/v2",
       "productName": "Google Cloud Data Loss Prevention",
       "productUrl": "https://cloud.google.com/dlp/",
-      "version": "4.7.0",
+      "version": "4.8.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Data Loss Prevention API, which provides methods for detection of privacy-sensitive fragments in text, images, and Google Cloud Platform storage repositories.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Add RPCs for getting and listing project, table, and column data profiles ([commit 5dd8bca](https://github.com/googleapis/google-cloud-dotnet/commit/5dd8bca0b4def432d3c7714d21947a2632208431))

### Documentation improvements

- Update urls to reflect branding change to Sensitive Data Protection ([commit 5dd8bca](https://github.com/googleapis/google-cloud-dotnet/commit/5dd8bca0b4def432d3c7714d21947a2632208431))
