### PR TITLE
Release Google.Cloud.Workflows.Common.V1Beta version 2.0.0-beta04

### DIFF
--- a/apis/Google.Cloud.Workflows.Common.V1Beta/Google.Cloud.Workflows.Common.V1Beta/Google.Cloud.Workflows.Common.V1Beta.csproj
+++ b/apis/Google.Cloud.Workflows.Common.V1Beta/Google.Cloud.Workflows.Common.V1Beta/Google.Cloud.Workflows.Common.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta03</Version>
+    <Version>2.0.0-beta04</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Common resource names used by all Workflows V1Beta APIs</Description>

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5287,7 +5287,7 @@
       "id": "Google.Cloud.Workflows.Common.V1Beta",
       "type": "other",
       "targetFrameworks": "netstandard2.0;net462",
-      "version": "2.0.0-beta03",
+      "version": "2.0.0-beta04",
       "description": "Common resource names used by all Workflows V1Beta APIs",
       "tags": [
         "Spanner"


### PR DESCRIPTION

This library has no dedicated release history. Changes are typically recorded in other libraries, or are just dependency updates.
