### PR TITLE
Release Google.Cloud.Container.V1 version 3.24.0

### DIFF
--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.23.0</Version>
+    <Version>3.24.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.</Description>

--- a/apis/Google.Cloud.Container.V1/docs/history.md
+++ b/apis/Google.Cloud.Container.V1/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 3.24.0, released 2024-03-26
+
+### New features
+
+- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
+- Add optional secondary_boot_disk_update_strategy field to NodePool API ([commit 0ad229c](https://github.com/googleapis/google-cloud-dotnet/commit/0ad229ca2762b397839871dbc12762e86a338a7b))
+- Allow existing clusters to enable multi-networking ([commit 0ad229c](https://github.com/googleapis/google-cloud-dotnet/commit/0ad229ca2762b397839871dbc12762e86a338a7b))
+
 ## Version 3.23.0, released 2024-03-21
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1516,7 +1516,7 @@
       "protoPath": "google/container/v1",
       "productName": "Google Kubernetes Engine",
       "productUrl": "https://cloud.google.com/kubernetes-engine/docs/reference/rest/",
-      "version": "3.23.0",
+      "version": "3.24.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.",
       "dependencies": {},


### PR DESCRIPTION

Changes in this release:

### New features

- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
- Add optional secondary_boot_disk_update_strategy field to NodePool API ([commit 0ad229c](https://github.com/googleapis/google-cloud-dotnet/commit/0ad229ca2762b397839871dbc12762e86a338a7b))
- Allow existing clusters to enable multi-networking ([commit 0ad229c](https://github.com/googleapis/google-cloud-dotnet/commit/0ad229ca2762b397839871dbc12762e86a338a7b))
