### PR TITLE
Release Firestore libraries version 3.6.0

### DIFF
--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.csproj
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.6.0-beta00</Version>
+    <Version>3.6.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Low-level Google client library to access the Firestore API. Users are recommended to use the Google.Cloud.Firestore package instead.</Description>

--- a/apis/Google.Cloud.Firestore.V1/docs/history.md
+++ b/apis/Google.Cloud.Firestore.V1/docs/history.md
@@ -4,6 +4,18 @@ This package is primarily a dependency of Google.Cloud.Firestore. See the
 [Google.Cloud.Firestore version history](https://googleapis.dev/dotnet/Google.Cloud.Firestore/latest/history.html)
 for more details.
 
+## Version 3.6.0, released 2024-03-27
+
+### New features
+
+- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
+- Add VectorSearch API ([commit 6b45d22](https://github.com/googleapis/google-cloud-dotnet/commit/6b45d2250c9652a430fc0ae1a371353e4ff31056))
+- Add new types ExplainOptions, ExplainMetrics, PlanSummary, ExecutionStats ([commit c2793f0](https://github.com/googleapis/google-cloud-dotnet/commit/c2793f0cc57d48470bb8834b6ac1d4ace0305a1e))
+- Add ExplainOptions field to RunQueryRequest ([commit c2793f0](https://github.com/googleapis/google-cloud-dotnet/commit/c2793f0cc57d48470bb8834b6ac1d4ace0305a1e))
+- Add ExplainMetrics field to RunQueryResponse ([commit c2793f0](https://github.com/googleapis/google-cloud-dotnet/commit/c2793f0cc57d48470bb8834b6ac1d4ace0305a1e))
+- Add ExplainOptions field to RunAggregationQueryRequest ([commit c2793f0](https://github.com/googleapis/google-cloud-dotnet/commit/c2793f0cc57d48470bb8834b6ac1d4ace0305a1e))
+- Add ExplainMetrics field to RunAggregationQueryResponse ([commit c2793f0](https://github.com/googleapis/google-cloud-dotnet/commit/c2793f0cc57d48470bb8834b6ac1d4ace0305a1e))
+
 ## Version 3.5.1, released 2024-02-14
 
 ### Bug fixes

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Google.Cloud.Firestore.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Google.Cloud.Firestore.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.6.0-beta00</Version>
+    <Version>3.6.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Firestore API.</Description>

--- a/apis/Google.Cloud.Firestore/docs/history.md
+++ b/apis/Google.Cloud.Firestore/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 3.6.0, released 2024-03-27
+
+### New features
+
+- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
+- Throw if an must-exist precondition is explicitly set to false for update. ([commit 5cfc625](https://github.com/googleapis/google-cloud-dotnet/commit/5cfc625fe2edfd7a7c565bd020ccfc9332b41be6))
+
 ## Version 3.5.1, released 2024-02-14
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2328,7 +2328,7 @@
       "productName": "Firestore",
       "productUrl": "https://firebase.google.com/docs/firestore/",
       "listingDescription": "Firestore high-level library",
-      "version": "3.6.0-beta00",
+      "version": "3.6.0",
       "type": "other",
       "metadataType": "GAPIC_MANUAL",
       "description": "Recommended Google client library to access the Firestore API.",
@@ -2359,7 +2359,7 @@
       "productName": "Firestore",
       "productUrl": "https://firebase.google.com",
       "listingDescription": "Firestore low-level API access",
-      "version": "3.6.0-beta00",
+      "version": "3.6.0",
       "type": "grpc",
       "description": "Low-level Google client library to access the Firestore API. Users are recommended to use the Google.Cloud.Firestore package instead.",
       "tags": [


### PR DESCRIPTION

Changes in Google.Cloud.Firestore version 3.6.0:

### New features

- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
- Throw if an must-exist precondition is explicitly set to false for update. ([commit 5cfc625](https://github.com/googleapis/google-cloud-dotnet/commit/5cfc625fe2edfd7a7c565bd020ccfc9332b41be6))

Changes in Google.Cloud.Firestore.V1 version 3.6.0:

### New features

- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
- Add VectorSearch API ([commit 6b45d22](https://github.com/googleapis/google-cloud-dotnet/commit/6b45d2250c9652a430fc0ae1a371353e4ff31056))
- Add new types ExplainOptions, ExplainMetrics, PlanSummary, ExecutionStats ([commit c2793f0](https://github.com/googleapis/google-cloud-dotnet/commit/c2793f0cc57d48470bb8834b6ac1d4ace0305a1e))
- Add ExplainOptions field to RunQueryRequest ([commit c2793f0](https://github.com/googleapis/google-cloud-dotnet/commit/c2793f0cc57d48470bb8834b6ac1d4ace0305a1e))
- Add ExplainMetrics field to RunQueryResponse ([commit c2793f0](https://github.com/googleapis/google-cloud-dotnet/commit/c2793f0cc57d48470bb8834b6ac1d4ace0305a1e))
- Add ExplainOptions field to RunAggregationQueryRequest ([commit c2793f0](https://github.com/googleapis/google-cloud-dotnet/commit/c2793f0cc57d48470bb8834b6ac1d4ace0305a1e))
- Add ExplainMetrics field to RunAggregationQueryResponse ([commit c2793f0](https://github.com/googleapis/google-cloud-dotnet/commit/c2793f0cc57d48470bb8834b6ac1d4ace0305a1e))

Packages in this release:
- Release Google.Cloud.Firestore version 3.6.0
- Release Google.Cloud.Firestore.V1 version 3.6.0
