### PR TITLE
Release Google.Cloud.Functions.V2 version 1.5.0

### DIFF
--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.csproj
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.4.0</Version>
+    <Version>1.5.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Functions API (v2), which manages lightweight user-provided functions executed in response to events.</Description>

--- a/apis/Google.Cloud.Functions.V2/docs/history.md
+++ b/apis/Google.Cloud.Functions.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.5.0, released 2024-03-26
+
+### New features
+
+- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
+
 ## Version 1.4.0, released 2024-02-28
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2413,7 +2413,7 @@
     },
     {
       "id": "Google.Cloud.Functions.V2",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "type": "grpc",
       "productName": "Cloud Functions",
       "productUrl": "https://cloud.google.com/functions",


### PR DESCRIPTION

Changes in this release:

### New features

- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
