### PR TITLE
feat: Added TopicName and SubsciptionName resolution from container as an extension point.

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/PublisherClientBuilder.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/PublisherClientBuilder.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License").
 // you may not use this file except in compliance with the License.
@@ -41,6 +41,13 @@ public sealed class PublisherClientBuilder : ClientBuilderBase<PublisherClient>
     {
         get; set;
     }
+
+    /// <summary>
+    /// The lambda that resolves name of the topic that the publisher publishes to.
+    /// Either this or <see cref="TopicName"/> must be non-null by the time <see cref="Build"/> or <see cref="BuildAsync(CancellationToken)"/> is called.
+    /// This takes precedence, value returned always overwrites value in <see cref="TopicName"/>.
+    /// </summary>
+    public Func<IServiceProvider, TopicName> TopicNameResolver { get; set; }
 
     private int? _clientCount;
 
@@ -145,6 +152,17 @@ public sealed class PublisherClientBuilder : ClientBuilderBase<PublisherClient>
             }
 
             return channel.ShutdownAsync();
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void Configure(IServiceProvider provider)
+    {
+        base.Configure(provider);
+
+        if (TopicNameResolver is not null)
+        {
+            TopicName = TopicNameResolver.Invoke(provider);
         }
     }
 

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberClientBuilder.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberClientBuilder.cs
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License").
 // you may not use this file except in compliance with the License.
@@ -41,6 +41,13 @@ public sealed class SubscriberClientBuilder : ClientBuilderBase<SubscriberClient
     {
         get; set;
     }
+
+    /// <summary>
+    /// The lambda that resolves the name of the subscription that the subscriber subscribes to.
+    /// Either this or <see cref="SubscriptionName"/> must be non-null by the time <see cref="Build"/> or <see cref="BuildAsync(CancellationToken)"/> is called.
+    /// This takes precedence, value returned always overwrites value in <see cref="SubscriptionName"/>.
+    /// </summary>
+    public Func<IServiceProvider, SubscriptionName> SubscriptionNameResolver { get; set; }
 
     private int? _clientCount;
 
@@ -146,6 +153,17 @@ public sealed class SubscriberClientBuilder : ClientBuilderBase<SubscriberClient
             return channel.ShutdownAsync();
         }
 
+    }
+
+    /// <inheritdoc />
+    protected override void Configure(IServiceProvider provider)
+    {
+        base.Configure(provider);
+
+        if (SubscriptionNameResolver is not null)
+        {
+            SubscriptionName = SubscriptionNameResolver.Invoke(provider);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
This PR provides functionality to resolve TopicName and SubscriptionName from the IServiceProvider. 
It is a better way to resolve such dependency because one can reuse Configuration validation through the IOptions<> registration.