### PR TITLE
Release Google.Cloud.NetworkManagement.V1 version 2.9.0

### DIFF
--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.csproj
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.8.0</Version>
+    <Version>2.9.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Network Management API, which provides a collection of network performance monitoring and diagnostic capabilities.</Description>

--- a/apis/Google.Cloud.NetworkManagement.V1/docs/history.md
+++ b/apis/Google.Cloud.NetworkManagement.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 2.9.0, released 2024-03-28
+
+### New features
+
+- Add an "unsupported" type of firewall policy rule ([commit d388abc](https://github.com/googleapis/google-cloud-dotnet/commit/d388abcac50e05f4baba9c436cedb0e11879ebcf))
+
+### Documentation improvements
+
+- Update possible firewall rule actions comment ([commit 1538880](https://github.com/googleapis/google-cloud-dotnet/commit/15388808e4c683b6fbe0c201e92562221cfae219))
+
 ## Version 2.8.0, released 2024-03-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3226,7 +3226,7 @@
     },
     {
       "id": "Google.Cloud.NetworkManagement.V1",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "type": "grpc",
       "productName": "Network Management",
       "productUrl": "https://cloud.google.com/network-intelligence-center/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add an "unsupported" type of firewall policy rule ([commit d388abc](https://github.com/googleapis/google-cloud-dotnet/commit/d388abcac50e05f4baba9c436cedb0e11879ebcf))

### Documentation improvements

- Update possible firewall rule actions comment ([commit 1538880](https://github.com/googleapis/google-cloud-dotnet/commit/15388808e4c683b6fbe0c201e92562221cfae219))
