### PR TITLE
Release Google.Cloud.SecurityCenter.V1 version 3.20.0

### DIFF
--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.csproj
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.19.0</Version>
+    <Version>3.20.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Security Command Center API (v1), which helps security teams gather data, identify threats, and act on them before they result in business damage or loss.</Description>

--- a/apis/Google.Cloud.SecurityCenter.V1/docs/history.md
+++ b/apis/Google.Cloud.SecurityCenter.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.20.0, released 2024-04-19
+
+### New features
+
+- Add cloud_armor field to finding's list of attributes ([commit c21e410](https://github.com/googleapis/google-cloud-dotnet/commit/c21e4103c713f0d46c9d730b979f240f7eb4cfaf))
+
 ## Version 3.19.0, released 2024-03-28
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4233,7 +4233,7 @@
       "protoPath": "google/cloud/securitycenter/v1",
       "productName": "Google Cloud Security Command Center",
       "productUrl": "https://cloud.google.com/security-command-center/",
-      "version": "3.19.0",
+      "version": "3.20.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Security Command Center API (v1), which helps security teams gather data, identify threats, and act on them before they result in business damage or loss.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Add cloud_armor field to finding's list of attributes ([commit c21e410](https://github.com/googleapis/google-cloud-dotnet/commit/c21e4103c713f0d46c9d730b979f240f7eb4cfaf))
