### PR TITLE
Release Google.Shopping.Type version 1.0.0-beta05

### DIFF
--- a/apis/Google.Shopping.Type/Google.Shopping.Type/Google.Shopping.Type.csproj
+++ b/apis/Google.Shopping.Type/Google.Shopping.Type/Google.Shopping.Type.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta04</Version>
+    <Version>1.0.0-beta05</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Version-agnostic types for Shopping APIs.</Description>

--- a/apis/Google.Shopping.Type/docs/history.md
+++ b/apis/Google.Shopping.Type/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 1.0.0-beta05, released 2024-03-28
+
+### New features
+
+- Add DEMAND_GEN_ADS and DEMAND_GEN_ADS_DISCOVER_SURFACE in ReportingContextEnum ([commit b785634](https://github.com/googleapis/google-cloud-dotnet/commit/b785634f5b24379b3fb6cfdda30ab917283a74e3))
+
+### Documentation improvements
+
+- Deprecate DISCOVERY_ADS and document the new enum values ([commit b785634](https://github.com/googleapis/google-cloud-dotnet/commit/b785634f5b24379b3fb6cfdda30ab917283a74e3))
+
 ## Version 1.0.0-beta04, released 2024-03-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5670,7 +5670,7 @@
     },
     {
       "id": "Google.Shopping.Type",
-      "version": "1.0.0-beta04",
+      "version": "1.0.0-beta05",
       "type": "other",
       "description": "Version-agnostic types for Shopping APIs.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- Add DEMAND_GEN_ADS and DEMAND_GEN_ADS_DISCOVER_SURFACE in ReportingContextEnum ([commit b785634](https://github.com/googleapis/google-cloud-dotnet/commit/b785634f5b24379b3fb6cfdda30ab917283a74e3))

### Documentation improvements

- Deprecate DISCOVERY_ADS and document the new enum values ([commit b785634](https://github.com/googleapis/google-cloud-dotnet/commit/b785634f5b24379b3fb6cfdda30ab917283a74e3))
