### PR TITLE
Release Google.Cloud.Asset.V1 version 3.11.0

### DIFF
--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.csproj
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.10.0</Version>
+    <Version>3.11.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Asset Inventory API (v1).</Description>

--- a/apis/Google.Cloud.Asset.V1/docs/history.md
+++ b/apis/Google.Cloud.Asset.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 3.11.0, released 2024-04-19
+
+### New features
+
+- Add tag key id support ([commit 74afcba](https://github.com/googleapis/google-cloud-dotnet/commit/74afcba52ed630e837ce66ebf6d7e9afef48d6cf))
+
+### Documentation improvements
+
+- Add tagKeyIds example for ResourceSearchResult.tags ([commit 74afcba](https://github.com/googleapis/google-cloud-dotnet/commit/74afcba52ed630e837ce66ebf6d7e9afef48d6cf))
+
 ## Version 3.10.0, released 2024-03-28
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -534,7 +534,7 @@
       "protoPath": "google/cloud/asset/v1",
       "productName": "Google Cloud Asset Inventory",
       "productUrl": "https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview",
-      "version": "3.10.0",
+      "version": "3.11.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Asset Inventory API (v1).",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Add tag key id support ([commit 74afcba](https://github.com/googleapis/google-cloud-dotnet/commit/74afcba52ed630e837ce66ebf6d7e9afef48d6cf))

### Documentation improvements

- Add tagKeyIds example for ResourceSearchResult.tags ([commit 74afcba](https://github.com/googleapis/google-cloud-dotnet/commit/74afcba52ed630e837ce66ebf6d7e9afef48d6cf))
