### PR TITLE
Release Google.Cloud.OrgPolicy.V1 version 3.2.0

### DIFF
--- a/apis/Google.Cloud.OrgPolicy.V1/Google.Cloud.OrgPolicy.V1/Google.Cloud.OrgPolicy.V1.csproj
+++ b/apis/Google.Cloud.OrgPolicy.V1/Google.Cloud.OrgPolicy.V1/Google.Cloud.OrgPolicy.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.1.0</Version>
+    <Version>3.2.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>OrgPolicy API messages.</Description>

--- a/apis/Google.Cloud.OrgPolicy.V1/docs/history.md
+++ b/apis/Google.Cloud.OrgPolicy.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.2.0, released 2024-03-26
+
+### New features
+
+- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
+
 ## Version 3.1.0, released 2024-02-28
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3424,7 +3424,7 @@
       "id": "Google.Cloud.OrgPolicy.V1",
       "generator": "proto",
       "protoPath": "google/cloud/orgpolicy/v1",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "type": "other",
       "targetFrameworks": "netstandard2.0;net462",
       "description": "OrgPolicy API messages.",


### PR DESCRIPTION

Changes in this release:

### New features

- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
