### PR TITLE
Release Google.Cloud.Security.PrivateCA.V1 version 3.5.0

### DIFF
--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.csproj
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.4.0</Version>
+    <Version>3.5.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Certificate Authority Service API version v1. The Certificate Authority Service API is a highly-available, scalable service that enables you to simplify and automate the management of private certificate authorities (CAs) while staying in control of your private keys.</Description>

--- a/apis/Google.Cloud.Security.PrivateCA.V1/docs/history.md
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/docs/history.md
@@ -1,5 +1,18 @@
 # Version history
 
+## Version 3.5.0, released 2024-03-21
+
+### New features
+
+- Add custom subject key identifier field ([commit 647855a](https://github.com/googleapis/google-cloud-dotnet/commit/647855a2168e237aa07731c959da23e7194be189))
+- Add support for fine-grained maximum certificate lifetime controls ([commit 647855a](https://github.com/googleapis/google-cloud-dotnet/commit/647855a2168e237aa07731c959da23e7194be189))
+
+### Documentation improvements
+
+- A comment for field `subject` in message `.google.cloud.security.privateca.v1.CertificateConfig` is changed ([commit 647855a](https://github.com/googleapis/google-cloud-dotnet/commit/647855a2168e237aa07731c959da23e7194be189))
+- A comment for method `FetchCaCerts` in service `CertificateAuthorityService` is changed ([commit 647855a](https://github.com/googleapis/google-cloud-dotnet/commit/647855a2168e237aa07731c959da23e7194be189))
+- A comment for field `ca_certs` in message `.google.cloud.security.privateca.v1.FetchCaCertsResponse` is changed ([commit 647855a](https://github.com/googleapis/google-cloud-dotnet/commit/647855a2168e237aa07731c959da23e7194be189))
+
 ## Version 3.4.0, released 2024-02-29
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4121,7 +4121,7 @@
     },
     {
       "id": "Google.Cloud.Security.PrivateCA.V1",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "type": "grpc",
       "productName": "Certificate Authority",
       "productUrl": "https://cloud.google.com/certificate-authority-service/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add custom subject key identifier field ([commit 647855a](https://github.com/googleapis/google-cloud-dotnet/commit/647855a2168e237aa07731c959da23e7194be189))
- Add support for fine-grained maximum certificate lifetime controls ([commit 647855a](https://github.com/googleapis/google-cloud-dotnet/commit/647855a2168e237aa07731c959da23e7194be189))

### Documentation improvements

- A comment for field `subject` in message `.google.cloud.security.privateca.v1.CertificateConfig` is changed ([commit 647855a](https://github.com/googleapis/google-cloud-dotnet/commit/647855a2168e237aa07731c959da23e7194be189))
- A comment for method `FetchCaCerts` in service `CertificateAuthorityService` is changed ([commit 647855a](https://github.com/googleapis/google-cloud-dotnet/commit/647855a2168e237aa07731c959da23e7194be189))
- A comment for field `ca_certs` in message `.google.cloud.security.privateca.v1.FetchCaCertsResponse` is changed ([commit 647855a](https://github.com/googleapis/google-cloud-dotnet/commit/647855a2168e237aa07731c959da23e7194be189))
