### PR TITLE
Release Google.Cloud.Location version 2.2.0

### DIFF
--- a/apis/Google.Cloud.Location/Google.Cloud.Location/Google.Cloud.Location.csproj
+++ b/apis/Google.Cloud.Location/Google.Cloud.Location/Google.Cloud.Location.csproj
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0</Version>
-    <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
+    <Version>2.2.0</Version>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>gRPC services for the Google Cloud Locations API. This library is typically used as a dependency for other API client libraries.</Description>
     <PackageTags>locations;zones;Google;Cloud</PackageTags>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.7.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.8.0, 5.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Location/docs/history.md
+++ b/apis/Google.Cloud.Location/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 2.2.0, released 2024-03-25
+
+### New features
+
+This library now targets netstandard2.0 instead of netstandard2.1.
+This should be compatible with existing libraries that depend on it,
+but will allow new libraries to also target netstandard2.0.
+
 ## Version 2.1.0, released 2024-02-28
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2852,8 +2852,10 @@
     },
     {
       "id": "Google.Cloud.Location",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "type": "grpc",
+      "targetFrameworks": "netstandard2.0;net462",
+      "testTargetFrameworks": "net6.0;net462",
       "listingDescription": "Support for the Google Cloud Locations mix-in API pattern",
       "metadataType": "CORE",
       "description": "gRPC services for the Google Cloud Locations API. This library is typically used as a dependency for other API client libraries.",
@@ -2861,7 +2863,9 @@
         "locations",
         "zones"
       ],
-      "dependencies": {},
+      "dependencies": {
+        "Google.Api.Gax.Grpc": "4.8.0"
+      },
       "generator": "micro",
       "protoPath": "google/cloud/location",
       "serviceConfigFile": "none",


### PR DESCRIPTION

Changes in this release:

### New features

This library now targets netstandard2.0 instead of netstandard2.1. This should be compatible with existing libraries that depend on it, but will allow new libraries to also target netstandard2.0.
