### PR TITLE
Release Google.Cloud.Monitoring.V3 version 3.8.0

### DIFF
--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.csproj
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.7.0</Version>
+    <Version>3.8.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Monitoring API, which manages your Google Cloud Monitoring data and configurations.</Description>

--- a/apis/Google.Cloud.Monitoring.V3/docs/history.md
+++ b/apis/Google.Cloud.Monitoring.V3/docs/history.md
@@ -1,5 +1,19 @@
 # Version history
 
+## Version 3.8.0, released 2024-04-19
+
+### New features
+
+- Added CloudRun, GkeNamespace, GkeWorkload, GkeService, and BasicService service types ([commit a63edc5](https://github.com/googleapis/google-cloud-dotnet/commit/a63edc53397e62b24240e474f2ee883aa1309d89))
+- Added Synthetic Monitor targets to Uptime data model ([commit 4b7d6bc](https://github.com/googleapis/google-cloud-dotnet/commit/4b7d6bc8c0fec524dae47dd164c91d85b29a03b2))
+- Added ServiceAgentAuthentication auth method for Uptime ([commit 4b7d6bc](https://github.com/googleapis/google-cloud-dotnet/commit/4b7d6bc8c0fec524dae47dd164c91d85b29a03b2))
+
+### Documentation improvements
+
+- Updated comments accordingly ([commit a63edc5](https://github.com/googleapis/google-cloud-dotnet/commit/a63edc53397e62b24240e474f2ee883aa1309d89))
+- Updated comments accordingly ([commit 4b7d6bc](https://github.com/googleapis/google-cloud-dotnet/commit/4b7d6bc8c0fec524dae47dd164c91d85b29a03b2))
+- Various updates ([commit dfa71a3](https://github.com/googleapis/google-cloud-dotnet/commit/dfa71a3129299e055d65da1badea1028f4144506))
+
 ## Version 3.7.0, released 2024-03-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3203,7 +3203,7 @@
       "protoPath": "google/monitoring/v3",
       "productName": "Google Cloud Monitoring",
       "productUrl": "https://cloud.google.com/monitoring/api/v3/",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Monitoring API, which manages your Google Cloud Monitoring data and configurations.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- Added CloudRun, GkeNamespace, GkeWorkload, GkeService, and BasicService service types ([commit a63edc5](https://github.com/googleapis/google-cloud-dotnet/commit/a63edc53397e62b24240e474f2ee883aa1309d89))
- Added Synthetic Monitor targets to Uptime data model ([commit 4b7d6bc](https://github.com/googleapis/google-cloud-dotnet/commit/4b7d6bc8c0fec524dae47dd164c91d85b29a03b2))
- Added ServiceAgentAuthentication auth method for Uptime ([commit 4b7d6bc](https://github.com/googleapis/google-cloud-dotnet/commit/4b7d6bc8c0fec524dae47dd164c91d85b29a03b2))

### Documentation improvements

- Updated comments accordingly ([commit a63edc5](https://github.com/googleapis/google-cloud-dotnet/commit/a63edc53397e62b24240e474f2ee883aa1309d89))
- Updated comments accordingly ([commit 4b7d6bc](https://github.com/googleapis/google-cloud-dotnet/commit/4b7d6bc8c0fec524dae47dd164c91d85b29a03b2))
- Various updates ([commit dfa71a3](https://github.com/googleapis/google-cloud-dotnet/commit/dfa71a3129299e055d65da1badea1028f4144506))
