### PR TITLE
Release Google.Cloud.BareMetalSolution.V2 version 1.5.0

### DIFF
--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.csproj
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.4.0</Version>
+    <Version>1.5.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Bare Metal Solution API (v2), which provides ways to manage Bare Metal Solution hardware installed in a regional extension located near a Google Cloud data center.</Description>

--- a/apis/Google.Cloud.BareMetalSolution.V2/docs/history.md
+++ b/apis/Google.Cloud.BareMetalSolution.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.5.0, released 2024-03-26
+
+### New features
+
+- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
+
 ## Version 1.4.0, released 2024-02-28
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -608,7 +608,7 @@
     },
     {
       "id": "Google.Cloud.BareMetalSolution.V2",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "type": "grpc",
       "productName": "Bare Metal Solution",
       "productUrl": "https://cloud.google.com/bare-metal/",


### PR DESCRIPTION

Changes in this release:

### New features

- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
