### PR TITLE
Release Spanner libraries version 5.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.csproj
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>5.0.0-beta01</Version>
+    <Version>5.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Spanner Database Admin API.</Description>

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.csproj
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>5.0.0-beta01</Version>
+    <Version>5.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Spanner Instance Admin API.</Description>

--- a/apis/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1.csproj
+++ b/apis/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>5.0.0-beta01</Version>
+    <Version>5.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Common resource names used by all Spanner V1 APIs</Description>

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.csproj
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>5.0.0-beta01</Version>
+    <Version>5.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google ADO.NET Provider for Google Cloud Spanner.</Description>

--- a/apis/Google.Cloud.Spanner.Data/docs/history.md
+++ b/apis/Google.Cloud.Spanner.Data/docs/history.md
@@ -1,5 +1,32 @@
 # Version history
 
+## Version 5.0.0-beta02, released 2024-04-04
+
+### New features
+
+- Ambient transactions support commit delays ([commit f4b4208](https://github.com/googleapis/google-cloud-dotnet/commit/f4b4208eb3d9b1ef9ce1c984d57e920c7ce0b5f1))
+- Implicit transactions support commit delay ([commit af15aaf](https://github.com/googleapis/google-cloud-dotnet/commit/af15aafce40ac46d20256cec0b47ca965c51a6e2))
+- Explicit transactions support commit delays ([commit 4934cfd](https://github.com/googleapis/google-cloud-dotnet/commit/4934cfd23e0d02376a1950bd825f72e1b388fc20))
+- Adding `EXPECTED_FULFILLMENT_PERIOD` to the indicate instance creation times (with `FULFILLMENT_PERIOD_NORMAL` or `FULFILLMENT_PERIOD_EXTENDED` ENUM) with the extended instance creation time triggered by On-Demand Capacity Feature ([commit 20bb7e7](https://github.com/googleapis/google-cloud-dotnet/commit/20bb7e736ffbcff1d9eb4f77cc5bea000d295fdc))
+- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
+- SpannerCommand supports directed reads ([commit dfeb2c0](https://github.com/googleapis/google-cloud-dotnet/commit/dfeb2c0de7889679320ffa71ef99b114511a7fbb))
+- SpannerConnection supports directed reads ([commit d7620e5](https://github.com/googleapis/google-cloud-dotnet/commit/d7620e524a3173904e4bb298615b16c2f7d13d8a))
+- PooledSession supports directed reads ([commit e26c8aa](https://github.com/googleapis/google-cloud-dotnet/commit/e26c8aab85cac8ab3bd1d9c9e286b706a43a2ec4))
+- Add PG.OID support ([commit 43818f3](https://github.com/googleapis/google-cloud-dotnet/commit/43818f3ccb9943ec83d84f3c300505cd58073532))
+- Update TransactionOptions to include new option exclude_txn_from_change_streams ([commit 89764a0](https://github.com/googleapis/google-cloud-dotnet/commit/89764a08f8fe1133bee9f89ef6fd02b8d5ce8f1d))
+- Add field for multiplexed session in spanner.proto ([commit 4bdb639](https://github.com/googleapis/google-cloud-dotnet/commit/4bdb639fe97f720a42f55305e40f6c355f109914))
+
+### Documentation improvements
+
+- Fix typo ([commit ce1be02](https://github.com/googleapis/google-cloud-dotnet/commit/ce1be0278bed346a12533f0f00c85588f3454136))
+- Update comments ([commit 4bdb639](https://github.com/googleapis/google-cloud-dotnet/commit/4bdb639fe97f720a42f55305e40f6c355f109914))
+
+### Other changes
+
+- Deprecate ambient transaction creation overloads ([commit 50f5f65](https://github.com/googleapis/google-cloud-dotnet/commit/50f5f654eb122e06fc0e0c25fcd089c2bbfac681))
+
+(This isn't a breaking change unless code is compiled with warnings as errors, but we do expect to remove these methods entirely in v6.0 of this library.)
+
 ## Version 5.0.0-beta01, released 2024-02-09
 
 ### Bug fixes

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.csproj
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>5.0.0-beta01</Version>
+    <Version>5.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Low-level Google client library to access the Google Cloud Spanner API. The ADO.NET provider (Google.Cloud.Spanner.Data) which depends on this package is generally preferred for Spanner access.</Description>

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4417,7 +4417,7 @@
       "protoPath": "google/spanner/admin/database/v1",
       "productName": "Google Cloud Spanner Database Administration",
       "productUrl": "https://cloud.google.com/spanner/",
-      "version": "5.0.0-beta01",
+      "version": "5.0.0-beta02",
       "commonResourcesConfig": "apis/Google.Cloud.Spanner.Common.V1/CommonResourcesConfig.json",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Spanner Database Admin API.",
@@ -4442,7 +4442,7 @@
       "protoPath": "google/spanner/admin/instance/v1",
       "productName": "Google Cloud Spanner Instance Administration",
       "productUrl": "https://cloud.google.com/spanner/",
-      "version": "5.0.0-beta01",
+      "version": "5.0.0-beta02",
       "commonResourcesConfig": "apis/Google.Cloud.Spanner.Common.V1/CommonResourcesConfig.json",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Spanner Instance Admin API.",
@@ -4464,7 +4464,7 @@
     {
       "id": "Google.Cloud.Spanner.Data",
       "targetFrameworks": "netstandard2.1;net462",
-      "version": "5.0.0-beta01",
+      "version": "5.0.0-beta02",
       "type": "other",
       "metadataType": "INTEGRATION",
       "description": "Google ADO.NET Provider for Google Cloud Spanner.",
@@ -4492,7 +4492,7 @@
     {
       "id": "Google.Cloud.Spanner.Common.V1",
       "type": "other",
-      "version": "5.0.0-beta01",
+      "version": "5.0.0-beta02",
       "description": "Common resource names used by all Spanner V1 APIs",
       "tags": [
         "Spanner"
@@ -4508,7 +4508,7 @@
       "protoPath": "google/spanner/v1",
       "productName": "Google Cloud Spanner",
       "productUrl": "https://cloud.google.com/spanner/",
-      "version": "5.0.0-beta01",
+      "version": "5.0.0-beta02",
       "commonResourcesConfig": "apis/Google.Cloud.Spanner.Common.V1/CommonResourcesConfig.json",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",


### PR DESCRIPTION

Changes in Google.Cloud.Spanner.Data version 5.0.0-beta02:

### New features

- Ambient transactions support commit delays ([commit f4b4208](https://github.com/googleapis/google-cloud-dotnet/commit/f4b4208eb3d9b1ef9ce1c984d57e920c7ce0b5f1))
- Implicit transactions support commit delay ([commit af15aaf](https://github.com/googleapis/google-cloud-dotnet/commit/af15aafce40ac46d20256cec0b47ca965c51a6e2))
- Explicit transactions support commit delays ([commit 4934cfd](https://github.com/googleapis/google-cloud-dotnet/commit/4934cfd23e0d02376a1950bd825f72e1b388fc20))
- Adding `EXPECTED_FULFILLMENT_PERIOD` to the indicate instance creation times (with `FULFILLMENT_PERIOD_NORMAL` or `FULFILLMENT_PERIOD_EXTENDED` ENUM) with the extended instance creation time triggered by On-Demand Capacity Feature ([commit 20bb7e7](https://github.com/googleapis/google-cloud-dotnet/commit/20bb7e736ffbcff1d9eb4f77cc5bea000d295fdc))
- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
- SpannerCommand supports directed reads ([commit dfeb2c0](https://github.com/googleapis/google-cloud-dotnet/commit/dfeb2c0de7889679320ffa71ef99b114511a7fbb))
- SpannerConnection supports directed reads ([commit d7620e5](https://github.com/googleapis/google-cloud-dotnet/commit/d7620e524a3173904e4bb298615b16c2f7d13d8a))
- PooledSession supports directed reads ([commit e26c8aa](https://github.com/googleapis/google-cloud-dotnet/commit/e26c8aab85cac8ab3bd1d9c9e286b706a43a2ec4))
- Add PG.OID support ([commit 43818f3](https://github.com/googleapis/google-cloud-dotnet/commit/43818f3ccb9943ec83d84f3c300505cd58073532))
- Update TransactionOptions to include new option exclude_txn_from_change_streams ([commit 89764a0](https://github.com/googleapis/google-cloud-dotnet/commit/89764a08f8fe1133bee9f89ef6fd02b8d5ce8f1d))
- Add field for multiplexed session in spanner.proto ([commit 4bdb639](https://github.com/googleapis/google-cloud-dotnet/commit/4bdb639fe97f720a42f55305e40f6c355f109914))

### Documentation improvements

- Fix typo ([commit ce1be02](https://github.com/googleapis/google-cloud-dotnet/commit/ce1be0278bed346a12533f0f00c85588f3454136))
- Update comments ([commit 4bdb639](https://github.com/googleapis/google-cloud-dotnet/commit/4bdb639fe97f720a42f55305e40f6c355f109914))

### Other changes

- Deprecate ambient transaction creation overloads ([commit 50f5f65](https://github.com/googleapis/google-cloud-dotnet/commit/50f5f654eb122e06fc0e0c25fcd089c2bbfac681))

(This isn't a breaking change unless code is compiled with warnings as errors, but we do expect to remove these methods entirely in v6.0 of this library.)

Packages in this release:
- Release Google.Cloud.Spanner.Admin.Database.V1 version 5.0.0-beta02
- Release Google.Cloud.Spanner.Admin.Instance.V1 version 5.0.0-beta02
- Release Google.Cloud.Spanner.Common.V1 version 5.0.0-beta02
- Release Google.Cloud.Spanner.Data version 5.0.0-beta02
- Release Google.Cloud.Spanner.V1 version 5.0.0-beta02
