### PR TITLE
Release Google.Cloud.Iam.V1 version 3.2.0

### DIFF
--- a/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.csproj
+++ b/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.csproj
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.1.0</Version>
-    <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
+    <Version>3.2.0</Version>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>gRPC services for the Google Identity and Access Management API. This library is typically used as a dependency for other API client libraries.</Description>
     <PackageTags>IAM;Identity;Access;Google;Cloud</PackageTags>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.7.0, 5.0.0)" />
+    <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.8.0, 5.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Iam.V1/docs/history.md
+++ b/apis/Google.Cloud.Iam.V1/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 3.2.0, released 2024-03-25
+
+### New features
+
+This library now targets netstandard2.0 instead of netstandard2.1.
+This should be compatible with existing libraries that depend on it,
+but will allow new libraries to also target netstandard2.0.
+
 ## Version 3.1.0, released 2024-02-28
 
 ### Documentation improvements

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2650,10 +2650,12 @@
     {
       "id": "Google.Cloud.Iam.V1",
       "generator": "micro",
+      "targetFrameworks": "netstandard2.0;net462",
+      "testTargetFrameworks": "net6.0;net462",
       "protoPath": "google/iam/v1",
       "productName": "Google Cloud Identity and Access Management (IAM)",
       "productUrl": "https://cloud.google.com/iam/",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "type": "grpc",
       "metadataType": "CORE",
       "description": "gRPC services for the Google Identity and Access Management API. This library is typically used as a dependency for other API client libraries.",
@@ -2662,7 +2664,9 @@
         "Identity",
         "Access"
       ],
-      "dependencies": {},
+      "dependencies": {
+        "Google.Api.Gax.Grpc": "4.8.0"
+      },
       "forceOwlBotRegeneration": "AuditData proto is generated in the wrong place.",
       "serviceConfigFile": "iam_meta_api.yaml",
       "includeCommonResourcesProto": false


### PR DESCRIPTION

Changes in this release:

### New features

This library now targets netstandard2.0 instead of netstandard2.1. This should be compatible with existing libraries that depend on it, but will allow new libraries to also target netstandard2.0.
