### PR TITLE
Release Google.Cloud.Deploy.V1 version 2.15.0

### DIFF
--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.csproj
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.14.0</Version>
+    <Version>2.15.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Deploy API, which automates delivery of your applications to a series of target environments in a defined sequence.</Description>

--- a/apis/Google.Cloud.Deploy.V1/docs/history.md
+++ b/apis/Google.Cloud.Deploy.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 2.15.0, released 2024-04-22
+
+### New features
+
+- Add Skaffold remote config support for GCB repos ([commit 153861e](https://github.com/googleapis/google-cloud-dotnet/commit/153861ed8a5c405967a43dd1e0c91aaa2a658780))
+
+### Documentation improvements
+
+- Clarified related comments ([commit 153861e](https://github.com/googleapis/google-cloud-dotnet/commit/153861ed8a5c405967a43dd1e0c91aaa2a658780))
+
 ## Version 2.14.0, released 2024-03-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1860,7 +1860,7 @@
     },
     {
       "id": "Google.Cloud.Deploy.V1",
-      "version": "2.14.0",
+      "version": "2.15.0",
       "type": "grpc",
       "productName": "Google Cloud Deploy",
       "productUrl": "https://cloud.google.com/deploy/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add Skaffold remote config support for GCB repos ([commit 153861e](https://github.com/googleapis/google-cloud-dotnet/commit/153861ed8a5c405967a43dd1e0c91aaa2a658780))

### Documentation improvements

- Clarified related comments ([commit 153861e](https://github.com/googleapis/google-cloud-dotnet/commit/153861ed8a5c405967a43dd1e0c91aaa2a658780))
