### PR TITLE
Release Google.Cloud.OsConfig.V1Alpha version 2.0.0-alpha04

### DIFF
--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.csproj
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha03</Version>
+    <Version>2.0.0-alpha04</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library for the Cloud OS Config API (v1 alpha). These are OS management tools that can be used for patch management, patch compliance, and configuration management on VM instances.</Description>

--- a/apis/Google.Cloud.OsConfig.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.0.0-alpha04, released 2024-03-26
+
+### New features
+
+- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
+
 ## Version 2.0.0-alpha03, released 2024-02-28
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3481,7 +3481,7 @@
     },
     {
       "id": "Google.Cloud.OsConfig.V1Alpha",
-      "version": "2.0.0-alpha03",
+      "version": "2.0.0-alpha04",
       "type": "grpc",
       "productName": "Google Cloud OS Config",
       "productUrl": "https://cloud.google.com/compute/docs/osconfig/rest",


### PR DESCRIPTION

Changes in this release:

### New features

- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
