### PR TITLE
Release Google.Maps.FleetEngine.V1 version 1.3.0

### DIFF
--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.csproj
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Maps Fleet Engine API (v1), which enables access to On Demand Rides and Deliveries and Last Mile Fleet Solutions.</Description>

--- a/apis/Google.Maps.FleetEngine.V1/docs/history.md
+++ b/apis/Google.Maps.FleetEngine.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.3.0, released 2024-03-27
+
+### New features
+
+- Change netstandard2.1 target to netstandard2.0 ([commit 7707366](https://github.com/googleapis/google-cloud-dotnet/commit/77073662b153c73c7f9a869ede1376f4c7a12661))
+
 ## Version 1.2.0, released 2024-02-29
 
 ### Documentation improvements

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5503,7 +5503,7 @@
     },
     {
       "id": "Google.Maps.FleetEngine.V1",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "type": "grpc",
       "productName": "Local Rides and Deliveries",
       "productUrl": "https://developers.google.com/maps/documentation/transportation-logistics/mobility",


### PR DESCRIPTION

Changes in this release:

### New features

- Change netstandard2.1 target to netstandard2.0 ([commit 7707366](https://github.com/googleapis/google-cloud-dotnet/commit/77073662b153c73c7f9a869ede1376f4c7a12661))
