### PR TITLE
Release Google.Cloud.SecretManager.V1 version 2.4.0

### DIFF
--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.csproj
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Secret Manager API (v1).</Description>

--- a/apis/Google.Cloud.SecretManager.V1/docs/history.md
+++ b/apis/Google.Cloud.SecretManager.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 2.4.0, released 2024-04-22
+
+### New features
+
+- Add Secret Version Delayed Destroy changes for client libraries ([commit 88109d4](https://github.com/googleapis/google-cloud-dotnet/commit/88109d4ef7e80a8b3aca73c85594b069b555583e))
+
+### Documentation improvements
+
+- Users can now enable secret version delayed destruction ([commit 88109d4](https://github.com/googleapis/google-cloud-dotnet/commit/88109d4ef7e80a8b3aca73c85594b069b555583e))
+
 ## Version 2.3.0, released 2024-03-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4070,7 +4070,7 @@
       "protoPath": "google/cloud/secretmanager/v1",
       "productName": "Secret Manager",
       "productUrl": "https://cloud.google.com/secret-manager",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Secret Manager API (v1).",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Add Secret Version Delayed Destroy changes for client libraries ([commit 88109d4](https://github.com/googleapis/google-cloud-dotnet/commit/88109d4ef7e80a8b3aca73c85594b069b555583e))

### Documentation improvements

- Users can now enable secret version delayed destruction ([commit 88109d4](https://github.com/googleapis/google-cloud-dotnet/commit/88109d4ef7e80a8b3aca73c85594b069b555583e))
