### PR TITLE
Release Google.Cloud.BigQuery.DataExchange.V1Beta1 version 2.0.0-beta04

### DIFF
--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.csproj
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta03</Version>
+    <Version>2.0.0-beta04</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery DataExchange API, which allows users to exchange data and analytics assets securely and efficiently.</Description>

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.0.0-beta04, released 2024-03-26
+
+### New features
+
+- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
+
 ## Version 2.0.0-beta03, released 2024-02-28
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -810,7 +810,7 @@
     },
     {
       "id": "Google.Cloud.BigQuery.DataExchange.V1Beta1",
-      "version": "2.0.0-beta03",
+      "version": "2.0.0-beta04",
       "type": "grpc",
       "productName": "Analytics Hub",
       "productUrl": "https://cloud.google.com/analytics-hub",


### PR DESCRIPTION

Changes in this release:

### New features

- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
