### PR TITLE
Release Google.Cloud.TextToSpeech.V1 version 3.5.0

### DIFF
--- a/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.csproj
+++ b/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.4.0</Version>
+    <Version>3.5.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Text-to-Speech API v1, synthesizes natural-sounding speech by applying powerful neural network models.</Description>

--- a/apis/Google.Cloud.TextToSpeech.V1/docs/history.md
+++ b/apis/Google.Cloud.TextToSpeech.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.5.0, released 2024-03-26
+
+### New features
+
+- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
+
 ## Version 3.4.0, released 2024-02-29
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4880,7 +4880,7 @@
       "protoPath": "google/cloud/texttospeech/v1",
       "productName": "Google Cloud Text-to-Speech",
       "productUrl": "https://cloud.google.com/text-to-speech",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Text-to-Speech API v1, synthesizes natural-sounding speech by applying powerful neural network models.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
