### PR TITLE
Release Google.Cloud.DiscoveryEngine.V1 version 1.0.0-beta05

### DIFF
--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.csproj
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta04</Version>
+    <Version>1.0.0-beta05</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Discovery Engine API (v1). Discovery Engine powers high-quality content recommendations on your digital properties for Discovery for Media.</Description>

--- a/apis/Google.Cloud.DiscoveryEngine.V1/docs/history.md
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/docs/history.md
@@ -1,5 +1,20 @@
 # Version history
 
+## Version 1.0.0-beta05, released 2024-04-19
+
+### New features
+
+- Promote recommendation service to v1 ([commit 1c69086](https://github.com/googleapis/google-cloud-dotnet/commit/1c69086ce35ba32d5e2b242f05cda05df5c19ded))
+- Promote blending search to v1 ([commit 1c69086](https://github.com/googleapis/google-cloud-dotnet/commit/1c69086ce35ba32d5e2b242f05cda05df5c19ded))
+- Promote healthcare search to v1 ([commit 1c69086](https://github.com/googleapis/google-cloud-dotnet/commit/1c69086ce35ba32d5e2b242f05cda05df5c19ded))
+- Promote online chunking search to v1 ([commit 1c69086](https://github.com/googleapis/google-cloud-dotnet/commit/1c69086ce35ba32d5e2b242f05cda05df5c19ded))
+- Support import data from Cloud Spanner, BigTable, SQL and Firestore ([commit 1c69086](https://github.com/googleapis/google-cloud-dotnet/commit/1c69086ce35ba32d5e2b242f05cda05df5c19ded))
+- Support boost/bury on multi-turn search ([commit 1c69086](https://github.com/googleapis/google-cloud-dotnet/commit/1c69086ce35ba32d5e2b242f05cda05df5c19ded))
+
+### Documentation improvements
+
+- Keep the API doc up-to-date with recent changes ([commit 1c69086](https://github.com/googleapis/google-cloud-dotnet/commit/1c69086ce35ba32d5e2b242f05cda05df5c19ded))
+
 ## Version 1.0.0-beta04, released 2024-03-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2046,7 +2046,7 @@
     },
     {
       "id": "Google.Cloud.DiscoveryEngine.V1",
-      "version": "1.0.0-beta04",
+      "version": "1.0.0-beta05",
       "type": "grpc",
       "productName": "Discovery Engine",
       "productUrl": "https://cloud.google.com/discovery-engine/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Promote recommendation service to v1 ([commit 1c69086](https://github.com/googleapis/google-cloud-dotnet/commit/1c69086ce35ba32d5e2b242f05cda05df5c19ded))
- Promote blending search to v1 ([commit 1c69086](https://github.com/googleapis/google-cloud-dotnet/commit/1c69086ce35ba32d5e2b242f05cda05df5c19ded))
- Promote healthcare search to v1 ([commit 1c69086](https://github.com/googleapis/google-cloud-dotnet/commit/1c69086ce35ba32d5e2b242f05cda05df5c19ded))
- Promote online chunking search to v1 ([commit 1c69086](https://github.com/googleapis/google-cloud-dotnet/commit/1c69086ce35ba32d5e2b242f05cda05df5c19ded))
- Support import data from Cloud Spanner, BigTable, SQL and Firestore ([commit 1c69086](https://github.com/googleapis/google-cloud-dotnet/commit/1c69086ce35ba32d5e2b242f05cda05df5c19ded))
- Support boost/bury on multi-turn search ([commit 1c69086](https://github.com/googleapis/google-cloud-dotnet/commit/1c69086ce35ba32d5e2b242f05cda05df5c19ded))

### Documentation improvements

- Keep the API doc up-to-date with recent changes ([commit 1c69086](https://github.com/googleapis/google-cloud-dotnet/commit/1c69086ce35ba32d5e2b242f05cda05df5c19ded))
