### PR TITLE
Release Google.Cloud.Speech.V2 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.Speech.V2/.repo-metadata.json
+++ b/apis/Google.Cloud.Speech.V2/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.Speech.V2",
-  "release_level": "preview",
+  "release_level": "stable",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Speech.V2/latest",
   "library_type": "GAPIC_AUTO",
   "language": "dotnet",

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.csproj
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta09</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Speech-to-Text API (v2) which converts audio to text by applying powerful neural network models.</Description>

--- a/apis/Google.Cloud.Speech.V2/docs/history.md
+++ b/apis/Google.Cloud.Speech.V2/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 1.0.0, released 2024-04-05
+
+### New features
+
+- Add `translation_config` in `RecognitionConfig` message ([commit 6808e61](https://github.com/googleapis/google-cloud-dotnet/commit/6808e61fbaf0b4230fb367a818158ca2f0355d4f))
+- Promotion from beta to General Availability
+
 ## Version 1.0.0-beta09, released 2024-03-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4575,7 +4575,7 @@
     },
     {
       "id": "Google.Cloud.Speech.V2",
-      "version": "1.0.0-beta09",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Cloud Speech-to-Text",
       "productUrl": "https://cloud.google.com/speech",


### PR DESCRIPTION

Changes in this release:

### New features

- Add `translation_config` in `RecognitionConfig` message ([commit 6808e61](https://github.com/googleapis/google-cloud-dotnet/commit/6808e61fbaf0b4230fb367a818158ca2f0355d4f))
- Promotion from beta to General Availability
