### PR TITLE
Release Google.Cloud.Storage.Control.V2 version 1.0.0-beta03

### DIFF
--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.csproj
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Storage Control API (v2), providing control-plane functionality for Google Cloud Storage.</Description>

--- a/apis/Google.Cloud.Storage.Control.V2/docs/history.md
+++ b/apis/Google.Cloud.Storage.Control.V2/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 1.0.0-beta03, released 2024-04-19
+
+### New features
+
+- Make Managed Folders operations public ([commit f904f90](https://github.com/googleapis/google-cloud-dotnet/commit/f904f9043d4f8be15e2cfa0fc14e87c182b32b70))
+
+### Documentation improvements
+
+- Update storage control documentation and add PHP for publishing ([commit 412992b](https://github.com/googleapis/google-cloud-dotnet/commit/412992b9d928fa7b111ca7018bf0c3448d6f0809))
+
 ## Version 1.0.0-beta02, released 2024-03-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4659,7 +4659,7 @@
     },
     {
       "id": "Google.Cloud.Storage.Control.V2",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0-beta03",
       "type": "grpc",
       "productName": "Cloud Storage",
       "productUrl": "https://cloud.google.com/storage/docs/overview",


### PR DESCRIPTION

Changes in this release:

### New features

- Make Managed Folders operations public ([commit f904f90](https://github.com/googleapis/google-cloud-dotnet/commit/f904f9043d4f8be15e2cfa0fc14e87c182b32b70))

### Documentation improvements

- Update storage control documentation and add PHP for publishing ([commit 412992b](https://github.com/googleapis/google-cloud-dotnet/commit/412992b9d928fa7b111ca7018bf0c3448d6f0809))
