### PR TITLE
Release Google.Cloud.Workflows.Common.V1 version 2.4.0

### DIFF
--- a/apis/Google.Cloud.Workflows.Common.V1/Google.Cloud.Workflows.Common.V1/Google.Cloud.Workflows.Common.V1.csproj
+++ b/apis/Google.Cloud.Workflows.Common.V1/Google.Cloud.Workflows.Common.V1/Google.Cloud.Workflows.Common.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Common resource names used by all Workflows V1 APIs</Description>

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5273,7 +5273,7 @@
       "id": "Google.Cloud.Workflows.Common.V1",
       "type": "other",
       "targetFrameworks": "netstandard2.0;net462",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "description": "Common resource names used by all Workflows V1 APIs",
       "tags": [
         "Spanner"


### PR DESCRIPTION

This library has no dedicated release history. Changes are typically recorded in other libraries, or are just dependency updates.
