### PR TITLE
Release Google.Cloud.Logging.Type version 4.2.0

### DIFF
--- a/apis/Google.Cloud.Logging.Type/Google.Cloud.Logging.Type/Google.Cloud.Logging.Type.csproj
+++ b/apis/Google.Cloud.Logging.Type/Google.Cloud.Logging.Type/Google.Cloud.Logging.Type.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.1.0</Version>
+    <Version>4.2.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Version-agnostic types for the Google Cloud Logging API.</Description>

--- a/apis/Google.Cloud.Logging.Type/docs/history.md
+++ b/apis/Google.Cloud.Logging.Type/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 4.2.0, released 2024-03-26
+
+### New features
+
+- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
+
 ## Version 4.1.0, released 2024-02-28
 
 ### Documentation improvements

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2944,7 +2944,7 @@
       "id": "Google.Cloud.Logging.Type",
       "generator": "proto",
       "protoPath": "google/logging/type",
-      "version": "4.1.0",
+      "version": "4.2.0",
       "type": "other",
       "targetFrameworks": "netstandard2.0;net462",
       "description": "Version-agnostic types for the Google Cloud Logging API.",


### PR DESCRIPTION

Changes in this release:

### New features

- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
