### PR TITLE
Release Google.Cloud.Workstations.V1 version 1.2.0

### DIFF
--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.csproj
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Allows administrators to create managed developer environments in the cloud.</Description>

--- a/apis/Google.Cloud.Workstations.V1/docs/history.md
+++ b/apis/Google.Cloud.Workstations.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.2.0, released 2024-03-26
+
+### New features
+
+- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
+
 ## Version 1.1.0, released 2024-02-29
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5386,7 +5386,7 @@
     },
     {
       "id": "Google.Cloud.Workstations.V1",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "type": "grpc",
       "productName": "Cloud Workstations",
       "productUrl": "https://cloud.google.com/workstations/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
