### PR TITLE
Release Google.Apps.Events.Subscriptions.V1 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.csproj
+++ b/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>The Google Workspace Events API lets you subscribe to events and manage change notifications across Google Workspace applications.</Description>

--- a/apis/Google.Apps.Events.Subscriptions.V1/docs/history.md
+++ b/apis/Google.Apps.Events.Subscriptions.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2024-03-26
+
+### New features
+
+- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
+
 ## Version 1.0.0-beta01, released 2024-03-20
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -61,7 +61,7 @@
     },
     {
       "id": "Google.Apps.Events.Subscriptions.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Google Workspace Events",
       "productUrl": "https://developers.google.com/workspace/events",


### PR DESCRIPTION

Changes in this release:

### New features

- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
