### PR TITLE
Release Spanner libraries version 5.0.0-beta03

### DIFF
--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.csproj
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>5.0.0-beta02</Version>
+    <Version>5.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Spanner Database Admin API.</Description>

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.csproj
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>5.0.0-beta02</Version>
+    <Version>5.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Spanner Instance Admin API.</Description>

--- a/apis/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1.csproj
+++ b/apis/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>5.0.0-beta02</Version>
+    <Version>5.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Common resource names used by all Spanner V1 APIs</Description>

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.csproj
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>5.0.0-beta02</Version>
+    <Version>5.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google ADO.NET Provider for Google Cloud Spanner.</Description>

--- a/apis/Google.Cloud.Spanner.Data/docs/history.md
+++ b/apis/Google.Cloud.Spanner.Data/docs/history.md
@@ -1,5 +1,18 @@
 # Version history
 
+## Version 5.0.0-beta03, released 2024-04-19
+
+### New features
+
+- Add support for FLOAT32 ([commit 83700dd](https://github.com/googleapis/google-cloud-dotnet/commit/83700dd7c2b05bb3b598ecb7fe43de255cd5fdc8))
+
+### Breaking changes
+
+- The default mapping for values of CLR type decimal was FLOAT64 and it is now Numeric. ([commit 9824a9c](https://github.com/googleapis/google-cloud-dotnet/commit/9824a9c3580e79e95a7bed5af12bcdb15ffbe4cc))
+- The default mapping for values of CLR type float was FLOAT64 and it is now FLOAT32. ([commit 83700dd](https://github.com/googleapis/google-cloud-dotnet/commit/83700dd7c2b05bb3b598ecb7fe43de255cd5fdc8))
+- Support for specifying a maximum commit delay was added in v5.0.0-beta02. Unfortunately properties and methods for this feature were erroneously named using "commit delay" instead of "max commit delay". All such names are being corrected in this commit. ([commit 03e66d7](https://github.com/googleapis/google-cloud-dotnet/commit/03e66d73b165fe10f945924f5e70498d378042d2))
+- Remove Obsolete code that had been introduced before v5.0.0-beta01. ([commit fdc4bff](https://github.com/googleapis/google-cloud-dotnet/commit/fdc4bff6a932d39e8d6c51f9efad040e427face8))
+
 ## Version 5.0.0-beta02, released 2024-04-04
 
 ### New features

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.csproj
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>5.0.0-beta02</Version>
+    <Version>5.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Low-level Google client library to access the Google Cloud Spanner API. The ADO.NET provider (Google.Cloud.Spanner.Data) which depends on this package is generally preferred for Spanner access.</Description>

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4479,7 +4479,7 @@
       "protoPath": "google/spanner/admin/database/v1",
       "productName": "Google Cloud Spanner Database Administration",
       "productUrl": "https://cloud.google.com/spanner/",
-      "version": "5.0.0-beta02",
+      "version": "5.0.0-beta03",
       "commonResourcesConfig": "apis/Google.Cloud.Spanner.Common.V1/CommonResourcesConfig.json",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Spanner Database Admin API.",
@@ -4504,7 +4504,7 @@
       "protoPath": "google/spanner/admin/instance/v1",
       "productName": "Google Cloud Spanner Instance Administration",
       "productUrl": "https://cloud.google.com/spanner/",
-      "version": "5.0.0-beta02",
+      "version": "5.0.0-beta03",
       "commonResourcesConfig": "apis/Google.Cloud.Spanner.Common.V1/CommonResourcesConfig.json",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Spanner Instance Admin API.",
@@ -4526,7 +4526,7 @@
     {
       "id": "Google.Cloud.Spanner.Data",
       "targetFrameworks": "netstandard2.1;net462",
-      "version": "5.0.0-beta02",
+      "version": "5.0.0-beta03",
       "type": "other",
       "metadataType": "INTEGRATION",
       "description": "Google ADO.NET Provider for Google Cloud Spanner.",
@@ -4554,7 +4554,7 @@
     {
       "id": "Google.Cloud.Spanner.Common.V1",
       "type": "other",
-      "version": "5.0.0-beta02",
+      "version": "5.0.0-beta03",
       "description": "Common resource names used by all Spanner V1 APIs",
       "tags": [
         "Spanner"
@@ -4570,7 +4570,7 @@
       "protoPath": "google/spanner/v1",
       "productName": "Google Cloud Spanner",
       "productUrl": "https://cloud.google.com/spanner/",
-      "version": "5.0.0-beta02",
+      "version": "5.0.0-beta03",
       "commonResourcesConfig": "apis/Google.Cloud.Spanner.Common.V1/CommonResourcesConfig.json",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",


### PR DESCRIPTION

Changes in Google.Cloud.Spanner.Data version 5.0.0-beta03:

### New features

- Add support for FLOAT32 ([commit 83700dd](https://github.com/googleapis/google-cloud-dotnet/commit/83700dd7c2b05bb3b598ecb7fe43de255cd5fdc8))

### Breaking changes

- The default mapping for values of CLR type decimal was FLOAT64 and it is now Numeric. ([commit 9824a9c](https://github.com/googleapis/google-cloud-dotnet/commit/9824a9c3580e79e95a7bed5af12bcdb15ffbe4cc))
- The default mapping for values of CLR type float was FLOAT64 and it is now FLOAT32. ([commit 83700dd](https://github.com/googleapis/google-cloud-dotnet/commit/83700dd7c2b05bb3b598ecb7fe43de255cd5fdc8))
- Support for specifying a maximum commit delay was added in v5.0.0-beta02. Unfortunately properties and methods for this feature were erroneously named using "commit delay" instead of "max commit delay". All such names are being corrected in this commit. ([commit 03e66d7](https://github.com/googleapis/google-cloud-dotnet/commit/03e66d73b165fe10f945924f5e70498d378042d2))
- Remove Obsolete code that had been introduced before v5.0.0-beta01. ([commit fdc4bff](https://github.com/googleapis/google-cloud-dotnet/commit/fdc4bff6a932d39e8d6c51f9efad040e427face8))

Packages in this release:
- Release Google.Cloud.Spanner.Admin.Database.V1 version 5.0.0-beta03
- Release Google.Cloud.Spanner.Admin.Instance.V1 version 5.0.0-beta03
- Release Google.Cloud.Spanner.Common.V1 version 5.0.0-beta03
- Release Google.Cloud.Spanner.Data version 5.0.0-beta03
- Release Google.Cloud.Spanner.V1 version 5.0.0-beta03
