### PR TITLE
Release Google.Shopping.Merchant.Inventories.V1Beta version 1.0.0-beta05

### DIFF
--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.csproj
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta04</Version>
+    <Version>1.0.0-beta05</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Merchant Inventories API (v1beta) which allows developers to programmatically showcase products with local (in-store) or regional availability for free on Google.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.8.0, 5.0.0)" />
-    <PackageReference Include="Google.Shopping.Type" Version="[1.0.0-beta04, 2.0.0)" />
+    <PackageReference Include="Google.Shopping.Type" Version="[1.0.0-beta05, 2.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/docs/history.md
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 1.0.0-beta05, released 2024-04-19
+
+### New features
+
+- Fix inventories sub-API publication by adding correct child_type in the API proto ([commit 012c5af](https://github.com/googleapis/google-cloud-dotnet/commit/012c5af36d1c7b91b0450989019937d4979c0c85))
+
+### Documentation improvements
+
+- A comment for field `store_code` in message `.google.shopping.merchant.inventories.v1beta.LocalInventory` is changed ([commit 012c5af](https://github.com/googleapis/google-cloud-dotnet/commit/012c5af36d1c7b91b0450989019937d4979c0c85))
+- A comment for field `region` in message `.google.shopping.merchant.inventories.v1beta.RegionalInventory` is changed ([commit 012c5af](https://github.com/googleapis/google-cloud-dotnet/commit/012c5af36d1c7b91b0450989019937d4979c0c85))
+
 ## Version 1.0.0-beta04, released 2024-03-27
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5691,7 +5691,7 @@
     },
     {
       "id": "Google.Shopping.Merchant.Inventories.V1Beta",
-      "version": "1.0.0-beta04",
+      "version": "1.0.0-beta05",
       "type": "grpc",
       "productName": "Merchant Inventories",
       "productUrl": "https://developers.google.com/merchant/api",
@@ -5701,7 +5701,7 @@
         "inventory"
       ],
       "dependencies": {
-        "Google.Shopping.Type": "1.0.0-beta04"
+        "Google.Shopping.Type": "1.0.0-beta05"
       },
       "generator": "micro",
       "protoPath": "google/shopping/merchant/inventories/v1beta",


### PR DESCRIPTION

Changes in this release:

### New features

- Fix inventories sub-API publication by adding correct child_type in the API proto ([commit 012c5af](https://github.com/googleapis/google-cloud-dotnet/commit/012c5af36d1c7b91b0450989019937d4979c0c85))

### Documentation improvements

- A comment for field `store_code` in message `.google.shopping.merchant.inventories.v1beta.LocalInventory` is changed ([commit 012c5af](https://github.com/googleapis/google-cloud-dotnet/commit/012c5af36d1c7b91b0450989019937d4979c0c85))
- A comment for field `region` in message `.google.shopping.merchant.inventories.v1beta.RegionalInventory` is changed ([commit 012c5af](https://github.com/googleapis/google-cloud-dotnet/commit/012c5af36d1c7b91b0450989019937d4979c0c85))
