### PR TITLE
Release Google.Cloud.Storage.Control.V2 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.csproj
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Storage Control API (v2), providing control-plane functionality for Google Cloud Storage.</Description>

--- a/apis/Google.Cloud.Storage.Control.V2/docs/history.md
+++ b/apis/Google.Cloud.Storage.Control.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2024-03-26
+
+### New features
+
+- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
+
 ## Version 1.0.0-beta01, released 2024-03-18
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4626,7 +4626,7 @@
     },
     {
       "id": "Google.Cloud.Storage.Control.V2",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Cloud Storage",
       "productUrl": "https://cloud.google.com/storage/docs/overview",


### PR DESCRIPTION

Changes in this release:

### New features

- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
