### PR TITLE
Release Google.Shopping.Type version 1.0.0-beta04

### DIFF
--- a/apis/Google.Shopping.Type/Google.Shopping.Type/Google.Shopping.Type.csproj
+++ b/apis/Google.Shopping.Type/Google.Shopping.Type/Google.Shopping.Type.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta03</Version>
+    <Version>1.0.0-beta04</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Version-agnostic types for Shopping APIs.</Description>

--- a/apis/Google.Shopping.Type/docs/history.md
+++ b/apis/Google.Shopping.Type/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta04, released 2024-03-26
+
+### New features
+
+- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
+
 ## Version 1.0.0-beta03, released 2024-02-29
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5705,7 +5705,7 @@
     },
     {
       "id": "Google.Shopping.Type",
-      "version": "1.0.0-beta03",
+      "version": "1.0.0-beta04",
       "targetFrameworks": "netstandard2.0;net462",
       "type": "other",
       "description": "Version-agnostic types for Shopping APIs.",


### PR DESCRIPTION

Changes in this release:

### New features

- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
