### PR TITLE
Release Google.Cloud.Compute.V1 version 2.15.0

### DIFF
--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.14.0</Version>
+    <Version>2.15.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Compute Engine API.</Description>

--- a/apis/Google.Cloud.Compute.V1/docs/history.md
+++ b/apis/Google.Cloud.Compute.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.15.0, released 2024-03-26
+
+### New features
+
+- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
+
 ## Version 2.14.0, released 2024-03-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1373,7 +1373,7 @@
     },
     {
       "id": "Google.Cloud.Compute.V1",
-      "version": "2.14.0",
+      "version": "2.15.0",
       "type": "regapic",
       "productName": "Compute Engine",
       "productUrl": "https://cloud.google.com/compute",


### PR DESCRIPTION

Changes in this release:

### New features

- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
