### PR TITLE
Release Google.Cloud.Config.V1 version 1.4.0

### DIFF
--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1/Google.Cloud.Config.V1.csproj
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1/Google.Cloud.Config.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Infrastructure Manager API, which creates and manages Google Cloud Platform resources and infrastructure.</Description>

--- a/apis/Google.Cloud.Config.V1/docs/history.md
+++ b/apis/Google.Cloud.Config.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.4.0, released 2024-03-26
+
+### New features
+
+- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
+
 ## Version 1.3.0, released 2024-03-21
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1439,7 +1439,7 @@
     },
     {
       "id": "Google.Cloud.Config.V1",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "type": "grpc",
       "productName": "Infrastructure Manager",
       "productUrl": "https://cloud.google.com/infrastructure-manager/docs/overview",


### PR DESCRIPTION

Changes in this release:

### New features

- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
