### PR TITLE
Release Google.Cloud.GkeBackup.V1 version 2.4.0

### DIFF
--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.csproj
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Backup for GKE API, which is a managed Kubernetes workload backup and restore service for GKE clusters.</Description>

--- a/apis/Google.Cloud.GkeBackup.V1/docs/history.md
+++ b/apis/Google.Cloud.GkeBackup.V1/docs/history.md
@@ -1,5 +1,19 @@
 # Version history
 
+## Version 2.4.0, released 2024-03-26
+
+### New features
+
+- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
+- Add smart scheduling ([commit 41a63ef](https://github.com/googleapis/google-cloud-dotnet/commit/41a63ef2d51dec24dd60ce04f2000841fe67245e))
+- Add backup indexing ([commit 41a63ef](https://github.com/googleapis/google-cloud-dotnet/commit/41a63ef2d51dec24dd60ce04f2000841fe67245e))
+
+### Documentation improvements
+
+- Remove the next id annotation ([commit 41a63ef](https://github.com/googleapis/google-cloud-dotnet/commit/41a63ef2d51dec24dd60ce04f2000841fe67245e))
+- Add output only and optional api field behavior label ([commit 41a63ef](https://github.com/googleapis/google-cloud-dotnet/commit/41a63ef2d51dec24dd60ce04f2000841fe67245e))
+- Update retention policy and cron schedule comment to include new constraints from smart scheduling ([commit 41a63ef](https://github.com/googleapis/google-cloud-dotnet/commit/41a63ef2d51dec24dd60ce04f2000841fe67245e))
+
 ## Version 2.3.0, released 2024-02-28
 
 ### Documentation improvements

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2482,7 +2482,7 @@
     },
     {
       "id": "Google.Cloud.GkeBackup.V1",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "type": "grpc",
       "productName": "Backup for GKE",
       "productUrl": "https://cloud.google.com/kubernetes-engine/docs/add-on/backup-for-gke",


### PR DESCRIPTION

Changes in this release:

### New features

- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
- Add smart scheduling ([commit 41a63ef](https://github.com/googleapis/google-cloud-dotnet/commit/41a63ef2d51dec24dd60ce04f2000841fe67245e))
- Add backup indexing ([commit 41a63ef](https://github.com/googleapis/google-cloud-dotnet/commit/41a63ef2d51dec24dd60ce04f2000841fe67245e))

### Documentation improvements

- Remove the next id annotation ([commit 41a63ef](https://github.com/googleapis/google-cloud-dotnet/commit/41a63ef2d51dec24dd60ce04f2000841fe67245e))
- Add output only and optional api field behavior label ([commit 41a63ef](https://github.com/googleapis/google-cloud-dotnet/commit/41a63ef2d51dec24dd60ce04f2000841fe67245e))
- Update retention policy and cron schedule comment to include new constraints from smart scheduling ([commit 41a63ef](https://github.com/googleapis/google-cloud-dotnet/commit/41a63ef2d51dec24dd60ce04f2000841fe67245e))
