### PR TITLE
Release Google.Cloud.DocumentAI.V1 version 3.15.0

### DIFF
--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.csproj
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.14.0</Version>
+    <Version>3.15.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Document AI API (v1), which is a service to parse structured information from unstructured or semi-structured documents using state-of-the-art Google AI such as natural language, computer vision, translation, and AutoML.</Description>

--- a/apis/Google.Cloud.DocumentAI.V1/docs/history.md
+++ b/apis/Google.Cloud.DocumentAI.V1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 3.15.0, released 2024-04-19
+
+### New features
+
+- A new message `FoundationModelTuningOptions` is added ([commit 409c062](https://github.com/googleapis/google-cloud-dotnet/commit/409c0621ce109d3dad62b578232b09a461e9fb93))
+- A new field `foundation_model_tuning_options` is added to message `.google.cloud.documentai.v1.TrainProcessorVersionRequest` ([commit 409c062](https://github.com/googleapis/google-cloud-dotnet/commit/409c0621ce109d3dad62b578232b09a461e9fb93))
+
+### Documentation improvements
+
+- Updated comments ([commit 409c062](https://github.com/googleapis/google-cloud-dotnet/commit/409c0621ce109d3dad62b578232b09a461e9fb93))
+
 ## Version 3.14.0, released 2024-03-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2115,7 +2115,7 @@
     },
     {
       "id": "Google.Cloud.DocumentAI.V1",
-      "version": "3.14.0",
+      "version": "3.15.0",
       "type": "grpc",
       "productName": "Cloud Document AI",
       "productUrl": "https://cloud.google.com/solutions/document-ai",


### PR DESCRIPTION

Changes in this release:

### New features

- A new message `FoundationModelTuningOptions` is added ([commit 409c062](https://github.com/googleapis/google-cloud-dotnet/commit/409c0621ce109d3dad62b578232b09a461e9fb93))
- A new field `foundation_model_tuning_options` is added to message `.google.cloud.documentai.v1.TrainProcessorVersionRequest` ([commit 409c062](https://github.com/googleapis/google-cloud-dotnet/commit/409c0621ce109d3dad62b578232b09a461e9fb93))

### Documentation improvements

- Updated comments ([commit 409c062](https://github.com/googleapis/google-cloud-dotnet/commit/409c0621ce109d3dad62b578232b09a461e9fb93))
