### PR TITLE
Release Google.Cloud.Dialogflow.V2 version 4.18.0

### DIFF
--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.csproj
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.17.0</Version>
+    <Version>4.18.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Dialogflow API (v2).</Description>

--- a/apis/Google.Cloud.Dialogflow.V2/docs/history.md
+++ b/apis/Google.Cloud.Dialogflow.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 4.18.0, released 2024-03-26
+
+### New features
+
+- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
+
 ## Version 4.17.0, released 2024-03-21
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1952,7 +1952,7 @@
       "protoPath": "google/cloud/dialogflow/v2",
       "productName": "Google Cloud Dialogflow",
       "productUrl": "https://cloud.google.com/dialogflow-enterprise/",
-      "version": "4.17.0",
+      "version": "4.18.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Dialogflow API (v2).",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
