### PR TITLE
Release Google.Cloud.DevTools.Common version 3.2.0-beta01

### DIFF
--- a/apis/Google.Cloud.DevTools.Common/Google.Cloud.DevTools.Common/Google.Cloud.DevTools.Common.csproj
+++ b/apis/Google.Cloud.DevTools.Common/Google.Cloud.DevTools.Common/Google.Cloud.DevTools.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.2.0-beta00</Version>
+    <Version>3.2.0-beta01</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Common Protocol Buffer messages for Google Cloud Developer Tools APIs.</Description>

--- a/apis/Google.Cloud.DevTools.Common/docs/history.md
+++ b/apis/Google.Cloud.DevTools.Common/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.2.0-beta01, released 2024-03-27
+
+### New features
+
+- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
+
 ## Version 3.1.1, released 2024-02-29
 
 Purely a release-process patch, re-releasing 3.1.0 which failed to

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1828,7 +1828,7 @@
     },
     {
       "id": "Google.Cloud.DevTools.Common",
-      "version": "3.2.0-beta00",
+      "version": "3.2.0-beta01",
       "type": "other",
       "description": "Common Protocol Buffer messages for Google Cloud Developer Tools APIs.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
