### PR TITLE
Release Google.Cloud.Security.PrivateCA.V1 version 3.7.0

### DIFF
--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.csproj
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.6.0</Version>
+    <Version>3.7.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Certificate Authority Service API version v1. The Certificate Authority Service API is a highly-available, scalable service that enables you to simplify and automate the management of private certificate authorities (CAs) while staying in control of your private keys.</Description>

--- a/apis/Google.Cloud.Security.PrivateCA.V1/docs/history.md
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/docs/history.md
@@ -1,5 +1,22 @@
 # Version history
 
+## Version 3.7.0, released 2024-04-19
+
+### New features
+
+- Add encoding format to `.google.cloud.security.privateca.v1.CaPool` Resource ([commit 260057c](https://github.com/googleapis/google-cloud-dotnet/commit/260057cebe44759acd64ec7780866f99bb127cea))
+
+### Documentation improvements
+
+- A comment for field `maximum_lifetime` in message `.google.cloud.security.privateca.v1.CaPool` is changed ([commit 260057c](https://github.com/googleapis/google-cloud-dotnet/commit/260057cebe44759acd64ec7780866f99bb127cea))
+- A comment for field `maximum_lifetime` in message `.google.cloud.security.privateca.v1.CertificateTemplate` is changed ([commit 260057c](https://github.com/googleapis/google-cloud-dotnet/commit/260057cebe44759acd64ec7780866f99bb127cea))
+- A comment for field `subject_key_id` in message `.google.cloud.security.privateca.v1.CertificateConfig` is changed ([commit 260057c](https://github.com/googleapis/google-cloud-dotnet/commit/260057cebe44759acd64ec7780866f99bb127cea))
+- A comment for method `FetchCaCerts` in service `CertificateAuthorityService` is changed ([commit 260057c](https://github.com/googleapis/google-cloud-dotnet/commit/260057cebe44759acd64ec7780866f99bb127cea))
+- A comment for field `ignore_dependent_resources` in message `.google.cloud.security.privateca.v1.DisableCertificateAuthorityRequest` is changed ([commit 260057c](https://github.com/googleapis/google-cloud-dotnet/commit/260057cebe44759acd64ec7780866f99bb127cea))
+- A comment for field `ignore_dependent_resources` in message `.google.cloud.security.privateca.v1.DeleteCertificateAuthorityRequest` is changed ([commit 260057c](https://github.com/googleapis/google-cloud-dotnet/commit/260057cebe44759acd64ec7780866f99bb127cea))
+- A comment for field `ignore_dependent_resources` in message `.google.cloud.security.privateca.v1.DeleteCaPoolRequest` is changed ([commit 260057c](https://github.com/googleapis/google-cloud-dotnet/commit/260057cebe44759acd64ec7780866f99bb127cea))
+- A comment for field `ca_certs` in message `.google.cloud.security.privateca.v1.FetchCaCertsResponse` is changed ([commit 260057c](https://github.com/googleapis/google-cloud-dotnet/commit/260057cebe44759acd64ec7780866f99bb127cea))
+
 ## Version 3.6.0, released 2024-03-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4161,7 +4161,7 @@
     },
     {
       "id": "Google.Cloud.Security.PrivateCA.V1",
-      "version": "3.6.0",
+      "version": "3.7.0",
       "type": "grpc",
       "productName": "Certificate Authority",
       "productUrl": "https://cloud.google.com/certificate-authority-service/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add encoding format to `.google.cloud.security.privateca.v1.CaPool` Resource ([commit 260057c](https://github.com/googleapis/google-cloud-dotnet/commit/260057cebe44759acd64ec7780866f99bb127cea))

### Documentation improvements

- A comment for field `maximum_lifetime` in message `.google.cloud.security.privateca.v1.CaPool` is changed ([commit 260057c](https://github.com/googleapis/google-cloud-dotnet/commit/260057cebe44759acd64ec7780866f99bb127cea))
- A comment for field `maximum_lifetime` in message `.google.cloud.security.privateca.v1.CertificateTemplate` is changed ([commit 260057c](https://github.com/googleapis/google-cloud-dotnet/commit/260057cebe44759acd64ec7780866f99bb127cea))
- A comment for field `subject_key_id` in message `.google.cloud.security.privateca.v1.CertificateConfig` is changed ([commit 260057c](https://github.com/googleapis/google-cloud-dotnet/commit/260057cebe44759acd64ec7780866f99bb127cea))
- A comment for method `FetchCaCerts` in service `CertificateAuthorityService` is changed ([commit 260057c](https://github.com/googleapis/google-cloud-dotnet/commit/260057cebe44759acd64ec7780866f99bb127cea))
- A comment for field `ignore_dependent_resources` in message `.google.cloud.security.privateca.v1.DisableCertificateAuthorityRequest` is changed ([commit 260057c](https://github.com/googleapis/google-cloud-dotnet/commit/260057cebe44759acd64ec7780866f99bb127cea))
- A comment for field `ignore_dependent_resources` in message `.google.cloud.security.privateca.v1.DeleteCertificateAuthorityRequest` is changed ([commit 260057c](https://github.com/googleapis/google-cloud-dotnet/commit/260057cebe44759acd64ec7780866f99bb127cea))
- A comment for field `ignore_dependent_resources` in message `.google.cloud.security.privateca.v1.DeleteCaPoolRequest` is changed ([commit 260057c](https://github.com/googleapis/google-cloud-dotnet/commit/260057cebe44759acd64ec7780866f99bb127cea))
- A comment for field `ca_certs` in message `.google.cloud.security.privateca.v1.FetchCaCertsResponse` is changed ([commit 260057c](https://github.com/googleapis/google-cloud-dotnet/commit/260057cebe44759acd64ec7780866f99bb127cea))
