### PR TITLE
Release Google.Cloud.AIPlatform.V1 version 2.26.0

### DIFF
--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.25.0</Version>
+    <Version>2.26.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AI Platform API, which allows you to train high-quality custom machine learning models with minimal machine learning expertise and effort.</Description>

--- a/apis/Google.Cloud.AIPlatform.V1/docs/history.md
+++ b/apis/Google.Cloud.AIPlatform.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 2.26.0, released 2024-03-26
+
+### New features
+
+- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
+- Add Optimized feature store proto ([commit a6e68f0](https://github.com/googleapis/google-cloud-dotnet/commit/a6e68f0a3dfeebe9c73ad415478efd5ed91a8e46))
+- Add data_key field in feature online store service ([commit a6e68f0](https://github.com/googleapis/google-cloud-dotnet/commit/a6e68f0a3dfeebe9c73ad415478efd5ed91a8e46))
+- Add dedicated_serving_endpoint ([commit a6e68f0](https://github.com/googleapis/google-cloud-dotnet/commit/a6e68f0a3dfeebe9c73ad415478efd5ed91a8e46))
+- Add index_config field ([commit a6e68f0](https://github.com/googleapis/google-cloud-dotnet/commit/a6e68f0a3dfeebe9c73ad415478efd5ed91a8e46))
+
 ## Version 2.25.0, released 2024-03-21
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -292,7 +292,7 @@
     },
     {
       "id": "Google.Cloud.AIPlatform.V1",
-      "version": "2.25.0",
+      "version": "2.26.0",
       "type": "grpc",
       "productName": "Cloud AI Platform",
       "productUrl": "https://cloud.google.com/ai-platform/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
- Add Optimized feature store proto ([commit a6e68f0](https://github.com/googleapis/google-cloud-dotnet/commit/a6e68f0a3dfeebe9c73ad415478efd5ed91a8e46))
- Add data_key field in feature online store service ([commit a6e68f0](https://github.com/googleapis/google-cloud-dotnet/commit/a6e68f0a3dfeebe9c73ad415478efd5ed91a8e46))
- Add dedicated_serving_endpoint ([commit a6e68f0](https://github.com/googleapis/google-cloud-dotnet/commit/a6e68f0a3dfeebe9c73ad415478efd5ed91a8e46))
- Add index_config field ([commit a6e68f0](https://github.com/googleapis/google-cloud-dotnet/commit/a6e68f0a3dfeebe9c73ad415478efd5ed91a8e46))
