### PR TITLE
Release Google.Cloud.EdgeNetwork.V1 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.csproj
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Distributed Cloud Edge Network API, which enables a management for Distributed Cloud Edge.</Description>

--- a/apis/Google.Cloud.EdgeNetwork.V1/docs/history.md
+++ b/apis/Google.Cloud.EdgeNetwork.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.1.0, released 2024-03-21
+
+### Bug fixes
+
+- Deprecate unimplemented Zone fields and methods ([commit 448a115](https://github.com/googleapis/google-cloud-dotnet/commit/448a115588ae828f33c669df2321f9221e295bd9))
+
 ## Version 1.0.0, released 2024-03-12
 
 No API surface changes; just dependency updates and promotion to GA.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2158,7 +2158,7 @@
     },
     {
       "id": "Google.Cloud.EdgeNetwork.V1",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "grpc",
       "productName": "Distributed Cloud Edge Network",
       "productUrl": "https://cloud.google.com/distributed-cloud/edge/latest/docs/overview",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Deprecate unimplemented Zone fields and methods ([commit 448a115](https://github.com/googleapis/google-cloud-dotnet/commit/448a115588ae828f33c669df2321f9221e295bd9))
