### PR TITLE
Release Google.Cloud.ResourceManager.V3 version 2.4.0

### DIFF
--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.csproj
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Resource Manager API (v3), which creates, reads, and updates metadata for Google Cloud Platform resource containers.</Description>

--- a/apis/Google.Cloud.ResourceManager.V3/docs/history.md
+++ b/apis/Google.Cloud.ResourceManager.V3/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.4.0, released 2024-03-26
+
+### New features
+
+- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
+
 ## Version 2.3.0, released 2024-02-29
 
 ### Documentation improvements

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3921,7 +3921,7 @@
     },
     {
       "id": "Google.Cloud.ResourceManager.V3",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "type": "grpc",
       "productName": "Cloud Resource Manager",
       "productUrl": "https://cloud.google.com/resource-manager/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
