### PR TITLE
Release Google.Apps.Meet.V2Beta version 1.0.0-beta04

### DIFF
--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.csproj
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta03</Version>
+    <Version>1.0.0-beta04</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Create and manage meetings in Google Meet.</Description>

--- a/apis/Google.Apps.Meet.V2Beta/docs/history.md
+++ b/apis/Google.Apps.Meet.V2Beta/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta04, released 2024-03-26
+
+### New features
+
+- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
+
 ## Version 1.0.0-beta03, released 2024-02-28
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -103,7 +103,7 @@
     },
     {
       "id": "Google.Apps.Meet.V2Beta",
-      "version": "1.0.0-beta03",
+      "version": "1.0.0-beta04",
       "type": "grpc",
       "productName": "Google Meet",
       "productUrl": "https://developers.google.com/meet/api/guides/overview",


### PR DESCRIPTION

Changes in this release:

### New features

- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
