### PR TITLE
Release Google.Cloud.Batch.V1Alpha version 1.0.0-alpha26

### DIFF
--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.csproj
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha25</Version>
+    <Version>1.0.0-alpha26</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Batch API (v1alpha), which allows you to manage the running of batch jobs on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Batch.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.Batch.V1Alpha/docs/history.md
@@ -1,5 +1,22 @@
 # Version history
 
+## Version 1.0.0-alpha26, released 2024-04-19
+
+### Bug fixes
+
+- **BREAKING CHANGE** Added optional flag of an existing field `limit`, `consumed`, `carryover` in ResourceAllowance ([commit c3a0f2a](https://github.com/googleapis/google-cloud-dotnet/commit/c3a0f2a7fcb458a0a4187348206f309e69d3ee43))
+
+### New features
+
+- Remove GOOGLE_INTERNAL restriction of update job api ([commit c3a0f2a](https://github.com/googleapis/google-cloud-dotnet/commit/c3a0f2a7fcb458a0a4187348206f309e69d3ee43))
+- Add a service_account field to taskGroup for service account support ([commit c3a0f2a](https://github.com/googleapis/google-cloud-dotnet/commit/c3a0f2a7fcb458a0a4187348206f309e69d3ee43))
+
+### Documentation improvements
+
+- State one Resource Allowance per region per project limitation on v1alpha ([commit 807a215](https://github.com/googleapis/google-cloud-dotnet/commit/807a215c2437421cef679d6a226f6798dec2e7b6))
+- A comment for field `max_run_duration` in message `.google.cloud.batch.v1alpha.TaskSpec` and `.google.cloud.batch.v1.TaskSpec` is changed ([commit 807a215](https://github.com/googleapis/google-cloud-dotnet/commit/807a215c2437421cef679d6a226f6798dec2e7b6))
+- Add non-negative restriction comment for usage_resource_allowance.spec.limit.limit exposed on v1alpha ([commit 807a215](https://github.com/googleapis/google-cloud-dotnet/commit/807a215c2437421cef679d6a226f6798dec2e7b6))
+
 ## Version 1.0.0-alpha25, released 2024-03-28
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -711,7 +711,7 @@
     },
     {
       "id": "Google.Cloud.Batch.V1Alpha",
-      "version": "1.0.0-alpha25",
+      "version": "1.0.0-alpha26",
       "type": "grpc",
       "productName": "Batch",
       "productUrl": "https://cloud.google.com/batch/docs/",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- **BREAKING CHANGE** Added optional flag of an existing field `limit`, `consumed`, `carryover` in ResourceAllowance ([commit c3a0f2a](https://github.com/googleapis/google-cloud-dotnet/commit/c3a0f2a7fcb458a0a4187348206f309e69d3ee43))

### New features

- Remove GOOGLE_INTERNAL restriction of update job api ([commit c3a0f2a](https://github.com/googleapis/google-cloud-dotnet/commit/c3a0f2a7fcb458a0a4187348206f309e69d3ee43))
- Add a service_account field to taskGroup for service account support ([commit c3a0f2a](https://github.com/googleapis/google-cloud-dotnet/commit/c3a0f2a7fcb458a0a4187348206f309e69d3ee43))

### Documentation improvements

- State one Resource Allowance per region per project limitation on v1alpha ([commit 807a215](https://github.com/googleapis/google-cloud-dotnet/commit/807a215c2437421cef679d6a226f6798dec2e7b6))
- A comment for field `max_run_duration` in message `.google.cloud.batch.v1alpha.TaskSpec` and `.google.cloud.batch.v1.TaskSpec` is changed ([commit 807a215](https://github.com/googleapis/google-cloud-dotnet/commit/807a215c2437421cef679d6a226f6798dec2e7b6))
- Add non-negative restriction comment for usage_resource_allowance.spec.limit.limit exposed on v1alpha ([commit 807a215](https://github.com/googleapis/google-cloud-dotnet/commit/807a215c2437421cef679d6a226f6798dec2e7b6))
