### PR TITLE
Release Google.Cloud.CloudQuotas.V1 version 1.0.0-beta03

### DIFF
--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.csproj
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Quotas API, which provides GCP service consumers with management and observability for resource usage, quotas, and restrictions of the services they consume.</Description>

--- a/apis/Google.Cloud.CloudQuotas.V1/docs/history.md
+++ b/apis/Google.Cloud.CloudQuotas.V1/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 1.0.0-beta03, released 2024-03-26
+
+### New features
+
+- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
+
+### Documentation improvements
+
+- Annotate QuotaPreference.dimensions field as immutable, annotate QuotaPreference.QuotaConfig.annotations field as optional ([commit afcf2a4](https://github.com/googleapis/google-cloud-dotnet/commit/afcf2a4837cc0b0adfb7602cbd3313677d8d52e5))
+- A comment for field `filter` in message `.google.api.cloudquotas.v1.ListQuotaPreferencesRequest` is changed ([commit 0e2e456](https://github.com/googleapis/google-cloud-dotnet/commit/0e2e4568ea884b2ded993c26e1189185c0181344))
+- A comment for field `order_by` in message `.google.api.cloudquotas.v1.ListQuotaPreferencesRequest` is changed ([commit 0e2e456](https://github.com/googleapis/google-cloud-dotnet/commit/0e2e4568ea884b2ded993c26e1189185c0181344))
+
 ## Version 1.0.0-beta02, released 2024-02-28
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1320,7 +1320,7 @@
     },
     {
       "id": "Google.Cloud.CloudQuotas.V1",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0-beta03",
       "type": "grpc",
       "productName": "Cloud Quotas",
       "productUrl": "https://cloud.google.com/docs/quotas/api-overview",


### PR DESCRIPTION

Changes in this release:

### New features

- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))

### Documentation improvements

- Annotate QuotaPreference.dimensions field as immutable, annotate QuotaPreference.QuotaConfig.annotations field as optional ([commit afcf2a4](https://github.com/googleapis/google-cloud-dotnet/commit/afcf2a4837cc0b0adfb7602cbd3313677d8d52e5))
- A comment for field `filter` in message `.google.api.cloudquotas.v1.ListQuotaPreferencesRequest` is changed ([commit 0e2e456](https://github.com/googleapis/google-cloud-dotnet/commit/0e2e4568ea884b2ded993c26e1189185c0181344))
- A comment for field `order_by` in message `.google.api.cloudquotas.v1.ListQuotaPreferencesRequest` is changed ([commit 0e2e456](https://github.com/googleapis/google-cloud-dotnet/commit/0e2e4568ea884b2ded993c26e1189185c0181344))
