### PR TITLE
Release Google.Cloud.Metastore.V1 version 2.7.0

### DIFF
--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.csproj
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Dataproc Metastore API which is used to manage the lifecycle and configuration of metastore services.</Description>

--- a/apis/Google.Cloud.Metastore.V1/docs/history.md
+++ b/apis/Google.Cloud.Metastore.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.7.0, released 2024-03-26
+
+### New features
+
+- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
+
 ## Version 2.6.0, released 2024-02-28
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3069,7 +3069,7 @@
     },
     {
       "id": "Google.Cloud.Metastore.V1",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "type": "grpc",
       "productName": "Dataproc Metastore",
       "productUrl": "https://cloud.google.com/dataproc-metastore/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
