### PR TITLE
Release Google.Cloud.Batch.V1Alpha version 1.0.0-alpha25

### DIFF
--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.csproj
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha24</Version>
+    <Version>1.0.0-alpha25</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Batch API (v1alpha), which allows you to manage the running of batch jobs on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Batch.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.Batch.V1Alpha/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-alpha25, released 2024-03-28
+
+### New features
+
+- Onboard Resource Allowance API methods on v1alpha ([commit 7591fca](https://github.com/googleapis/google-cloud-dotnet/commit/7591fcafd36fc37ca49b64b4fdf866cda4ee36b5))
+
 ## Version 1.0.0-alpha24, released 2024-03-27
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -652,7 +652,7 @@
     },
     {
       "id": "Google.Cloud.Batch.V1Alpha",
-      "version": "1.0.0-alpha24",
+      "version": "1.0.0-alpha25",
       "type": "grpc",
       "productName": "Batch",
       "productUrl": "https://cloud.google.com/batch/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Onboard Resource Allowance API methods on v1alpha ([commit 7591fca](https://github.com/googleapis/google-cloud-dotnet/commit/7591fcafd36fc37ca49b64b4fdf866cda4ee36b5))
