### PR TITLE
Release Google.Cloud.Workflows.V1 version 2.4.0

### DIFF
--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.csproj
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Workflows API v1.</Description>

--- a/apis/Google.Cloud.Workflows.V1/docs/history.md
+++ b/apis/Google.Cloud.Workflows.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.4.0, released 2024-03-27
+
+### New features
+
+- Change netstandard2.1 target to netstandard2.0 ([commit 7707366](https://github.com/googleapis/google-cloud-dotnet/commit/77073662b153c73c7f9a869ede1376f4c7a12661))
+
 ## Version 2.3.0, released 2024-02-29
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5313,7 +5313,7 @@
     },
     {
       "id": "Google.Cloud.Workflows.V1",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "commonResourcesConfig": "apis/Google.Cloud.Workflows.Common.V1/CommonResourcesConfig.json",
       "type": "grpc",
       "productName": "Workflows",


### PR DESCRIPTION

Changes in this release:

### New features

- Change netstandard2.1 target to netstandard2.0 ([commit 7707366](https://github.com/googleapis/google-cloud-dotnet/commit/77073662b153c73c7f9a869ede1376f4c7a12661))
