### PR TITLE
Release Google.Cloud.ServiceControl.V1 version 2.3.0

### DIFF
--- a/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1.csproj
+++ b/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.2.0</Version>
+    <Version>2.3.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Service Control API, which provides control plane functionality to managed services, such as logging, monitoring, and status checks.</Description>

--- a/apis/Google.Cloud.ServiceControl.V1/docs/history.md
+++ b/apis/Google.Cloud.ServiceControl.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.3.0, released 2024-03-27
+
+### New features
+
+- Change netstandard2.1 target to netstandard2.0 ([commit 7707366](https://github.com/googleapis/google-cloud-dotnet/commit/77073662b153c73c7f9a869ede1376f4c7a12661))
+
 ## Version 2.2.0, released 2024-02-27
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4264,7 +4264,7 @@
     },
     {
       "id": "Google.Cloud.ServiceControl.V1",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "type": "grpc",
       "productName": "Service Control",
       "productUrl": "https://cloud.google.com/service-infrastructure/docs/service-control/reference/rpc",


### PR DESCRIPTION

Changes in this release:

### New features

- Change netstandard2.1 target to netstandard2.0 ([commit 7707366](https://github.com/googleapis/google-cloud-dotnet/commit/77073662b153c73c7f9a869ede1376f4c7a12661))
