### PR TITLE
tests: Stop specifying the transport for Grafeas smoke tests.

### DIFF
--- a/apis/Grafeas.V1/smoketests.json
+++ b/apis/Grafeas.V1/smoketests.json
@@ -3,7 +3,6 @@
     "method": "ListNotes",
     "client": "GrafeasClient",
     "endpoint": "containeranalysis.googleapis.com",
-    "transports": [ "Grpc" ],
     "arguments": {
       "parent": "projects/${PROJECT_ID}",
       "filter": ""
@@ -13,7 +12,6 @@
     "method": "ListOccurrences",
     "client": "GrafeasClient",
     "endpoint": "containeranalysis.googleapis.com",
-    "transports": [ "Grpc" ],
     "arguments": {
       "parent": "projects/${PROJECT_ID}",
       "filter": ""


### PR DESCRIPTION
The API transport was set back to gRPC only.