### PR TITLE
docs: Add note around Google.Apis.Logging beeing hidden from Intellisense

### DIFF
--- a/tools/Google.Cloud.Docs.Snippets/FaqSnippets.cs
+++ b/tools/Google.Cloud.Docs.Snippets/FaqSnippets.cs
@@ -26,6 +26,8 @@ namespace Google.Cloud.Tools.Snippets
             // Required using directives:
             // using static Google.Apis.Http.ConfigurableMessageHandler;
             // using Google;
+            // The following namespace is hidden from Intellisense so don't
+            // expect to be prompted for it. Add it explicitly.
             // using Google.Apis.Logging;
             // using Google.Cloud.Translation.V2;
 


### PR DESCRIPTION
Because we are releasing googleapis/google-api-dotnet-client#2707