### PR TITLE
Release Google.Maps.AddressValidation.V1 version 1.3.0

### DIFF
--- a/apis/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1.csproj
+++ b/apis/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Maps Address Validation API, which allows developers to verify the accuracy of addresses. Given an address, it returns information about the correctness of the components of the parsed address, a geocode, and a verdict on the deliverability of the parsed address.</Description>

--- a/apis/Google.Maps.AddressValidation.V1/docs/history.md
+++ b/apis/Google.Maps.AddressValidation.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.3.0, released 2024-03-27
+
+### New features
+
+- Change netstandard2.1 target to netstandard2.0 ([commit 7707366](https://github.com/googleapis/google-cloud-dotnet/commit/77073662b153c73c7f9a869ede1376f4c7a12661))
+
 ## Version 1.2.0, released 2024-03-13
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5459,7 +5459,7 @@
     },
     {
       "id": "Google.Maps.AddressValidation.V1",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "type": "grpc",
       "productName": "Address Validation",
       "productUrl": "https://developers.google.com/maps/documentation/address-validation/requests-validate-address",


### PR DESCRIPTION

Changes in this release:

### New features

- Change netstandard2.1 target to netstandard2.0 ([commit 7707366](https://github.com/googleapis/google-cloud-dotnet/commit/77073662b153c73c7f9a869ede1376f4c7a12661))
