### PR TITLE
Release Google.Cloud.ApigeeRegistry.V1 version 1.0.0-beta06

### DIFF
--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.csproj
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta05</Version>
+    <Version>1.0.0-beta06</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Apigee Registry API which allows teams to upload and share machine-readable descriptions of APIs that are in use and in development.</Description>

--- a/apis/Google.Cloud.ApigeeRegistry.V1/docs/history.md
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta06, released 2024-03-26
+
+### New features
+
+- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
+
 ## Version 1.0.0-beta05, released 2024-02-28
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -357,7 +357,7 @@
     },
     {
       "id": "Google.Cloud.ApigeeRegistry.V1",
-      "version": "1.0.0-beta05",
+      "version": "1.0.0-beta06",
       "type": "grpc",
       "productName": "Apigee Registry",
       "description": "Recommended Google client library to access the Apigee Registry API which allows teams to upload and share machine-readable descriptions of APIs that are in use and in development.",


### PR DESCRIPTION

Changes in this release:

### New features

- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
