### PR TITLE
chore: Update transports for ConfidentialComputing

### DIFF
--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1430,7 +1430,8 @@
       "shortName": "confidentialcomputing",
       "serviceConfigFile": "confidentialcomputing_v1.yaml",
       "restNumericEnums": true,
-      "includeCommonResourcesProto": true
+      "includeCommonResourcesProto": true,
+      "transport": "grpc+rest"
     },
     {
       "id": "Google.Cloud.ConfidentialComputing.V1Alpha1",
@@ -1453,7 +1454,8 @@
       "shortName": "confidentialcomputing",
       "serviceConfigFile": "confidentialcomputing_v1alpha1.yaml",
       "restNumericEnums": true,
-      "includeCommonResourcesProto": true
+      "includeCommonResourcesProto": true,
+      "transport": "grpc+rest"
     },
     {
       "id": "Google.Cloud.Config.V1",


### PR DESCRIPTION
This is just synchronizing the values in the API catalog with those in the Bazel file.

See https://github.com/googleapis/googleapis/commit/9b6f3aa6d29fbf7931153a295e3784fe4ea8a4d9 for the change to the Bazel files.