### PR TITLE
Release Google.Cloud.Audit version 2.4.0

### DIFF
--- a/apis/Google.Cloud.Audit/Google.Cloud.Audit/Google.Cloud.Audit.csproj
+++ b/apis/Google.Cloud.Audit/Google.Cloud.Audit/Google.Cloud.Audit.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Protobuf messages for Google Cloud audit logs.</Description>

--- a/apis/Google.Cloud.Audit/docs/history.md
+++ b/apis/Google.Cloud.Audit/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.4.0, released 2024-03-26
+
+### New features
+
+- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
+
 ## Version 2.3.0, released 2024-02-28
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -568,7 +568,7 @@
     },
     {
       "id": "Google.Cloud.Audit",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "targetFrameworks": "netstandard2.0;net462",
       "productName": "Google Cloud Audit",
       "productUrl": "https://cloud.google.com/logging/docs/audit",


### PR DESCRIPTION

Changes in this release:

### New features

- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
