### PR TITLE
Release Google.Cloud.NetApp.V1 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.csproj
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud NetApp Volumes API, which is a fully-managed, cloud-based data storage service that provides advanced data management capabilities and highly scalable performance with global availability.</Description>

--- a/apis/Google.Cloud.NetApp.V1/docs/history.md
+++ b/apis/Google.Cloud.NetApp.V1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 1.1.0, released 2024-03-26
+
+### New features
+
+- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
+
+### Documentation improvements
+
+- Rephrase comment on psa_range ([commit 0387455](https://github.com/googleapis/google-cloud-dotnet/commit/038745567fb5baf838ac550c5733a08113a602df))
+- Fix comment for UNIX of SecurityStyle ([commit 0387455](https://github.com/googleapis/google-cloud-dotnet/commit/038745567fb5baf838ac550c5733a08113a602df))
+
 ## Version 1.0.0, released 2024-03-12
 
 This is the first GA release of the library.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3183,7 +3183,7 @@
     },
     {
       "id": "Google.Cloud.NetApp.V1",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "grpc",
       "productName": "NetApp",
       "productUrl": "https://cloud.google.com/netapp/volumes/docs/discover/overview",


### PR DESCRIPTION

Changes in this release:

### New features

- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))

### Documentation improvements

- Rephrase comment on psa_range ([commit 0387455](https://github.com/googleapis/google-cloud-dotnet/commit/038745567fb5baf838ac550c5733a08113a602df))
- Fix comment for UNIX of SecurityStyle ([commit 0387455](https://github.com/googleapis/google-cloud-dotnet/commit/038745567fb5baf838ac550c5733a08113a602df))
