### PR TITLE
Release Google.Cloud.PubSub.V1 version 3.11.0

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.10.1</Version>
+    <Version>3.11.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.</Description>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.6.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.7.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.1.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>

--- a/apis/Google.Cloud.PubSub.V1/docs/history.md
+++ b/apis/Google.Cloud.PubSub.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.11.0, released 2024-03-25
+
+### New features
+
+- Added TopicName and SubsciptionName resolution from container as an extension point. ([issue 12215](https://github.com/googleapis/google-cloud-dotnet/issues/12215)) ([commit 73c457d](https://github.com/googleapis/google-cloud-dotnet/commit/73c457d2f8f915656d9c14eaeb594c189072f4a7))
+
 ## Version 3.10.1, released 2024-03-19
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3722,17 +3722,15 @@
       "protoPath": "google/pubsub/v1",
       "productName": "Cloud Pub/Sub",
       "productUrl": "https://cloud.google.com/pubsub/",
-      "version": "3.10.1",
+      "version": "3.11.0",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.",
       "dependencies": {
-        "Google.Api.Gax.Grpc": "4.6.0",
-        "Google.Cloud.Iam.V1": "3.1.0",
-        "Grpc.Core": "2.46.6"
+        "Google.Cloud.Iam.V1": "3.1.0"
       },
       "testDependencies": {
-        "Google.Api.Gax.Testing": "4.7.0",
+        "Google.Api.Gax.Testing": "default",
         "Google.Apis.CloudResourceManager.v1": "1.67.0.3314",
         "Microsoft.Extensions.DependencyInjection": "6.0.1",
         "Microsoft.Extensions.Hosting": "6.0.1",


### PR DESCRIPTION

Changes in this release:

### New features

- Added TopicName and SubsciptionName resolution from container as an extension point. ([issue 12215](https://github.com/googleapis/google-cloud-dotnet/issues/12215)) ([commit 73c457d](https://github.com/googleapis/google-cloud-dotnet/commit/73c457d2f8f915656d9c14eaeb594c189072f4a7))
