### PR TITLE
docs: Revert previous note around Google.Apis.Logging

### DIFF
--- a/tools/Google.Cloud.Docs.Snippets/FaqSnippets.cs
+++ b/tools/Google.Cloud.Docs.Snippets/FaqSnippets.cs
@@ -26,8 +26,6 @@ namespace Google.Cloud.Tools.Snippets
             // Required using directives:
             // using static Google.Apis.Http.ConfigurableMessageHandler;
             // using Google;
-            // The following namespace is hidden from Intellisense so don't
-            // expect to be prompted for it. Add it explicitly.
             // using Google.Apis.Logging;
             // using Google.Cloud.Translation.V2;
 


### PR DESCRIPTION
It's not the whole namespace which is hidden from Intellisense - it's just ILogger. So with the sample code using ConsoleLogger, we should be fine, with users prompted to add using directives appropriately.

(Sorry for not spotting this before.)