### PR TITLE
Release Google.Cloud.BeyondCorp.AppConnectors.V1 version 1.2.0

### DIFF
--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.csproj
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BeyondCorp Enterprise AppConnectors API.</Description>

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/docs/history.md
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.2.0, released 2024-03-26
+
+### New features
+
+- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
+
 ## Version 1.1.0, released 2024-02-28
 
 ### Documentation improvements

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -700,7 +700,7 @@
     },
     {
       "id": "Google.Cloud.BeyondCorp.AppConnectors.V1",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "type": "grpc",
       "productName": "BeyondCorp AppConnectors",
       "productUrl": "https://cloud.google.com/beyondcorp-enterprise",


### PR DESCRIPTION

Changes in this release:

### New features

- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
