### PR TITLE
Release Google.Apps.Script.Type version 2.3.0

### DIFF
--- a/apis/Google.Apps.Script.Type/Google.Apps.Script.Type/Google.Apps.Script.Type.csproj
+++ b/apis/Google.Apps.Script.Type/Google.Apps.Script.Type/Google.Apps.Script.Type.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.2.0</Version>
+    <Version>2.3.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Version-agnostic types for Apps Script APIs.</Description>

--- a/apis/Google.Apps.Script.Type/docs/history.md
+++ b/apis/Google.Apps.Script.Type/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.3.0, released 2024-03-26
+
+### New features
+
+- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
+
 ## Version 2.2.0, released 2024-02-28
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -123,7 +123,7 @@
     },
     {
       "id": "Google.Apps.Script.Type",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "targetFrameworks": "netstandard2.0;net462",
       "type": "other",
       "description": "Version-agnostic types for Apps Script APIs.",


### PR DESCRIPTION

Changes in this release:

### New features

- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
