### PR TITLE
Release Google.Cloud.Datastream.V1 version 2.6.0

### DIFF
--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.csproj
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.5.0</Version>
+    <Version>2.6.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Datastream API (v1), which allows you to synchronize data across heterogeneous databases and applications reliably, and with minimal latency and downtime.</Description>

--- a/apis/Google.Cloud.Datastream.V1/docs/history.md
+++ b/apis/Google.Cloud.Datastream.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.6.0, released 2024-03-26
+
+### New features
+
+- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
+
 ## Version 2.5.0, released 2024-02-28
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1758,7 +1758,7 @@
     },
     {
       "id": "Google.Cloud.Datastream.V1",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "type": "grpc",
       "productName": "DataStream",
       "productUrl": "https://cloud.google.com/datastream/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
