### PR TITLE
Release Google.Maps.Routing.V2 version 1.0.0-beta13

### DIFF
--- a/apis/Google.Maps.Routing.V2/Google.Maps.Routing.V2/Google.Maps.Routing.V2.csproj
+++ b/apis/Google.Maps.Routing.V2/Google.Maps.Routing.V2/Google.Maps.Routing.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta12</Version>
+    <Version>1.0.0-beta13</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Maps Routes Preferred API.</Description>

--- a/apis/Google.Maps.Routing.V2/docs/history.md
+++ b/apis/Google.Maps.Routing.V2/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 1.0.0-beta13, released 2024-04-19
+
+### New features
+
+- Adds support for new toll passes ([commit 7a7acef](https://github.com/googleapis/google-cloud-dotnet/commit/7a7acef8882ee0c598289e68288fd32348ddc8bd))
+- Adds support for specifying units in the ComputeRouteMatrix request ([commit 7a7acef](https://github.com/googleapis/google-cloud-dotnet/commit/7a7acef8882ee0c598289e68288fd32348ddc8bd))
+
+### Documentation improvements
+
+- Various formatting and grammar fixes for proto documentation ([commit 7a7acef](https://github.com/googleapis/google-cloud-dotnet/commit/7a7acef8882ee0c598289e68288fd32348ddc8bd))
+
 ## Version 1.0.0-beta12, released 2024-03-27
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5646,7 +5646,7 @@
     },
     {
       "id": "Google.Maps.Routing.V2",
-      "version": "1.0.0-beta12",
+      "version": "1.0.0-beta13",
       "type": "grpc",
       "productName": "Maps Routing",
       "productUrl": "https://developers.google.com/maps/documentation/routes_preferred",


### PR DESCRIPTION

Changes in this release:

### New features

- Adds support for new toll passes ([commit 7a7acef](https://github.com/googleapis/google-cloud-dotnet/commit/7a7acef8882ee0c598289e68288fd32348ddc8bd))
- Adds support for specifying units in the ComputeRouteMatrix request ([commit 7a7acef](https://github.com/googleapis/google-cloud-dotnet/commit/7a7acef8882ee0c598289e68288fd32348ddc8bd))

### Documentation improvements

- Various formatting and grammar fixes for proto documentation ([commit 7a7acef](https://github.com/googleapis/google-cloud-dotnet/commit/7a7acef8882ee0c598289e68288fd32348ddc8bd))
