### PR TITLE
Release Google.Cloud.NetworkManagement.V1 version 2.8.0

### DIFF
--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.csproj
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.7.0</Version>
+    <Version>2.8.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Network Management API, which provides a collection of network performance monitoring and diagnostic capabilities.</Description>

--- a/apis/Google.Cloud.NetworkManagement.V1/docs/history.md
+++ b/apis/Google.Cloud.NetworkManagement.V1/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 2.8.0, released 2024-03-26
+
+### New features
+
+- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
+- Add new fields and enum values related to round-trip ([commit 9570290](https://github.com/googleapis/google-cloud-dotnet/commit/95702900d2f99bbfb4ebf393f2e54b6b99054563))
+
+### Documentation improvements
+
+- Update a few outdated comments ([commit 9570290](https://github.com/googleapis/google-cloud-dotnet/commit/95702900d2f99bbfb4ebf393f2e54b6b99054563))
+- Update comments for fields related to load balancing ([commit 0172996](https://github.com/googleapis/google-cloud-dotnet/commit/017299691b681ee74da40ad277492c6cab41fbd8))
+
 ## Version 2.7.0, released 2024-03-21
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3251,7 +3251,7 @@
     },
     {
       "id": "Google.Cloud.NetworkManagement.V1",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "type": "grpc",
       "productName": "Network Management",
       "productUrl": "https://cloud.google.com/network-intelligence-center/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
- Add new fields and enum values related to round-trip ([commit 9570290](https://github.com/googleapis/google-cloud-dotnet/commit/95702900d2f99bbfb4ebf393f2e54b6b99054563))

### Documentation improvements

- Update a few outdated comments ([commit 9570290](https://github.com/googleapis/google-cloud-dotnet/commit/95702900d2f99bbfb4ebf393f2e54b6b99054563))
- Update comments for fields related to load balancing ([commit 0172996](https://github.com/googleapis/google-cloud-dotnet/commit/017299691b681ee74da40ad277492c6cab41fbd8))
